### PR TITLE
Update schema for /permissions endpoint to have scopes

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -53,8 +53,8 @@ type TimeSeries interface {
 	Connect(context.Context, *Source) error
 	// UsersStore represents the user accounts within the TimeSeries database
 	Users(context.Context) UsersStore
-	// Allowances returns all valid names permissions in this database
-	Allowances(context.Context) Allowances
+	// Permissions returns all valid names permissions in this database
+	Permissions(context.Context) Permissions
 	// Roles represents the roles associated with this TimesSeriesDatabase
 	Roles(context.Context) (RolesStore, error)
 }

--- a/enterprise/enterprise.go
+++ b/enterprise/enterprise.go
@@ -147,8 +147,8 @@ func (c *Client) Roles(ctx context.Context) (chronograf.RolesStore, error) {
 }
 
 // Allowances returns all Influx Enterprise permission strings
-func (c *Client) Allowances(context.Context) chronograf.Allowances {
-	return chronograf.Allowances{
+func (c *Client) Permissions(context.Context) chronograf.Permissions {
+	all := chronograf.Allowances{
 		"NoPermissions",
 		"ViewAdmin",
 		"ViewChronograf",
@@ -168,6 +168,17 @@ func (c *Client) Allowances(context.Context) chronograf.Allowances {
 		"CopyShard",
 		"KapacitorAPI",
 		"KapacitorConfigAPI",
+	}
+
+	return chronograf.Permissions{
+		{
+			Scope:   chronograf.AllScope,
+			Allowed: all,
+		},
+		{
+			Scope:   chronograf.DBScope,
+			Allowed: all,
+		},
 	}
 }
 

--- a/enterprise/enterprise_test.go
+++ b/enterprise/enterprise_test.go
@@ -145,41 +145,70 @@ func Test_Enterprise_ComplainsIfNotOpened(t *testing.T) {
 	}
 }
 
-func TestClient_Allowances(t *testing.T) {
+func TestClient_Permissions(t *testing.T) {
 	tests := []struct {
 		name string
 
-		want chronograf.Allowances
+		want chronograf.Permissions
 	}{
 		{
 			name: "All possible enterprise permissions",
-			want: chronograf.Allowances{
-				"NoPermissions",
-				"ViewAdmin",
-				"ViewChronograf",
-				"CreateDatabase",
-				"CreateUserAndRole",
-				"AddRemoveNode",
-				"DropDatabase",
-				"DropData",
-				"ReadData",
-				"WriteData",
-				"Rebalance",
-				"ManageShard",
-				"ManageContinuousQuery",
-				"ManageQuery",
-				"ManageSubscription",
-				"Monitor",
-				"CopyShard",
-				"KapacitorAPI",
-				"KapacitorConfigAPI",
+			want: chronograf.Permissions{
+				{
+					Scope: chronograf.AllScope,
+					Allowed: chronograf.Allowances{
+						"NoPermissions",
+						"ViewAdmin",
+						"ViewChronograf",
+						"CreateDatabase",
+						"CreateUserAndRole",
+						"AddRemoveNode",
+						"DropDatabase",
+						"DropData",
+						"ReadData",
+						"WriteData",
+						"Rebalance",
+						"ManageShard",
+						"ManageContinuousQuery",
+						"ManageQuery",
+						"ManageSubscription",
+						"Monitor",
+						"CopyShard",
+						"KapacitorAPI",
+						"KapacitorConfigAPI",
+					},
+				},
+				{
+					Scope: chronograf.DBScope,
+					Allowed: chronograf.Allowances{
+						"NoPermissions",
+						"ViewAdmin",
+						"ViewChronograf",
+						"CreateDatabase",
+						"CreateUserAndRole",
+						"AddRemoveNode",
+						"DropDatabase",
+						"DropData",
+						"ReadData",
+						"WriteData",
+						"Rebalance",
+						"ManageShard",
+						"ManageContinuousQuery",
+						"ManageQuery",
+						"ManageSubscription",
+						"Monitor",
+						"CopyShard",
+						"KapacitorAPI",
+						"KapacitorConfigAPI",
+					},
+				},
 			},
 		},
 	}
 	for _, tt := range tests {
 		c := &enterprise.Client{}
-		if got := c.Allowances(context.Background()); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. Client.Allowances() = %v, want %v", tt.name, got, tt.want)
+		if got := c.Permissions(context.Background()); !reflect.DeepEqual(got, tt.want) {
+			t.Errorf("%q. Client.Permissions() = %v, want %v", tt.name, got, tt.want)
 		}
 	}
 }

--- a/enterprise/mocks_test.go
+++ b/enterprise/mocks_test.go
@@ -114,8 +114,8 @@ func (ts *TimeSeries) Roles(ctx context.Context) (chronograf.RolesStore, error) 
 	return nil, nil
 }
 
-func (ts *TimeSeries) Allowances(ctx context.Context) chronograf.Allowances {
-	return chronograf.Allowances{}
+func (ts *TimeSeries) Permissions(ctx context.Context) chronograf.Permissions {
+	return chronograf.Permissions{}
 }
 
 func NewMockTimeSeries(urls ...string) *TimeSeries {

--- a/influx/permissions.go
+++ b/influx/permissions.go
@@ -26,9 +26,18 @@ var (
 	Write = "WRITE"
 )
 
-// Allowances return just READ and WRITE for OSS Influx
-func (c *Client) Allowances(context.Context) chronograf.Allowances {
-	return chronograf.Allowances{"READ", "WRITE"}
+// Permissions return just READ and WRITE for OSS Influx
+func (c *Client) Permissions(context.Context) chronograf.Permissions {
+	return chronograf.Permissions{
+		{
+			Scope:   chronograf.AllScope,
+			Allowed: AllowAll,
+		},
+		{
+			Scope:   chronograf.DBScope,
+			Allowed: AllowAll,
+		},
+	}
 }
 
 // showResults is used to deserialize InfluxQL SHOW commands

--- a/mocks/timeseries.go
+++ b/mocks/timeseries.go
@@ -16,8 +16,8 @@ type TimeSeries struct {
 	ConnectF func(context.Context, *chronograf.Source) error
 	// UsersStore represents the user accounts within the TimeSeries database
 	UsersF func(context.Context) chronograf.UsersStore
-	// Allowances returns all valid names permissions in this database
-	AllowancesF func(context.Context) chronograf.Allowances
+	// Permissions returns all valid names permissions in this database
+	PermissionsF func(context.Context) chronograf.Permissions
 	// RolesF represents the roles. Roles group permissions and Users
 	RolesF func(context.Context) (chronograf.RolesStore, error)
 }
@@ -47,7 +47,7 @@ func (t *TimeSeries) Roles(ctx context.Context) (chronograf.RolesStore, error) {
 	return t.RolesF(ctx)
 }
 
-// Allowances returns all valid names permissions in this database
-func (t *TimeSeries) Allowances(ctx context.Context) chronograf.Allowances {
-	return t.AllowancesF(ctx)
+// Permissions returns all valid names permissions in this database
+func (t *TimeSeries) Permissions(ctx context.Context) chronograf.Permissions {
+	return t.PermissionsF(ctx)
 }

--- a/server/admin.go
+++ b/server/admin.go
@@ -298,15 +298,15 @@ func (h *Service) Permissions(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	perms := ts.Allowances(ctx)
+	perms := ts.Permissions(ctx)
 	if err != nil {
 		Error(w, http.StatusBadRequest, err.Error(), h.Logger)
 		return
 	}
 	httpAPISrcs := "/chronograf/v1/sources"
 	res := struct {
-		Permissions chronograf.Allowances `json:"permissions"`
-		Links       map[string]string     `json:"links"` // Links are URI locations related to user
+		Permissions chronograf.Permissions `json:"permissions"`
+		Links       map[string]string      `json:"links"` // Links are URI locations related to user
 	}{
 		Permissions: perms,
 		Links: map[string]string{

--- a/server/admin_test.go
+++ b/server/admin_test.go
@@ -751,15 +751,20 @@ func TestService_Permissions(t *testing.T) {
 					ConnectF: func(ctx context.Context, src *chronograf.Source) error {
 						return nil
 					},
-					AllowancesF: func(ctx context.Context) chronograf.Allowances {
-						return chronograf.Allowances{"READ", "WRITE"}
+					PermissionsF: func(ctx context.Context) chronograf.Permissions {
+						return chronograf.Permissions{
+							{
+								Scope:   chronograf.AllScope,
+								Allowed: chronograf.Allowances{"READ", "WRITE"},
+							},
+						}
 					},
 				},
 			},
 			ID:              "1",
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody: `{"permissions":["READ","WRITE"],"links":{"self":"/chronograf/v1/sources/1/permissions","source":"/chronograf/v1/sources/1"}}
+			wantBody: `{"permissions":[{"scope":"all","allowed":["READ","WRITE"]}],"links":{"self":"/chronograf/v1/sources/1/permissions","source":"/chronograf/v1/sources/1"}}
 `,
 		},
 	}

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2732,7 +2732,7 @@
 			"type": "object",
 			"properties": {
 				"permissions": {
-					"$ref": "#/definitions/Allowances"
+					"$ref": "#/definitions/Permissions"
 				},
 				"links": {
 					"type": "object",


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #933 

### The problem
The front-end needs to know what permissions are scoped to `all` or `database`

### The Solution
The schema has now changed to:

```json
{
	"permissions": [{
		"scope": "all",
		"allowed": ["READ", "WRITE"]
	}, {
		"scope": "database",
		"allowed": ["READ", "WRITE"]
	}],
	"links": {
		"self": "http://example.com/chronograf/v1/sources/1/permissions",
		"source": "http://example.com/chronograf/v1/sources/1"
	}
}
```


Permissions with scope `all` represent the set of permissions that can be scoped with `all`.
Permissions with scope `database` represent the set of permissions that can be scoped to a specific database.

