### PR TITLE
Make the scrollbar thumb element larger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   1. [#873](https://github.com/influxdata/chronograf/pull/873): Add [TLS](https://github.com/influxdata/chronograf/blob/master/docs/tls.md) support 
 
 ### UI Improvements
+  1. [#905](https://github.com/influxdata/chronograf/pull/905): Make scroll bar thumb element bigger
 
 ## v1.2.0-beta3 [2017-02-15]
 

--- a/ui/src/style/mixins/mixins.scss
+++ b/ui/src/style/mixins/mixins.scss
@@ -30,12 +30,12 @@ $scrollbar-width: 16px;
 		}
 		&-track-piece {
 			background-color: $trackColor;
-			border: 6px solid $trackColor;
+			border: 3px solid $trackColor;
 			border-radius: ($scrollbar-width / 2);
 		}
 		&-thumb {
 			background-color: $handleColor;
-			border: 6px solid $trackColor;
+			border: 3px solid $trackColor;
 			border-radius: ($scrollbar-width / 2);
 		}
 		&-corner {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #843 

### The problem
User reported having difficulty navigating a long host list and having difficulty grabbing the scrollbar because it was so small.

### The Solution
Made the scrollbar thumb element bigger.
