### PR TITLE
Add ElasticSearch Layout

### DIFF
--- a/canned/elasticsearch.json
+++ b/canned/elasticsearch.json
@@ -1,0 +1,191 @@
+{
+  "id": "1f3ac9d0-bfb3-4e13-91a6-8949f7643ee9",
+  "measurement": "elasticsearch_indices",
+  "app": "elasticsearch",
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 4,
+      "i": "3254c2ee-4b0f-440e-9cba-b996b96bf12a",
+      "name": "ElasticSearch - Query Throughput",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(search_query_total)) as searches_per_min, non_negative_derivative(mean(search_scroll_total)) as scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) as fetches_per_min, non_negative_derivative(mean(search_suggest_total)) as suggests_per_min from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 4,
+      "w": 12,
+      "h": 4,
+      "i": "7db341c0-455b-4595-8d34-61dfbdaf6cc6",
+      "name": "ElasticSearch - Open Connections",
+      "queries": [
+        {
+          "query": "select mean(current_open) from elasticsearch_http",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 8,
+      "w": 6,
+      "h": 4,
+      "i": "ca304109-35db-4066-91e4-00875a618abb",
+      "name": "ElasticSearch - Query Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(search_query_time_in_millis)) as mean, non_negative_derivative(median(search_query_time_in_millis)) as median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 6,
+      "y": 8,
+      "w": 6,
+      "h": 4,
+      "i": "e0418118-a562-49d1-bf50-83943f72b245",
+      "name": "ElasticSearch - Fetch Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(search_fetch_time_in_millis)) as mean, non_negative_derivative(median(search_fetch_time_in_millis)) as median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 12,
+      "w": 6,
+      "h": 4,
+      "i": "3912091e-2ee5-4f47-bc74-40520239372d",
+      "name": "ElasticSearch - Suggest Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(search_suggest_time_in_millis)) as mean, non_negative_derivative(median(search_suggest_time_in_millis)) as median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 6,
+      "y": 12,
+      "w": 6,
+      "h": 4,
+      "i": "01e536cd-baf8-4bf3-9cee-9c1d149b58ef",
+      "name": "ElasticSearch - Suggest Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(search_scroll_time_in_millis)) as mean, non_negative_derivative(median(search_scroll_time_in_millis)) as median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 16,
+      "w": 12,
+      "h": 4,
+      "i": "306d6cdc-93ef-49d9-8151-a1bae355dfc6",
+      "name": "ElasticSearch - Indexing Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(indexing_time_in_millis)) as mean from elasticsearch_indices",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [
+            "time(1m)"
+          ],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 20,
+      "w": 4,
+      "h": 4,
+      "i": "5ef57f9f-4cba-4f9e-9264-15aa2954c724",
+      "name": "ElasticSearch - JVM GC Collection Counts",
+      "queries": [
+        {
+          "query": "select mean(gc_collectors_old_collection_count) as old_count, mean(gc_collectors_young_collection_count) as young_count from elasticsearch_jvm",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 4,
+      "y": 20,
+      "w": 4,
+      "h": 4,
+      "i": "fa7c807e-3e87-4d26-869b-e0ffd3ef344a",
+      "name": "ElasticSearch - JVM GC Latency",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(gc_collectors_old_collection_time_in_millis)) as mean_old_time, non_negative_derivative(mean(gc_collectors_young_collection_time_in_millis)) as mean_young_time from elasticsearch_jvm",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [],
+          "wheres": []
+        }
+      ]
+    },
+    {
+      "x": 8,
+      "y": 20,
+      "w": 4,
+      "h": 4,
+      "i": "6f4e01c4-31d6-4302-8e62-9f31f6c3f46f",
+      "name": "ElasticSearch - JVM Heap Usage",
+      "queries": [
+        {
+          "query": "select mean(mem_heap_used_percent) from elasticsearch_jvm",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [],
+          "wheres": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Connect #535 

### The problem

Users want to monitor Elasticsearch

### The Solution

This adds an ElasticSearch layout that will allow users to monitor query
throughput, JVM GC stats, and Latencies for querying and indexing.