### PR TITLE
Bugfix/legend data order

### DIFF
--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -322,7 +322,7 @@ describe('timeSeriesToDygraph', () => {
     expect(dygraphSeries["m2.f2"].strokeWidth).to.be.above(dygraphSeries["m1.f1"].strokeWidth);
   });
 
-  it('parses a raw InfluxDB response into a dygraph friendly data format', () => {
+  it('parses labels alphabetically with the correct field values for multiple series', () => {
     const influxResponse = [
       {
         "response":
@@ -331,36 +331,26 @@ describe('timeSeriesToDygraph', () => {
             {
               "series": [
                 {
-                  "name":"mb",
-                  "columns": ["time","f1"],
-                  "values": [[1000, 1],[2000, 2]],
-                },
-              ]
-            },
-            {
-              "series": [
-                {
                   "name":"ma",
-                  "columns": ["time","f1"],
-                  "values": [[1000, 1],[2000, 2]],
+                  "columns": ["time","fa","fc","fb"],
+                  "values": [
+                    [1000, 20, 10, 10],
+                    [2000, 30, 15, 9],
+                    [3000, 40, 20, 8],
+                  ],
                 },
               ]
             },
             {
               "series": [
                 {
-                  "name":"mc",
-                  "columns": ["time","f2"],
-                  "values": [[2000, 3],[4000, 4]],
-                },
-              ]
-            },
-            {
-              "series": [
-                {
-                  "name":"mc",
-                  "columns": ["time","f1"],
-                  "values": [[2000, 3],[4000, 4]],
+                  "name":"mb",
+                  "columns": ["time","fa","fc","fb"],
+                  "values": [
+                    [1000, 200, 100, 100],
+                    [2000, 300, 150, 90],
+                    [3000, 400, 200, 80],
+                  ],
                 },
               ]
             },
@@ -371,14 +361,25 @@ describe('timeSeriesToDygraph', () => {
 
     const actual = timeSeriesToDygraph(influxResponse);
 
-    const expected = [
-      'time',
-      `ma.f1`,
-      `mb.f1`,
-      `mc.f1`,
-      `mc.f2`,
-    ];
+    const expected = {
+      labels: [
+        'time',
+        `ma.fa`,
+        `ma.fb`,
+        `ma.fc`,
+        `mb.fa`,
+        `mb.fb`,
+        `mb.fc`,
+      ],
+      timeSeries: [
+        [new Date(1000), 20, 10, 10],
+        [new Date(2000), 30, 9, 15],
+        [new Date(3000), 40, 8, 20],
+      ],
+    };
 
-    expect(actual.labels).to.deep.equal(expected);
+    console.log(actual.timeSeries);
+    expect(actual.labels).to.deep.equal(expected.labels);
+    expect(actual.timeSeries).to.deep.equal(expected.timeSeries);
   });
 });

--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -57,6 +57,16 @@ describe('timeSeriesToDygraph', () => {
         [new Date(2000), 2, 3],
         [new Date(4000), null, 4],
       ],
+      dygraphSeries: {
+        'm1.f1': {
+          axis: 'y',
+          strokeWidth,
+        },
+        'm1.f2': {
+          axis: 'y',
+          strokeWidth,
+        },
+      },
     };
 
     expect(actual).to.deep.equal(expected);
@@ -148,19 +158,21 @@ describe('timeSeriesToDygraph', () => {
     const actual = timeSeriesToDygraph(influxResponse);
 
     const expected = {
-        'm1.f1': {
-          axis: 'y',
-          strokeWidth,
-        },
-        'm1.f2': {
-          axis: 'y',
-          strokeWidth,
-        },
-        'm3.f3': {
-          axis: 'y2',
-          strokeWidth,
-        },
+      'm1.f1': {
+        axis: 'y',
+        strokeWidth,
+      },
+      'm1.f2': {
+        axis: 'y',
+        strokeWidth,
+      },
+      'm3.f3': {
+        axis: 'y2',
+        strokeWidth,
+      },
     };
+
+    // console.log('BEAP EXPECTED', JSON.stringify(expected, null, 2))
 
     expect(actual.dygraphSeries).to.deep.equal(expected);
   });
@@ -224,6 +236,16 @@ describe('timeSeriesToDygraph', () => {
         [new Date(2000), 2, 3],
         [new Date(4000), null, 4],
       ],
+      dygraphSeries: {
+        'm1.f1': {
+          axis: 'y',
+          strokeWidth,
+        },
+        'm1.f1': {
+          axis: 'y2',
+          strokeWidth,
+        },
+      },
     };
 
     expect(actual).to.deep.equal(expected);

--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -16,6 +16,10 @@ describe('timeSeriesToDygraph', () => {
                   "name":"m1",
                   "columns": ["time","f1"],
                   "values": [[1000, 1],[2000, 2]],
+                  "tags": {
+                    tk1: "tv1",
+                    tk2: "tv2",
+                  },
                 },
               ]
             },
@@ -25,6 +29,9 @@ describe('timeSeriesToDygraph', () => {
                   "name":"m1",
                   "columns": ["time","f2"],
                   "values": [[2000, 3],[4000, 4]],
+                  "tags": {
+                    tk3: "tv3",
+                  },
                 },
               ]
             },
@@ -33,24 +40,13 @@ describe('timeSeriesToDygraph', () => {
       }
     ];
 
-    //  dygraphSeries: {
-    //    'm1.f1': {
-    //      axis: 'y',
-    //      strokeWidth,
-    //    },
-    //    'm1.f2': {
-    //      axis: 'y',
-    //      strokeWidth,
-    //    },
-    //  },
-
     const actual = timeSeriesToDygraph(influxResponse);
 
     const expected = {
       labels: [
         'time',
-        `m1.f1`,
-        `m1.f2`,
+        `m1.f1[tk1=tv1][tk2=tv2]`,
+        `m1.f2[tk3=tv3]`,
       ],
       timeSeries: [
         [new Date(1000), 1, null],
@@ -58,11 +54,11 @@ describe('timeSeriesToDygraph', () => {
         [new Date(4000), null, 4],
       ],
       dygraphSeries: {
-        'm1.f1': {
+        'm1.f1[tk1=tv1][tk2=tv2]': {
           axis: 'y',
           strokeWidth,
         },
-        'm1.f2': {
+        'm1.f2[tk3=tv3]': {
           axis: 'y',
           strokeWidth,
         },

--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -168,8 +168,6 @@ describe('timeSeriesToDygraph', () => {
       },
     };
 
-    // console.log('BEAP EXPECTED', JSON.stringify(expected, null, 2))
-
     expect(actual.dygraphSeries).to.deep.equal(expected);
   });
 
@@ -210,16 +208,6 @@ describe('timeSeriesToDygraph', () => {
     ];
 
     const actual = timeSeriesToDygraph(influxResponse);
-    //  dygraphSeries: {
-    //    'm1.f1': {
-    //      axis: 'y',
-    //      strokeWidth,
-    //    },
-    //    'm1.f1-1': {
-    //      axis: 'y2',
-    //      strokeWidth,
-    //    },
-    //  },
 
     const expected = {
       labels: [
@@ -408,7 +396,6 @@ describe('timeSeriesToDygraph', () => {
       ],
     };
 
-    // console.log(actual.timeSeries);
     expect(actual.labels).to.deep.equal(expected.labels);
     expect(actual.timeSeries).to.deep.equal(expected.timeSeries);
   });

--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -33,6 +33,17 @@ describe('timeSeriesToDygraph', () => {
       }
     ];
 
+    //  dygraphSeries: {
+    //    'm1.f1': {
+    //      axis: 'y',
+    //      strokeWidth,
+    //    },
+    //    'm1.f2': {
+    //      axis: 'y',
+    //      strokeWidth,
+    //    },
+    //  },
+
     const actual = timeSeriesToDygraph(influxResponse);
 
     const expected = {
@@ -46,16 +57,6 @@ describe('timeSeriesToDygraph', () => {
         [new Date(2000), 2, 3],
         [new Date(4000), null, 4],
       ],
-      dygraphSeries: {
-        'm1.f1': {
-          axis: 'y',
-          strokeWidth,
-        },
-        'm1.f2': {
-          axis: 'y',
-          strokeWidth,
-        },
-      },
     };
 
     expect(actual).to.deep.equal(expected);
@@ -201,28 +202,28 @@ describe('timeSeriesToDygraph', () => {
     ];
 
     const actual = timeSeriesToDygraph(influxResponse);
+    //  dygraphSeries: {
+    //    'm1.f1': {
+    //      axis: 'y',
+    //      strokeWidth,
+    //    },
+    //    'm1.f1-1': {
+    //      axis: 'y2',
+    //      strokeWidth,
+    //    },
+    //  },
 
     const expected = {
       labels: [
         'time',
         `m1.f1`,
-        `m1.f1-1`,
+        `m1.f1`,
       ],
       timeSeries: [
         [new Date(1000), 1, null],
         [new Date(2000), 2, 3],
-        [new Date(4000), 4, null],
+        [new Date(4000), null, 4],
       ],
-      dygraphSeries: {
-        'm1.f1': {
-          axis: 'y',
-          strokeWidth,
-        },
-        'm1.f1-1': {
-          axis: 'y2',
-          strokeWidth,
-        },
-      },
     };
 
     expect(actual).to.deep.equal(expected);
@@ -322,7 +323,7 @@ describe('timeSeriesToDygraph', () => {
     expect(dygraphSeries["m2.f2"].strokeWidth).to.be.above(dygraphSeries["m1.f1"].strokeWidth);
   });
 
-  it.only('parses labels alphabetically with the correct field values for multiple series', () => {
+  it('parses labels alphabetically with the correct field values for multiple series', () => {
     const influxResponse = [
       {
         "response":

--- a/ui/spec/utils/timeSeriesToDygraphSpec.js
+++ b/ui/spec/utils/timeSeriesToDygraphSpec.js
@@ -322,12 +322,35 @@ describe('timeSeriesToDygraph', () => {
     expect(dygraphSeries["m2.f2"].strokeWidth).to.be.above(dygraphSeries["m1.f1"].strokeWidth);
   });
 
-  it('parses labels alphabetically with the correct field values for multiple series', () => {
+  it.only('parses labels alphabetically with the correct field values for multiple series', () => {
     const influxResponse = [
       {
         "response":
         {
           "results": [
+            {
+              "series": [
+                {
+                  "name":"mb",
+                  "columns": ["time","fa"],
+                  "values": [
+                    [1000, 200],
+                    [2000, 300],
+                    [4000, 400],
+                  ],
+                },
+                {
+                  "name":"mc",
+                  "columns": ["time","fa"],
+                  "values": [
+                    [1000, 400],
+                    [2000, 600],
+                    [3000, 800],
+                    [5000, 1000],
+                  ],
+                },
+              ]
+            },
             {
               "series": [
                 {
@@ -337,19 +360,6 @@ describe('timeSeriesToDygraph', () => {
                     [1000, 20, 10, 10],
                     [2000, 30, 15, 9],
                     [3000, 40, 20, 8],
-                  ],
-                },
-              ]
-            },
-            {
-              "series": [
-                {
-                  "name":"mb",
-                  "columns": ["time","fa","fc","fb"],
-                  "values": [
-                    [1000, 200, 100, 100],
-                    [2000, 300, 150, 90],
-                    [3000, 400, 200, 80],
                   ],
                 },
               ]
@@ -368,17 +378,18 @@ describe('timeSeriesToDygraph', () => {
         `ma.fb`,
         `ma.fc`,
         `mb.fa`,
-        `mb.fb`,
-        `mb.fc`,
+        `mc.fa`,
       ],
       timeSeries: [
-        [new Date(1000), 20, 10, 10],
-        [new Date(2000), 30, 9, 15],
-        [new Date(3000), 40, 8, 20],
+        [new Date(1000), 20, 10, 10, 200, 400],
+        [new Date(2000), 30, 9, 15, 300, 600],
+        [new Date(3000), 40, 8, 20, null, 800],
+        [new Date(4000), null, null, null, 400, null],
+        [new Date(5000), null, null, null, null, 1000],
       ],
     };
 
-    console.log(actual.timeSeries);
+    // console.log(actual.timeSeries);
     expect(actual.labels).to.deep.equal(expected.labels);
     expect(actual.timeSeries).to.deep.equal(expected.timeSeries);
   });

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -20,7 +20,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
   }, []);
 
   // convert series into cells with rows and columns
-  const cells = serieses.reduce((acc, {name, columns, values, index, responseIndex}) => {
+  const cells = serieses.reduce((acc, {name, columns, values, index, responseIndex, tags = {}}) => {
     const rows = values.map((vals) => ({
       name,
       columns,
@@ -28,12 +28,18 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
       index,
     }));
 
-    rows.forEach(({vals, columns: cols, name: n, index: seriesIndex}) => {
+    // tagSet is each tag key and value for a series
+    const tagSet = Object.keys(tags).map((tag) => {
+      return `[${tag}=${tags[tag]}]`;
+    }).sort().join('');
+
+    rows.forEach(({vals, columns: cols, name: measurement, index: seriesIndex}) => {
       const [time, ...rowValues] = vals;
+
       rowValues.forEach((value, i) => {
-        const column = cols[i + 1];
+        const field = cols[i + 1];
         acc.push({
-          label: `${n}.${column}`,
+          label: `${measurement}.${field}${tagSet}`,
           value,
           time,
           seriesIndex,

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -15,7 +15,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
   }, []);
 
   // collect each series
-  const serieses = results.reduce((acc, {series, responseIndex}, index) => {
+  const serieses = results.reduce((acc, {series = [], responseIndex}, index) => {
     return [...acc, ...series.map((item) => ({...item, responseIndex, index}))];
   }, []);
 

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -5,8 +5,7 @@ import {STROKE_WIDTH} from 'src/shared/constants';
  * that Dygraph understands.
  */
 
-// activeQueryIndex is an optional argument that indicated which query's series
-// we want highlighted.
+// activeQueryIndex is an optional argument that indicated which query's series we want highlighted.
 export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInDataExplorer) {
   // const labels = []; // all of the effective field names (i.e. <measurement>.<field>)
   const fieldToIndex = {}; // see parseSeries
@@ -31,14 +30,17 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
    */
   const dateToFieldValue = {};
 
+  // collect results from each influx response
   const results = raw.reduce((acc, response) => {
     return [...acc, ..._.get(response, 'response.results', [])]
   }, [])
 
+  // collect each series
   const serieses = results.reduce((acc, result, index) => {
     return [...acc, ...result.series.map((item) => ({...item, index}))];
   }, [])
 
+  // convert series into cells with rows and columns
   const cells = serieses.reduce((acc, {name, columns, values, index}) => {
     const rows = values.map((values) => ({
       name,
@@ -46,7 +48,6 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
       values,
       index,
     }))
-    console.log("HI IM Rerws: ", rows)
 
     rows.forEach(({values: vals, columns: cols, name: n, index: seriesIndex}) => {
       const [time, ...rowValues] = vals
@@ -63,8 +64,6 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
 
     return acc
   }, [])
-
-  console.log("HI IM CELLS: ", cells)
 
   const labels = cells.reduce((acc, cell) => {
     const existingLabel = acc.find(({label, seriesIndex}) => cell.label === label && cell.seriesIndex === seriesIndex)
@@ -93,10 +92,10 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
       existingRowIndex = acc.length - 1
     }
 
-      const values = acc[existingRowIndex].values
-      const labelIndex = sortedLabels.findIndex(({label}) => label === cell.label)
-      values[labelIndex] = cell.value
-      acc[existingRowIndex].values = values
+    const values = acc[existingRowIndex].values
+    const labelIndex = sortedLabels.findIndex(({label, seriesIndex}) => label === cell.label && cell.seriesIndex === seriesIndex);
+    values[labelIndex] = cell.value
+    acc[existingRowIndex].values = values
 
     return acc
   }, [])
@@ -111,10 +110,10 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
 
   // console.log("MY CAT LOVES LABELS: ", labels)
   // console.log("MY CAT HATES SORTED LABELS: ", sortedLabels)
- console.log("sorted term serrrrries: ", JSON.stringify(timeSeriesToDygraph, null, 2))
+  // console.log("sorted term serrrrries: ", JSON.stringify(timeSeriesToDygraph, null, 2))
 
   return timeSeriesToDygraph;
-// timeSeriesToDygraph , {labels: [], timeSeries: []}
+  // timeSeriesToDygraph , {labels: [], timeSeries: []}
 
   // raw.forEach(({response}, queryIndex) => {
   //   // If a response is an empty result set or a query returned an error

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import {STROKE_WIDTH} from 'src/shared/constants';
 /**
  * Accepts an array of raw influxdb responses and returns a format
@@ -7,7 +8,7 @@ import {STROKE_WIDTH} from 'src/shared/constants';
 // activeQueryIndex is an optional argument that indicated which query's series
 // we want highlighted.
 export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInDataExplorer) {
-  const labels = []; // all of the effective field names (i.e. <measurement>.<field>)
+  // const labels = []; // all of the effective field names (i.e. <measurement>.<field>)
   const fieldToIndex = {}; // see parseSeries
   const dates = {}; // map of date as string to date value to minimize string coercion
   const dygraphSeries = {}; // dygraphSeries is a graph legend label and its corresponding y-axis e.g. {legendLabel1: 'y', legendLabel2: 'y2'};
@@ -30,152 +31,235 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
    */
   const dateToFieldValue = {};
 
-  raw.forEach(({response}, queryIndex) => {
-    // If a response is an empty result set or a query returned an error
-    // from InfluxDB, don't try and parse.
-    if (response.results.length) {
-      if (isEmpty(response) || hasError(response)) {
-        return;
-      }
+  const results = raw.reduce((acc, response) => {
+    return [...acc, ..._.get(response, 'response.results', [])]
+  }, [])
+
+  const serieses = results.reduce((acc, result, index) => {
+    return [...acc, ...result.series.map((item) => ({...item, index}))];
+  }, [])
+
+  const cells = serieses.reduce((acc, {name, columns, values, index}) => {
+    const rows = values.map((values) => ({
+      name,
+      columns,
+      values,
+      index,
+    }))
+    console.log("HI IM Rerws: ", rows)
+
+    rows.forEach(({values: vals, columns: cols, name: n, index: seriesIndex}) => {
+      const [time, ...rowValues] = vals
+      rowValues.forEach((value, i) => {
+        const column = cols[i + 1]
+        acc.push({
+          label: `${n}.${column}`,
+          value,
+          time,
+          seriesIndex,
+        })
+      })
+    })
+
+    return acc
+  }, [])
+
+  console.log("HI IM CELLS: ", cells)
+
+  const labels = cells.reduce((acc, cell) => {
+    const existingLabel = acc.find(({label, seriesIndex}) => cell.label === label && cell.seriesIndex === seriesIndex)
+
+    if (!existingLabel) {
+      acc.push({
+        label: cell.label,
+        seriesIndex: cell.seriesIndex,
+      })
     }
 
-    /**
-     * response looks like:
-     * {
-     *   results: [
-     *     { series: [...] },
-     *     { series: [...] },
-     *   ]
-     * }
-     */
-    response.results.forEach(parseResult);
+    return acc
+  }, [])
 
-    function parseResult(s) {
-      /*
-       * s looks like:
-       * {
-       *   series: [
-       *     {
-       *       name: "<measurement>",
-       *       columns: ["time", "<field name 1>", "<field name 2>", ...],
-       *       values: [<time>, <value of field 1>, <value of field 2>, ...],
-       *     },
-       * }
-       */
-      s.series.forEach(parseSeries);
+  const sortedLabels = _.sortBy(labels, 'label')
+
+  const timeSeries = cells.reduce((acc, cell) => {
+    let existingRowIndex = acc.findIndex(({time}) => cell.time === time)
+
+    if (existingRowIndex === -1) {
+      acc.push({
+        time: cell.time,
+        values: Array(sortedLabels.length).fill(null),
+      })
+
+      existingRowIndex = acc.length - 1
     }
 
-    function parseSeries(series) {
-      /*
-       * series looks like:
-       * {
-       *   name: "<measurement>",
-       *   columns: ["time", "<field name 1>", "<field name 2>", ...],
-       *   values: [
-       *    [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...],
-       *    [<time2>, <value of field 1 @ time2>, <value of field 2 @ time2>, ...],
-       *   ]
-       * }
-       */
-      const measurementName = series.name;
-      const columns = series.columns;
-      // Tags are only included in an influxdb response under certain circumstances, e.g.
-      // when a query is using GROUP BY (<tag key>).
-      const tags = Object.keys(series.tags || {}).map((key) => {
-        return `[${key}=${series.tags[key]}]`;
-      }).sort().join('');
+      const values = acc[existingRowIndex].values
+      const labelIndex = sortedLabels.findIndex(({label}) => label === cell.label)
+      values[labelIndex] = cell.value
+      acc[existingRowIndex].values = values
 
-      const c = columns.slice(1).sort();
-      let previousColumnLength = 0;
+    return acc
+  }, [])
 
-      if (c.length != previousColumnLength) {
-        previousColumnLength = c.length;
-      }
+  const sortedTimeSeries = _.sortBy(timeSeries, 'time')
 
-      c.forEach((fieldName) => {
-        let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
-
-        // If there are duplicate effectiveFieldNames identify them by their queryIndex
-        if (effectiveFieldName in dygraphSeries) {
-          effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
-        }
-
-        // Given a field name, identify which column in the timeSeries result should hold the field's value
-        // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
-        fieldToIndex[effectiveFieldName] = c.indexOf(fieldName) + previousColumnLength;
-        labels.push(effectiveFieldName);
-
-        const {light, heavy} = STROKE_WIDTH;
-
-        const dygraphSeriesStyles = {
-          strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
-        };
-
-        if (!isInDataExplorer) {
-          dygraphSeriesStyles.axis = queryIndex === 0 ? 'y' : 'y2';
-        }
-
-        dygraphSeries[effectiveFieldName] = dygraphSeriesStyles;
-      });
-
-      (series.values || []).forEach(parseRow);
-
-      function parseRow(row) {
-        /**
-         * row looks like:
-         *   [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...]
-         */
-        const date = row[0];
-        const dateString = date.toString();
-        row.forEach((value, index) => {
-          if (index === 0) {
-            // index 0 in a row is always the timestamp
-            if (!dateToFieldValue[dateString]) {
-              dateToFieldValue[dateString] = {};
-              dates[dateString] = date;
-            }
-            return;
-          }
-
-          const fieldName = columns[index];
-          let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
-
-          // If there are duplicate effectiveFieldNames identify them by their queryIndex
-          if (effectiveFieldName in dateToFieldValue[dateString]) {
-            effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
-          }
-
-          dateToFieldValue[dateString][effectiveFieldName] = value;
-        });
-      }
-    }
-  });
-
-  function buildTimeSeries() {
-    const allDates = Object.keys(dateToFieldValue);
-    allDates.sort((a, b) => a - b);
-    const rowLength = labels.length + 1;
-    return allDates.map((date) => {
-      const row = new Array(rowLength);
-
-      row.fill(null);
-      row[0] = new Date(dates[date]);
-
-      const fieldsForRow = dateToFieldValue[date];
-
-      Object.keys(fieldsForRow).forEach((effectiveFieldName) => {
-        row[fieldToIndex[effectiveFieldName]] = fieldsForRow[effectiveFieldName];
-      });
-
-      return row;
-    });
+  const timeSeriesToDygraph = {
+    timeSeries: sortedTimeSeries.map(({time, values}) => ([new Date(time), ...values])),
+    labels: ["time", ...sortedLabels.map(({label}) => label)],
   }
 
-  return {
-    labels: ['time', ...labels.sort()],
-    timeSeries: buildTimeSeries(),
-    dygraphSeries,
-  };
+
+  // console.log("MY CAT LOVES LABELS: ", labels)
+  // console.log("MY CAT HATES SORTED LABELS: ", sortedLabels)
+ console.log("sorted term serrrrries: ", JSON.stringify(timeSeriesToDygraph, null, 2))
+
+  return timeSeriesToDygraph;
+// timeSeriesToDygraph , {labels: [], timeSeries: []}
+
+  // raw.forEach(({response}, queryIndex) => {
+  //   // If a response is an empty result set or a query returned an error
+  //   // from InfluxDB, don't try and parse.
+  //   if (response.results.length) {
+  //     if (isEmpty(response) || hasError(response)) {
+  //       return;
+  //     }
+  //   }
+  //
+  //   /**
+  //    * response looks like:
+  //    * {
+  //    *   results: [
+  //    *     { series: [...] },
+  //    *     { series: [...] },
+  //    *   ]
+  //    * }
+  //    */
+  //   response.results.forEach(parseResult);
+  //
+  //   function parseResult(s) {
+  //     /*
+  //      * s looks like:
+  //      * {
+  //      *   series: [
+  //      *     {
+  //      *       name: "<measurement>",
+  //      *       columns: ["time", "<field name 1>", "<field name 2>", ...],
+  //      *       values: [<time>, <value of field 1>, <value of field 2>, ...],
+  //      *     },
+  //      * }
+  //      */
+  //     s.series.forEach(parseSeries);
+  //   }
+  //
+  //   function parseSeries(series) {
+  //     /*
+  //      * series looks like:
+  //      * {
+  //      *   name: "<measurement>",
+  //      *   columns: ["time", "<field name 1>", "<field name 2>", ...],
+  //      *   values: [
+  //      *    [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...],
+  //      *    [<time2>, <value of field 1 @ time2>, <value of field 2 @ time2>, ...],
+  //      *   ]
+  //      * }
+  //      */
+  //     const measurementName = series.name;
+  //     const columns = series.columns;
+  //     // Tags are only included in an influxdb response under certain circumstances, e.g.
+  //     // when a query is using GROUP BY (<tag key>).
+  //     const tags = Object.keys(series.tags || {}).map((key) => {
+  //       return `[${key}=${series.tags[key]}]`;
+  //     }).sort().join('');
+  //
+  //     const c = columns.slice(1).sort();
+  //     let previousColumnLength = 0;
+  //
+  //     if (c.length != previousColumnLength) {
+  //       previousColumnLength = c.length;
+  //     }
+  //
+  //     c.forEach((fieldName) => {
+  //       let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+  //
+  //       // If there are duplicate effectiveFieldNames identify them by their queryIndex
+  //       if (effectiveFieldName in dygraphSeries) {
+  //         effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
+  //       }
+  //
+  //       // Given a field name, identify which column in the timeSeries result should hold the field's value
+  //       // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
+  //       fieldToIndex[effectiveFieldName] = c.indexOf(fieldName);
+  //       labels.push(effectiveFieldName);
+  //
+  //       const {light, heavy} = STROKE_WIDTH;
+  //
+  //       const dygraphSeriesStyles = {
+  //         strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
+  //       };
+  //
+  //       if (!isInDataExplorer) {
+  //         dygraphSeriesStyles.axis = queryIndex === 0 ? 'y' : 'y2';
+  //       }
+  //
+  //       dygraphSeries[effectiveFieldName] = dygraphSeriesStyles;
+  //     });
+  //
+  //     (series.values || []).forEach(parseRow);
+  //
+  //
+  //
+  //     function parseRow(row) {
+  //       /**
+  //        * row looks like:
+  //        *   [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...]
+  //        */
+  //       const date = row[0];
+  //       const dateString = date.toString();
+  //       row.forEach((value, index) => {
+  //         if (index === 0) {
+  //           // index 0 in a row is always the timestamp
+  //           if (!dateToFieldValue[dateString]) {
+  //             dateToFieldValue[dateString] = {};
+  //             dates[dateString] = date;
+  //           }
+  //           return;
+  //         }
+  //
+  //         const fieldName = columns[index];
+  //         let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
+  //
+  //         // If there are duplicate effectiveFieldNames identify them by their queryIndex
+  //         if (effectiveFieldName in dateToFieldValue[dateString]) {
+  //           effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
+  //         }
+  //
+  //         dateToFieldValue[dateString][effectiveFieldName] = value;
+  //       });
+  //     }
+  //   }
+  // });
+  //
+  // function buildTimeSeries() {
+  //   const allDates = Object.keys(dateToFieldValue);
+  //   allDates.sort((a, b) => a - b);
+  //   const rowLength = labels.length + 1;
+  //   return allDates.map((date) => {
+  //     const row = new Array(rowLength);
+  //
+  //     row.fill(null);
+  //     row[0] = new Date(dates[date]);
+  //
+  //     const fieldsForRow = dateToFieldValue[date];
+  //
+  //     Object.keys(fieldsForRow).forEach((effectiveFieldName) => {
+  //       row[fieldToIndex[effectiveFieldName]] = fieldsForRow[effectiveFieldName];
+  //     });
+  //
+  //     return row;
+  //   });
+  // }
+
+
 }
 
 function isEmpty(resp) {

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -8,257 +8,101 @@ import {STROKE_WIDTH} from 'src/shared/constants';
 // activeQueryIndex is an optional argument that indicated which query's series we want highlighted.
 export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInDataExplorer) {
   // collect results from each influx response
-  const results = raw.reduce((acc, response, responseIndex) => {
-    const responses = _.get(response, 'response.results', [])
-    const indexedResponses = responses.map((response) => ({...response, responseIndex}))
-    return [...acc, ...indexedResponses]
-  }, [])
+  const results = raw.reduce((acc, rawResponse, responseIndex) => {
+    const responses = _.get(rawResponse, 'response.results', []);
+    const indexedResponses = responses.map((response) => ({...response, responseIndex}));
+    return [...acc, ...indexedResponses];
+  }, []);
 
   // collect each series
   const serieses = results.reduce((acc, {series, responseIndex}, index) => {
     return [...acc, ...series.map((item) => ({...item, responseIndex, index}))];
-  }, [])
+  }, []);
 
   // convert series into cells with rows and columns
   const cells = serieses.reduce((acc, {name, columns, values, index, responseIndex}) => {
-    const rows = values.map((values) => ({
+    const rows = values.map((vals) => ({
       name,
       columns,
-      values,
+      vals,
       index,
-    }))
+    }));
 
-    rows.forEach(({values: vals, columns: cols, name: n, index: seriesIndex}) => {
-      const [time, ...rowValues] = vals
+    rows.forEach(({vals, columns: cols, name: n, index: seriesIndex}) => {
+      const [time, ...rowValues] = vals;
       rowValues.forEach((value, i) => {
-        const column = cols[i + 1]
+        const column = cols[i + 1];
         acc.push({
           label: `${n}.${column}`,
           value,
           time,
           seriesIndex,
           responseIndex,
-        })
-      })
-    })
+        });
+      });
+    });
 
-    return acc
-  }, [])
+    return acc;
+  }, []);
 
   const labels = cells.reduce((acc, {label, seriesIndex, responseIndex}) => {
     const existingLabel = acc.find(({
       label: findLabel,
       seriesIndex: findSeriesIndex,
-    }) => findLabel === label && findSeriesIndex === seriesIndex)
+    }) => findLabel === label && findSeriesIndex === seriesIndex);
 
     if (!existingLabel) {
       acc.push({
         label,
         seriesIndex,
         responseIndex,
-      })
+      });
     }
 
-    return acc
-  }, [])
+    return acc;
+  }, []);
 
-  const sortedLabels = _.sortBy(labels, 'label')
+  const sortedLabels = _.sortBy(labels, 'label');
 
   const timeSeries = cells.reduce((acc, cell) => {
-    let existingRowIndex = acc.findIndex(({time}) => cell.time === time)
+    let existingRowIndex = acc.findIndex(({time}) => cell.time === time);
 
     if (existingRowIndex === -1) {
       acc.push({
         time: cell.time,
         values: Array(sortedLabels.length).fill(null),
-      })
+      });
 
-      existingRowIndex = acc.length - 1
+      existingRowIndex = acc.length - 1;
     }
 
-    const values = acc[existingRowIndex].values
+    const values = acc[existingRowIndex].values;
     const labelIndex = sortedLabels.findIndex(({label, seriesIndex}) => label === cell.label && cell.seriesIndex === seriesIndex);
-    values[labelIndex] = cell.value
-    acc[existingRowIndex].values = values
+    values[labelIndex] = cell.value;
+    acc[existingRowIndex].values = values;
 
-    return acc
-  }, [])
+    return acc;
+  }, []);
 
-  const sortedTimeSeries = _.sortBy(timeSeries, 'time')
+  const sortedTimeSeries = _.sortBy(timeSeries, 'time');
 
   const {light, heavy} = STROKE_WIDTH;
 
   const dygraphSeries = sortedLabels.reduce((acc, {label, responseIndex}) => {
     acc[label] = {
       strokeWidth: responseIndex === activeQueryIndex ? heavy : light,
-    }
+    };
 
     if (!isInDataExplorer) {
-      acc[label].axis = responseIndex === 0 ? 'y' : 'y2'
+      acc[label].axis = responseIndex === 0 ? 'y' : 'y2';
     }
 
-    return acc
-  }, {})
+    return acc;
+  }, {});
 
-  const timeSeriesToDygraph = {
+  return {
     timeSeries: sortedTimeSeries.map(({time, values}) => ([new Date(time), ...values])),
     labels: ["time", ...sortedLabels.map(({label}) => label)],
     dygraphSeries,
-  }
-
-  return timeSeriesToDygraph;
-  // timeSeriesToDygraph , {labels: [], timeSeries: []}
-
-  // raw.forEach(({response}, queryIndex) => {
-  //   // If a response is an empty result set or a query returned an error
-  //   // from InfluxDB, don't try and parse.
-  //   if (response.results.length) {
-  //     if (isEmpty(response) || hasError(response)) {
-  //       return;
-  //     }
-  //   }
-  //
-  //   /**
-  //    * response looks like:
-  //    * {
-  //    *   results: [
-  //    *     { series: [...] },
-  //    *     { series: [...] },
-  //    *   ]
-  //    * }
-  //    */
-  //   response.results.forEach(parseResult);
-  //
-  //   function parseResult(s) {
-  //     /*
-  //      * s looks like:
-  //      * {
-  //      *   series: [
-  //      *     {
-  //      *       name: "<measurement>",
-  //      *       columns: ["time", "<field name 1>", "<field name 2>", ...],
-  //      *       values: [<time>, <value of field 1>, <value of field 2>, ...],
-  //      *     },
-  //      * }
-  //      */
-  //     s.series.forEach(parseSeries);
-  //   }
-  //
-  //   function parseSeries(series) {
-  //     /*
-  //      * series looks like:
-  //      * {
-  //      *   name: "<measurement>",
-  //      *   columns: ["time", "<field name 1>", "<field name 2>", ...],
-  //      *   values: [
-  //      *    [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...],
-  //      *    [<time2>, <value of field 1 @ time2>, <value of field 2 @ time2>, ...],
-  //      *   ]
-  //      * }
-  //      */
-  //     const measurementName = series.name;
-  //     const columns = series.columns;
-  //     // Tags are only included in an influxdb response under certain circumstances, e.g.
-  //     // when a query is using GROUP BY (<tag key>).
-  //     const tags = Object.keys(series.tags || {}).map((key) => {
-  //       return `[${key}=${series.tags[key]}]`;
-  //     }).sort().join('');
-  //
-  //     const c = columns.slice(1).sort();
-  //     let previousColumnLength = 0;
-  //
-  //     if (c.length != previousColumnLength) {
-  //       previousColumnLength = c.length;
-  //     }
-  //
-  //     c.forEach((fieldName) => {
-  //       let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
-  //
-  //       // If there are duplicate effectiveFieldNames identify them by their queryIndex
-  //       if (effectiveFieldName in dygraphSeries) {
-  //         effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
-  //       }
-  //
-  //       // Given a field name, identify which column in the timeSeries result should hold the field's value
-  //       // ex given this timeSeries [Date, 10, 20, 30] field index at 2 would correspond to value 20
-  //       fieldToIndex[effectiveFieldName] = c.indexOf(fieldName);
-  //       labels.push(effectiveFieldName);
-  //
-  //       const {light, heavy} = STROKE_WIDTH;
-  //
-  //       const dygraphSeriesStyles = {
-  //         strokeWidth: queryIndex === activeQueryIndex ? heavy : light,
-  //       };
-  //
-  //       if (!isInDataExplorer) {
-  //         dygraphSeriesStyles.axis = queryIndex === 0 ? 'y' : 'y2';
-  //       }
-  //
-  //       dygraphSeries[effectiveFieldName] = dygraphSeriesStyles;
-  //     });
-  //
-  //     (series.values || []).forEach(parseRow);
-  //
-  //
-  //
-  //     function parseRow(row) {
-  //       /**
-  //        * row looks like:
-  //        *   [<time1>, <value of field 1 @ time1>, <value of field 2 @ time1>, ...]
-  //        */
-  //       const date = row[0];
-  //       const dateString = date.toString();
-  //       row.forEach((value, index) => {
-  //         if (index === 0) {
-  //           // index 0 in a row is always the timestamp
-  //           if (!dateToFieldValue[dateString]) {
-  //             dateToFieldValue[dateString] = {};
-  //             dates[dateString] = date;
-  //           }
-  //           return;
-  //         }
-  //
-  //         const fieldName = columns[index];
-  //         let effectiveFieldName = `${measurementName}.${fieldName}${tags}`;
-  //
-  //         // If there are duplicate effectiveFieldNames identify them by their queryIndex
-  //         if (effectiveFieldName in dateToFieldValue[dateString]) {
-  //           effectiveFieldName = `${effectiveFieldName}-${queryIndex}`;
-  //         }
-  //
-  //         dateToFieldValue[dateString][effectiveFieldName] = value;
-  //       });
-  //     }
-  //   }
-  // });
-  //
-  // function buildTimeSeries() {
-  //   const allDates = Object.keys(dateToFieldValue);
-  //   allDates.sort((a, b) => a - b);
-  //   const rowLength = labels.length + 1;
-  //   return allDates.map((date) => {
-  //     const row = new Array(rowLength);
-  //
-  //     row.fill(null);
-  //     row[0] = new Date(dates[date]);
-  //
-  //     const fieldsForRow = dateToFieldValue[date];
-  //
-  //     Object.keys(fieldsForRow).forEach((effectiveFieldName) => {
-  //       row[fieldToIndex[effectiveFieldName]] = fieldsForRow[effectiveFieldName];
-  //     });
-  //
-  //     return row;
-  //   });
-  // }
-
-
-}
-
-function isEmpty(resp) {
-  return !resp.results[0].series;
-}
-
-function hasError(resp) {
-  return !!resp.results[0].error;
+  };
 }

--- a/ui/src/utils/timeSeriesToDygraph.js
+++ b/ui/src/utils/timeSeriesToDygraph.js
@@ -29,9 +29,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
     }));
 
     // tagSet is each tag key and value for a series
-    const tagSet = Object.keys(tags).map((tag) => {
-      return `[${tag}=${tags[tag]}]`;
-    }).sort().join('');
+    const tagSet = Object.keys(tags).map((tag) => `[${tag}=${tags[tag]}]`).sort().join('');
 
     rows.forEach(({vals, columns: cols, name: measurement, index: seriesIndex}) => {
       const [time, ...rowValues] = vals;
@@ -51,6 +49,7 @@ export default function timeSeriesToDygraph(raw = [], activeQueryIndex, isInData
     return acc;
   }, []);
 
+  // labels are a unique combination of measurement, fields, and tags that indicate a specific series on the graph legend
   const labels = cells.reduce((acc, {label, seriesIndex, responseIndex}) => {
     const existingLabel = acc.find(({
       label: findLabel,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #785 #745 (perhaps others)

### The problem
timeSeriesToDygraph was taking an approach to the "shape of data" problem of handling InfluxDB responses that proved problematic, as it may have been mixing up data responses and their labels.

### The Solution
@121watts was reaching the limits of what he could do with the logic in that function, so together we re-implemented the function entirely. We created a flat collection of "cells" (objects with time, label, and value data), and reduced them back into the data format required to render by dygraph.

All current tests pass with this new approach.

We should also backport this new approach to any other utility libraries we may have out there. Then we might be able to import that library as a dependency, once it's been provided to the community.