### PR TITLE
Sort graph legend alphabetically

### DIFF
--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -176,4 +176,64 @@ describe('timeSeriesToDygraph', () => {
 
     expect(actual.dygraphSeries).to.deep.equal(expected.dygraphSeries);
   });
+
+  it('parses a raw InfluxDB response into a dygraph friendly data format', () => {
+    const influxResponse = [
+      {
+        "response":
+        {
+          "results": [
+            {
+              "series": [
+                {
+                  "name":"mb",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+            {
+              "series": [
+                {
+                  "name":"ma",
+                  "columns": ["time","f1"],
+                  "values": [[1000, 1],[2000, 2]],
+                },
+              ]
+            },
+            {
+              "series": [
+                {
+                  "name":"mc",
+                  "columns": ["time","f2"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+            {
+              "series": [
+                {
+                  "name":"mc",
+                  "columns": ["time","f1"],
+                  "values": [[2000, 3],[4000, 4]],
+                },
+              ]
+            },
+          ],
+        },
+      }
+    ];
+
+    const actual = timeSeriesToDygraph(influxResponse);
+
+    const expected = [
+      'time',
+      `ma.f1`,
+      `mb.f1`,
+      `mc.f1`,
+      `mc.f2`,
+    ];
+
+    expect(actual.labels).to.deep.equal(expected);
+  });
 });

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -7,7 +7,7 @@ import {STROKE_WIDTH} from 'src/shared/constants';
 // activeQueryIndex is an optional argument that indicated which query's series
 // we want highlighted.
 export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
-  const labels = ['time']; // all of the effective field names (i.e. <measurement>.<field>)
+  const labels = []; // all of the effective field names (i.e. <measurement>.<field>)
   const fieldToIndex = {}; // see parseSeries
   const dates = {}; // map of date as string to date value to minimize string coercion
   const dygraphSeries = {}; // dygraphSeries is a graph legend label and its corresponding y-axis e.g. {legendLabel1: 'y', legendLabel2: 'y2'};
@@ -91,7 +91,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
 
         // Given a field name, identify which column in the timeSeries result should hold the field's value
         // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
-        fieldToIndex[effectiveFieldName] = labels.length;
+        fieldToIndex[effectiveFieldName] = labels.length + 1;
         labels.push(effectiveFieldName);
 
         const {light, heavy} = STROKE_WIDTH;
@@ -132,7 +132,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
   function buildTimeSeries() {
     const allDates = Object.keys(dateToFieldValue);
     allDates.sort((a, b) => a - b);
-    const rowLength = labels.length;
+    const rowLength = labels.length + 1;
     return allDates.map((date) => {
       const row = new Array(rowLength);
 
@@ -148,15 +148,8 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
     });
   }
 
-  function sortLabels() {
-    const time = labels.shift();
-    labels.sort();
-    labels.unshift(time);
-    return labels;
-  }
-
   return {
-    labels: sortLabels(labels),
+    labels: ['time', ...labels.sort()],
     timeSeries: buildTimeSeries(),
     dygraphSeries,
   };

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -148,8 +148,15 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex) {
     });
   }
 
+  function sortLabels() {
+    const time = labels.shift();
+    labels.sort();
+    labels.unshift(time);
+    return labels;
+  }
+
   return {
-    labels,
+    labels: sortLabels(labels),
     timeSeries: buildTimeSeries(),
     dygraphSeries,
   };


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #719 

### The problem
Legend was difficult to parse visually.

### The Solution
Sort it

<img width="182" alt="screen shot 2017-01-06 at 11 55 18 am" src="https://cloud.githubusercontent.com/assets/7582765/21731057/5cdcc164-d407-11e6-8ef7-e83f89fe36a9.png">


