### PR TITLE
Fix bug that stopped apps from displaying

### DIFF
--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
 import {Link} from 'react-router';
 import _ from 'lodash';
 
@@ -141,7 +142,7 @@ const HostRow = React.createClass({
   },
 
   shouldComponentUpdate(nextProps) {
-    return this.props.host !== nextProps.host;
+    return shallowCompare(this, nextProps);
   },
 
   render() {


### PR DESCRIPTION
This fixes an issue where rows would not repaint when apps were applied by
getAppsForHost. This is because shouldComponentUpdate was only examining the
hostnames of each row. Will P. actually fixed this on December 5th, 2016, but
this was removed by a bad merge conflict resolution performed by myself. Will
P.'s picked this up and commented:

> This could be okay if we use it right, but it's a bit dangerous IMO Sayconst
> host = {name: "Will", load: 99};, then HostRow receives that prop on one
> render, then later we do Object.assign(host, {load: 0, apps: [...]}), and the
> same HostRow receives that prop on second render,
> this shouldComponentUpdate will prevent the new data from appearing, since this.props.host === nextProps.host

> Hence, shallowCompare. Like I said, this may work out. Would be interested to know why this was changed though.

This reintroduces his patch and properly resolves the aforementioned merge
conflict.

Connect #716 