### PR TITLE
Update layouts to have unique cell ids and layout ids

### DIFF
--- a/canned/netstat.json
+++ b/canned/netstat.json
@@ -32,7 +32,7 @@
       "y": 0,
       "w": 10,
       "h": 10,
-      "i": "cf5d0608-b513-4244-a55f-accf520da3a1",
+      "i": "63503235-a588-49a7-ae0a-fb015c888e5b",
       "name": "Sockets created/second ",
       "queries": [
         {

--- a/canned/win_mem.json
+++ b/canned/win_mem.json
@@ -1,5 +1,5 @@
 {
-  "id": "d795c66f-0d8a-4fc0-b7bf-2cef1d2f4519",
+  "id": "cef6c954-f066-4348-9425-4132429fe817",
   "measurement": "win_mem",
   "app": "Windows Host memory metrics",
   "cells": [
@@ -8,7 +8,7 @@
       "y": 0,
       "w": 10,
       "h": 10,
-      "i": "ff51a6a0-c58c-44b8-a6ed-e35f652bb524",
+      "i": "1c275ca5-84a7-4146-9cf0-8ed654abb627",
       "name": "Available bytes",
       "queries": [
         {

--- a/canned/win_net.json
+++ b/canned/win_net.json
@@ -8,7 +8,7 @@
       "y": 0,
       "w": 10,
       "h": 10,
-      "i": "ff51a6a0-c58c-44b8-a6ed-e35f652bb524",
+      "i": "3bf8c678-5904-46e7-9c9f-d0d16f0c3fc4",
       "name": "TX bytes/second",
       "queries": [
         {
@@ -25,7 +25,7 @@
       "y": 0,
       "w": 10,
       "h": 10,
-      "i": "ff51a6a0-c58c-44b8-a6ed-e35f652bb524",
+      "i": "46963ea2-b09b-4dcf-b08b-7cbcd8766f77",
       "name": "RX bytes/second",
       "queries": [
         {


### PR DESCRIPTION

### The problem
I copy/pasted ids into several layout cells causing the layout render not to work.
### The Solution
Updated to have unique ids

I used this to find copied cell ids:

`for file in `ls *.json` ; do cat $file |jq .cells[].i; done |sort |uniq -c`

and for layout ids:

`for file in `ls *.json` ; do cat $file |jq .id; done |sort |uniq -c`



