### PR TITLE
Add Source Indicator to Data Explorer

### DIFF
--- a/ui/src/chronograf/containers/Header.js
+++ b/ui/src/chronograf/containers/Header.js
@@ -33,7 +33,9 @@ const Header = React.createClass({
   },
 
   contextTypes: {
-    source: PropTypes.shape(),
+    source: PropTypes.shape({
+      name: PropTypes.string,
+    }),
   },
 
   handleChooseTimeRange(bounds) {
@@ -113,6 +115,9 @@ const Header = React.createClass({
             selected={this.getName(selectedExplorer)}
           />
           <div className="btn btn-sm btn-primary sessions-dropdown__btn" onClick={this.handleCreateExploration}>New Exploration</div>
+        </div>
+        <div className="source-indicator">
+          Source: {this.context.source.name}
         </div>
         <div className="enterprise-header__right">
           <TimeRangeDropdown onChooseTimeRange={this.handleChooseTimeRange} selected={this.findSelected(timeRange)} />

--- a/ui/src/style/chronograf/components/_Header.scss
+++ b/ui/src/style/chronograf/components/_Header.scss
@@ -126,3 +126,7 @@
     min-width: 2em; // Override bootstrap min-width
   }
 }
+
+.source-indicator {
+  width: 640px;
+}


### PR DESCRIPTION
This places an indicator on the data explorer showing what source data
explorer queries are issued against. Sources were stored in the React
context already, presumably for other parts of the data explorer to
function, so it was possible to glean the name of the source from there.

Connect #128
