### PR TITLE
Add PostgreSQL Layout

### DIFF
--- a/canned/postgresql.json
+++ b/canned/postgresql.json
@@ -6,27 +6,46 @@
     {
       "x": 0,
       "y": 0,
-      "w": 4,
+      "w": 12,
       "h": 4,
       "i": "",
       "i": "b417bc9f-b16d-4691-91a7-85adfdd3e8ec",
       "name": "PostgreSQL Rows",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(tup_fetched)) as fetched, non_negative_derivative(mean(tup_returned)) as returned, non_negative_derivative(mean(tup_inserted)) as inserted, non_negative_derivative(mean(tup_updated)) as updated from postgresql",
+          "query": "select non_negative_derivative(tup_fetched) as fetched, non_negative_derivative(tup_returned) as returned, non_negative_derivative(tup_inserted) as inserted, non_negative_derivative(tup_updated) as updated from postgresql",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [
-            "time(1m)"
+            "db"
           ],
           "wheres": []
         }
       ]
     },
     {
-      "x": 10,
-      "y": 0,
-      "w": 4,
+      "x": 0,
+      "y": 8,
+      "w": 12,
+      "h": 4,
+      "i": "230d5baa-9376-438c-9a55-6f97f8c68e69",
+      "name": "PostgreSQL QPS",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(xact_commit) as xact_commit from postgresql",
+          "db": "telegraf",
+          "rp": "autogen",
+          "groupbys": [
+            "db"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 4,
+      "w": 6,
       "h": 4,
       "i": "4762130d-7005-467f-80ad-8c7f6dfe822e",
       "name": "PostgreSQL Buffers",
@@ -43,34 +62,15 @@
       ]
     },
     {
-      "x": 20,
-      "y": 0,
-      "w": 4,
+      "x": 6,
+      "y": 4,
+      "w": 6,
       "h": 4,
       "i": "95e73bda-7527-4aca-89dd-109cb6bb4294",
       "name": "PostgreSQL Conflicts/Deadlocks",
       "queries": [
         {
           "query": "select mean(conflicts) as conflicts, mean(deadlocks) as deadlocks from postgresql",
-          "db": "telegraf",
-          "rp": "autogen",
-          "groupbys": [
-            "time(1m)"
-          ],
-          "wheres": []
-        }
-      ]
-    },
-    {
-      "x": 20,
-      "y": 10,
-      "w": 15,
-      "h": 10,
-      "i": "230d5baa-9376-438c-9a55-6f97f8c68e69",
-      "name": "PostgreSQL QPS",
-      "queries": [
-        {
-          "query": "select mean(xact_commit) as xact_commit from postgresql",
           "db": "telegraf",
           "rp": "autogen",
           "groupbys": [


### PR DESCRIPTION
This adds graphs for monitoring rows returned, buffers used, any
conflicts/deadlocks, as well as the current queries per second.

This looks like:
<img width="1439" alt="chronograf" src="https://cloud.githubusercontent.com/assets/288061/20184359/6bf383e8-a736-11e6-9736-8da1826dbd42.png">
