### PR TITLE
Dashboard api spike

### DIFF
--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,52 +1,57 @@
 ## Dashboard API
 
-### Visualization Metadata
-Currently, we don't know all features we want in the dashboard visualization.  So, we'll hand-wave over that until we are actually creating the dashboards.  We'll keep the codebase agile enough to add in visualization metadata as we need 'em.
-
 ### TL; DR 
-Here are the objects we are thinking about; dashboards contain layouts which contain explorations.
+Here are the objects we are thinking about; dashboards contain layouts which
+contain explorations.
 
 #### Dashboard
+
 ```json
 {
 	"links": {
 		"self": "/chronograf/v1/dashboards/myid"
 	},
 	"id": "myid",
-	"layouts": [
-		"/chronograf/v1/layouts/a",
-		"/chronograf/v1/layouts/b"
+	"queries": [
+		{
+			"x": 0,
+			"y": 0,
+			"w": 2,
+			"h": 1,
+			"label": "Objects/Second",
+			"range": {
+				"upper": 100,
+				"lower": 10
+			},
+			"link": "/chronograf/v1/queries/1"
+		},
+		{
+			"x": 2,
+			"y": 0,
+			"w": 2,
+			"h": 1,
+			"label": "Widgets/Second",
+			"range": {
+				"upper": 10,
+				"lower": 0
+			},
+			"link": "/chronograf/v1/queries/2"
+		}
 	],
 	"name": "This is my dashboard",
-	... visualization metadata here ...
 }
 ```
 
-#### Layout
-(Notice that we added explorations in the cell object) 
-```json
-{
-	"id": "6dfb4d49-20dc-4157-9018-2b1b1cb75c2d",
-	"dashboards" :[
-		"/chronograf/v1/dashboards/myid"
-	],
-	"cells": [
-		{
-		  "visualization": "graph",
-		  "name": "Apache Bytes/Second",
-		  "exploration": "/chronograf/v1/explorations/1"
-		}
-	]
-}
-```
-
-#### Exploration
-This is the same object we currently use for explorations.
+#### Query
 
 ```json
 {
-	"name": "my exploration",
-	"data":{}
+	"query": "SELECT mean(n_cpu) from cpu GROUP BY time(15m)",
+	"db": "telegraf",
+	"rp": "",
+	"links" : {
+		"self": "/chronograf/v1/queries/1"
+	}
 }
 
 ```
@@ -59,30 +64,74 @@ Returns a list of dashboards
 
 ```json
 {
-	"dashboards": [
-		{
-			"links": {
-				"self": "/chronograf/v1/dashboards/myid"
-			},
-			"id": "myid",
-			"layouts": [
-				"/chronograf/v1/layouts/a",
-				"/chronograf/v1/layouts/b"
-			],
-			"name": "This is my dashboard",
-		},
-		{
-			"links": {
-				"self": "/chronograf/v1/dashboards/myother"
-			},
-			"id": "myother",
-			"layouts": [
-				"/chronograf/v1/layouts/b",
-				"/chronograf/v1/layouts/c"
-			],
-			"name": "This is my other dashboard",
-		}
-	]
+    "dashboards": [
+        {
+            "links": {
+                "self": "/chronograf/v1/dashboards/myid"
+            },
+            "id": "myid",
+            "queries": [
+                {
+                    "x": 0,
+                    "y": 0,
+                    "w": 2,
+                    "h": 1,
+                    "label": "Objects/Second",
+                    "range": {
+                        "upper": 100,
+                        "lower": 10
+                    },
+                    "link": "/chronograf/v1/queries/1"
+                },
+                {
+                    "x": 2,
+                    "y": 0,
+                    "w": 2,
+                    "h": 1,
+                    "label": "Widgets/Second",
+                    "range": {
+                        "upper": 10,
+                        "lower": 0
+                    },
+                    "link": "/chronograf/v1/queries/2"
+                }
+            ],
+            "name": "This is my dashboard"
+        },
+        {
+            "links": {
+                "self": "/chronograf/v1/dashboards/myid"
+            },
+            "id": "myid",
+            "queries": [
+                {
+                    "x": 0,
+                    "y": 0,
+                    "w": 2,
+                    "h": 1,
+                    "label": "Objects/Second",
+                    "range": {
+                        "upper": 100,
+                        "lower": 10
+                    },
+                    "link": "/chronograf/v1/queries/1"
+                },
+                {
+                    "x": 2,
+                    "y": 0,
+                    "w": 2,
+                    "h": 1,
+                    "label": "Widgets/Second",
+                    "range": {
+                        "upper": 10,
+                        "lower": 0
+                    },
+                    "link": "/chronograf/v1/queries/2"
+                }
+            ],
+            "name": "This is my dashboard"
+        }
+    ]
 }
 ```
 #### GET /dashboards/myid
