### PR TITLE
Fix react-router warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
   1. [#882](https://github.com/influxdata/chronograf/pull/882): Fix y-axis graph padding
+  2. [#907](https://github.com/influxdata/chronograf/pull/907): Fix react-router warning
 
 ### Features
   1. [#873](https://github.com/influxdata/chronograf/pull/873): Add [TLS](https://github.com/influxdata/chronograf/blob/master/docs/tls.md) support 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import {render} from 'react-dom';
 import {Provider} from 'react-redux';
-import {Router, Route, Redirect} from 'react-router';
-import {createHistory, useBasename} from 'history';
+import {Router, Route, Redirect, useRouterHistory} from 'react-router';
+import {createHistory} from 'history';
 
 import App from 'src/App';
 import AlertsApp from 'src/alerts';
@@ -29,11 +29,11 @@ let browserHistory;
 const basepath = rootNode.dataset.basepath;
 window.basepath = basepath;
 if (basepath) {
-  browserHistory = useBasename(createHistory)({
+  browserHistory = useRouterHistory(createHistory)({
     basename: basepath, // this is written in when available by the URL prefixer middleware
   });
 } else {
-  browserHistory = useBasename(createHistory)({
+  browserHistory = useRouterHistory(createHistory)({
     basename: "",
   });
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #906 

### The problem
An unnecessary and unconventional usage of `useBasename` was being used to set a basepath when creating initial history.

### The Solution
The updated v2.0 docs call for `useRouterHistory` to create a history with a custom basepath: https://github.com/ReactTraining/react-router/blob/master/docs/guides/Histories.md.

