### PR TITLE
Add gzip compression to all of our server responses and caching for assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Upcoming Features
   1. [#838](https://github.com/influxdata/chronograf/issues/838): Add detail node to kapacitor alerts
   2. [#853](https://github.com/influxdata/chronograf/issues/853): Updated builds to use yarn over npm install
+  3. [#860](https://github.com/influxdata/chronograf/issues/860): Add gzip encoding and caching of static assets to server
 
 ### Upcoming UI Improvements
 

--- a/Godeps
+++ b/Godeps
@@ -1,3 +1,4 @@
+github.com/NYTimes/gziphandler 6710af535839f57c687b62c4c23d649f9545d885
 github.com/Sirupsen/logrus 3ec0642a7fb6488f65b06f9040adc67e3990296a
 github.com/boltdb/bolt 5cc10bbbc5c141029940133bb33c9e969512a698
 github.com/bouk/httprouter ee8b3818a7f51fbc94cc709b5744b52c2c725e91

--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -1,4 +1,5 @@
 ### Go
+* github.com/NYTimes/gziphandler [APACHE-2.0](https://github.com/NYTimes/gziphandler/blob/master/LICENSE.md)
 * github.com/Sirupsen/logrus [MIT](https://github.com/Sirupsen/logrus/blob/master/LICENSE)
 * github.com/boltdb/bolt [MIT](https://github.com/boltdb/bolt/blob/master/LICENSE)
 * github.com/bouk/httprouter [BSD](https://github.com/bouk/httprouter/blob/master/LICENSE)

--- a/server/mux.go
+++ b/server/mux.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/NYTimes/gziphandler"
 	"github.com/bouk/httprouter"
 	"github.com/influxdata/chronograf" // When julienschmidt/httprouter v2 w/ context is out, switch
 	"github.com/influxdata/chronograf/jwt"
@@ -119,7 +120,10 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 		auth := AuthAPI(opts, router)
 		return Logger(opts.Logger, auth)
 	}
-	return Logger(opts.Logger, router)
+
+	compressed := gziphandler.GzipHandler(router)
+	logged := Logger(opts.Logger, compressed)
+	return logged
 }
 
 // AuthAPI adds the OAuth routes if auth is enabled.


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #860 

### The problem
Server was not respecting `Accept-Encoding` for gzip.
Server was not adding cache information to static assets

### The Solution

Server now will gzip compress all responses if accepted.
For production assets server now adds cache control for one hour and etags based on file size and modtime. 


