### PR TITLE
Fix kapacitor create using defaults causing undefined.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
+  1. [#875](https://github.com/influxdata/chronograf/issues/875): Connecting to new kapacitor with defalt values fails
+
 ### Features
 ### UI Improvements
 

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -72,8 +72,8 @@ export const KapacitorPage = React.createClass({
     const {addFlashMessage, source} = this.props;
     const {newURL, newName, newUsername} = this.state;
     createKapacitor(source, {
-      url: newURL.trim(),
-      name: newName.trim(),
+      url: (newURL || defaultKapacitorUrl).trim(),
+      name: (newName || defaultKapacitorName).trim(),
       username: newUsername,
       password: this.kapacitorPassword.value,
     }).then(({data: createdKapacitor}) => {
@@ -157,11 +157,11 @@ export const KapacitorPage = React.createClass({
                       <div>
                         <div className="form-group col-xs-12 col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-2">
                           <label htmlFor="connect-string">Connection String</label>
-                          <input ref={(r) => this.kapacitorURL = r} className="form-control" id="connect-string" placeholder={defaultKapacitorUrl} value={url} onChange={this.updateURL}></input>
+                          <input ref={(r) => this.kapacitorURL = r} className="form-control" id="connect-string" defaultValue={defaultKapacitorUrl} value={url} onChange={this.updateURL}></input>
                         </div>
                         <div className="form-group col-xs-12 col-sm-8 col-sm-offset-2 col-md-4 col-md-offset-0">
                           <label htmlFor="name">Name</label>
-                          <input ref={(r) => this.kapacitorName = r} className="form-control" id="name" placeholder={defaultKapacitorName} value={name} onChange={this.updateName}></input>
+                          <input ref={(r) => this.kapacitorName = r} className="form-control" id="name" defaultValue={defaultKapacitorName} value={name} onChange={this.updateName}></input>
                         </div>
                         <div className="form-group col-xs-12 col-sm-4 col-sm-offset-2 col-md-4 col-md-offset-2">
                           <label htmlFor="username">Username</label>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #875 

### The problem
If no changes were made to the default kapacitor connection URL or name when created there would be an undefined typeError.

Looks like this has been around a while.

### The Solution

Quick check to see if those fields were undefined and set to default values.

