### PR TITLE
Move chronograf files in Docker image to `/var/lib/chronograf`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,8 @@ MAINTAINER Chris Goller <chris@influxdb.com>
 
 RUN apk add --update ca-certificates && \
     rm /var/cache/apk/*
-    
-ENV BOLT_PATH /var/lib/chronograf/chronograf.db
-ENV CANNED_PATH /var/lib/chronograf/cannded/
 
 ADD chronograf /usr/bin/chronograf
-ADD canned/*.json /var/lib/chronograf/canned/
+ADD canned/*.json /usr/share/chronograf/canned/
 
-CMD ["/usr/bin/chronograf"]
+CMD ["/usr/bin/chronograf", "-b", "/var/lib/chronograf/chronograf-v1.db", "-c", "/usr/share/chronograf/canned"]


### PR DESCRIPTION
Connect #

### The problem

When using the standard dockerfile all the files necessary for chronograf are coppied into `/`. This makes it hard to mount a volume under all necessary files for persistence. 

### The Solution

Move the files to `/var/lib/chronograf/`


