### PR TITLE
Misc UI Polish

### DIFF
--- a/ui/src/kapacitor/components/RuleGraph.js
+++ b/ui/src/kapacitor/components/RuleGraph.js
@@ -34,7 +34,7 @@ export const RuleGraph = React.createClass({
     if (!queryText) {
       return (
         <div className="rule-preview--graph-empty">
-          <p>Select a <strong>Metric</strong> to preview on a graph</p>
+          <p>Select a <strong>Time-Series</strong> to preview on a graph</p>
         </div>
       );
     }

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -98,7 +98,7 @@ const Threshold = React.createClass({
     return (
       <div className="value-selector">
         <p>Send Alert where</p>
-        <span>{query.fields.length ? query.fields[0].field : 'Select a Metric'}</span>
+        <span>{query.fields.length ? query.fields[0].field : 'Select a Time-Series'}</span>
         <p>is</p>
         <Dropdown className="size-176 dropdown-kapacitor" items={operators} selected={operator} onChoose={this.handleDropdownChange} />
         <input className="form-control input-sm size-166 form-control--green" type="text" ref={(r) => this.valueInput = r} defaultValue={value} onKeyUp={this.handleInputChange} />

--- a/ui/src/style/theme/bootstrap-theme.scss
+++ b/ui/src/style/theme/bootstrap-theme.scss
@@ -454,17 +454,17 @@ a:active.link-warning {
 }
 ::-moz-selection {
   color: #fff;
-  background-color: #757888;
+  background-color: #22ADF6;
   /* WebKit/Blink Browsers */
 }
 ::selection {
   color: #fff;
-  background-color: #757888;
+  background-color: #22ADF6;
   /* WebKit/Blink Browsers */
 }
 ::-moz-selection {
   color: #fff;
-  background-color: #757888;
+  background-color: #22ADF6;
   /* Gecko Browsers */
 }
 .btn {

--- a/ui/src/style/theme/theme-dark.scss
+++ b/ui/src/style/theme/theme-dark.scss
@@ -105,20 +105,6 @@
   border-color: $g5-pepper !important;
   color: $g15-platinum !important;
 
-  &::-webkit-input-placeholder { color: $g10-wolf; }
-  &::-moz-placeholder { color: $g10-wolf; }
-  &:-ms-input-placeholder { color: $g10-wolf; }
-  &:-moz-placeholder { color: $g10-wolf; }
-
-  &::selection {
-    background-color: $c-laser;
-    color: $g20-white;
-  }
-  &::-moz-selection {
-    background-color: $c-laser;
-    color: $g20-white;
-  }
-
   &:hover {
     border-color: $g6-smoke !important;
   }
@@ -143,20 +129,25 @@
 .form-group-submit {
   margin-top: 30px;
 }
-textarea {
+
+/* Placeholder Text */
+.form-control,
+textarea,
+input {
   &::-webkit-input-placeholder { color: $g10-wolf; }
   &::-moz-placeholder { color: $g10-wolf; }
   &:-ms-input-placeholder { color: $g10-wolf; }
   &:-moz-placeholder { color: $g10-wolf; }
+}
 
-  &::selection {
-    background-color: $c-laser;
-    color: $g20-white;
-  }
-  &::-moz-selection {
-    background-color: $c-laser;
-    color: $g20-white;
-  }
+/* Text Selection Styling */
+::selection {
+  background-color: $c-pool !important;
+  color: $g20-white !important;
+}
+::-moz-selection {
+  background-color: $c-pool !important;
+  color: $g20-white !important;
 }
 
 

--- a/ui/webpack/devConfig.js
+++ b/ui/webpack/devConfig.js
@@ -72,7 +72,7 @@ module.exports = {
       $: "jquery",
       jQuery: "jquery",
     }),
-    new ExtractTextPlugin("style.css"),
+    new ExtractTextPlugin("chronograf.css"),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '..', 'src', 'index.template.html'),
       inject: 'body',

--- a/ui/webpack/prodConfig.js
+++ b/ui/webpack/prodConfig.js
@@ -77,7 +77,7 @@ var config = {
       $: "jquery",
       jQuery: "jquery",
     }),
-    new ExtractTextPlugin("style.css"),
+    new ExtractTextPlugin("chronograf.css"),
     new HtmlWebpackPlugin({
       template: path.resolve(__dirname, '..', 'src', 'index.template.html'),
       inject: 'body',


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Previously fixed an issue in which users could not tell if text was selected or not, but it was limited to just inputs. Now all selected text is styled uniformly.
<img width="701" alt="screen shot 2017-01-12 at 11 02 05 am" src="https://cloud.githubusercontent.com/assets/2433762/21903943/985badaa-d8b6-11e6-8663-b2d0be470827.png">

Made some minor copy changes to be more consistent. "Metric" --> "Time-Series"
<img width="875" alt="screen shot 2017-01-12 at 11 00 15 am" src="https://cloud.githubusercontent.com/assets/2433762/21903947/9e8cbb60-d8b6-11e6-90ef-c670695a23e6.png">

Lastly, realized the built stylesheet is just called `style.css` while the uncompiled sheet is called `chronograf.scss` so I changed it to match. Not much of a measurable benefit other than making the product slightly more branded.
