### PR TITLE
Update circle's docker build tag to chronograf-20170127

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ machine:
   services:
     - docker
   environment:
-    DOCKER_TAG: chronograf-20161207
+    DOCKER_TAG: chronograf-20170127
 
 dependencies:
   override:


### PR DESCRIPTION
This will update our builds to use go 1.7.5 and node 6.9.4