@@ -95,45 +144,66 @@ Returns an single dashboard object
         "self": "/chronograf/v1/dashboards/myid"
     },
     "id": "myid",
-    "layouts": [
-        "/chronograf/v1/layouts/a",
-        "/chronograf/v1/layouts/b"
+    "queries": [
+        {
+            "x": 0,
+            "y": 0,
+            "w": 2,
+            "h": 1,
+            "label": "Objects/Second",
+            "range": {
+                "upper": 100,
+                "lower": 10
+            },
+            "link": "/chronograf/v1/queries/1"
+        },
+        {
+            "x": 2,
+            "y": 0,
+            "w": 2,
+            "h": 1,
+            "label": "Widgets/Second",
+            "range": {
+                "upper": 10,
+                "lower": 0
+            },
+            "link": "/chronograf/v1/queries/2"
+        }
     ],
-    "name": "This is my dashboard",
+    "name": "This is my dashboard"
 }
 ```
 
 #### PUT /dashboards/myid
-We want complete updates to the dashboards because we don't know if we can actually incrementally update visualization metadata
+We want complete updates to the dashboards because we don't know if we can 
+actually incrementally update visualization metadata
 
 This endpoint will respond with the dashboard after update.
 
 #### DELETE 
-Removes a dashboard but will not remove the explorations or layouts.  This could lead to orphans.
+Removes a dashboard but will not remove the queries.  This will lead to orphans.
 
-
-Should we have a page that lists all the explorations and layouts and associated dashboards?
+Should we have a page that lists all the queries?
 
 #### POST
 Creating a dashboard from an exploration would need to be a two-step process
 
-1. Create Layout containing exploration
-2. Create dashboard including Layout link
+1. Create a query
+2. Create dashboard including query link
 
-Perhaps the creation of a new dashboard could create associated layouts?
+### /queries
+The queries endpoint will be a simple CRUD endpoint storing the raw query:
 
-### Modifications to /layouts
-
-A layout would have an array of associated dashboards.  This is a many-to-many relationship with the dashboards.
-
-If one edits a layout it could edit the layout for all dashboards. If a layout belongs to multiple dashboards, we could prompt the user to decide if they want to edit one or all.
-
-We will add another filter parameter, `dashboard`, to layouts.
-
-To get the layouts associated with dashboards `mydashboard` and `myotherdashboard`:
-```http
-GET /chronograf/v1/layouts?dashboard=mydashboard&dashboard=myotherdashboard HTTP/1.1
+```json
+{
+	"query": "SELECT mean(n_cpu) from cpu GROUP BY time(15m)",
+	"db": "telegraf",
+	"rp": "",
+	"links" : {
+		"self": "/chronograf/v1/queries/1"
+	}
+}
 ```
 
