### PR TITLE
Add encryption of source and server passwords

### DIFF
--- a/Godeps
+++ b/Godeps
@@ -11,5 +11,6 @@ github.com/influxdata/usage-client 6d3895376368aa52a3a81d2a16e90f0f52371967
 github.com/jessevdk/go-flags 4cc2832a6e6d1d3b815e2b9d544b2a4dfb3ce8fa
 github.com/satori/go.uuid b061729afc07e77a8aa4fad0a2fd840958f1942a
 github.com/tylerb/graceful 50a48b6e73fcc75b45e22c05b79629a67c79e938
+golang.org/x/crypto 5dc8cb4b8a8eb076cbb5a06bc3b8682c15bdbbd3
 golang.org/x/net 749a502dd1eaf3e5bfd4f8956748c502357c0bbe
 golang.org/x/oauth2 1e695b1c8febf17aad3bfa7bf0a819ef94b98ad5

--- a/bolt/client.go
+++ b/bolt/client.go
@@ -22,11 +22,11 @@ type Client struct {
 	AlertsStore      *AlertsStore
 }
 
-func NewClient() *Client {
+func NewClient(key string) *Client {
 	c := &Client{Now: time.Now}
 	c.ExplorationStore = &ExplorationStore{client: c}
-	c.SourcesStore = &SourcesStore{client: c}
-	c.ServersStore = &ServersStore{client: c}
+	c.SourcesStore = &SourcesStore{client: c, key: key}
+	c.ServersStore = &ServersStore{client: c, key: key}
 	c.AlertsStore = &AlertsStore{client: c}
 	c.LayoutStore = &LayoutStore{
 		client: c,

--- a/bolt/client_test.go
+++ b/bolt/client_test.go
@@ -26,7 +26,7 @@ func NewTestClient() (*TestClient, error) {
 	f.Close()
 
 	c := &TestClient{
-		Client: bolt.NewClient(),
+		Client: bolt.NewClient("testkey"),
 	}
 	c.Path = f.Name()
 	c.Now = func() time.Time { return TestNow }

--- a/bolt/internal/internal_test.go
+++ b/bolt/internal/internal_test.go
@@ -42,9 +42,10 @@ func TestMarshalSource(t *testing.T) {
 	}
 
 	var vv chronograf.Source
-	if buf, err := internal.MarshalSource(v); err != nil {
+	key := "testkey"
+	if buf, err := internal.MarshalSource(v, key); err != nil {
 		t.Fatal(err)
-	} else if err := internal.UnmarshalSource(buf, &vv); err != nil {
+	} else if err := internal.UnmarshalSource(buf, &vv, key); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(v, vv) {
 		t.Fatalf("source protobuf copy error: got %#v, expected %#v", vv, v)
@@ -62,9 +63,10 @@ func TestMarshalServer(t *testing.T) {
 	}
 
 	var vv chronograf.Server
-	if buf, err := internal.MarshalServer(v); err != nil {
+	key := "testkey"
+	if buf, err := internal.MarshalServer(v, key); err != nil {
 		t.Fatal(err)
-	} else if err := internal.UnmarshalServer(buf, &vv); err != nil {
+	} else if err := internal.UnmarshalServer(buf, &vv, key); err != nil {
 		t.Fatal(err)
 	} else if !reflect.DeepEqual(v, vv) {
 		t.Fatalf("source protobuf copy error: got %#v, expected %#v", vv, v)

--- a/chronograf.go
+++ b/chronograf.go
@@ -15,6 +15,8 @@ const (
 	ErrLayoutNotFound      = Error("layout not found")
 	ErrAlertNotFound       = Error("alert not found")
 	ErrAuthentication      = Error("user not authenticated")
+	ErrEncryption          = Error("encryption failed")
+	ErrDecryption          = Error("decryption failed")
 )
 
 // Error is a domain error encountered while processing chronograf requests

--- a/nacl/secretbox.go
+++ b/nacl/secretbox.go
@@ -1,0 +1,58 @@
+package nacl
+
+import (
+	"crypto/rand"
+	"io"
+
+	"github.com/influxdata/chronograf"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+const (
+	// Note that the encryption key will be padded or truncated to 32 bytes.
+	keySize   = 32
+	nonceSize = 24
+)
+
+// Encrypt will seal message using the key and a randomly generated nonce.
+func Encrypt(k string, message string) (string, error) {
+	key := new([keySize]byte)
+	if len(k) > keySize {
+		k = k[:keySize]
+	}
+	copy(key[:], k[:len(k)])
+
+	nonce := new([nonceSize]byte)
+	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+		return "", chronograf.ErrEncryption
+	}
+
+	out := make([]byte, len(nonce))
+	copy(out, nonce[:])
+	out = secretbox.Seal(out, []byte(message), nonce, key)
+
+	return string(out), nil
+}
+
+// Decrypt will open the box.
+func Decrypt(k string, box string) (string, error) {
+	key := new([keySize]byte)
+	if len(k) > keySize {
+		k = k[:keySize]
+	}
+	copy(key[:], k[:len(k)])
+
+	b := []byte(box)
+	if len(b) < (nonceSize + secretbox.Overhead) {
+		return "", chronograf.ErrDecryption
+	}
+
+	var nonce [nonceSize]byte
+	copy(nonce[:], b[:nonceSize])
+	out, ok := secretbox.Open(nil, b[nonceSize:], &nonce, key)
+	if !ok {
+		return "", chronograf.ErrDecryption
+	}
+
+	return string(out), nil
+}


### PR DESCRIPTION
Connect #258 

### The problem

We want to encrypt source passwords so there is some security from prying eyes.

### The Solution

Symmetric encryption is required since the source password needs to be recoverable in plaintext. This PR uses [NaCl](https://en.wikipedia.org/wiki/NaCl_(software)) with a user supplied key.

My personal opinion is that this is not a good feature because it provides an illusion of security. If an attacker is able to access the database file, they'll have access to environment variables as well. So, while the encryption does obfuscate the passwords, all info needed to read them is present at runtime.