### PR TITLE
allow users to filter by apps

### DIFF
--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -29,7 +29,18 @@ const HostsTable = React.createClass({
   },
 
   filterHosts(allHosts, searchTerm) {
-    const hosts = allHosts.filter((h) => h.name.search(searchTerm) !== -1);
+    const hosts = allHosts.filter((h) => {
+      let apps = null;
+      if (h.apps) {
+        apps = h.apps.join(', ');
+      } else {
+        apps = '';
+      }
+      return (
+        h.name.search(searchTerm) !== -1 ||
+        apps.search(searchTerm) !== -1
+      );
+    });
     this.setState({searchTerm, filteredHosts: hosts});
   },
 


### PR DESCRIPTION
Connect #240 
### The problem

We need to be able to filter by app.
### The Solution

Add substring searching for both name and app.

The filter method (which runs every time state changes) is getting a little busy, so we could take some of the work out of here by modifying `getAppsForHost` and doing our join there.
