### PR TITLE
Create new queries rather than reusing old ones

### DIFF
--- a/ui/src/hosts/components/LayoutRenderer.js
+++ b/ui/src/hosts/components/LayoutRenderer.js
@@ -44,15 +44,18 @@ export const LayoutRenderer = React.createClass({
 
     return this.props.cells.map((cell) => {
       const qs = cell.queries.map((q) => {
-        _.merge(q, {host: source});
-        q.text += ` where \"host\" = '${host}' and time > ${timeRange}`;
+        let text = q.text;
+        text += ` where \"host\" = '${host}' and time > ${timeRange}`;
         if (q.wheres && q.wheres.length > 0) {
-          q.text += ` and ${q.wheres.join(' and ')}`;
+          text += ` and ${q.wheres.join(' and ')}`;
         }
         if (q.groupbys && q.groupbys.length > 0) {
-          q.text += ` group by ${q.groupbys.join(',')}`;
+          text += ` group by ${q.groupbys.join(',')}`;
         }
-        return q;
+        return {
+          host: source,
+          text,
+        };
       });
       return (
         <div key={cell.i}>


### PR DESCRIPTION
Connect #424

### The Problem
When choosing a new time range, graphs would not update. This was because the `AutoRefresh` component was comparing old props to new props, but it wasn't being passed new queries. It was being passed the same queries each render, just with particular properties amended.
For example,
```javascript
var car = {wheels: 4};
var bike = _.merge(car, {wheels: 2})

car === bike // true
```
This is because things like `_.merge` and `Object.assign` assign properties to objects _in place_ - i.e. without changing the location in memory.

### The Solution
The solution I implemented is to create brand new queries each time we hand them to `AutoRefresh`, so it can differentiate between old queries and new queries. The good news is, if it notices that there is no practical difference between the old and new, it won't try to fetch anything new.

