### PR TITLE
Fix several handlers that were not returning after error

### DIFF
--- a/server/exploration.go
+++ b/server/exploration.go
@@ -183,6 +183,7 @@ func (h *Service) NewExploration(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		msg := fmt.Errorf("Error: Failed to save Exploration")
 		unknownErrorWithMessage(w, msg)
+		return
 	}
 
 	res := newExploration(e)

--- a/server/layout.go
+++ b/server/layout.go
@@ -45,6 +45,7 @@ func (h *Service) NewLayout(w http.ResponseWriter, r *http.Request) {
 	if layout, err = h.LayoutStore.Add(r.Context(), layout); err != nil {
 		msg := fmt.Errorf("Error storing layout %v: %v", layout, err)
 		unknownErrorWithMessage(w, msg)
+		return
 	}
 
 	res := newLayoutResponse(layout)

--- a/server/mappings.go
+++ b/server/mappings.go
@@ -17,6 +17,7 @@ func (h *Service) GetMappings(w http.ResponseWriter, r *http.Request) {
 	layouts, err := h.LayoutStore.All(ctx)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, "Error loading layouts")
+		return
 	}
 
 	mp := getMappingsResponse{


### PR DESCRIPTION
### The problem
Several endpoints were not returning during errors leading to multiple headers.
### The Solution
Return immediately after error
