### PR TITLE
Add aggregates to Postgres layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.0 [unreleased]
+
+- #574: Fix broken graphs on Postgres Layouts by adding aggregates.
+
 ## v1.1-alpha [2016-11-14]
 
 ### Release Notes

--- a/canned/postgresql.json
+++ b/canned/postgresql.json
@@ -12,7 +12,7 @@
       "name": "PostgreSQL - Rows",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(\"tup_fetched\") AS \"fetched\", non_negative_derivative(\"tup_returned\") AS \"returned\", non_negative_derivative(\"tup_inserted\") AS \"inserted\", non_negative_derivative(\"tup_updated\") AS \"updated\" FROM postgresql",
+          "query": "SELECT non_negative_derivative(mean(\"tup_fetched\")) AS \"fetched\", non_negative_derivative(mean(\"tup_returned\")) AS \"returned\", non_negative_derivative(mean(\"tup_inserted\")) AS \"inserted\", non_negative_derivative(mean(\"tup_updated\")) AS \"updated\" FROM postgresql",
           "db": "telegraf",
           "rp": "",
           "groupbys": [
@@ -31,7 +31,7 @@
       "name": "PostgreSQL - QPS",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(\"xact_commit\") AS \"xact_commit\" FROM postgresql",
+          "query": "SELECT non_negative_derivative(mean(\"xact_commit\")) AS \"xact_commit\" FROM postgresql",
           "db": "telegraf",
           "rp": "",
           "groupbys": [


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem

Some graphs were broken on the Postgres layout

### The Solution

Because the host page now adds group by time()s to queries
automatically, all queries need to have aggregates. This adds aggregates
to the fields used by the Rows and the Throughput graphs on the Postgres
layout.