### PR TITLE
Clean up Elasticsearch Layout

### DIFF
--- a/canned/elasticsearch.json
+++ b/canned/elasticsearch.json
@@ -15,9 +15,7 @@
           "query": "select non_negative_derivative(mean(search_query_total)) as searches_per_min, non_negative_derivative(mean(search_scroll_total)) as scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) as fetches_per_min, non_negative_derivative(mean(search_suggest_total)) as suggests_per_min from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -34,9 +32,7 @@
           "query": "select mean(current_open) from elasticsearch_http",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -53,9 +49,7 @@
           "query": "select non_negative_derivative(mean(search_query_time_in_millis)) as mean, non_negative_derivative(median(search_query_time_in_millis)) as median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -72,9 +66,7 @@
           "query": "select non_negative_derivative(mean(search_fetch_time_in_millis)) as mean, non_negative_derivative(median(search_fetch_time_in_millis)) as median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -91,9 +83,7 @@
           "query": "select non_negative_derivative(mean(search_suggest_time_in_millis)) as mean, non_negative_derivative(median(search_suggest_time_in_millis)) as median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -104,15 +94,13 @@
       "w": 6,
       "h": 4,
       "i": "01e536cd-baf8-4bf3-9cee-9c1d149b58ef",
-      "name": "ElasticSearch - Suggest Latency",
+      "name": "ElasticSearch - Scroll Latency",
       "queries": [
         {
           "query": "select non_negative_derivative(mean(search_scroll_time_in_millis)) as mean, non_negative_derivative(median(search_scroll_time_in_millis)) as median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]
@@ -126,12 +114,10 @@
       "name": "ElasticSearch - Indexing Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(indexing_time_in_millis)) as mean from elasticsearch_indices",
+          "query": "select non_negative_derivative(mean(indexing_index_time_in_millis)) as mean from elasticsearch_indices",
           "db": "telegraf",
           "rp": "",
-          "groupbys": [
-            "time(1m)"
-          ],
+          "groupbys": [],
           "wheres": []
         }
       ]


### PR DESCRIPTION
One graph was misnamed, another used the wrong field name, and there's a
whole lot of unnecessary group bys

Connect #535 

Some screencaps with a single node under simultaneous query and indexing load:

<img width="1428" alt="chronograf" src="https://cloud.githubusercontent.com/assets/288061/20290347/8533b0ba-aaad-11e6-9a84-db6a3e939cfe.png">

<img width="1427" alt="chronograf 2" src="https://cloud.githubusercontent.com/assets/288061/20290349/88701624-aaad-11e6-97b0-aa2738f815ed.png">
