### PR TITLE
Fix missing version

### DIFF
--- a/cmd/chronograf/main.go
+++ b/cmd/chronograf/main.go
@@ -10,15 +10,15 @@ import (
 
 // Build flags
 var (
-	Version = ""
-	Commit  = ""
+	version = ""
+	commit  = ""
 )
 
 func main() {
 	srv := server.Server{
 		BuildInfo: server.BuildInfo{
-			Version: Version,
-			Commit:  Commit,
+			Version: version,
+			Commit:  commit,
 		},
 	}
 
@@ -37,7 +37,7 @@ func main() {
 	}
 
 	if srv.ShowVersion {
-		log.Printf("Chronograf %s (git: %s)\n", Version, Commit)
+		log.Printf("Chronograf %s (git: %s)\n", version, commit)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Previously, using the version switch (`chronograf --version`) would
yield no version or commit information. This was because those two
package vars were exported, when the build script expects them to be
package private. To keep the build script as consistent as possible
across repos, the solution was to just make those package vars private

Connect #679