### PR TITLE
Update derivatives to be the correct units (and make query faster)

### DIFF
--- a/canned/kubernetes_pod_network.json
+++ b/canned/kubernetes_pod_network.json
@@ -12,11 +12,10 @@
       "name": "TX bytes/second",
       "queries": [
         {
-          "query": "select non_negative_derivative(last(\"tx_bytes\"), 10s) / 10.0 as tx_bytes_second from kubernetes_pod_network",
+          "query": "select non_negative_derivative(\"tx_bytes\") as tx_bytes_per_second from kubernetes_pod_network",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [
-            "time(10s)",
             "\"pod_name\"",
             "\"host\""
           ],
@@ -33,11 +32,10 @@
       "name": "RX bytes/second ",
       "queries": [
         {
-          "query": "select non_negative_derivative(last(\"rx_bytes\"), 10s) / 10.0 as rx_bytes_per_second from kubernetes_pod_network",
+          "query": "select non_negative_derivative(\"rx_bytes\") as rx_bytes_per_second from kubernetes_pod_network",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [
-            "time(10s)",
             "\"pod_name\"",
             "\"host\""
           ],

--- a/canned/netstat.json
+++ b/canned/netstat.json
@@ -36,21 +36,17 @@
       "name": "Sockets created/second ",
       "queries": [
         {
-          "query": "select derivative(last(\"tcp_established\"), 10s)  from netstat",
+          "query": "select derivative(\"tcp_established\") from netstat",
           "db": "telegraf",
           "rp": "autogen",
-          "groupbys": [
-            "time(10s)"
-          ],
+          "groupbys": [],
           "wheres": []
         },
         {
-          "query": "select derivative(last(\"udp_socket\"), 10s)  from netstat",
+          "query": "select derivative(\"udp_socket\") from netstat",
           "db": "telegraf",
           "rp": "autogen",
-          "groupbys": [
-            "time(10s)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]


### PR DESCRIPTION
### The problem
I was using influxql derivatives incorrectly.  No need to do unit conversions to get to per seconds as units.
### The Solution
Simplify the queries to no longer require last nor a group by time.

