### PR TITLE
Add consul layout

### DIFF
--- a/canned/consul.json
+++ b/canned/consul.json
@@ -1,0 +1,49 @@
+{
+  "id": "f3bec493-0bc1-49d5-a40a-a09bd5cfb60c",
+  "measurement": "consul_health_checks",
+  "app": "consul",
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "9e14639d-b8d9-4245-8c45-862ed4383d31",
+      "name": "Consul – Number of Critical Health Checks",
+      "queries": [
+        {
+          "query": "SELECT count(\"check_id\") as \"Number Critical\" FROM consul_health_checks",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "\"service_name\""
+          ],
+          "wheres": [
+            "\"status\" = 'critical'"
+          ]
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "595be39d-85db-4410-b349-35c25465a4b8",
+      "name": "Consul – Number of Warning Health Checks",
+      "queries": [
+        {
+          "query": "SELECT count(\"check_id\") as \"Number Warning\" FROM consul_health_checks",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "\"service_name\""
+          ],
+          "wheres": [
+            "\"status\" = 'warning'"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Connect #478

<img width="1036" alt="consul" src="https://cloud.githubusercontent.com/assets/1922921/20281694/0c4d060a-aa77-11e6-9d48-3d3739e5675a.png">

This layout will count the number of health service check failures grouped by the `service_name`.
In my graph above I turned off apache and followed by turning off haproxy.  Next, I turned 'em back on.  Finally, I restart apache.
