### PR TITLE
Add BASE_PATH env var to -basepath cli option

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -49,8 +49,8 @@ type Server struct {
 	GithubOrgs         []string `short:"o" long:"github-organization" description:"Github organization user is required to have active membership" env:"GH_ORGS" env-delim:","`
 	ReportingDisabled  bool     `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
 	LogLevel           string   `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"warn" choice:"error" choice:"fatal" choice:"panic" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
+	Basepath           string   `short:"p" long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted" env:"BASE_PATH"`
 	ShowVersion        bool     `short:"v" long:"version" description:"Show Chronograf version info"`
-	Basepath           string   `long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted"`
 	BuildInfo          BuildInfo
 	Listener           net.Listener
 	handler            http.Handler


### PR DESCRIPTION

  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #721

### The problem
New option to set basepath did not have an environment variable override.
### The Solution

Add env var `BASE_PATH` to override chronograf's base path for the assets.


