### PR TITLE
extract kapacitor error to separate component, share it with rules page

### DIFF
--- a/ui/src/alerts/containers/AlertsApp.js
+++ b/ui/src/alerts/containers/AlertsApp.js
@@ -1,9 +1,9 @@
 import React, {PropTypes} from 'react';
-import {Link} from 'react-router';
 import AlertsTable from '../components/AlertsTable';
 import {getAlerts} from '../apis';
 import AJAX from 'utils/ajax';
 import _ from 'lodash';
+import NoKapacitorError from '../../shared/components/NoKapacitorError';
 
 // Kevin: because we were getting strange errors saying
 // "Failed prop type: Required prop `source` was not specified in `AlertsApp`."
@@ -83,16 +83,10 @@ const AlertsApp = React.createClass({
       const {source} = this.props;
       if (this.state.hasKapacitor) {
         component = (
-          <AlertsTable source={this.props.source} alerts={this.state.alerts} />
+          <AlertsTable source={source} alerts={this.state.alerts} />
         );
       } else {
-        const path = `/sources/${source.id}/kapacitor-config`;
-        component = (
-          <div>
-            <p>The current source does not have an associated Kapacitor instance, please configure one.</p>
-            <Link to={path}>Add Kapacitor</Link>
-          </div>
-        );
+        component = <NoKapacitorError source={source} />;
       }
     }
     return component;

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -43,16 +43,14 @@ export function loadDefaultRule() {
   };
 }
 
-export function fetchRules(source) {
+export function fetchRules(kapacitor) {
   return (dispatch) => {
-    getKapacitor(source).then((kapacitor) => {
-      getRules(kapacitor).then(({data: {rules}}) => {
-        dispatch({
-          type: 'LOAD_RULES',
-          payload: {
-            rules,
-          },
-        });
+    getRules(kapacitor).then(({data: {rules}}) => {
+      dispatch({
+        type: 'LOAD_RULES',
+        payload: {
+          rules,
+        },
       });
     });
   };

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -2,11 +2,14 @@ import React, {PropTypes} from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import {Link} from 'react-router';
-import * as kapacitorActionCreators from 'src/kapacitor/actions/view';
+import {getKapacitor} from 'src/shared/apis';
+import * as kapacitorActionCreators from '../actions/view';
+import NoKapacitorError from '../../shared/components/NoKapacitorError';
 
 export const KapacitorRulesPage = React.createClass({
   propTypes: {
     source: PropTypes.shape({
+      id: PropTypes.string.isRequired,
       links: PropTypes.shape({
         proxy: PropTypes.string.isRequired,
         self: PropTypes.string.isRequired,
@@ -26,8 +29,20 @@ export const KapacitorRulesPage = React.createClass({
     addFlashMessage: PropTypes.func,
   },
 
+  getInitialState() {
+    return {
+      hasKapacitor: false,
+      loading: true,
+    };
+  },
+
   componentDidMount() {
-    this.props.actions.fetchRules(this.props.source);
+    getKapacitor(this.props.source).then((kapacitor) => {
+      if (kapacitor) {
+        this.props.actions.fetchRules(kapacitor);
+      }
+      this.setState({loading: false, hasKapacitor: !!kapacitor});
+    });
   },
 
   handleDeleteRule(rule) {
@@ -35,9 +50,45 @@ export const KapacitorRulesPage = React.createClass({
     actions.deleteRule(rule);
   },
 
-  render() {
+  renderSubComponent() {
     const {source} = this.props;
+    const {hasKapacitor, loading} = this.state;
 
+    let component;
+    if (loading) {
+      component = (<p>Loading...</p>);
+    } else if (hasKapacitor) {
+      component = (
+        <div className="panel panel-minimal">
+          <div className="panel-heading u-flex u-ai-center u-jc-space-between">
+            <h2 className="panel-title">Alert Rules</h2>
+            <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
+          </div>
+          <div className="panel-body">
+            <table className="table v-center">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Trigger</th>
+                  <th>Message</th>
+                  <th>Alerts</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {this.renderAlertsTableRows()}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      );
+    } else {
+      component = <NoKapacitorError source={source} />;
+    }
+    return component;
+  },
+
+  render() {
     return (
       <div className="kapacitor-rules-page">
         <div className="enterprise-header">
@@ -49,28 +100,7 @@ export const KapacitorRulesPage = React.createClass({
         </div>
         <div className="hosts-page-scroll-container">
           <div className="container-fluid">
-            <div className="panel panel-minimal">
-              <div className="panel-heading u-flex u-ai-center u-jc-space-between">
-                <h2 className="panel-title">Alert Rules</h2>
-                <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
-              </div>
-              <div className="panel-body">
-                <table className="table v-center">
-                  <thead>
-                    <tr>
-                      <th>Name</th>
-                      <th>Trigger</th>
-                      <th>Message</th>
-                      <th>Alerts</th>
-                      <th></th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {this.renderAlertsTableRows()}
-                  </tbody>
-                </table>
-              </div>
-            </div>
+            {this.renderSubComponent()}
           </div>
         </div>
       </div>

--- a/ui/src/shared/components/NoKapacitorError.js
+++ b/ui/src/shared/components/NoKapacitorError.js
@@ -1,0 +1,22 @@
+import React, {PropTypes} from 'react';
+import {Link} from 'react-router';
+
+const NoKapacitorError = React.createClass({
+  propTypes: {
+    source: PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    }).isRequired,
+  },
+
+  render() {
+    const path = `/sources/${this.props.source.id}/kapacitor-config`;
+    return (
+      <div>
+        <p>The current source does not have an associated Kapacitor instance, please configure one.</p>
+        <Link to={path}>Add Kapacitor</Link>
+      </div>
+    );
+  },
+});
+
+export default NoKapacitorError;


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #536

### The problem

The kapacitor rules page does not direct users to add a kapacitor if the chosen source does not have one.

### The Solution

I've extracted the notification that we show on the alerts page and shared it with the rules page.