### PR TITLE
Fix incorrect Links in Exploration

### DIFF
--- a/handlers/exploration.go
+++ b/handlers/exploration.go
@@ -32,7 +32,7 @@ func (h *Store) Explorations(ctx context.Context, params op.GetUsersUserIDExplor
 	exs := make([]*models.Exploration, len(mrExs))
 	for i, e := range mrExs {
 		rel := "self"
-		href := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", uID, e.ID)
+		href := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", uID, e.ID)
 		exs[i] = &models.Exploration{
 			Data:      e.Data,
 			Name:      e.Name,
@@ -79,7 +79,7 @@ func (h *Store) Exploration(ctx context.Context, params op.GetUsersUserIDExplora
 	}
 
 	rel := "self"
-	href := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", uID, eID)
+	href := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", uID, eID)
 	res := &models.Exploration{
 		Name:      e.Name,
 		Data:      e.Data,
@@ -144,7 +144,7 @@ func (h *Store) UpdateExploration(ctx context.Context, params op.PatchUsersUserI
 
 func explToModel(e *chronograf.Exploration) *models.Exploration {
 	rel := "self"
-	href := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", e.UserID, e.ID)
+	href := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", e.UserID, e.ID)
 	return &models.Exploration{
 		Name:      e.Name,
 		Data:      e.Data,

--- a/mock/handlers.go
+++ b/mock/handlers.go
@@ -228,7 +228,7 @@ func (m *Handler) Explorations(ctx context.Context, params op.GetUsersUserIDExpl
 	res := &models.Explorations{}
 	for i, e := range exs {
 		rel := "self"
-		href := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", id, i)
+		href := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", id, i)
 		res.Explorations = append(res.Explorations, &models.Exploration{
 			Data:      e.Data,
 			Name:      e.Name,
@@ -265,7 +265,7 @@ func (m *Handler) Exploration(ctx context.Context, params op.GetUsersUserIDExplo
 	}
 
 	rel := "self"
-	href := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", id, eID)
+	href := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", id, eID)
 	res := &models.Exploration{
 		Data:      e.Data,
 		Name:      e.Name,
@@ -325,7 +325,7 @@ func (m *Handler) NewExploration(ctx context.Context, params op.PostUsersUserIDE
 	params.Exploration.UpdatedAt = strfmt.DateTime(time.Now())
 	params.Exploration.CreatedAt = strfmt.DateTime(time.Now())
 
-	loc := fmt.Sprintf("/chronograf/v1/sources/1/users/%d/explorations/%d", id, eID)
+	loc := fmt.Sprintf("/chronograf/v1/users/%d/explorations/%d", id, eID)
 	rel := "self"
 
 	link := &models.Link{


### PR DESCRIPTION
Connect #164 
### The Problem

Could not rename explorations.  In reality, you couldn't update or save explorations at all.  
### The Solution

The link being returned from the server was incorrect and included `sources/1`.  We don't need that nonsense anymore.
