### PR TITLE
Fix layout being displayed when measurement not present

### DIFF
--- a/ui/src/hosts/apis/index.js
+++ b/ui/src/hosts/apis/index.js
@@ -81,3 +81,28 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
     return newHosts;
   });
 }
+
+export function getMeasurementsForHost(source, host) {
+  return proxy({
+    source: source.links.proxy,
+    query: `SHOW MEASUREMENTS WHERE "host" = '${host}'`,
+    db: source.telegraf,
+  }).then(({data}) => {
+    if (_isEmpty(data) || _hasError(data)) {
+      return [];
+    }
+
+    const series = data.results[0].series[0];
+    return series.values.map((measurement) => {
+      return measurement[0];
+    });
+  });
+}
+
+function _isEmpty(resp) {
+  return !resp.results[0].series;
+}
+
+function _hasError(resp) {
+  return !!resp.results[0].error;
+}


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #494 

### The problem
We are populating the host view with empty layouts because we are not detecting whether a particular host even has a layout's measurement.

### The Solution
Get the measurements for a host and filter the layouts based on said measurements. 

### Before
![screen shot 2016-11-22 at 11 27 06 am](https://cloud.githubusercontent.com/assets/7582765/20538808/9af4d9ec-b0a7-11e6-9976-e509f91eab7a.png)
### After
![screen shot 2016-11-22 at 11 27 24 am](https://cloud.githubusercontent.com/assets/7582765/20538820/a020b260-b0a7-11e6-9639-a0e74a06bcc5.png)




