### PR TITLE
Duplicate defaults appearing in InfluxDB configuration

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -14,6 +14,8 @@
     "start": "node_modules/webpack/bin/webpack.js -w --config ./webpack/devConfig.js",
     "lint": "node_modules/eslint/bin/eslint.js src/",
     "test": "karma start",
+    "test:lint": "npm run lint; npm run test",
+    "test:dev": "nodemon --exec npm run test:lint",
     "clean": "rm -rf build",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",

--- a/ui/spec/shared/reducers/sourcesSpec.js
+++ b/ui/spec/shared/reducers/sourcesSpec.js
@@ -1,0 +1,48 @@
+import reducer from 'src/shared/reducers/sources';
+
+import {
+  loadSources,
+  updateSource,
+  removeSource,
+  addSource,
+} from 'src/shared/actions/sources';
+
+describe('Shared.Reducers.sources', () => {
+  it('can correctly show default sources when adding a source', () => {
+    let state = [];
+
+    state = reducer(state, addSource({
+      id: '1',
+      default: true,
+    }));
+
+    state = reducer(state, addSource({
+      id: '2',
+      default: true,
+    }));
+
+    expect(state.filter((s) => s.default).length).to.equal(1);
+  });
+
+  it('can correctly show default sources when updating a source', () => {
+    let state = [];
+
+    state = reducer(state, addSource({
+      id: '1',
+      default: true,
+    }));
+
+    state = reducer(state, addSource({
+      id: '2',
+      default: true,
+    }));
+
+    state = reducer(state, updateSource({
+      id: '1',
+      default: true,
+    }));
+
+    expect(state.find(({id}) => id === '1').default).to.equal(true);
+    expect(state.find(({id}) => id === '2').default).to.equal(false);
+  });
+});

--- a/ui/src/shared/reducers/sources.js
+++ b/ui/src/shared/reducers/sources.js
@@ -7,7 +7,9 @@ export default function sources(state = [], action) {
     case 'SOURCE_UPDATED': {
       const {source} = action.payload;
       const updatedIndex = state.findIndex((s) => s.id === source.id);
-      const updatedSources = Object.assign([], state);
+      const updatedSources = source.default ? state.map((s) => {
+        s.default = false; return s;
+      }) : [...state];
       updatedSources[updatedIndex] = source;
       return updatedSources;
     }
@@ -20,7 +22,10 @@ export default function sources(state = [], action) {
 
     case 'SOURCE_ADDED': {
       const {source} = action.payload;
-      return state.concat([source]);
+      const updatedSources = source.default ? state.map((s) => {
+        s.default = false; return s;
+      }) : state;
+      return [...updatedSources, source];
     }
   }
 


### PR DESCRIPTION
Add reducer spec for shared/sources. Add nodemon script to package.json to help with TDD. Fix actual issue: duplicate defaults in sources.

  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #769 

### The problem
Duplicate defaults appear when managing them in the InfluxDB configuration screen.

### The Solution
Defaults are properly exclusionary when adding or updating them. The expected behavior for removing a default is a bit ambiguous, however, and that functionality was not corrected in this branch.
