### PR TITLE
add group by statement to queries if provided by layout

### DIFF
--- a/ui/src/hosts/components/LayoutRenderer.js
+++ b/ui/src/hosts/components/LayoutRenderer.js
@@ -47,7 +47,7 @@ export const LayoutRenderer = React.createClass({
         _.merge(q, {host: source});
         q.text += ` where host = '${host}' and time > ${timeRange}$`;
         if (q.wheres & q.wheres.length > 0) {
-          q.text += ` and ${q.wheres.join(' and ')}`
+          q.text += ` and ${q.wheres.join(' and ')}`;
         }
         if (q.groupbys && q.groupbys.length > 0) {
           q.text += ` group by ${q.groupBys.join(',')}`;


### PR DESCRIPTION
Connect #395 

### The problem

We aren't querying with the provided groupBy (added by #405).

### The Solution

Add it to the query.

Also, per goller's comment in #395, I've added support for multiple `where` here as well.