### PR TITLE
Add nginx layout

### DIFF
--- a/canned/new_apps.sh
+++ b/canned/new_apps.sh
@@ -32,11 +32,8 @@ if [ -z "$measurement" ]; then
 	exit
 fi
 
-CELLID=$(uuidgen)
-CELLID="$(tr [A-Z] [a-z] <<< "$CELLID")"
-
-UUID=$(uuidgen)
-UUID="$(tr [A-Z] [a-z] <<< "$UUID")"
+CELLID=$(uuidgen | tr A-Z a-z)
+UUID=$(uuidgen | tr A-Z a-z)
 APP_FILE="$measurement".json
 echo Creating measurement file $APP_FILE
 cat > $APP_FILE << EOF

--- a/canned/nginx.json
+++ b/canned/nginx.json
@@ -1,0 +1,87 @@
+{
+  "id": "b805d661-e5a3-45e4-af18-de0e9360e6e7",
+  "measurement": "nginx",
+  "app": "nginx",
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "a209be7f-33c6-4612-88b2-848ae402c66a",
+      "name": "NGINX – Client connections",
+      "queries": [
+        {
+          "query": "select mean(\"accepts\") as \"accepts\", mean(\"handled\") as \"handled\", mean(\"active\") as \"active\" from nginx",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+              "time(10s)",
+              "\"server\""
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "0fc591ad-8541-4de3-a36e-4ae69ff954c4",
+      "name": "NGINX – Client errors",
+      "queries": [
+        {
+          "query": "select mean(\"accepts\") - mean(\"handled\") as \"dropped\" from nginx",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+              "time(10s)",
+            "\"server\""
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "a1f37574-b86e-4278-8acc-ba78d3ac2e4e",
+      "name": "NGINX – Client requests",
+      "queries": [
+        {
+          "query": "select mean(\"requests\") as \"requests\" from nginx",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+              "time(10s)",
+            "\"server\""
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "5b91c5b0-d270-4d03-aeae-007f2351c80c",
+      "name": "NGINX – Active Client state",
+      "queries": [
+        {
+          "query": "select mean(\"waiting\") as \"waiting\", mean(\"reading\") as \"reading\", mean(\"writing\") as \"writing\" from nginx",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+              "time(10s)",
+            "\"server\""
+          ],
+          "wheres": []
+        }
+      ]
+    }
+  ]
+}

--- a/canned/uuid.sh
+++ b/canned/uuid.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+uuidgen | tr A-Z a-z


### PR DESCRIPTION
Connect #476

### The problem
Need default layout for nginx
### The Solution
Using the information from [datadog's nginx](https://www.datadoghq.com/blog/how-to-monitor-nginx/) blog I put together layouts for nginx.

<img width="1217" alt="nginx" src="https://cloud.githubusercontent.com/assets/1922921/20222541/4c7bd9c8-a7fb-11e6-9978-efd6662ba2a6.png">


Once @jademcgough 's PR #492 is merged I'll remove the groupbys time(10s).