### PR TITLE
Fix jank in hosts dropdown

### DIFF
--- a/ui/src/style/components/page-header-dropdown.scss
+++ b/ui/src/style/components/page-header-dropdown.scss
@@ -24,4 +24,17 @@
   .dropdown-toggle:hover {
     color: $c-pool;
   }
+  /* Menu */
+  .dropdown-menu {
+    z-index: 9000;
+    width: 250px;
+    min-width: 250px;
+    max-width: 250px;
+
+    & > li > a {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
 }

--- a/ui/src/style/pages/hosts.scss
+++ b/ui/src/style/pages/hosts.scss
@@ -91,6 +91,6 @@
 /* Hacky way to ensure that legends cannot be obscured by neighboring graphs */
 .react-grid-item {
   &:hover {
-    z-index: 9999;
+    z-index: 8999;
   }
 }


### PR DESCRIPTION
Fixes #842 

#### Notes:
- Dropdown menu is always 250px wide
- Dropdown menu items are truncated with … when they are too long

<img width="381" alt="screen shot 2017-02-02 at 2 44 24 pm" src="https://cloud.githubusercontent.com/assets/2433762/22571945/e08ba412-e956-11e6-9384-4a50ab851fdd.png">
