### PR TITLE
Fix uneditable telegraf text input 

### DIFF
--- a/ui/src/sources/containers/CreateSource.js
+++ b/ui/src/sources/containers/CreateSource.js
@@ -57,11 +57,11 @@ export const CreateSource = React.createClass({
                     <div>
                       <div className="form-group col-xs-6 col-sm-4 col-sm-offset-2">
                         <label htmlFor="connect-string">Connection String</label>
-                        <input ref={(r) => this.sourceURL = r} className="form-control" id="connect-string" placeholder="http://localhost:8086"></input>
+                        <input ref={(r) => this.sourceURL = r} className="form-control" id="connect-string" defaultValue="http://localhost:8086"></input>
                       </div>
                       <div className="form-group col-xs-6 col-sm-4">
                         <label htmlFor="name">Name</label>
-                        <input ref={(r) => this.sourceName = r} className="form-control" id="name" placeholder="Influx 1"></input>
+                        <input ref={(r) => this.sourceName = r} className="form-control" id="name" defaultValue="Influx 1"></input>
                       </div>
                       <div className="form-group col-xs-6 col-sm-4 col-sm-offset-2">
                         <label htmlFor="username">Username</label>
@@ -74,7 +74,7 @@ export const CreateSource = React.createClass({
                     </div>
                     <div className="form-group col-xs-8 col-xs-offset-2">
                       <label htmlFor="telegraf">Telegraf database</label>
-                      <input ref={(r) => this.sourceTelegraf = r} className="form-control" id="telegraf" type="text" value="telegraf"></input>
+                      <input ref={(r) => this.sourceTelegraf = r} className="form-control" id="telegraf" type="text" defaultValue="telegraf"></input>
                     </div>
                     <div className="form-group col-xs-12 text-center">
                       <button className="btn btn-success" type="submit">Create New Server</button>


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #586 

### The problem
User cannot type into the telegraf text input field. 
### The Solution
The solution can be summed up pretty well by the console warning 

Failed form propType: You provided a `value` prop to a form field without an `onChange` handler. This will render a read-only field. If the field should be mutable use `defaultValue`. Otherwise, set either `onChange` or `readOnly`. Check the render method of `CreateSource`.

I also updated the `sourceURL` and source `name` as per a previous request from @nathanielc 