### PR TITLE
Fix kapacitor auth with basic auth in header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v1.1.0 [unreleased]
 
 ### Upcoming Bug Fixes
+  1. [#755](https://github.com/influxdata/chronograf/pull/755): Fix kapacitor basic auth proxying
+
 ### Upcoming Features
   1. [#660](https://github.com/influxdata/chronograf/issues/660): Add option to accept any certificate from InfluxDB.
   2. [#733](https://github.com/influxdata/chronograf/pull/733): Add optional Github organization membership checks to authentication


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fix #754

### The problem
Kapacitor authentication was not proxied correctly.

### The Solution
Proxying the basic auth via URL path was not working, so, this places it directly into the header.


