### PR TITLE
Zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.1.0 [unreleased]
 
+- #576: Fix broken zoom on graphs that aren't the first.
 - #575: Add Varnish Layout
 - #574: Fix broken graphs on Postgres Layouts by adding aggregates.
 

--- a/ui/src/kubernetes/components/KubernetesDashboard.js
+++ b/ui/src/kubernetes/components/KubernetesDashboard.js
@@ -66,12 +66,12 @@ export const KubernetesPage = React.createClass({
 
     return (
       <div className="host-dashboard hosts-page">
-        <div className="enterprise-header hosts-dashboard-header">
-          <div className="enterprise-header__container">
-            <div className="enterprise-header__left">
+        <div className="chronograf-header hosts-dashboard-header">
+          <div className="chronograf-header__container">
+            <div className="chronograf-header__left">
               <h1>Kubernetes Dashboard</h1>
             </div>
-            <div className="enterprise-header__right">
+            <div className="chronograf-header__right">
               <h1>Range:</h1>
               <TimeRangeDropdown onChooseTimeRange={this.handleChooseTimeRange} selected={timeRange.inputValue} />
             </div>

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -100,7 +100,7 @@ export const LayoutRenderer = React.createClass({
 
   render() {
     return (
-      <GridLayout layout={this.state.layout} isDraggable={false} isResizable={false} cols={12} rowHeight={90} width={1200}>
+      <GridLayout useCSSTransforms={false} layout={this.state.layout} isDraggable={false} isResizable={false} cols={12} rowHeight={90} width={1200}>
         {this.generateGraphs()}
       </GridLayout>
     );


### PR DESCRIPTION
  - [ X] CHANGELOG.md updated
  - [ X] Rebased/mergable
  - [ X] Tests pass
  - [ X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #539 

### The problem
`ReactGridLayout` uses css transforms by default for positioning on the page.  According to the docs it does this because transforms are ~6X faster at painting to the DOM than using `position` `top` and `left`. 
### The Solution
The thing about css transforms is that the technology is still experimental and can cause odd things to happen (like click and mouse drags not rendering).  Luckily, we are able to opt out of using transforms with setting the `ReactGridLayout` prop `useCSSTransforms` to `false`.   

Yay.   