### PR TITLE
Fix missing fields from non-default RP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v1.1.0 [unreleased]
 
 ### Upcoming Bug Fixes
+  1. [#788](https://github.com/influxdata/chronograf/pull/788): Fix missing fields in data explorer when using non-default retention policy
+
 ### Upcoming Features
 ### Upcoming UI Improvements
 

--- a/ui/src/data_explorer/components/FieldList.js
+++ b/ui/src/data_explorer/components/FieldList.js
@@ -11,6 +11,7 @@ const FieldList = React.createClass({
   propTypes: {
     query: shape({
       database: string,
+      retentionPolicy: string,
       measurement: string,
     }).isRequired,
     onToggleField: func.isRequired,
@@ -40,14 +41,14 @@ const FieldList = React.createClass({
   },
 
   componentDidMount() {
-    const {database, measurement} = this.props.query;
+    const {database, measurement, retentionPolicy} = this.props.query;
     if (!database || !measurement) {
       return;
     }
 
     const {source} = this.context;
     const proxySource = source.links.proxy;
-    showFieldKeys(proxySource, database, measurement).then((resp) => {
+    showFieldKeys(proxySource, database, measurement, retentionPolicy).then((resp) => {
       const {errors, fieldSets} = showFieldKeysParser(resp.data);
       if (errors.length) {
         // TODO: do something

--- a/ui/src/shared/apis/metaQuery.js
+++ b/ui/src/shared/apis/metaQuery.js
@@ -71,8 +71,8 @@ export function dropShard(host, shard, clusterID) {
   return proxy(url, clusterID);
 }
 
-export function showFieldKeys(source, db, measurement) {
-  const query = `SHOW FIELD KEYS FROM "${measurement}"`;
+export function showFieldKeys(source, db, measurement, rp) {
+  const query = `SHOW FIELD KEYS FROM "${rp}"."${measurement}"`;
 
   return proxy({source, query, db});
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #731 

When attempting to extract fields from a non-default retention policy in
the Data Explorer, fields would not appear. This was because the query
was sent without an explicit RP, which would use the default RP instead.
This adds an explicit RP to the SHOW FIELDS query.


