### PR TITLE
Fix Content-Type of the index.html page to be text/html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,25 @@
 ## v1.1.0 [unreleased]
 
+## v1.1.0-beta2 []
+
+### Bug Fixes
+  1. [#664](https://github.com/influxdata/chronograf/issues/664): Fix Content-Type of single-page app to always be text/html
+  1. [#671](https://github.com/influxdata/chronograf/issues/671): Fix multiple influxdb source freezing page
+
 ## v1.1.0-beta1 [2016-12-06]
-- Layouts
+### Layouts
   1. [#575](https://github.com/influxdata/chronograf/issues/556): Varnish Layout
   2. [#535](https://github.com/influxdata/chronograf/issues/535): Elasticsearch Layout
-- Features
+
+### Features
   1. [#565](https://github.com/influxdata/chronograf/issues/565) [#246](https://github.com/influxdata/chronograf/issues/246) [#234](https://github.com/influxdata/chronograf/issues/234) [#311](https://github.com/influxdata/chronograf/issues/311) Github Oauth login
   2. [#487](https://github.com/influxdata/chronograf/issues/487): Warn users if they are using a kapacitor instance that is configured to use an influxdb instance that does not match the current source
   3. [#597](https://github.com/influxdata/chronograf/issues/597): Filter host by series tags
   4. [#568](https://github.com/influxdata/chronograf/issues/568): [#569](https://github.com/influxdata/chronograf/issues/569): Add support for multiple y-axis, labels, and ranges
   5. [#605](https://github.com/influxdata/chronograf/issues/605): Number visualization type in host view
   5. [#607](https://github.com/influxdata/chronograf/issues/607): Number and line graph visualization type in host view
-- Bug Fixes
+
+### Bug Fixes
   1. [#536](https://github.com/influxdata/chronograf/issues/536) Redirect the user to the kapacitor config screen if they are attempting to view or edit alerts without a configured kapacitor
   2. [#539](https://github.com/influxdata/chronograf/issues/539) Zoom works only on the first graph of a layout
   3. [#494](https://github.com/influxdata/chronograf/issues/494) Layouts should only be displayed when the measurement is present

--- a/server/assets.go
+++ b/server/assets.go
@@ -16,6 +16,8 @@ const (
 	DebugDir = "ui/build"
 	// DebugDefault is the default item to load if 404
 	DebugDefault = "ui/build/index.html"
+	// DefaultContentType is the content-type to return for the Default file
+	DefaultContentType = "text/html; charset=utf-8"
 )
 
 // AssetsOpts configures the asset middleware
@@ -36,8 +38,9 @@ func Assets(opts AssetsOpts) http.Handler {
 		}
 	} else {
 		assets = &dist.BindataAssets{
-			Prefix:  Dir,
-			Default: Default,
+			Prefix:             Dir,
+			Default:            Default,
+			DefaultContentType: DefaultContentType,
 		}
 	}
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fix #664 

### The problem
I'm using http.FileServer to serve the site from our bindata.  To facilitate a single-page react-app with its own router, index.html is returned for all unknown routes.  

However, some of those routes could end with a file extension that causes http.FileServer's mime-type discovery to return the incorrect `Content-Type` header.  For example, in the case of a route that ended in `.com` it would return `application/x-msdos-program`.

### The Solution
If the route returns the default content (index.html) the `Content-Type` header is set to `text/html; charset=utf-8`

