### PR TITLE
Fix y-axis graph padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
+  1. [#882](https://github.com/influxdata/chronograf/pull/882): Fix y-axis graph padding
+
 ### Features
 ### UI Improvements
 

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -40,4 +40,19 @@ describe('getRangeForDygraphSpec', () => {
 
     expect(actual).to.deep.equal(expected);
   });
+
+  it('returns a padded range when an additional value is provided that is near or exceeds range of timeSeries data', () => {
+    const value0 = -10;
+    const value1 = 20;
+    const timeSeries = [[new Date(1000), value0], [new Date(2000), 1], [new Date(3000), value1]];
+    const unpadded = getRange(timeSeries);
+
+    const actualOne = getRange(timeSeries, undefined, value0);
+    const actualTwo = getRange(timeSeries, undefined, value1);
+
+    expect(actualOne[0]).to.be.below(unpadded[0]);
+    expect(actualOne[1]).to.equal(unpadded[1]);
+    expect(actualTwo[1]).to.be.above(unpadded[1]);
+    expect(actualTwo[0]).to.equal(unpadded[0]);
+  });
 });

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -55,4 +55,15 @@ describe('getRangeForDygraphSpec', () => {
     expect(actualTwo[1]).to.be.above(unpadded[1]);
     expect(actualTwo[0]).to.equal(unpadded[0]);
   });
+
+  it('returns an expected range when an additional value is provided that is well within range of timeSeries data', () => {
+    const value = 0;
+    const timeSeries = [[new Date(1000), -10], [new Date(2000), 1], [new Date(3000), 20]];
+    const unpadded = getRange(timeSeries);
+
+    const actual = getRange(timeSeries, undefined, value);
+
+    expect(actual[0]).to.equal(unpadded[0]);
+    expect(actual[1]).to.equal(unpadded[1]);
+  });
 });

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -41,29 +41,47 @@ describe('getRangeForDygraphSpec', () => {
     expect(actual).to.deep.equal(expected);
   });
 
-  it('returns a padded range when an additional value is provided that is near or exceeds range of timeSeries data', () => {
-    const value0 = -10;
-    const value1 = 20;
-    const timeSeries = [[new Date(1000), value0], [new Date(2000), 1], [new Date(3000), value1]];
-    const unpadded = getRange(timeSeries);
+  describe('when user provides a rule value', () => {
+    const defaultMax = 20;
+    const defaultMin = -10;
+    const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]];
 
-    const actualOne = getRange(timeSeries, undefined, value0);
-    const actualTwo = getRange(timeSeries, undefined, value1);
+    it('can pad positive values', () => {
+      const value = 20;
+      const [min, max] = getRange(timeSeries, undefined, value);
 
-    expect(actualOne[0]).to.be.below(unpadded[0]);
-    expect(actualOne[1]).to.equal(unpadded[1]);
-    expect(actualTwo[1]).to.be.above(unpadded[1]);
-    expect(actualTwo[0]).to.equal(unpadded[0]);
+      expect(min).to.equal(defaultMin);
+      expect(max).to.be.above(defaultMax);
+    });
+
+    it('can pad negative values', () => {
+      const value = -10;
+      const [min, max] = getRange(timeSeries, undefined, value);
+
+      expect(min).to.be.below(defaultMin);
+      expect(max).to.equal(defaultMax);
+    });
   });
 
-  it('returns an expected range when an additional value is provided that is well within range of timeSeries data', () => {
-    const value = 0;
-    const timeSeries = [[new Date(1000), -10], [new Date(2000), 1], [new Date(3000), 20]];
-    const unpadded = getRange(timeSeries);
+  describe('when user provides a rule range value', () => {
+    const defaultMax = 20;
+    const defaultMin = -10;
+    const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]];
 
-    const actual = getRange(timeSeries, undefined, value);
+    it('can pad positive values', () => {
+      const rangeValue = 20;
+      const [min, max] = getRange(timeSeries, undefined, 0, rangeValue);
 
-    expect(actual[0]).to.equal(unpadded[0]);
-    expect(actual[1]).to.equal(unpadded[1]);
+      expect(min).to.equal(defaultMin);
+      expect(max).to.be.above(defaultMax);
+    });
+
+    it('can pad negative values', () => {
+      const rangeValue = -10;
+      const [min, max] = getRange(timeSeries, undefined, 0, rangeValue);
+
+      expect(min).to.be.below(defaultMin);
+      expect(max).to.equal(defaultMax);
+    });
   });
 });

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -5,25 +5,21 @@ export default function getRange(timeSeries, override, value = null, rangeValue 
     return override;
   }
 
-  const subtractPadding = (val) => +val - val * PADDING_FACTOR;
-  const addPadding = (val) => +val + val * PADDING_FACTOR;
+  const subtractPadding = (val) => +val - Math.abs(val * PADDING_FACTOR);
+  const addPadding = (val) => +val + Math.abs(val * PADDING_FACTOR);
 
-  const pad = (val, side) => {
+  const pad = (val) => {
     if (val === null || val === '') {
       return null;
     }
 
-    if (val < 0) {
-      return side === "top" ? subtractPadding(val) : addPadding(val);
-    }
-
-    return side === "top" ? addPadding(val) : subtractPadding(val);
+    return val < 0 ? subtractPadding(val) : addPadding(val);
   };
 
   const points = [
     ...timeSeries,
     [null, pad(value)],
-    [null, pad(rangeValue, "top")],
+    [null, pad(rangeValue)],
   ];
 
   const range = points.reduce(([min, max] = [], series) => {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #881 

### The problem
Graph did not properly display highlighted range when value for "greater than" rule exceeded local data peak value. This bug also showed up in "inside range" and "outside range".

### The Solution
* Fixed the math for adding and subtracting padding.
* Removed incorrect and arbitrary "top" argument to allow "range" rules to display correct highlighting regardless of which value was greater.

Fixed display for "greater than":
<img width="649" alt="screen shot 2017-02-15 at 1 46 14 am" src="https://cloud.githubusercontent.com/assets/6403018/22968765/9611ad54-f320-11e6-8966-f5806cfec528.png">


