### PR TITLE
Make /mappings use App Name instead of ID

### DIFF
--- a/server/mappings.go
+++ b/server/mappings.go
@@ -29,7 +29,7 @@ func (h *Service) GetMappings(w http.ResponseWriter, r *http.Request) {
 		if seen[layout.Measurement+layout.ID] {
 			continue
 		}
-		mp.Mappings = append(mp.Mappings, mapping{layout.Measurement, layout.ID})
+		mp.Mappings = append(mp.Mappings, mapping{layout.Measurement, layout.Application})
 		seen[layout.Measurement+layout.ID] = true
 	}
 


### PR DESCRIPTION
Due to developer confusion over nomenclature, the ID was used in lieu of
the Application property of `Layout`. `layout.Application` holds the
user-facing name for a particular layout, and is what should be paired
with a measurement name in the `/mappings` endpoint.

Before
------
```
% curl http://localhost:8888/chronograf/v1/mappings
{
   "mappings" : [
      {
         "name" : "18aed9a7-dc83-406e-a4dc-40d53049541a",
         "measurement" : "disk"
      }
   ]
}
```

After
-----
```
% curl http://localhost:8888/chronograf/v1/mappings
{
   "mappings" : [
      {
         "measurement" : "disk",
         "name" : "User Facing Application Name"
      }
   ]
}
```

Connect #326