### PR TITLE
Add Github organization restriction to authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Upcoming Bug Fixes
 ### Upcoming Features
-
+  1. [#660](https://github.com/influxdata/chronograf/issues/660): Add option to accept any certificate from InfluxDB.
+  1. [#733](https://github.com/influxdata/chronograf/pull/733): Add optional Github organization membership checks to authentication
+ 
 ## v1.1.0-beta5 [2017-01-05]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -83,8 +83,6 @@ Please open [an issue](https://github.com/influxdata/chronograf/issues/new)!
 
 The Chronograf team has identified and is working on the following issues:
 
-* Chronograf's [OAuth 2.0 Style Authentication](https://github.com/influxdata/chronograf/blob/master/docs/auth.md) allows all users to authenticate with any GitHub account.
-It does not yet offer any additional security or allow administrators to whitelist users or organizations.
 * Currently, Chronograf requires users to run Telegraf's [CPU](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/CPU_README.md) and [system](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/SYSTEM_README.md) plugins to ensure that all Apps appear on the [HOST LIST](https://github.com/influxdata/chronograf/blob/master/docs/GETTING_STARTED.md#host-list) page.
 
 ## Installation

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -41,6 +41,21 @@ user authorization. If you are running multiple chronograf servers in an HA conf
 export TOKEN_SECRET=supersupersecret
 ```
 
+#### Optional Github Organizations
+
+To require an organization membership for a user, set the `GH_ORGS` environment variables
+```sh
+export GH_ORGS=biffs-gang
+```
+
+If the user is not a member, then the user will not be allowed access.
+
+To support multiple organizations use a comma delimted list like so:
+
+```sh
+export GH_ORGS=hill-valley-preservation-sociey,the-pinheads
+```
+
 ### Design
 
 The Chronograf authentication scheme is a standard [web application](https://developer.github.com/v3/oauth/#web-application-flow) OAuth flow.

--- a/server/dashboards.go
+++ b/server/dashboards.go
@@ -131,7 +131,7 @@ func (s *Service) UpdateDashboard(w http.ResponseWriter, r *http.Request) {
 
 	_, err = s.DashboardsStore.Get(ctx, id)
 	if err != nil {
-		Error(w, http.StatusNotFound, fmt.Sprintf("ID %s not found", id), s.Logger)
+		Error(w, http.StatusNotFound, fmt.Sprintf("ID %d not found", id), s.Logger)
 		return
 	}
 
@@ -148,7 +148,7 @@ func (s *Service) UpdateDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.DashboardsStore.Update(ctx, req); err != nil {
-		msg := fmt.Sprintf("Error updating dashboard ID %s: %v", id, err)
+		msg := fmt.Sprintf("Error updating dashboard ID %d: %v", id, err)
 		Error(w, http.StatusInternalServerError, msg, s.Logger)
 		return
 	}

--- a/server/mux.go
+++ b/server/mux.go
@@ -20,11 +20,12 @@ const (
 // MuxOpts are the options for the router.  Mostly related to auth.
 type MuxOpts struct {
 	Logger             chronograf.Logger
-	Develop            bool   // Develop loads assets from filesystem instead of bindata
-	UseAuth            bool   // UseAuth turns on Github OAuth and JWT
-	TokenSecret        string // TokenSecret is the JWT secret
-	GithubClientID     string // GithubClientID is the GH OAuth id
-	GithubClientSecret string // GithubClientSecret is the GH OAuth secret
+	Develop            bool     // Develop loads assets from filesystem instead of bindata
+	UseAuth            bool     // UseAuth turns on Github OAuth and JWT
+	TokenSecret        string   // TokenSecret is the JWT secret
+	GithubClientID     string   // GithubClientID is the GH OAuth id
+	GithubClientSecret string   // GithubClientSecret is the GH OAuth secret
+	GithubOrgs         []string // GithubOrgs is the list of organizations a user my be a member of
 }
 
 // NewMux attaches all the route handlers; handler returned servers chronograf.
@@ -136,6 +137,7 @@ func AuthAPI(opts MuxOpts, router *httprouter.Router) http.Handler {
 		opts.GithubClientSecret,
 		successURL,
 		failureURL,
+		opts.GithubOrgs,
 		&auth,
 		opts.Logger,
 	)

--- a/server/server.go
+++ b/server/server.go
@@ -37,20 +37,19 @@ type Server struct {
 	TLSCertificateKey flags.Filename `long:"tls-key" description:"the private key to use for secure conections" env:"TLS_PRIVATE_KEY"`
 	*/
 
-	Develop            bool   `short:"d" long:"develop" description:"Run server in develop mode."`
-	BoltPath           string `short:"b" long:"bolt-path" description:"Full path to boltDB file (/var/lib/chronograf/chronograf-v1.db)" env:"BOLT_PATH" default:"chronograf-v1.db"`
-	CannedPath         string `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
-	TokenSecret        string `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
-	GithubClientID     string `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
-	GithubClientSecret string `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`
-	ReportingDisabled  bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
-	LogLevel           string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal" choice:"panic" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
-
-	ShowVersion bool `short:"v" long:"version" description:"Show Chronograf version info"`
-	BuildInfo   BuildInfo
-
-	Listener net.Listener
-	handler  http.Handler
+	Develop            bool     `short:"d" long:"develop" description:"Run server in develop mode."`
+	BoltPath           string   `short:"b" long:"bolt-path" description:"Full path to boltDB file (/var/lib/chronograf/chronograf-v1.db)" env:"BOLT_PATH" default:"chronograf-v1.db"`
+	CannedPath         string   `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
+	TokenSecret        string   `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
+	GithubClientID     string   `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
+	GithubClientSecret string   `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`
+	GithubOrgs         []string `short:"o" long:"github-organization" description:"Github organization user is required to have active membership" env:"GH_ORGS" env-delim:","`
+	ReportingDisabled  bool     `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
+	LogLevel           string   `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal" choice:"panic" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
+	ShowVersion        bool     `short:"v" long:"version" description:"Show Chronograf version info"`
+	BuildInfo          BuildInfo
+	Listener           net.Listener
+	handler            http.Handler
 }
 
 // BuildInfo is sent to the usage client to track versions and commits
@@ -72,6 +71,7 @@ func (s *Server) Serve() error {
 		TokenSecret:        s.TokenSecret,
 		GithubClientID:     s.GithubClientID,
 		GithubClientSecret: s.GithubClientSecret,
+		GithubOrgs:         s.GithubOrgs,
 		Logger:             logger,
 		UseAuth:            s.useAuth(),
 	}, service)


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #732

### The problem
Chronograf would allow any authenticated github user access.  We need to restrict this by organization.
### The Solution

With the `-o` cli option or `GH_ORGS` environment variable, chronograf can now restrict access to users that are in a set of organizations.


