### PR TITLE
Fix layout autoflow to handle multiple cells per layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Upcoming Bug Fixes
   1. [#788](https://github.com/influxdata/chronograf/pull/788): Fix missing fields in data explorer when using non-default retention policy
+  1. [#774](https://github.com/influxdata/chronograf/issues/774): Fix gaps in layouts for hosts
 
 ### Upcoming Features
   1. [#779](https://github.com/influxdata/chronograf/issues/779): Add layout for telegraf's diskio system plugin

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -86,13 +86,17 @@ export const HostPage = React.createClass({
     const cellHeight = 4;
     const pageWidth = 12;
 
-    const autoflowCells = autoflowLayouts.reduce((allCells, layout, i) => {
-      return allCells.concat(layout.cells.map((cell, j) => {
+    let cellCount = 0;
+    const autoflowCells = autoflowLayouts.reduce((allCells, layout) => {
+      return allCells.concat(layout.cells.map((cell) => {
+        const x = (cellCount * cellWidth % pageWidth);
+        const y = Math.floor(cellCount * cellWidth / pageWidth) * cellHeight;
+        cellCount += 1;
         return Object.assign(cell, {
           w: cellWidth,
           h: cellHeight,
-          x: ((i + j) * cellWidth % pageWidth),
-          y: Math.floor(((i + j) * cellWidth / pageWidth)) * cellHeight,
+          x,
+          y,
         });
       }));
     }, []);


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Fix #774

### The problem
If layouts had multiple cells the autoflow logic would create gaps.
### The Solution
Fix by using a counter for all cells.