-
-
+Over time I'd like this queries endpoint to support a `format` parameter to return 
+the query data in different JSON formats such as `QueryConfig`.

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,0 +1,139 @@
+## Dashboard API
+
+### Visualization Metadata
+Currently, we don't know all features we want in the dashboard visualization.  So, we'll hand-wave over that until we are actually creating the dashboards.  We'll keep the codebase agile enough to add in visualization metadata as we need 'em.
+
+### TL; DR 
+Here are the objects we are thinking about; dashboards contain layouts which contain explorations.
+
+#### Dashboard
+```json
+{
+	"links": {
+		"self": "/chronograf/v1/dashboards/myid"
+	},
+	"id": "myid",
+	"layouts": [
+		"/chronograf/v1/layouts/a",
+		"/chronograf/v1/layouts/b"
+	],
+	"name": "This is my dashboard",
+	... visualization metadata here ...
+}
+```
+
+#### Layout
+(Notice that we added explorations in the cell object) 
+```json
+{
+	"id": "6dfb4d49-20dc-4157-9018-2b1b1cb75c2d",
+	"dashboards" :[
+		"/chronograf/v1/dashboards/myid"
+	],
+	"cells": [
+		{
+		  "visualization": "graph",
+		  "name": "Apache Bytes/Second",
+		  "exploration": "/chronograf/v1/explorations/1"
+		}
+	]
+}
+```
+
+#### Exploration
+This is the same object we currently use for explorations.
+
+```json
+{
+	"name": "my exploration",
+	"data":{}
+}
+
+```
+
+## API
+### /dashboards
+#### GET /dashboards
+
+Returns a list of dashboards
+
+```json
+{
+	"dashboards": [
+		{
+			"links": {
+				"self": "/chronograf/v1/dashboards/myid"
+			},
+			"id": "myid",
+			"layouts": [
+				"/chronograf/v1/layouts/a",
+				"/chronograf/v1/layouts/b"
+			],
+			"name": "This is my dashboard",
+		},
+		{
+			"links": {
+				"self": "/chronograf/v1/dashboards/myother"
+			},
+			"id": "myother",
+			"layouts": [
+				"/chronograf/v1/layouts/b",
+				"/chronograf/v1/layouts/c"
+			],
+			"name": "This is my other dashboard",
+		}
+	]
+}
+```
+#### GET /dashboards/myid
+
+Returns an single dashboard object
+
+```json
+{
+    "links": {
+        "self": "/chronograf/v1/dashboards/myid"
+    },
+    "id": "myid",
+    "layouts": [
+        "/chronograf/v1/layouts/a",
+        "/chronograf/v1/layouts/b"
+    ],
+    "name": "This is my dashboard",
+}
+```
+
+#### PUT /dashboards/myid
+We want complete updates to the dashboards because we don't know if we can actually incrementally update visualization metadata
+
+This endpoint will respond with the dashboard after update.
+
+#### DELETE 
+Removes a dashboard but will not remove the explorations or layouts.  This could lead to orphans.
+
+
+Should we have a page that lists all the explorations and layouts and associated dashboards?
+
+#### POST
+Creating a dashboard from an exploration would need to be a two-step process
+
+1. Create Layout containing exploration
+2. Create dashboard including Layout link
+
+Perhaps the creation of a new dashboard could create associated layouts?
+
+### Modifications to /layouts
+
+A layout would have an array of associated dashboards.  This is a many-to-many relationship with the dashboards.
+
+If one edits a layout it could edit the layout for all dashboards. If a layout belongs to multiple dashboards, we could prompt the user to decide if they want to edit one or all.
+
+We will add another filter parameter, `dashboard`, to layouts.
+
+To get the layouts associated with dashboards `mydashboard` and `myotherdashboard`:
+```http
+GET /chronograf/v1/layouts?dashboard=mydashboard&dashboard=myotherdashboard HTTP/1.1
+```
+
+
+

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -1,4 +1,5 @@
 ## Dashboard API
+The dashboard API will support collections of resizable InfluxQL visualizations.
 
 ### TL; DR 
 Here are the objects we are thinking about; dashboards contain layouts which
@@ -55,8 +56,28 @@ contain explorations.
 }
 
 ```
+## Older Chronograf dashboards
+Older chronograf dashboards had the following features:
+
+* View Dashboard
+* Add new visualization to dashboard
+* Add existing visualization to dashboard
+* Remove visualizatoin from dashboard
+* Naming of dashboards
+* Delete dashboard
+* Edit visualization in dashboard
 
 ## API
+This API supports a user defined grid layout by specifying `x`, `y`, `w`, `h`.
+These fields align with the [react-grid-layout](https://github.com/STRML/react-grid-layout#usage)
+methodology.
+
+This layout style has:
+
+* Draggable query cells
+* Resizable query cells
+* Vertical auto-packing
+
 ### /dashboards
 #### GET /dashboards
 
@@ -136,7 +157,8 @@ Returns a list of dashboards
 ```
 #### GET /dashboards/myid
 
