### PR TITLE
change alert order to descending

### DIFF
--- a/ui/src/alerts/apis/index.js
+++ b/ui/src/alerts/apis/index.js
@@ -3,7 +3,7 @@ import {proxy} from 'utils/queryUrlGenerator';
 export function getAlerts(proxyLink) {
   return proxy({
     source: proxyLink,
-    query: "select host, value, level, alertName from alerts",
+    query: "select host, value, level, alertName from alerts order by time desc",
     db: "chronograf",
   });
 }


### PR DESCRIPTION
Connect #491 

Changes alert order to descending.

I haven't gotten kapacitor set up locally yet and haven't been able to verify this, but should work fine in theory.


