### PR TITLE
Add X-Chronograf-Version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   4. [#706](https://github.com/influxdata/chronograf/issues/706): Alerts on threshold where value is inside of range
   5. [#707](https://github.com/influxdata/chronograf/issues/707): Alerts on threshold where value is outside of range
   6. [#766](https://github.com/influxdata/chronograf/pull/766): Add click-to-insert functionality to rule message templates
+  7. [#766](https://github.com/influxdata/chronograf/pull/772): Add X-Chronograf-Version header to all requests
 
 ## v1.1.0-beta5 [2017-01-05]
 

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ COMMIT ?= $(shell git rev-parse --short=8 HEAD)
 
 SOURCES := $(shell find . -name '*.go')
 
-LDFLAGS=-ldflags "-s -X main.Version=${VERSION} -X main.Commit=${COMMIT}"
+LDFLAGS=-ldflags "-s -X main.version=${VERSION} -X main.commit=${COMMIT}"
 BINARY=chronograf
 
 default: dep build

--- a/server/server.go
+++ b/server/server.go
@@ -76,6 +76,8 @@ func (s *Server) Serve() error {
 		UseAuth:            s.useAuth(),
 	}, service)
 
+	s.handler = Version(s.BuildInfo.Version, s.handler)
+
 	var err error
 	s.Listener, err = net.Listen("tcp", net.JoinHostPort(s.Host, strconv.Itoa(s.Port)))
 	if err != nil {

--- a/server/version.go
+++ b/server/version.go
@@ -1,0 +1,13 @@
+package server
+
+import (
+	"net/http"
+)
+
+func Version(version string, h http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Add("X-Chronograf-Version", version)
+		h.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}


### PR DESCRIPTION
- [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

The rest of the TICK stack reports a version header. Now Chronograf does too. (This is helpful for pings and debugging)