### PR TITLE
Fix basepath documentation to have double dash

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ A UI for [Kapacitor](https://github.com/influxdata/kapacitor) alert creation and
 See [Chronograf with OAuth 2.0](https://github.com/influxdata/chronograf/blob/master/docs/auth.md) for more information.
 
 ### Advanced Routing
-Change the default root path of the Chronograf server with the `—basepath` option.
+Change the default root path of the Chronograf server with the `--basepath` option.
 
 ## Versions
 


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #845

### The problem
Basepath was specified with a single dash in the readme.  This causes problems with the boltdb option

### The Solution
Add the double dash.

