### PR TITLE
Rule template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   3. [#564](https://github.com/influxdata/chronograf/issues/564): Add RabbitMQ pre-canned layout.
   4. [#706](https://github.com/influxdata/chronograf/issues/706): Alerts on threshold where value is inside of range
   5. [#707](https://github.com/influxdata/chronograf/issues/707): Alerts on threshold where value is outside of range
+  6. [#766](https://github.com/influxdata/chronograf/pull/766): Add click-to-insert functionality to rule message templates
 
 ## v1.1.0-beta5 [2017-01-05]
 

--- a/ui/src/kapacitor/components/RuleMessage.js
+++ b/ui/src/kapacitor/components/RuleMessage.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react';
 import Dropdown from 'shared/components/Dropdown';
 import ReactTooltip from 'react-tooltip';
-import {RULE_MESSAGE_TEMPLATES as templates} from 'src/shared/constants/index.js';
+import {RULE_MESSAGE_TEMPLATES as templates} from '../constants/index.js';
 
 const {
   arrayOf,

--- a/ui/src/kapacitor/components/RuleMessage.js
+++ b/ui/src/kapacitor/components/RuleMessage.js
@@ -1,14 +1,22 @@
 import React, {PropTypes} from 'react';
 import Dropdown from 'shared/components/Dropdown';
 import ReactTooltip from 'react-tooltip';
+import {RULE_MESSAGE_TEMPLATES as templates} from 'src/shared/constants/index.js';
+
+const {
+  arrayOf,
+  func,
+  shape,
+  string,
+} = PropTypes;
 
 export const RuleMessage = React.createClass({
   propTypes: {
-    rule: PropTypes.shape({}).isRequired,
-    actions: PropTypes.shape({
-      updateMessage: PropTypes.func.isRequired,
+    rule: shape({}).isRequired,
+    actions: shape({
+      updateMessage: func.isRequired,
     }).isRequired,
-    enabledAlerts: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+    enabledAlerts: arrayOf(string.isRequired).isRequired,
   },
 
   handleChangeMessage() {
@@ -38,16 +46,14 @@ export const RuleMessage = React.createClass({
             placeholder="Compose your alert message here"
             value={rule.message}
           />
+
           <div className="alert-message--formatting">
             <p>Templates:</p>
-            <code data-tip="The ID of the alert">&#123;&#123;.ID&#125;&#125;</code>
-            <code data-tip="Measurement name">&#123;&#123;.Name&#125;&#125;</code>
-            <code data-tip="The name of the task">&#123;&#123;.TaskName&#125;&#125;</code>
-            <code data-tip="Concatenation of all group-by tags of the form <code>&#91;key=value,&#93;+</code>. If no groupBy is performed equal to literal &quot;nil&quot;">&#123;&#123;.Group&#125;&#125;</code>
-            <code data-tip="Map of tags. Use <code>&#123;&#123; index .Tags &quot;key&quot; &#125;&#125;</code> to get a specific tag value">&#123;&#123;.Tags&#125;&#125;</code>
-            <code data-tip="Alert Level, one of: <code>INFO</code><code>WARNING</code><code>CRITICAL</code>">&#123;&#123;.Level&#125;&#125;</code>
-            <code data-tip="Map of fields. Use <code>&#123;&#123; index .Fields &quot;key&quot; &#125;&#125;</code> to get a specific field value">&#123;&#123;.Fields&#125;&#125;</code>
-            <code data-tip="The time of the point that triggered the event">&#123;&#123;.Time&#125;&#125;</code>
+            {
+              Object.keys(templates).map(t => {
+                return <CodeData key={t} template={templates[t]} />;
+              })
+            }
             <ReactTooltip effect="solid" html={true} offset={{top: -4}} class="influx-tooltip kapacitor-tooltip" />
           </div>
           <div className="rule-section--item bottom alert-message--endpoint">
@@ -59,4 +65,23 @@ export const RuleMessage = React.createClass({
     );
   },
 });
+
+const CodeData = React.createClass({
+  propTypes: {
+    onClickTemplate: func,
+    template: shape({
+      label: string,
+      text: string,
+    }),
+  },
+
+  render() {
+    const {label, text} = this.props.template;
+
+    return (
+      <code data-tip={text}>{label}</code>
+    );
+  },
+});
+
 export default RuleMessage;

--- a/ui/src/kapacitor/components/RuleMessage.js
+++ b/ui/src/kapacitor/components/RuleMessage.js
@@ -51,7 +51,13 @@ export const RuleMessage = React.createClass({
             <p>Templates:</p>
             {
               Object.keys(templates).map(t => {
-                return <CodeData key={t} template={templates[t]} />;
+                return (
+                <CodeData
+                  key={t}
+                  template={templates[t]}
+                  onClickTemplate={() => actions.updateMessage(rule.id, `${this.message.value} ${templates[t].label}`)}
+                />
+                );
               })
             }
             <ReactTooltip effect="solid" html={true} offset={{top: -4}} class="influx-tooltip kapacitor-tooltip" />
@@ -76,10 +82,11 @@ const CodeData = React.createClass({
   },
 
   render() {
-    const {label, text} = this.props.template;
+    const {onClickTemplate, template} = this.props;
+    const {label, text} = template;
 
     return (
-      <code data-tip={text}>{label}</code>
+      <code data-tip={text} onClick={onClickTemplate}>{label}</code>
     );
   },
 });

--- a/ui/src/kapacitor/components/RuleMessage.js
+++ b/ui/src/kapacitor/components/RuleMessage.js
@@ -43,7 +43,7 @@ export const RuleMessage = React.createClass({
             className="alert-message"
             ref={(r) => this.message = r}
             onChange={() => actions.updateMessage(rule.id, this.message.value)}
-            placeholder="Compose your alert message here"
+            placeholder='Example: {{ .ID }} is {{ .Level }} value: {{ index .Fields "value" }}'
             value={rule.message}
           />
 

--- a/ui/src/kapacitor/constants/index.js
+++ b/ui/src/kapacitor/constants/index.js
@@ -25,3 +25,14 @@ export const SHIFTS = ['1m', '5m', '10m', '30m', '1h', '2h', '24h'];
 export const ALERTS = ['hipchat', 'opsgenie', 'pagerduty', 'sensu', 'slack', 'smtp', 'talk', 'telegram', 'victorops'];
 
 export const DEFAULT_RULE_ID = 'DEFAULT_RULE_ID';
+
+export const RULE_MESSAGE_TEMPLATES = {
+  id: {label: "{{.ID}}", text: "The ID of the alert"},
+  name: {label: "{{.Name}}", text: "Measurement name"},
+  taskName: {label: "{{.TaskName}}", text: "The name of the task"},
+  group: {label: "{{.Group}}", text: "Concatenation of all group-by tags of the form <code>&#91;key=value,&#93;+</code>. If no groupBy is performed equal to literal &quot;nil&quot;"},
+  tags: {label: "{{.Tags}}", text: "Map of tags. Use <code>&#123;&#123; index .Tags &quot;key&quot; &#125;&#125;</code> to get a specific tag value"},
+  level: {label: "{{.Level}}", text: "Alert Level, one of: <code>INFO</code><code>WARNING</code><code>CRITICAL</code>"},
+  fields: {label: "{{.Fields}}", text: "Map of fields. Use <code>&#123;&#123; index .Fields &quot;key&quot; &#125;&#125;</code> to get a specific field value"},
+  time: {label: "{{.Time}}", text: "The time of the point that triggered the event"},
+};

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -467,14 +467,3 @@ export const STROKE_WIDTH = {
   heavy: 3.5,
   light: 1.5,
 };
-
-export const RULE_MESSAGE_TEMPLATES = {
-  id: {label: "{{.ID}}", text: "The ID of the alert"},
-  name: {label: "{{.Name}}", text: "Measurement name"},
-  taskName: {label: "{{.TaskName}}", text: "The name of the task"},
-  group: {label: "{{.Group}}", text: "Concatenation of all group-by tags of the form <code>&#91;key=value,&#93;+</code>. If no groupBy is performed equal to literal &quot;nil&quot;"},
-  tags: {label: "{{.Tags}}", text: "Map of tags. Use <code>&#123;&#123; index .Tags &quot;key&quot; &#125;&#125;</code> to get a specific tag value"},
-  level: {label: "{{.Level}}", text: "Alert Level, one of: <code>INFO</code><code>WARNING</code><code>CRITICAL</code>"},
-  fields: {label: "{{.Fields}}", text: "Map of fields. Use <code>&#123;&#123; index .Fields &quot;key&quot; &#125;&#125;</code> to get a specific field value"},
-  time: {label: "{{.Time}}", text: "The time of the point that triggered the event"},
-};

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -467,3 +467,14 @@ export const STROKE_WIDTH = {
   heavy: 3.5,
   light: 1.5,
 };
+
+export const RULE_MESSAGE_TEMPLATES = {
+  id: {label: "{{.ID}}", text: "The ID of the alert"},
+  name: {label: "{{.Name}}", text: "Measurement name"},
+  taskName: {label: "{{.TaskName}}", text: "The name of the task"},
+  group: {label: "{{.Group}}", text: "Concatenation of all group-by tags of the form <code>&#91;key=value,&#93;+</code>. If no groupBy is performed equal to literal &quot;nil&quot;"},
+  tags: {label: "{{.Tags}}", text: "Map of tags. Use <code>&#123;&#123; index .Tags &quot;key&quot; &#125;&#125;</code> to get a specific tag value"},
+  level: {label: "{{.Level}}", text: "Alert Level, one of: <code>INFO</code><code>WARNING</code><code>CRITICAL</code>"},
+  fields: {label: "{{.Fields}}", text: "Map of fields. Use <code>&#123;&#123; index .Fields &quot;key&quot; &#125;&#125;</code> to get a specific field value"},
+  time: {label: "{{.Time}}", text: "The time of the point that triggered the event"},
+};

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -421,6 +421,7 @@ div.qeditor.kapacitor-metric-selector {
 
     &:hover {
       color: $c-rainforest;
+      cursor: pointer;
     }
   }
 }

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -389,7 +389,7 @@ div.qeditor.kapacitor-metric-selector {
 
   > p {
     margin-right: $kap-padding-sm !important;
-  } 
+  }
 }
 .alert-message--formatting {
   padding: ($kap-padding-sm - 2px) $kap-padding-lg;
@@ -421,7 +421,6 @@ div.qeditor.kapacitor-metric-selector {
 
     &:hover {
       color: $c-rainforest;
-      cursor: pointer;
     }
   }
 }


### PR DESCRIPTION
  - [x] Update CHANGELOG.md
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
There was some ugliness. 

### The Solution
@alexpaxton and I made it less ugly. No more confusing UX

### Note
The template items below rule message had a `pointer` cursor on hover which lead people to believe they could click and something would happen. This is not the case so it was confusing for users.

### Preview
![insert-template-string](https://cloud.githubusercontent.com/assets/2433762/21943935/6391e6ac-d988-11e6-9fcb-d41fbe10d806.gif)

