### PR TITLE
Graph weirdness

### DIFF
--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -147,18 +147,6 @@ describe('timeSeriesToDygraph', () => {
     const actual = timeSeriesToDygraph(influxResponse);
 
     const expected = {
-      labels: [
-        'time',
-        `m1.f1`,
-        `m1.f2`,
-        `m3.f3`,
-      ],
-      timeSeries: [
-        [new Date(1000), 1, null, 1],
-        [new Date(2000), 2, 3, 2],
-        [new Date(4000), null, 4, null],
-      ],
-      dygraphSeries: {
         'm1.f1': {
           axis: 'y',
           strokeWidth,
@@ -171,10 +159,167 @@ describe('timeSeriesToDygraph', () => {
           axis: 'y2',
           strokeWidth,
         },
+    };
+
+    expect(actual.dygraphSeries).to.deep.equal(expected);
+  });
+
+  it('can parse multiple responses with the same field and measurement', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+    ];
+
+    const actual = timeSeriesToDygraph(influxResponse);
+
+    const expected = {
+      labels: [
+        'time',
+        `m1.f1`,
+        `m1.f1-1`,
+      ],
+      timeSeries: [
+        [new Date(1000), 1, null],
+        [new Date(2000), 2, 3],
+        [new Date(4000), 4, null],
+      ],
+      dygraphSeries: {
+        'm1.f1': {
+          axis: 'y',
+          strokeWidth,
+        },
+        'm1.f1-1': {
+          axis: 'y2',
+          strokeWidth,
+        },
       },
     };
 
-    expect(actual.dygraphSeries).to.deep.equal(expected.dygraphSeries);
+    expect(actual).to.deep.equal(expected);
+  });
+
+  it('it does not use multiple axes if being used for the DataExplorer', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f2"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+    ];
+
+    const isInDataExplorer = true;
+    const actual = timeSeriesToDygraph(influxResponse, undefined, isInDataExplorer);
+
+    const expected = {
+      'm1.f1': {
+        strokeWidth,
+      },
+      'm1.f2': {
+        strokeWidth,
+      },
+    };
+
+    expect(actual.dygraphSeries).to.deep.equal(expected);
+  });
+
+  it('it highlights the appropriate response', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m1",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"m2",
+                  "columns": ["time","f2"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+          ],
+        },
+      },
+    ];
+
+    const highlightIndex = 1;
+    const actual = timeSeriesToDygraph(influxResponse, highlightIndex);
+    const {dygraphSeries} = actual;
+
+    expect(dygraphSeries["m2.f2"].strokeWidth).to.be.above(dygraphSeries["m1.f1"].strokeWidth);
   });
 
   it('parses a raw InfluxDB response into a dygraph friendly data format', () => {

--- a/ui/src/chronograf/components/Visualization.js
+++ b/ui/src/chronograf/components/Visualization.js
@@ -58,6 +58,7 @@ const Visualization = React.createClass({
       return {host: [proxyLink], text: s.text, id: s.id};
     });
     const autoRefreshMs = 10000;
+    const isInDataExplorer = true;
 
     return (
       <div ref={(p) => this.panel = p} className={classNames("graph", {active: isActive})}>
@@ -78,6 +79,7 @@ const Visualization = React.createClass({
               queries={queries}
               autoRefresh={autoRefreshMs}
               activeQueryIndex={activeQueryIndex}
+              isInDataExplorer={isInDataExplorer}
               />
           ) : <MultiTable queries={queries} />}
         </div>

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -50,13 +50,14 @@ export default React.createClass({
   },
 
   componentWillMount() {
-    this._timeSeries = timeSeriesToDygraph(this.props.data, this.props.activeQueryIndex);
+    const {data, activeQueryIndex, isInDataExplorer} = this.props;
+    this._timeSeries = timeSeriesToDygraph(data, activeQueryIndex, isInDataExplorer);
   },
 
   componentWillUpdate(nextProps) {
     const {data, activeQueryIndex} = this.props;
     if (data !== nextProps.data || activeQueryIndex !== nextProps.activeQueryIndex) {
-      this._timeSeries = timeSeriesToDygraph(nextProps.data, nextProps.activeQueryIndex);
+      this._timeSeries = timeSeriesToDygraph(nextProps.data, nextProps.activeQueryIndex, nextProps.isInDataExplorer);
     }
   },
 

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -10,11 +10,11 @@ import lastValues from 'src/shared/parsing/lastValues';
 const {
   array,
   arrayOf,
-  number,
   bool,
+  func,
+  number,
   shape,
   string,
-  func,
 } = PropTypes;
 
 export default React.createClass({
@@ -35,6 +35,7 @@ export default React.createClass({
     showSingleStat: bool,
     activeQueryIndex: number,
     ruleValues: shape({}),
+    isInDataExplorer: bool,
   },
 
   getDefaultProps() {

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -87,7 +87,12 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
       }).sort().join('');
 
       columns.slice(1).forEach((fieldName) => {
-        const effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+        let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+
+        // If there are duplicate effectiveFieldNames identify them by their queryIndex
+        if (effectiveFieldName in dygraphSeries) {
+          effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
+        }
 
         // Given a field name, identify which column in the timeSeries result should hold the field's value
         // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
@@ -129,7 +134,13 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
           }
 
           const fieldName = columns[index];
-          const effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+          let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+
+          // If there are duplicate effectiveFieldNames identify them by their queryIndex
+          if (effectiveFieldName in dateToFieldValue[dateString]) {
+            effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
+          }
+
           dateToFieldValue[dateString][effectiveFieldName] = value;
         });
       }

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -6,7 +6,7 @@ import {STROKE_WIDTH} from 'src/shared/constants';
 
 // activeQueryIndex is an optional argument that indicated which query's series
 // we want highlighted.
-export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
+export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInDataExplorer) {
   const labels = []; // all of the effective field names (i.e. <measurement>.<field>)
   const fieldToIndex = {}; // see parseSeries
   const dates = {}; // map of date as string to date value to minimize string coercion
@@ -96,10 +96,17 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
 
         const {light, heavy} = STROKE_WIDTH;
 
-        dygraphSeries[effectiveFieldName] = {
-          axis: queryIndex === 0 ? 'y' : 'y2',
-          strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
-        };
+        // only want to set multiple axes for precanned dashboards
+        if (isInDataExplorer) {
+          dygraphSeries[effectiveFieldName] = {
+            strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
+          };
+        } else {
+          dygraphSeries[effectiveFieldName] = {
+            axis: queryIndex === 0 ? 'y' : 'y2',
+            strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
+          };
+        }
       });
 
       (series.values || []).forEach(parseRow);

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -101,17 +101,15 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
 
         const {light, heavy} = STROKE_WIDTH;
 
-        // only want to set multiple axes for precanned dashboards
-        if (isInDataExplorer) {
-          dygraphSeries[effectiveFieldName] = {
-            strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
-          };
-        } else {
-          dygraphSeries[effectiveFieldName] = {
-            axis: queryIndex === 0 ? 'y' : 'y2',
-            strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
-          };
+        const dygraphSeriesStyles = {
+          strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
+        };
+
+        if (!isInDataExplorer) {
+          dygraphSeriesStyles.axis = queryIndex === 0 ? 'y' : 'y2';
         }
+
+        dygraphSeries[effectiveFieldName] = dygraphSeriesStyles;
       });
 
       (series.values || []).forEach(parseRow);


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #734 
Connect #703  

### The problem
Copying an InfluxQL query from an auto-generated query caused a couple of problems:

1)  There was some visual grossness caused by multiple axes rendering weirdly.
2)  `timeSeriesToDygraph` could not differentiate two separate responses that had the same field and measurement names.  This would cause one of the similar series to not be rendered.  

### The Solution
1)  For reasons I explained here: https://github.com/influxdata/chronograf/commit/7cbdb700f2dd45c63cc17b4ba3cc7d59666a6692, I removed multiple axes from the DataExplorer.  
2) In `timeSeriesToDygraph` when two or more Influx responses share the same field and measurement names, I append an id to the end of the legend string / dygraphSeries key.  

### Notes
The `timeSeriesToDygraph` now has three concerns: 
1) parse Influx responses into a Dygraph readable format
2) Am I parsing this for the DE?
 2a) If I'm in the DE, which series do I highlight?
3) Am I parsing this for a pre-canned dashboard?

I fell like it should only be concerned with 1.  

