### PR TITLE
Update circle to push latest tag for master builds

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -33,6 +33,8 @@ deployment:
       - docker login -e $QUAY_EMAIL -u "$QUAY_USER" -p $QUAY_PASS quay.io
       - docker tag chronograf quay.io/influxdb/chronograf:${CIRCLE_SHA1:0:7}
       - docker push quay.io/influxdb/chronograf:${CIRCLE_SHA1:0:7}
+      - docker tag chronograf quay.io/influxdb/chronograf:latest
+      - docker push quay.io/influxdb/chronograf:latest
       - mv ./build/* $CIRCLE_ARTIFACTS
   pre-release:
     tag: /^[0-9]+(\.[0-9]+)*(\S*)([a|rc|beta]([0-9]+))+$/


### PR DESCRIPTION


Fix #631

### The problem
Master was not pushing `latest` docker container tag
### The Solution
When master is built it will update the latest tag on quay


