### PR TITLE
remove references to enterprise

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -50,7 +50,7 @@ const App = React.createClass({
     const {sourceID, base64ExplorerID} = this.props.params;
 
     return (
-      <div className="enterprise-wrapper--flex">
+      <div className="chronograf-wrapper--flex">
         <SideNavContainer sourceID={sourceID} explorationID={base64ExplorerID} addFlashMessage={this.handleNotification} currentLocation={this.props.location.pathname} />
         <div className="page-wrapper">
           {this.renderNotifications()}

--- a/ui/src/alerts/containers/AlertsApp.js
+++ b/ui/src/alerts/containers/AlertsApp.js
@@ -14,7 +14,7 @@ const AlertsApp = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string, // 'influx-chronograf'
+      type: PropTypes.string, // 'influx-enterprise'
       links: PropTypes.shape({
         proxy: PropTypes.string.isRequired,
       }).isRequired,

--- a/ui/src/alerts/containers/AlertsApp.js
+++ b/ui/src/alerts/containers/AlertsApp.js
@@ -14,7 +14,7 @@ const AlertsApp = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string, // 'influx-enterprise'
+      type: PropTypes.string, // 'influx-chronograf'
       links: PropTypes.shape({
         proxy: PropTypes.string.isRequired,
       }).isRequired,
@@ -103,9 +103,9 @@ const AlertsApp = React.createClass({
       // I stole this from the Hosts page.
       // Perhaps we should create an abstraction?
       <div className="hosts hosts-page">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>
                 Alert History
               </h1>

--- a/ui/src/chronograf/containers/Header.js
+++ b/ui/src/chronograf/containers/Header.js
@@ -108,8 +108,8 @@ const Header = React.createClass({
       {text: 'Delete', icon: 'trash', target: '#deleteExplorerModal', handler: this.openDeleteExplorerModal},
     ];
     return (
-      <div className="enterprise-header data-explorer__header">
-        <div className="enterprise-header__left">
+      <div className="chronograf-header data-explorer__header">
+        <div className="chronograf-header__left">
           <h1 className="dropdown-title">Exploration:</h1>
           <Dropdown
             className="sessions-dropdown"
@@ -120,7 +120,7 @@ const Header = React.createClass({
           />
           <div className="btn btn-sm btn-primary sessions-dropdown__btn" onClick={this.handleCreateExploration}>New Exploration</div>
         </div>
-        <div className="enterprise-header__right">
+        <div className="chronograf-header__right">
           <h1>Source:</h1>
           <div className="source-indicator">
             <span className="icon cpu"></span>

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -93,12 +93,12 @@ export const HostPage = React.createClass({
 
     return (
       <div className="host-dashboard hosts-page">
-        <div className="enterprise-header hosts-dashboard-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header hosts-dashboard-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>{hostID}</h1>
             </div>
-            <div className="enterprise-header__right">
+            <div className="chronograf-header__right">
               <h1>Range:</h1>
               <TimeRangeDropdown onChooseTimeRange={this.handleChooseTimeRange} selected={timeRange.inputValue} />
             </div>

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -8,7 +8,7 @@ export const HostsPage = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string, // 'influx-enterprise'
+      type: PropTypes.string, // 'influx-chronograf'
       links: PropTypes.shape({
         proxy: PropTypes.string.isRequired,
       }).isRequired,
@@ -44,9 +44,9 @@ export const HostsPage = React.createClass({
   render() {
     return (
       <div className="hosts hosts-page">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>
                 Host List
               </h1>

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -8,7 +8,7 @@ export const HostsPage = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string, // 'influx-chronograf'
+      type: PropTypes.string, // 'influx-enterprise'
       links: PropTypes.shape({
         proxy: PropTypes.string.isRequired,
       }).isRequired,

--- a/ui/src/kapacitor/components/RuleHeader.js
+++ b/ui/src/kapacitor/components/RuleHeader.js
@@ -44,12 +44,12 @@ export const RuleHeader = React.createClass({
 
   render() {
     return (
-      <div className="enterprise-header">
-        <div className="enterprise-header__container">
-          <div className="enterprise-header__left">
+      <div className="chronograf-header">
+        <div className="chronograf-header__container">
+          <div className="chronograf-header__left">
             {this.renderEditName()}
           </div>
-          <div className="enterprise-header__right">
+          <div className="chronograf-header__right">
             {this.renderSave()}
           </div>
         </div>
@@ -78,7 +78,7 @@ export const RuleHeader = React.createClass({
 
     if (!this.state.isEditingName) {
       return (
-        <h1 className="enterprise-header__editable" onClick={this.toggleEditName} data-for="rename-kapacitor-tooltip" data-tip="Click to Rename">
+        <h1 className="chronograf-header__editable" onClick={this.toggleEditName} data-for="rename-kapacitor-tooltip" data-tip="Click to Rename">
           {rule.name}
           <ReactTooltip id="rename-kapacitor-tooltip" delayShow="200" effect="solid" html={true} offset={{top: 2}} place="bottom" class="influx-tooltip kapacitor-tooltip place-bottom" />
         </h1>
@@ -87,7 +87,7 @@ export const RuleHeader = React.createClass({
 
     return (
       <input
-        className="enterprise-header__editing"
+        className="chronograf-header__editing"
         autoFocus={true}
         defaultValue={rule.name}
         ref={r => this.ruleName = r}

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -118,9 +118,9 @@ export const KapacitorPage = React.createClass({
 
     return (
       <div className="kapacitor">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>
                 Configure Kapacitor
               </h1>

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -40,9 +40,9 @@ export const KapacitorRulesPage = React.createClass({
 
     return (
       <div className="kapacitor-rules-page">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>Kapacitor Rules</h1>
             </div>
           </div>

--- a/ui/src/kapacitor/containers/KapacitorTasksPage.js
+++ b/ui/src/kapacitor/containers/KapacitorTasksPage.js
@@ -5,7 +5,7 @@ export const KapacitorTasksPage = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string.isRequired, // 'influx-chronograf'
+      type: PropTypes.string.isRequired, // 'influx-enterprise'
       username: PropTypes.string.isRequired,
       links: PropTypes.shape({
         kapacitors: PropTypes.string.isRequired,

--- a/ui/src/kapacitor/containers/KapacitorTasksPage.js
+++ b/ui/src/kapacitor/containers/KapacitorTasksPage.js
@@ -5,7 +5,7 @@ export const KapacitorTasksPage = React.createClass({
     source: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired,
-      type: PropTypes.string.isRequired, // 'influx-enterprise'
+      type: PropTypes.string.isRequired, // 'influx-chronograf'
       username: PropTypes.string.isRequired,
       links: PropTypes.shape({
         kapacitors: PropTypes.string.isRequired,

--- a/ui/src/shared/components/NoClusterLinksError.js
+++ b/ui/src/shared/components/NoClusterLinksError.js
@@ -13,7 +13,7 @@ const NoClusterLinksError = React.createClass({
                 </h2>
               </div>
               <div className="panel-body text-center">
-                <p>Many features in EnterpriseWeb require your user to be associated with a cluster account.</p>
+                <p>Many features in Chronograf require your user to be associated with a cluster account.</p>
                 <p>Ask an administrator to associate your user with a cluster account.</p>
               </div>
             </div>

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -65,9 +65,9 @@ export const ManageSources = React.createClass({
 
     return (
       <div id="manage-sources-page">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>InfluxDB Sources</h1>
             </div>
           </div>

--- a/ui/src/sources/containers/SourceForm.js
+++ b/ui/src/sources/containers/SourceForm.js
@@ -82,9 +82,9 @@ export const SourceForm = React.createClass({
 
     return (
       <div id="source-form-page">
-        <div className="enterprise-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>
                 {editMode ? "Edit Source" : "Add a New Source"}
               </h1>

--- a/ui/src/style/chronograf/layout/_main.scss
+++ b/ui/src/style/chronograf/layout/_main.scss
@@ -39,7 +39,7 @@
     justify-content: center;
   }
   /* Sessions Dropdown Styles */
-  .enterprise-header__left {
+  .chronograf-header__left {
     flex-direction: row;
     align-items: center;
   }
@@ -54,8 +54,8 @@
   align-items: stretch;
   position: absolute;
   left: 0;
-  top: $enterprise-page-header-height;
-  height: calc(100% - #{$enterprise-page-header-height});
+  top: $chronograf-page-header-height;
+  height: calc(100% - #{$chronograf-page-header-height});
   width: 100%;
 }
 

--- a/ui/src/style/enterprise_style/_enterprise-custom.scss
+++ b/ui/src/style/enterprise_style/_enterprise-custom.scss
@@ -1,5 +1,5 @@
 /*
-	This is a bunch of stuff built on top of the bootstrap theme for the Enterprise app.
+	This is a bunch of stuff built on top of the bootstrap theme for the Chronograf app.
 */
 
 body {
@@ -29,7 +29,7 @@ body > #react-root {
     ----------------------------------------------
 */
 
-.enterprise-wrapper {
+.chronograf-wrapper {
   width: 100%;
   position: relative;
 
@@ -87,12 +87,12 @@ body > #react-root {
 }
 
 /*
-    Enterprise Page Header
+    Chronograf Page Header
     ----------------------------------------------
 */
-.enterprise-header {
+.chronograf-header {
   background-color: $g20-white;
-  height: $enterprise-page-header-height;
+  height: $chronograf-page-header-height;
   margin-bottom: 15px;
   padding: 0 ($page-wrapper-padding + $scrollbar-width) 0 $page-wrapper-padding;
   display: flex;
@@ -128,7 +128,7 @@ body > #react-root {
     > * {
       margin: 0 4px 0 0;
     }
-  } 
+  }
   &__right {
     > * {
       margin: 0 0 0 4px;
@@ -452,7 +452,7 @@ a {
     }
     &.alert-warning {
       background-color: $c-comet;
-      
+
     }
     &.alert-danger {
       background-color: $c-dreamsicle;
@@ -733,7 +733,7 @@ table .monotype {
 #source-form-page,
 #manage-sources-page,
 .kapacitor {
-  .enterprise-header {
+  .chronograf-header {
     margin-bottom: 45px;
   }
 }
@@ -754,7 +754,7 @@ table .monotype {
       margin-bottom: 16px;
     }
     > *:first-child {
-      margin-top: 75px; 
+      margin-top: 75px;
     }
     > *:last-child {
       margin-bottom: 75px;

--- a/ui/src/style/enterprise_style/hosts.scss
+++ b/ui/src/style/enterprise_style/hosts.scss
@@ -13,7 +13,7 @@
   @include gradient-v($g2-kevlar,$g0-obsidian);
   color: $g17-whisper;
 
-  .enterprise-header {
+  .chronograf-header {
     position: absolute;
     top: 0;
     width: 100%;
@@ -22,17 +22,17 @@
   }
   .hosts-page-scroll-container {
     position: absolute;
-    top: $enterprise-page-header-height;
+    top: $chronograf-page-header-height;
     left: 0;
     width: 100%;
-    height: calc(100% - #{$enterprise-page-header-height});
+    height: calc(100% - #{$chronograf-page-header-height});
     overflow: auto;
     overflow-x: hidden;
     overflow-y: scroll;
     @include custom-scrollbar($g2-kevlar,$c-pool);
 
     .container-fluid {
-      padding-bottom: $enterprise-page-header-height;
+      padding-bottom: $chronograf-page-header-height;
     }
   }
 
@@ -154,10 +154,10 @@
   border-radius: 4px 4px 0 0;
 }
 .hosts-dashboard-header {
-  .enterprise-header__container {
+  .chronograf-header__container {
     max-width: 100%;
   }
-  .enterprise-header__left {
+  .chronograf-header__left {
     flex-direction: row;
     align-items: center;
 
@@ -168,7 +168,7 @@
       }
     }
   }
-  .enterprise-header__right {
+  .chronograf-header__right {
     font-size: inherit;
   }
 }

--- a/ui/src/style/enterprise_style/kapacitor.scss
+++ b/ui/src/style/enterprise_style/kapacitor.scss
@@ -2,7 +2,7 @@
     Kapacitor Rule Builder
     ----------------------------------------------
 */
-$kapacitor-page-padding: ($enterprise-page-header-height / 2);
+$kapacitor-page-padding: ($chronograf-page-header-height / 2);
 $kapacitor-page-gutter: 46px;
 $kapacitor-dot-size: 18px;
 $kapacitor-line-width: 3px;
@@ -31,7 +31,7 @@ $kapacitor-font-sm: 13px;
   @include gradient-v($g2-kevlar,$g0-obsidian);
   color: $g17-whisper;
 
-  .enterprise-header {
+  .chronograf-header {
     background-color: $g0-obsidian;
     position: absolute;
     top: 0;
@@ -42,15 +42,15 @@ $kapacitor-font-sm: 13px;
 }
 .rule-builder-wrapper {
   position: absolute;
-  top: $enterprise-page-header-height;
+  top: $chronograf-page-header-height;
   left: 0;
   width: 100%;
-  height: calc(100% - #{$enterprise-page-header-height});
+  height: calc(100% - #{$chronograf-page-header-height});
   overflow: auto;
   @include custom-scrollbar($g0-obsidian,$kapacitor-accent);
 
   .container-fluid {
-    padding-bottom: $enterprise-page-header-height;
+    padding-bottom: $chronograf-page-header-height;
   }
 }
 .rule-builder {
@@ -651,14 +651,14 @@ div.query-editor.kapacitor-metric-selector {
   }
 }
 
-.enterprise-header__editable {
+.chronograf-header__editable {
   transition: color 0.25s ease;
 
   &:hover {
     color: $g13-mist;
   }
 }
-.enterprise-header__editing {
+.chronograf-header__editing {
   border: 0;
   outline: none;
   background-color: $g0-obsidian;

--- a/ui/src/style/modules/_sizes.scss
+++ b/ui/src/style/modules/_sizes.scss
@@ -7,7 +7,7 @@ $page-wrapper-padding: 58px;
 $page-wrapper-max-width: 1300px;
 $current-user-height: 56px;
 $cluster-switcher-height: 56px;
-$enterprise-page-header-height: 60px;
+$chronograf-page-header-height: 60px;
 $sidebar-tier1-height:  56px;
 
 // Data Explorer


### PR DESCRIPTION
Connect #490 

This removes most references to Enterprise, changing them to Chronograf.

We still have a `_enterprise-custom.scss` file, and the `/enterprise_style` directory. There's already a `/chronograf` directory for styles from the old chronograf project, so I wasn't sure how to rename it without being confusing.