### PR TITLE
Remove identifier (host) from timeSeriesToDygraph converter

### DIFF
--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -1,0 +1,88 @@
+import timeSeriesToDygraph from 'src/utils/timeSeriesToDygraph';
+
+describe('timeSeriesToDygraph', () => {
+  it('parses a raw InfluxDB response into a dygraph friendly data format', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f2"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+          ],
+        },
+      }
+    ];
+
+    const actual = timeSeriesToDygraph(influxResponse);
+
+    const expected = {
+      fields: [
+        'time',
+        `m1.f1`,
+        `m1.f2`,
+      ],
+      timeSeries: [
+        [new Date(1000), 1, null],
+        [new Date(2000), 2, 3],
+        [new Date(4000), null, 4],
+      ],
+    };
+
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('can sort numerical timestamps correctly', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[100, 1],[3000, 3],[200, 2]],
+                },
+              ]
+            },
+          ],
+        },
+      }
+    ];
+
+
+    const actual = timeSeriesToDygraph(influxResponse);
+
+    const expected = {
+      fields: [
+        'time',
+        'm1.f1',
+      ],
+      timeSeries: [
+        [new Date(100), 1],
+        [new Date(200), 2],
+        [new Date(3000), 3],
+      ],
+    };
+
+    expect(actual).to.deep.equal(expected);
+  });
+});

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -60,7 +60,7 @@ export default function AutoRefresh(ComposedComponent) {
       const newSeries = [];
       queries.forEach(({host, database, rp, text}) => {
         _fetchTimeSeries(host, database, rp, text).then((resp) => {
-          newSeries.push({identifier: host, response: resp.data});
+          newSeries.push({response: resp.data});
           count += 1;
           if (count === queries.length) {
             this.setState({

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -131,6 +131,7 @@ export default React.createClass({
 
     const timeSeries = this.getTimeSeries();
     const {fields, yRange} = this.props;
+
     dygraph.updateOptions({
       labels: fields,
       file: timeSeries,

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -26,7 +26,7 @@ export default function timeSeriesToDygraph(raw = []) {
    */
   const dateToFieldValue = {};
 
-  raw.forEach(({identifier = '', response}) => {
+  raw.forEach(({response}) => {
     // If a response is an empty result set or a query returned an error
     // from InfluxDB, don't try and parse.
     if (response.results.length) {
@@ -83,8 +83,7 @@ export default function timeSeriesToDygraph(raw = []) {
       }).sort().join('');
 
       columns.slice(1).forEach((fieldName) => {
-        const identString = identifier ? `(${identifier})` : '';
-        const effectiveFieldName = `${measurementName}.${fieldName}${tags}${identString}`;
+        const effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
 
         // Given a field name, identify which column in the timeSeries result should hold the field's value
         // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
@@ -112,8 +111,7 @@ export default function timeSeriesToDygraph(raw = []) {
           }
 
           const fieldName = columns[index];
-          const identString = identifier ? `(${identifier})` : '';
-          const effectiveFieldName = `${measurementName}.${fieldName}${tags}${identString}`;
+          const effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
           dateToFieldValue[dateString][effectiveFieldName] = value;
         });
       }


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #544 

Before:
![screen shot 2016-11-17 at 4 26 47 pm](https://cloud.githubusercontent.com/assets/7582765/20413636/e3f4afc8-ace2-11e6-8de0-8932458d053f.png)

After:
![screen shot 2016-11-17 at 4 26 29 pm](https://cloud.githubusercontent.com/assets/7582765/20413628/dd7cbc08-ace2-11e6-9364-260553aacb66.png)

### The problem
The `identifier` in the `timeSeriesToDygraph` function is a relic from old-chronograf.  No longer needed.  [See old test](https://github.com/influxdata/chronograf-old/blob/master/ui/spec/timeSeriesToDygraphSpec.js#L38) for reference.

### The Solution
Remove relic.  Add updated tests. Works empirically in DE, and layouts.



