### PR TITLE
Update package canned directory

### DIFF
--- a/etc/build.py
+++ b/etc/build.py
@@ -23,12 +23,14 @@ LOG_DIR = "/var/log/chronograf"
 DATA_DIR = "/var/lib/chronograf"
 SCRIPT_DIR = "/usr/lib/chronograf/scripts"
 LOGROTATE_DIR = "/etc/logrotate.d"
+CANNED_DIR = "/usr/share/chronograf/canned"
 
 INIT_SCRIPT = "etc/scripts/init.sh"
 SYSTEMD_SCRIPT = "etc/scripts/chronograf.service"
 POSTINST_SCRIPT = "etc/scripts/post-install.sh"
 POSTUNINST_SCRIPT = "etc/scripts/post-uninstall.sh"
 LOGROTATE_SCRIPT = "etc/scripts/logrotate"
+CANNED_SCRIPTS = "canned/*json"
 
 # Default AWS S3 bucket for uploads
 DEFAULT_BUCKET = "dl.influxdata.com/chronograf/artifacts"
@@ -112,7 +114,8 @@ def create_package_fs(build_root):
         LOG_DIR[1:],
         DATA_DIR[1:],
         SCRIPT_DIR[1:],
-        LOGROTATE_DIR[1:]
+        LOGROTATE_DIR[1:],
+        CANNED_DIR[1:]
     ]
     for d in dirs:
         os.makedirs(os.path.join(build_root, d))
@@ -135,6 +138,10 @@ def package_scripts(build_root, config_only=False, windows=False):
             logging.debug("Moving {} to {}".format(script, dest))
             shutil.copyfile(script, dest)
             os.chmod(dest, 0o644)
+        run("cp {} {} && chmod 644 {}".format(CANNED_SCRIPTS,
+                                              os.path.join(build_root, CANNED_DIR[1:]),
+                                              os.path.join(build_root, CANNED_DIR[1:], "*json")),
+            shell=True)
 
 def run_generate():
     """Generate static assets.

--- a/etc/scripts/chronograf.service
+++ b/etc/scripts/chronograf.service
@@ -8,7 +8,7 @@ After=network-online.target
 [Service]
 User=chronograf
 Group=chronograf
-ExecStart=/usr/bin/chronograf --host localhost --port 10000 -b /var/lib/chronograf/chronograf.db -c /usr/share/chronograf
+ExecStart=/usr/bin/chronograf --host localhost --port 10000 -b /var/lib/chronograf/chronograf.db -c /usr/share/chronograf/canned
 KillMode=control-group
 Restart=on-failure
 

--- a/etc/scripts/init.sh
+++ b/etc/scripts/init.sh
@@ -13,7 +13,7 @@
 # Script to execute when starting
 SCRIPT="/usr/bin/chronograf"
 # Options to pass to the script on startup
-SCRIPT_OPTS="--host localhost --port 10000 -b /var/lib/chronograf/chronograf.db -c /usr/share/chronograf"
+SCRIPT_OPTS="--host localhost --port 10000 -b /var/lib/chronograf/chronograf.db -c /usr/share/chronograf/canned"
 
 # User to run the process under
 RUNAS=chronograf


### PR DESCRIPTION
### The problem

Canned queries were not included in the Chronograf packages.

### The Solution

Canned queries are included in the Chronograf packages (under `/usr/share/chronograf/canned`)

