### PR TITLE
removing unimplemented endpoint from swagger

### DIFF
--- a/server/swagger.json
+++ b/server/swagger.json
@@ -273,26 +273,6 @@
 			}
 		},
 		"/users": {
-			"get": {
-				"tags": [
-					"users"
-				],
-				"summary": "List of all users on this data source",
-				"responses": {
-					"200": {
-						"description": "An array of users",
-						"schema": {
-							"$ref": "#/definitions/Users"
-						}
-					},
-					"default": {
-						"description": "Unexpected internal service error",
-						"schema": {
-							"$ref": "#/definitions/Error"
-						}
-					}
-				}
-			},
 			"post": {
 				"tags": [
 					"users"


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Noticed this while working on the dashboards endpoint:

Our swagger docs describe a `/users` `GET`, which does not exist. This PR removes it from our documentation.