### PR TITLE
Update k8s CPU field name to millicores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ chronograf
 node_modules/
 build/
 chronograf.db
+chronograf-v1.db
 npm-debug.log
 .vscode

--- a/canned/kubernetes_pod_container.json
+++ b/canned/kubernetes_pod_container.json
@@ -12,7 +12,7 @@
       "name": "Pod cpu usage millicores",
       "queries": [
         {
-          "query": "select \"cpu_usage_nanocores\" / 1000000 as cpu_usage_nanocores from kubernetes_pod_container",
+          "query": "select \"cpu_usage_nanocores\" / 1000000 as cpu_usage_millicores from kubernetes_pod_container",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [

--- a/canned/kubernetes_system_container.json
+++ b/canned/kubernetes_system_container.json
@@ -12,7 +12,7 @@
       "name": "Kubelet cpu usage millicores",
       "queries": [
         {
-          "query": "select \"cpu_usage_nanocores\" / 1000000 as cpu_usage_nanocores from kubernetes_system_container",
+          "query": "select \"cpu_usage_nanocores\" / 1000000 as cpu_usage_millicores from kubernetes_system_container",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [],

--- a/canned/new_apps.sh
+++ b/canned/new_apps.sh
@@ -47,8 +47,8 @@ cat > $APP_FILE << EOF
  	"cells": [{
  		"x": 0,
  		"y": 0,
- 		"w": 10,
- 		"h": 10,
+ 		"w": 4,
+ 		"h": 4,
         "i": "$CELLID",
         "name": "User facing cell Name",
  		"queries": [{


### PR DESCRIPTION

### The problem
K8s field names were nanocores, but, the units are millicores.
### The Solution
Changed the name to millicores and added a .gitignore entry for fun.

