### PR TITLE
Fix bug that stopped apps from displaying

### DIFF
--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import {Link} from 'react-router';
 import _ from 'lodash';
 
@@ -140,12 +141,13 @@ const HostRow = React.createClass({
   },
 
   shouldComponentUpdate(nextProps) {
-    return this.props.host !== nextProps.host;
+    return shallowCompare(this, nextProps);
   },
 
   render() {
     const {host, source} = this.props;
     const {name, cpu, load, apps = []} = host;
+
     return (
       <tr>
         <td className="monotype"><Link to={`/sources/${source.id}/hosts/${name}`}>{name}</Link></td>


### PR DESCRIPTION
### The Problem
Apps were not showing up on the host list because of the new `shouldComponentUpdate` for a host list item. This was because hosts we modify the hosts in place, meaning `this.props.host !== nextProps.host` was given us a fraudulent result.

### The Solution
Actually compare the keys of the two hosts



