### PR TITLE
Update k8s network layout to show bytes per second per host/pod

### DIFF
--- a/canned/kubernetes_pod_network.json
+++ b/canned/kubernetes_pod_network.json
@@ -12,15 +12,15 @@
       "name": "TX bytes/second",
       "queries": [
         {
-          "query": "select non_negative_derivative(last(\"tx_bytes\"), 10) from kubernetes_pod_network",
+          "query": "select non_negative_derivative(last(\"tx_bytes\"), 10s) / 10.0 as tx_bytes_second from kubernetes_pod_network",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [
-            "time"
+            "time(10s)",
+            "pod_name",
+            "host"
           ],
-          "wheres": [
-            "\"namespace\" = 'kube-system'\""
-          ]
+          "wheres": []
         }
       ]
     },
@@ -33,15 +33,15 @@
       "name": "RX bytes/second ",
       "queries": [
         {
-          "query": "select non_negative_derivative(last(\"rx_bytes\"), 10) from kubernetes_pod_network",
+          "query": "select non_negative_derivative(last(\"rx_bytes\"), 10s) / 10.0 as rx_bytes_per_second from kubernetes_pod_network",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [
-            "time"
+            "time(10s)",
+            "pod_name",
+            "host"
           ],
-          "wheres": [
-            "\"namespace\" = 'kube-system'\""
-          ]
+          "wheres": []
         }
       ]
     }


### PR DESCRIPTION

### The problem
My influxql was wrong for k8s networking
### The Solution
Fixed the non_negative_derivative and time group by.  Additionally, I've removed the restriction of the kube-system namespace.


