### PR TITLE
Add layout for telegraf's system diskio plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Upcoming Bug Fixes
 ### Upcoming Features
-  1. [#776](https://github.com/influxdata/chronograf/issues/776): Add layout for telegraf's diskio system plugin
+  1. [#779](https://github.com/influxdata/chronograf/issues/779): Add layout for telegraf's diskio system plugin
 
 ### Upcoming UI Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ### Upcoming Bug Fixes
 ### Upcoming Features
+  1. [#776](https://github.com/influxdata/chronograf/issues/776): Add layout for telegraf's diskio system plugin
+
 ### Upcoming UI Improvements
 
 ## v1.1.0-beta6 [2017-01-13]
 ### Bug Fixes
   1. [#748](https://github.com/influxdata/chronograf/pull/748): Fix missing kapacitors on source index page
-  1. [#755](https://github.com/influxdata/chronograf/pull/755): Fix kapacitor basic auth proxying
-  2. [#704](https://github.com/influxdata/chronograf/issues/704): Fix RPM and DEB install script and systemd unit file
+  2. [#755](https://github.com/influxdata/chronograf/pull/755): Fix kapacitor basic auth proxying
+  3. [#704](https://github.com/influxdata/chronograf/issues/704): Fix RPM and DEB install script and systemd unit file
 
 ### Features
   1. [#660](https://github.com/influxdata/chronograf/issues/660): Add option to accept any certificate from InfluxDB

--- a/README.md
+++ b/README.md
@@ -38,7 +38,13 @@ Currently, Chronograf offers dashboard templates for the following Telegraf inpu
 * RabbitMQ
 * Redis
 * Riak
-* System
+* [System](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/SYSTEM_README.md)
+    * [CPU](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/CPU_README.md)
+    * [Disk](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/DISK_README.md)
+    * [DiskIO](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/disk.go#L136)
+    * [Memory](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/MEM_README.md)
+    * [Netstat](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/NETSTAT_README.md)
+    * [Processes](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/system/PROCESSES_README.md)
 * Varnish
 * Windows Performance Counters
 

--- a/canned/diskio.json
+++ b/canned/diskio.json
@@ -1,0 +1,33 @@
+{
+  "id": "9e3a9fcd-a363-4470-991e-a4d6987a94c8",
+  "measurement": "diskio",
+  "app": "system",
+  "autoflow": true,
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "7f647740-d9f0-4012-8e7a-5d898c8f271e",
+      "name": "System – Disk MB/s",
+      "queries": [
+        {
+          "query": "SELECT non_negative_derivative(max(\"read_bytes\"), 1s) / 1000000 AS \"read_megabytes_per_second\" FROM diskio",
+          "groupbys": [
+            "\"name\""
+          ],
+          "wheres": [],
+          "label": "MB/s"
+        },
+        {
+          "query": "SELECT non_negative_derivative(max(\"write_bytes\"), 1s) / 1000000 AS \"write_megabytes_per_second\" FROM diskio",
+          "groupbys": [
+            "\"name\""
+          ],
+          "wheres": []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
diskio are counters that give the total reads/writes since a system reboot.


  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fix #776 

### The problem
Layout for telegraf's diskio needed.

Telegraf does not have documentation about diskio, but, it uses [github.com/shirou/gopsuti/disk](https://github.com/shirou/gopsutil/blob/master/disk/disk_linux.go#L276).   In turn `disk_linux.go` uses `/proc/diskstats`.  `/proc/diskstats` are documented [here](https://www.kernel.org/doc/Documentation/iostats.txt)

### The Solution
Because the stats are long running counters, I'm using `non_negative_derivative`.  Additionally, I'm scaling the queries from bytes to megabytes.  Finally, I'm grouping by the name of the device.

<img width="401" alt="diskio" src="https://cloud.githubusercontent.com/assets/1922921/21957424/623ba1b6-da5b-11e6-8ef4-43cf199b5b96.png">



