### PR TITLE
Allow deletion of explorations with new API

### DIFF
--- a/ui/src/chronograf/actions/view/index.js
+++ b/ui/src/chronograf/actions/view/index.js
@@ -162,31 +162,33 @@ export function createExploration(source, push) {
   };
 }
 
-export function deleteExplorer(clusterID, explorerID, push) {
+export function deleteExplorer(source, explorerURI, push) {
   return (dispatch, getState) => {
     AJAX({
-      url: `/api/int/v1/explorers/${explorerID}`,
+      url: explorerURI,
       method: 'DELETE',
     }).then(() => {
       const state = getState();
 
       // If the currently active explorer is being deleted, load another session;
-      if (state.activeExplorer.id === explorerID) {
-        const explorer = state.explorers[0];
+      if (state.activeExplorer.id === explorerURI) {
+        const explorerURIs = Object.keys(state.explorers);
+        const explorer = state.explorers[explorerURIs[0]];
 
-        // If we don't have an explorer to navigate to, it means we're deleting the last
-        // explorer and should create a new one.
-        if (explorer) {
-          dispatch(loadExploration(explorer));
-          push(`/chronograf/data_explorer/${explorer.id}`);
+        // If there's only one exploration left, it means we're deleting the last
+        // exploration and should create a new one.  If not, navigate to the first
+        // exploration in state.
+        if (explorerURIs.length === 1) {
+          dispatch(createExploration(source, push));
         } else {
-          dispatch(createExploration(clusterID, push));
+          dispatch(loadExploration(explorer));
+          push(`/sources/${source.id}/chronograf/data_explorer/${btoa(explorer.id)}`);
         }
       }
 
       dispatch({
         type: 'DELETE_EXPLORER',
-        payload: {id: explorerID},
+        payload: {id: explorerURI},
       });
     });
   };

--- a/ui/src/chronograf/containers/Header.js
+++ b/ui/src/chronograf/containers/Header.js
@@ -74,7 +74,11 @@ const Header = React.createClass({
   },
 
   confirmDeleteExplorer() {
-    this.props.actions.deleteExplorer(this.state.explorerIDToDelete, this.props.router.push);
+    this.props.actions.deleteExplorer(
+      this.context.source,
+      this.state.explorerIDToDelete,
+      this.props.router.push
+    );
   },
 
   openEditExplorerModal({id}) {


### PR DESCRIPTION
### What

User can now delete an exploration.  If they delete an exploration they are currently viewing they will be navigated to the first explorer in state.  If they delete the last exploration, they will be navigated to a new empty exploration.  
### Notes

The `deleteExplorer` block logic had to change slightly to support `explorers` being an object instead of an array.  

Connect #84 
