### PR TITLE
Fix layout group by commas when array is empty

### DIFF
--- a/ui/src/hosts/components/LayoutRenderer.js
+++ b/ui/src/hosts/components/LayoutRenderer.js
@@ -54,8 +54,10 @@ export const LayoutRenderer = React.createClass({
     if (groupbys) {
       if (groupbys.find((g) => g.includes("time"))) {
         text += ` group by ${groupbys.join(',')}`;
-      } else {
+      } else if (groupbys.length > 0) {
         text += ` group by time(${timeRange.defaultGroupBy}),${groupbys.join(',')}`;
+      } else {
+        text += ` group by time(${timeRange.defaultGroupBy})`;
       }
     } else {
       text += ` group by time(${timeRange.defaultGroupBy})`;


### PR DESCRIPTION
### The problem
Layout's with empty group by arrays would render with a trailing comma
### The Solution
Added logic to check for this case.

