### PR TITLE
Fix missing Kapacitor on Source index page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.1.0 [unreleased]
 
 ### Upcoming Bug Fixes
+  1. [#748](https://github.com/influxdata/chronograf/pull/748): Fix missing kapacitors on source index page
   1. [#755](https://github.com/influxdata/chronograf/pull/755): Fix kapacitor basic auth proxying
 
 ### Upcoming Features

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -31,12 +31,16 @@ export const ManageSources = React.createClass({
   },
 
   componentDidMount() {
+    const updates = [];
+    const kapas = {};
     this.props.sources.forEach((source) => {
-      const kapacitors = {};
-      getKapacitor(source).then((kapacitor) => {
-        kapacitors[source.id] = kapacitor;
+      const prom = getKapacitor(source).then((kapacitor) => {
+        kapas[source.id] = kapacitor;
       });
-      this.setState(kapacitors);
+      updates.push(prom);
+    });
+    Promise.all(updates).then(() => {
+      this.setState({kapacitors: kapas});
     });
   },
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #702

When visiting the Sources page, any InfluxDB sources that had a
configured Kapacitor would not show them. This turned out to be racey
logic. Kapacitors for a particular source are fetched from the API. The
update to the component state happened outside of the promise chained
onto the API call, so the state update was racing against the fetch from
the API (and would always win, pushing the empty object).

Instead, the chained promises for each API fetch are collected, and each
promise updates a single kapacitors object. The final promise that
updates the state is then blocked on all those promises by Promise.all.

Performing updates like this saves some allocations, since we aren't
allocating an object for each source<->kapacitor pairing to send to
setState. It also reduces setState's work, since it doesn't have to
coalesce state updates.

