### PR TITLE
Remove RPM posttrans scriptlet and small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Upcoming Bug Fixes
   1. [#755](https://github.com/influxdata/chronograf/pull/755): Fix kapacitor basic auth proxying
+  2. [#704](https://github.com/influxdata/chronograf/issue/704): Fix RPM install script and systemd unit file
 
 ### Upcoming Features
   1. [#660](https://github.com/influxdata/chronograf/issues/660): Add option to accept any certificate from InfluxDB.

--- a/etc/build.py
+++ b/etc/build.py
@@ -647,7 +647,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils --rpm-posttrans {} ".format(POSTINST_SCRIPT)
+                            fpm_command += "--depends coreutils"
                         # TODO: Check for changelog
                         # elif package_type == "deb":
                         #     fpm_command += "--deb-changelog {} ".format(os.path.join(os.getcwd(), "CHANGELOG.md"))

--- a/etc/scripts/chronograf.service
+++ b/etc/scripts/chronograf.service
@@ -14,4 +14,3 @@ Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target
-Alias=chronograf.service

--- a/etc/scripts/post-install.sh
+++ b/etc/scripts/post-install.sh
@@ -12,6 +12,9 @@ function install_init {
 }
 
 function install_systemd {
+    # Remove any existing symlinks
+    rm -f /etc/systemd/system/chronograf.service
+
     cp -f $SCRIPT_DIR/chronograf.service /lib/systemd/system/chronograf.service
     systemctl enable chronograf || true
     systemctl daemon-reload || true


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

This removes the posttrans scriptlet from the RPM packaging so the `/etc/scripts/post-install.sh` script is not called twice.

Adds a step to remove any existing symlinks to the systemd service before linking the unit file.

Also removes the `Alias` from the unit file, which is superfluous.

@rossmcdonald