-Returns an single dashboard object
+Returns an single dashboard object.  The fields `x`, `y`, `w`, `h`, default to 
+not existing unless a user has modified the particular cell.
 
 ```json
 {

--- a/docs/dashboards.md
+++ b/docs/dashboards.md
@@ -13,7 +13,7 @@ contain explorations.
 		"self": "/chronograf/v1/dashboards/myid"
 	},
 	"id": "myid",
-	"queries": [
+	"cells": [
 		{
 			"x": 0,
 			"y": 0,
@@ -24,7 +24,7 @@ contain explorations.
 				"upper": 100,
 				"lower": 10
 			},
-			"link": "/chronograf/v1/queries/1"
+			"queries": ["/chronograf/v1/queries/1"]
 		},
 		{
 			"x": 2,
@@ -36,7 +36,7 @@ contain explorations.
 				"upper": 10,
 				"lower": 0
 			},
-			"link": "/chronograf/v1/queries/2"
+			"queries": ["/chronograf/v1/queries/2"]
 		}
 	],
 	"name": "This is my dashboard",
@@ -91,7 +91,7 @@ Returns a list of dashboards
                 "self": "/chronograf/v1/dashboards/myid"
             },
             "id": "myid",
-            "queries": [
+            "cells": [
                 {
                     "x": 0,
                     "y": 0,
@@ -102,7 +102,7 @@ Returns a list of dashboards
                         "upper": 100,
                         "lower": 10
                     },
-                    "link": "/chronograf/v1/queries/1"
+                    "queries": ["/chronograf/v1/queries/1"]
                 },
                 {
                     "x": 2,
@@ -114,7 +114,7 @@ Returns a list of dashboards
                         "upper": 10,
                         "lower": 0
                     },
-                    "link": "/chronograf/v1/queries/2"
+                    "queries": ["/chronograf/v1/queries/2"]
                 }
             ],
             "name": "This is my dashboard"
@@ -124,7 +124,7 @@ Returns a list of dashboards
                 "self": "/chronograf/v1/dashboards/myid"
             },
             "id": "myid",
-            "queries": [
+            "cells": [
                 {
                     "x": 0,
                     "y": 0,
@@ -135,7 +135,7 @@ Returns a list of dashboards
                         "upper": 100,
                         "lower": 10
                     },
-                    "link": "/chronograf/v1/queries/1"
+                    "queries": ["/chronograf/v1/queries/1"]
                 },
                 {
                     "x": 2,
@@ -147,7 +147,7 @@ Returns a list of dashboards
                         "upper": 10,
                         "lower": 0
                     },
-                    "link": "/chronograf/v1/queries/2"
+                    "queries": ["/chronograf/v1/queries/2"]
                 }
             ],
             "name": "This is my dashboard"
@@ -166,7 +166,7 @@ not existing unless a user has modified the particular cell.
         "self": "/chronograf/v1/dashboards/myid"
     },
     "id": "myid",
-    "queries": [
+    "cells": [
         {
             "x": 0,
             "y": 0,
@@ -177,7 +177,7 @@ not existing unless a user has modified the particular cell.
                 "upper": 100,
                 "lower": 10
             },
-            "link": "/chronograf/v1/queries/1"
+            "queries": ["/chronograf/v1/queries/1"]
         },
         {
             "x": 2,
@@ -189,7 +189,7 @@ not existing unless a user has modified the particular cell.
                 "upper": 10,
                 "lower": 0
             },
-            "link": "/chronograf/v1/queries/2"
+            "queries": ["/chronograf/v1/queries/2"]
         }
     ],
     "name": "This is my dashboard"


### PR DESCRIPTION
Connect #621

### The problem
Design Dashboards API
### The Solution
This is a simple solution that allows us to begin work on the first implementation of dashboards.  
The API will include two new routes using our standard REST style:

1. /chronograf/v1/dashboards
2. /chronograf/v1/queries

`/dashboards` contains visualization meta-data and links to the queries

`/queries` contain raw InfluxQL commands.  This means that we cannot edit the queries at the moment with the explorations interface.

However we've designed in the ability to support much more comprehensive set of InfluxQL UI editing support.  In follow-on work, we can enhance the `/queries` endpoint feature by feature to structure InfluxQL as JSON.
