### PR TITLE
Pin ESLint to 3.5.x

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "css-loader": "^0.23.1",
     "envify": "^3.4.0",
     "enzyme": "^2.4.1",
-    "eslint": "^3.5.0",
+    "eslint": "~3.5.0",
     "eslint-loader": "^1.5.0",
     "eslint-plugin-react": "^6.2.2",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
In 3.9.x, ESLint changed how many spaces are expected on a trailing
parens following a return. Previously it expected:

```
01234567890
  return (
    <div>
    </div>
    );
01234567890
    ^~~~~~~~ It previously expected 5 spaces here

01234567890
  return (
    <div>
    </div>
  );
01234567890
  ^~~~~~~~~~ Now it wants 3
```

Until we're ready to explicitly make that change, we're going to pin to
3.5.x (which expects 5 spaces in the example above.