### PR TITLE
Fix prod go-bindata assets to redirect correctly at / as compared to all other paths.

### DIFF
--- a/dist/dist.go
+++ b/dist/dist.go
@@ -2,7 +2,6 @@ package dist
 
 import (
 	"net/http"
-	"path"
 
 	"github.com/elazarl/go-bindata-assetfs"
 )
@@ -28,9 +27,17 @@ type BindataAssets struct {
 func (b *BindataAssets) Handler() http.Handler {
 	// def wraps the assets to return the default file if the file doesn't exist
 	def := func(name string) ([]byte, error) {
+		// If the named asset exists, then return it directly.
 		octets, err := Asset(name)
 		if err != nil {
-			return Asset(path.Join(b.Prefix, b.Default))
+			// If this is at / then we just error out so we can return a Directory
+			// This directory will then be redirected by go to the /index.html
+			if name == b.Prefix {
+				return nil, err
+			}
+			// If this is anything other than slash, we just return the default
+			// asset.  This default asset will handle the routing.
+			return Asset(b.Default)
 		}
 		return octets, nil
 	}

--- a/restapi/configure_mr_fusion.go
+++ b/restapi/configure_mr_fusion.go
@@ -61,7 +61,7 @@ func assets() mrfusion.Assets {
 	}
 	return &dist.BindataAssets{
 		Prefix:  "ui/build",
-		Default: "index.html",
+		Default: "ui/build/index.html",
 	}
 }
 
@@ -236,8 +236,6 @@ func setupGlobalMiddleware(handler http.Handler) http.Handler {
 		if strings.Contains(r.URL.Path, "/chronograf/v1") {
 			handler.ServeHTTP(w, r)
 			return
-		} else if r.URL.Path == "//" {
-			http.Redirect(w, r, "/index.html", http.StatusFound)
 		} else {
 			assets().Handler().ServeHTTP(w, r)
 			return


### PR DESCRIPTION
### The problem

Go http file server will redirect /index.html to /. Redirects to / need to send an error to the asset fs so that asset fs will return a directory.  The directory is sent to the go http file server.  After this, the server will return the contents of index.html.

Additionally, our app must have all unknown paths return the contents of index.html.
### The Solution

Essentially, I needed to return an error when the http fileserver asks for /.  assetfs will then represent that directory as an http.Dir.  Go fileserver then knows it should get /index.html.

This code is forced into knowing quite a bit about go's http file server and the assetfs implementation of an http file system over go-bindata.
