### PR TITLE
Add layout for telegraf's net meassurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Upcoming Features
   1. [#779](https://github.com/influxdata/chronograf/issues/779): Add layout for telegraf's diskio system plugin
+  1. [#810](https://github.com/influxdata/chronograf/issues/810): Add layout for telegraf's net system plugin
 
 ### Upcoming UI Improvements
 

--- a/canned/net.json
+++ b/canned/net.json
@@ -1,0 +1,49 @@
+{
+	"id": "4585a7db-73af-4ca1-9378-47ee67c71f99",
+	"measurement": "net",
+	"app": "system",
+	"autoflow": true,
+	"cells": [
+		{
+			"x": 0,
+			"y": 0,
+			"w": 4,
+			"h": 4,
+			"i": "e2f65d45-1898-4a16-860c-14b655575925",
+			"name": "System – Network Mb/s",
+			"queries": [
+				{
+					"query": "SELECT non_negative_derivative(max(\"bytes_recv\"), 1s) / 125000 as \"rx_megabits_per_second\" FROM \"net\"",
+					"groupbys": [],
+					"wheres": [],
+					"label": "Mb/s"
+				},
+				{
+					"query": "SELECT non_negative_derivative(max(\"bytes_sent\"), 1s) / 125000 as \"tx_megabits_per_second\" FROM \"net\"",
+					"groupbys": [],
+					"wheres": []
+				}
+			]
+		},
+		{
+			"x": 0,
+			"y": 0,
+			"w": 4,
+			"h": 4,
+			"i": "5e957624-b28b-4904-8068-5e7a9a058609",
+			"name": "System – Network Error Rate",
+			"queries": [
+				{
+					"query": "SELECT non_negative_derivative(max(\"err_in\"), 1s) / 125000 as \"tx_errors_per_second\" FROM \"net\"",
+					"groupbys": [],
+					"wheres": []
+				},
+				{
+					"query": "SELECT non_negative_derivative(max(\"err_out\"), 1s) / 125000 as \"rx_errors_per_second\" FROM \"net\"",
+					"groupbys": [],
+					"wheres": []
+				}
+			]
+		}
+	]
+}

--- a/canned/new_apps.sh
+++ b/canned/new_apps.sh
@@ -49,7 +49,7 @@ cat > $APP_FILE << EOF
 		"i": "$CELLID",
 		"name": "User facing cell Name",
 		"queries": [{
-			"query": "select mean(\"used_percent from\") from disk",
+			"query": "select mean(\"used_percent\") from disk",
 			"groupbys": [],
 			"wheres": []
 				}]


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #774
Connect #775 

### The problem
Telegraf's `input.net` measurement needs to be rendered.


### The Solution
<img width="805" alt="net" src="https://cloud.githubusercontent.com/assets/1922921/22380802/75e614c0-e484-11e6-8ad3-406ee9e22fa8.png">

