### PR TITLE
Add Varnish Layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.1.0 [unreleased]
 
+- #575: Add Varnish Layout
 - #574: Fix broken graphs on Postgres Layouts by adding aggregates.
 
 ## v1.1-alpha [2016-11-14]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Currently, Chronograf offers dashboard templates for the following Telegraf inpu
 * IIS
 * etcd
 * Elastic
+* Varnish
 
 ### Data Explorer
 

--- a/canned/varnish.json
+++ b/canned/varnish.json
@@ -1,0 +1,24 @@
+{
+  "id": "83c57d16-a778-43ed-8941-0f9fec3408fa",
+  "measurement": "varnish",
+  "app": "varnish",
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 12,
+      "h": 4,
+      "i": "10b406cc-50a8-4c14-bf0e-5fe8bce1661c",
+      "name": "Varnish - Cache Hits/Misses",
+      "queries": [
+        {
+          "query": "select non_negative_derivative(mean(cache_hit)) as hits, non_negative_derivative(mean(cache_miss)) as misses from varnish",
+          "db": "telegraf",
+          "rp": "",
+          "groupbys": [],
+          "wheres": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #556

### The problem

Users want to monitor Varnish!

### The Solution

This adds a varnish layout with a single graph for monitoring cache hits
vs. misses. The varnish plugin in Telegraf is able to collect far more
statistics on Varnish (complete list:
https://github.com/influxdata/telegraf/tree/master/plugins/inputs/varnish).
However, by default only hits, misses, and uptime are present in the
configuration. We don't currently have a way for a layout to inspect the
fields present for a particular measurement for it to decide which cells
to show, so this will be necessary if we wish to add monitoring for
things like ESI errors, backend connects, memory stats, threads, etc.