### PR TITLE
Side Nav Simplification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,11 @@
   2. [#907](https://github.com/influxdata/chronograf/pull/907): Fix react-router warning
 
 ### Features
-  1. [#873](https://github.com/influxdata/chronograf/pull/873): Add [TLS](https://github.com/influxdata/chronograf/blob/master/docs/tls.md) support 
+  1. [#873](https://github.com/influxdata/chronograf/pull/873): Add [TLS](https://github.com/influxdata/chronograf/blob/master/docs/tls.md) support
 
 ### UI Improvements
   1. [#905](https://github.com/influxdata/chronograf/pull/905): Make scroll bar thumb element bigger
+  2. [#917](https://github.com/influxdata/chronograf/pull/917): Simplify side navigation
 
 ## v1.2.0-beta3 [2017-02-15]
 

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -39,9 +39,9 @@ const DashboardsPage = React.createClass({
     if (this.state.waiting) {
       tableHeader = "Loading Dashboards...";
     } else if (this.state.dashboards.length === 0) {
-      tableHeader = "No Dashboards";
+      tableHeader = "1 Dashboard";
     } else {
-      tableHeader = `${this.state.dashboards.length} Dashboards`;
+      tableHeader = `${this.state.dashboards.length + 1} Dashboards`;
     }
 
     return (
@@ -84,6 +84,13 @@ const DashboardsPage = React.createClass({
                               );
                             })
                           }
+                          <tr>
+                            <td className="monotype">
+                              <Link to={`${dashboardLink}/kubernetes`}>
+                                {'Kubernetes'}
+                              </Link>
+                            </td>
+                          </tr>
                       </tbody>
                     </table>
                   </div>

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -34,6 +34,7 @@ const DashboardsPage = React.createClass({
   },
 
   render() {
+    const dashboardLink = `/sources/${this.props.source.id}`;
     let tableHeader;
     if (this.state.waiting) {
       tableHeader = "Loading Dashboards...";
@@ -75,7 +76,7 @@ const DashboardsPage = React.createClass({
                               return (
                                 <tr key={dashboard.id}>
                                   <td className="monotype">
-                                    <Link to={`/sources/${this.props.source.id}/dashboards/${dashboard.id}`}>
+                                    <Link to={`${dashboardLink}/dashboards/${dashboard.id}`}>
                                       {dashboard.name}
                                     </Link>
                                   </td>

--- a/ui/src/side_nav/components/SideNav.js
+++ b/ui/src/side_nav/components/SideNav.js
@@ -23,22 +23,21 @@ const SideNav = React.createClass({
         <div className="sidebar__logo">
           <a href="/"><span className="icon cubo-uniform"></span></a>
         </div>
-        <NavBlock icon="cpu" link={`${sourcePrefix}/hosts`}>
-          <NavHeader link={`${sourcePrefix}/hosts`} title="Infrastructure" />
-          <NavListItem link={`${sourcePrefix}/hosts`}>Host List</NavListItem>
-          <NavListItem link={`${sourcePrefix}/kubernetes`}>Kubernetes Dashboard</NavListItem>
+        <NavBlock icon="cubo-node" link={`${sourcePrefix}/hosts`}>
+          <NavHeader link={`${sourcePrefix}/hosts`} title="Host List" />
         </NavBlock>
         <NavBlock icon="graphline" link={dataExplorerLink}>
-          <NavHeader link={dataExplorerLink} title={'Data'} />
-          <NavListItem link={dataExplorerLink}>Explorer</NavListItem>
-          <NavListItem link={`${sourcePrefix}/dashboards`}>Dashboards</NavListItem>
+          <NavHeader link={dataExplorerLink} title="Data Explorer" />
         </NavBlock>
-        <NavBlock matcher="alerts" icon="pulse-b" link={`${sourcePrefix}/alerts`}>
+        <NavBlock icon="dash-h" link={`${sourcePrefix}/dashboards`}>
+          <NavHeader link={`${sourcePrefix}/dashboards`} title={'Dashboards'} />
+        </NavBlock>
+        <NavBlock matcher="alerts" icon="alert-triangle" link={`${sourcePrefix}/alerts`}>
           <NavHeader link={`${sourcePrefix}/alerts`} title="Alerting" />
           <NavListItem link={`${sourcePrefix}/alerts`}>Alert History</NavListItem>
           <NavListItem link={`${sourcePrefix}/alert-rules`}>Kapacitor Rules</NavListItem>
         </NavBlock>
-        <NavBlock icon="access-key" link={`${sourcePrefix}/manage-sources`}>
+        <NavBlock icon="cog-thick" link={`${sourcePrefix}/manage-sources`}>
           <NavHeader link={`${sourcePrefix}/manage-sources`} title="Configuration" />
           <NavListItem link={`${sourcePrefix}/manage-sources`}>InfluxDB</NavListItem>
           <NavListItem link={`${sourcePrefix}/kapacitor-config`}>Kapacitor</NavListItem>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

### The problem
- Icons were not clear enough
- Organization scheme not obvious
- Lots of nested nav items

### The Solution
- Goal was to flatten the nav tree a bit
- Moved `Kubernetes` dash into `Dashboards` table
- Flattened `Infrastructure` into 1 top level item `Hosts List`, removed `Kubernetes`
- Flattened `Data` into 2 top level items `Data Explorer` `Dashboards`
- New icon for `Alerting` (Alert Triangle)
- New icon for `Configuration` (Cog)
- New icon for `Host List` (Cubo Node)
- New icon for `Dashboards` (Cog)

### Preview
![side-nav-experiment4](https://cloud.githubusercontent.com/assets/2433762/23242159/3b5a5c6e-f92c-11e6-9242-3b90d4eba39a.gif)


