### PR TITLE
kapacitor threshold critical value strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.2.0 [unreleased]
 
 ### Upcoming Bug Fixes
+  1. [#865](https://github.com/influxdata/chronograf/issues/865): Support for String fields compare kapacitor rules in Chronograf UI
 
 ### Upcoming Features
   1. [#838](https://github.com/influxdata/chronograf/issues/838): Add detail node to kapacitor alerts

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -40,10 +40,7 @@ func Vars(rule chronograf.AlertRule) (string, error) {
 		%s
         var crit = %s
  `
-			// If critical value is a string, we'll
-			// need to single-quote it.
-			crit := critVar(rule.TriggerValues.Value)
-			return fmt.Sprintf(vars, common, crit), nil
+			return fmt.Sprintf(vars, common, formatValue(rule.TriggerValues.Value)), nil
 		} else {
 			vars := `
 			%s
@@ -181,10 +178,9 @@ func whereFilter(q chronograf.QueryConfig) string {
 	return "lambda: TRUE"
 }
 
-// critVar return the same string if a numeric type
-// or if it is a string will return it as a kapacitor
-// formatted single-quoted string
-func critVar(value string) string {
+// formatValue return the same string if a numeric type or if it is a string
+// will return it as a kapacitor formatted single-quoted string
+func formatValue(value string) string {
 	// Test if numeric if it can be converted to a float
 	if _, err := strconv.ParseFloat(value, 64); err == nil {
 		return value

--- a/kapacitor/vars_test.go
+++ b/kapacitor/vars_test.go
@@ -1,0 +1,50 @@
+package kapacitor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/chronograf"
+)
+
+func TestVarsCritStringEqual(t *testing.T) {
+	alert := chronograf.AlertRule{
+		Name:    "name",
+		Trigger: "threshold",
+		TriggerValues: chronograf.TriggerValues{
+			Operator: "equal to",
+			Value:    "DOWN",
+		},
+		Every: "30s",
+		Query: chronograf.QueryConfig{
+			Database:        "telegraf",
+			Measurement:     "haproxy",
+			RetentionPolicy: "autogen",
+			Fields: []chronograf.Field{
+				{
+					Field: "status",
+				},
+			},
+			GroupBy: chronograf.GroupBy{
+				Time: "10m",
+				Tags: []string{"pxname"},
+			},
+			AreTagsAccepted: true,
+		},
+	}
+
+	raw, err := Vars(alert)
+	if err != nil {
+		fmt.Printf("%s", raw)
+		t.Fatalf("Error generating alert: %v %s", err, raw)
+	}
+
+	tick, err := formatTick(raw)
+	if err != nil {
+		t.Errorf("Error formatting alert: %v %s", err, raw)
+	}
+
+	if err := validateTick(tick); err != nil {
+		t.Errorf("Error validating alert: %v %s", err, tick)
+	}
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #865 

### The problem
If threshold alert rule's critical value was a string, the tickscript wasn't generated correctly.

### The Solution
This checks if the critical value is a string and formats it with kapacitor's single-quotes.

This patch does not address string inequality nor threshold ranges.


