### PR TITLE
Only warn on non-compliant style issues

### DIFF
--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -21,7 +21,7 @@ const AlertsTable = React.createClass({
     return {
       searchTerm: '',
       filteredAlerts: this.props.alerts,
-        sortDirection: null,
+      sortDirection: null,
       sortKey: null,
     };
   },


### PR DESCRIPTION
The example here is the `indent` rule. Because indentation checking is something
we want to keep as a development tool, it should remain in the eslint config, but
we can set it to warn instead of error. This causes it to output to STDOUT, but
return a 0 exit code in the case of a warning without any errors.

A related, but different issue is that people are complaining of only seeing the failure when running `npm run lint` as opposed to when doing JS development. I believe this is because we use the `devConfig.js` when developing (through `npm start`) and the `make` command uses the `npm run build` which specifies `prodConfig.js`.

This second issue is not directly related to `node_modules` caching.

<img width="601" alt="influxdata_chronograf__3267_-_circleci" src="https://cloud.githubusercontent.com/assets/24348/20121899/e8e1c8c0-a5c8-11e6-8479-a889d04fdaef.png">
