### PR TITLE
Fix rule disable bug

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -230,7 +230,7 @@
     'react/no-string-refs': 0, // TODO: 2
     'react/no-unknown-property': 2,
     'react/prop-types': 2,
-    'react/prefer-es6-class': [2, 'never'],
+    'react/prefer-es6-class': [0, 'never'],
     'react/react-in-jsx-scope': 2,
     'react/require-extension': 0,
     'react/self-closing-comp': 0, // TODO: we can re-enable this if some brave soul wants to update the code (mostly spans acting as icons)

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -163,12 +163,11 @@ export function deleteRule(rule) {
   };
 }
 
-export function updateRuleStatus(rule, {status}) {
+export function updateRuleStatus(rule, status) {
   return (dispatch) => {
     updateRuleStatusAPI(rule, status).then(() => {
       dispatch(publishNotification('success', `${rule.name} ${status} successfully`));
     }).catch(() => {
-      dispatch(updateRuleStatusSuccess(rule.id, status));
       dispatch(publishNotification('error', `${rule.name} could not be ${status}`));
     });
   };

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -1,6 +1,8 @@
 import React, {PropTypes} from 'react';
-import NoKapacitorError from '../../shared/components/NoKapacitorError';
 import {Link} from 'react-router';
+
+import NoKapacitorError from '../../shared/components/NoKapacitorError';
+import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 
 const KapacitorRules = ({
   source,
@@ -10,112 +12,54 @@ const KapacitorRules = ({
   onDelete,
   onChangeRuleStatus,
 }) => {
-  if (loading) {
-    return <Loading />
+  if (!hasKapacitor) {
+    return (
+      <PageContents>
+        <NoKapacitorError source={source} />
+      </PageContents>
+    )
   }
 
-  if (!hasKapacitor) {
-    return <KapacitorError source={source} />
+  if (loading) {
+    return (
+      <PageContents>
+        <h2>Loading...</h2>
+      </PageContents>
+    )
   }
 
   return (
     <PageContents>
-      <div className="panel panel-minimal">
-        <div className="panel-heading u-flex u-ai-center u-jc-space-between">
-          <h2 className="panel-title">Alert Rules</h2>
-          <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
-        </div>
-        <KapacitorRuleTable
-          source={source}
-          rules={rules}
-          onDelete={onDelete}
-          onChangeRuleStatus={onChangeRuleStatus}
-        />
+      <div className="panel-heading u-flex u-ai-center u-jc-space-between">
+        <h2 className="panel-title">Alert Rules</h2>
+        <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
       </div>
+      <KapacitorRulesTable
+        source={source}
+        rules={rules}
+        onDelete={onDelete}
+        onChangeRuleStatus={onChangeRuleStatus}
+      />
     </PageContents>
   )
 }
 
-const KapacitorRuleTable = ({source, rules, onDelete, onChangeRuleStatus}) => {
-  return (
-    <div className="panel-body">
-      <table className="table v-center">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th>Trigger</th>
-            <th>Message</th>
-            <th>Alerts</th>
-            <th className="text-center">Enabled</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {
-            rules.map((rule) => {
-              return <RuleRow key={rule.id} rule={rule} source={source} onDelete={onDelete} onChangeRuleStatus={onChangeRuleStatus} />
-            })
-          }
-        </tbody>
-      </table>
-    </div>
-  )
-}
-
-const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) => {
-  return (
-    <tr key={rule.id}>
-      <td className="monotype"><Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>{rule.name}</Link></td>
-      <td className="monotype">{rule.trigger}</td>
-      <td className="monotype">{rule.message}</td>
-      <td className="monotype">{rule.alerts.join(', ')}</td>
-      <td className="monotype text-center">
-        <div className="dark-checkbox">
-          <input
-            id={`kapacitor-enabled ${rule.id}`}
-            className="form-control-static"
-            type="checkbox"
-            defaultChecked={rule.status === "enabled"}
-            onClick={() => onChangeRuleStatus(rule)}
-          />
-          <label htmlFor={`kapacitor-enabled ${rule.id}`}></label>
-        </div>
-      </td>
-      <td className="text-right"><button className="btn btn-danger btn-xs" onClick={() => onDelete(rule)}>Delete</button></td>
-    </tr>
-  )
-}
-
-const Header = () => (
-  <div className="page-header">
-    <div className="page-header__container">
-      <div className="page-header__left">
-        <h1>Kapacitor Rules</h1>
-      </div>
-    </div>
-  </div>
-)
-
-const Loading = () => (
-  <PageContents>
-    <h1>Loading...</h1>
-  </PageContents>
-)
-
-const KapacitorError = ({source}) => (
-  <PageContents>
-    <NoKapacitorError source={source} />;
-  </PageContents>
-)
-
 const PageContents = ({children}) => (
   <div className="page">
-    <Header />
+    <div className="page-header">
+      <div className="page-header__container">
+        <div className="page-header__left">
+          <h1>Kapacitor Rules</h1>
+        </div>
+      </div>
+    </div>
     <div className="page-contents">
       <div className="container-fluid">
         <div className="row">
           <div className="col-md-12">
-            {children}
+            <div className="panel panel-minimal">
+              {children}
+            </div>
           </div>
         </div>
       </div>
@@ -128,6 +72,7 @@ const {
   bool,
   func,
   shape,
+  node,
 } = PropTypes
 
 KapacitorRules.propTypes = {
@@ -139,22 +84,8 @@ KapacitorRules.propTypes = {
   onDelete: func,
 }
 
-KapacitorRuleTable.propTypes = {
-  source: shape(),
-  rules: arrayOf(shape()),
-  onChangeRuleStatus: func,
-  onDelete: func,
-}
-
-RuleRow.propTypes = {
-  rule: shape(),
-  source: shape(),
-  onChangeRuleStatus: func,
-  onDelete: func,
-}
-
-KapacitorError.propTypes = {
-  source: shape(),
+PageContents.propTypes = {
+  children: node,
 }
 
 export default KapacitorRules

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -1,0 +1,160 @@
+import React, {PropTypes} from 'react';
+import NoKapacitorError from '../../shared/components/NoKapacitorError';
+import {Link} from 'react-router';
+
+const KapacitorRules = ({
+  source,
+  rules,
+  hasKapacitor,
+  loading,
+  onDelete,
+  onChangeRuleStatus,
+}) => {
+  if (loading) {
+    return <Loading />
+  }
+
+  if (!hasKapacitor) {
+    return <KapacitorError source={source} />
+  }
+
+  return (
+    <PageContents>
+      <div className="panel panel-minimal">
+        <div className="panel-heading u-flex u-ai-center u-jc-space-between">
+          <h2 className="panel-title">Alert Rules</h2>
+          <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
+        </div>
+        <KapacitorRuleTable
+          source={source}
+          rules={rules}
+          onDelete={onDelete}
+          onChangeRuleStatus={onChangeRuleStatus}
+        />
+      </div>
+    </PageContents>
+  )
+}
+
+const KapacitorRuleTable = ({source, rules, onDelete, onChangeRuleStatus}) => {
+  return (
+    <div className="panel-body">
+      <table className="table v-center">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Trigger</th>
+            <th>Message</th>
+            <th>Alerts</th>
+            <th className="text-center">Enabled</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            rules.map((rule) => {
+              return <RuleRow key={rule.id} rule={rule} source={source} onDelete={onDelete} onChangeRuleStatus={onChangeRuleStatus} />
+            })
+          }
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) => {
+  return (
+    <tr key={rule.id}>
+      <td className="monotype"><Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>{rule.name}</Link></td>
+      <td className="monotype">{rule.trigger}</td>
+      <td className="monotype">{rule.message}</td>
+      <td className="monotype">{rule.alerts.join(', ')}</td>
+      <td className="monotype text-center">
+        <div className="dark-checkbox">
+          <input
+            id={`kapacitor-enabled ${rule.id}`}
+            className="form-control-static"
+            type="checkbox"
+            defaultChecked={rule.status === "enabled"}
+            onClick={() => onChangeRuleStatus(rule)}
+          />
+          <label htmlFor={`kapacitor-enabled ${rule.id}`}></label>
+        </div>
+      </td>
+      <td className="text-right"><button className="btn btn-danger btn-xs" onClick={() => onDelete(rule)}>Delete</button></td>
+    </tr>
+  )
+}
+
+const Header = () => (
+  <div className="page-header">
+    <div className="page-header__container">
+      <div className="page-header__left">
+        <h1>Kapacitor Rules</h1>
+      </div>
+    </div>
+  </div>
+)
+
+const Loading = () => (
+  <PageContents>
+    <h1>Loading...</h1>
+  </PageContents>
+)
+
+const KapacitorError = ({source}) => (
+  <PageContents>
+    <NoKapacitorError source={source} />;
+  </PageContents>
+)
+
+const PageContents = ({children}) => (
+  <div className="page">
+    <Header />
+    <div className="page-contents">
+      <div className="container-fluid">
+        <div className="row">
+          <div className="col-md-12">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+const {
+  arrayOf,
+  bool,
+  func,
+  shape,
+} = PropTypes
+
+KapacitorRules.propTypes = {
+  source: shape(),
+  rules: arrayOf(shape()),
+  hasKapacitor: bool,
+  loading: bool,
+  onChangeRuleStatus: func,
+  onDelete: func,
+}
+
+KapacitorRuleTable.propTypes = {
+  source: shape(),
+  rules: arrayOf(shape()),
+  onChangeRuleStatus: func,
+  onDelete: func,
+}
+
+RuleRow.propTypes = {
+  rule: shape(),
+  source: shape(),
+  onChangeRuleStatus: func,
+  onDelete: func,
+}
+
+KapacitorError.propTypes = {
+  source: shape(),
+}
+
+export default KapacitorRules

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -1,0 +1,74 @@
+import React, {PropTypes} from 'react';
+import {Link} from 'react-router';
+
+const KapacitorRulesTable = ({source, rules, onDelete, onChangeRuleStatus}) => {
+  return (
+    <div className="panel-body">
+      <table className="table v-center">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Trigger</th>
+            <th>Message</th>
+            <th>Alerts</th>
+            <th className="text-center">Enabled</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            rules.map((rule) => {
+              return <RuleRow key={rule.id} rule={rule} source={source} onDelete={onDelete} onChangeRuleStatus={onChangeRuleStatus} />
+            })
+          }
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) => {
+  return (
+    <tr key={rule.id}>
+      <td className="monotype"><Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>{rule.name}</Link></td>
+      <td className="monotype">{rule.trigger}</td>
+      <td className="monotype">{rule.message}</td>
+      <td className="monotype">{rule.alerts.join(', ')}</td>
+      <td className="monotype text-center">
+        <div className="dark-checkbox">
+          <input
+            id={`kapacitor-enabled ${rule.id}`}
+            className="form-control-static"
+            type="checkbox"
+            defaultChecked={rule.status === "enabled"}
+            onClick={() => onChangeRuleStatus(rule)}
+          />
+          <label htmlFor={`kapacitor-enabled ${rule.id}`}></label>
+        </div>
+      </td>
+      <td className="text-right"><button className="btn btn-danger btn-xs" onClick={() => onDelete(rule)}>Delete</button></td>
+    </tr>
+  )
+}
+
+const {
+  arrayOf,
+  func,
+  shape,
+} = PropTypes
+
+KapacitorRulesTable.propTypes = {
+  source: shape(),
+  rules: arrayOf(shape()),
+  onChangeRuleStatus: func,
+  onDelete: func,
+}
+
+RuleRow.propTypes = {
+  rule: shape(),
+  source: shape(),
+  onChangeRuleStatus: func,
+  onDelete: func,
+}
+
+export default KapacitorRulesTable

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -1,48 +1,21 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import {getKapacitor} from 'src/shared/apis'
 import * as kapacitorActionCreators from '../actions/view'
 import KapacitorRules from 'src/kapacitor/components/KapacitorRules'
 
-const {
-  arrayOf,
-  func,
-  shape,
-  string,
-} = PropTypes
-
-export const KapacitorRulesPage = React.createClass({
-  propTypes: {
-    source: shape({
-      id: string.isRequired,
-      links: shape({
-        proxy: string.isRequired,
-        self: string.isRequired,
-        kapacitors: string.isRequired,
-      }),
-    }),
-    rules: arrayOf(shape({
-      name: string.isRequired,
-      trigger: string.isRequired,
-      message: string.isRequired,
-      alerts: arrayOf(string.isRequired).isRequired,
-    })).isRequired,
-    actions: shape({
-      fetchRules: func.isRequired,
-      deleteRule: func.isRequired,
-      updateRuleStatus: func.isRequired,
-    }).isRequired,
-    addFlashMessage: func,
-  },
-
-  getInitialState() {
-    return {
+class KapacitorRulesPage extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
       hasKapacitor: false,
       loading: true,
-      fooRule: 'HAI',
-    };
-  },
+    }
+
+    this.handleDeleteRule = this.handleDeleteRule.bind(this)
+    this.handleRuleStatus = this.handleRuleStatus.bind(this)
+  }
 
   componentDidMount() {
     getKapacitor(this.props.source).then((kapacitor) => {
@@ -51,12 +24,12 @@ export const KapacitorRulesPage = React.createClass({
       }
       this.setState({loading: false, hasKapacitor: !!kapacitor});
     });
-  },
+  }
 
   handleDeleteRule(rule) {
-    const {actions} = this.props;
-    actions.deleteRule(rule);
-  },
+    const {actions} = this.props
+    actions.deleteRule(rule)
+  }
 
   handleRuleStatus(rule) {
     const {actions} = this.props
@@ -64,7 +37,7 @@ export const KapacitorRulesPage = React.createClass({
 
     actions.updateRuleStatus(rule, status)
     actions.updateRuleStatusSuccess(rule.id, status)
-  },
+  }
 
   render() {
     const {source, rules} = this.props
@@ -80,19 +53,49 @@ export const KapacitorRulesPage = React.createClass({
         onChangeRuleStatus={this.handleRuleStatus}
       />
     )
-  },
-});
+  }
+}
 
-function mapStateToProps(state) {
+const {
+  arrayOf,
+  func,
+  shape,
+  string,
+} = PropTypes
+
+KapacitorRulesPage.propTypes = {
+  source: shape({
+    id: string.isRequired,
+    links: shape({
+      proxy: string.isRequired,
+      self: string.isRequired,
+      kapacitors: string.isRequired,
+    }),
+  }),
+  rules: arrayOf(shape({
+    name: string.isRequired,
+    trigger: string.isRequired,
+    message: string.isRequired,
+    alerts: arrayOf(string.isRequired).isRequired,
+  })).isRequired,
+  actions: shape({
+    fetchRules: func.isRequired,
+    deleteRule: func.isRequired,
+    updateRuleStatus: func.isRequired,
+  }).isRequired,
+  addFlashMessage: func,
+}
+
+const mapStateToProps = (state) => {
   return {
     rules: Object.values(state.rules),
-  };
+  }
 }
 
-function mapDispatchToProps(dispatch) {
+const mapDispatchToProps = (dispatch) => {
   return {
     actions: bindActionCreators(kapacitorActionCreators, dispatch),
-  };
+  }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulesPage);
+export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulesPage)

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -13,8 +13,8 @@ class KapacitorRulesPage extends Component {
       loading: true,
     }
 
-    this.handleDeleteRule = this.handleDeleteRule.bind(this)
-    this.handleRuleStatus = this.handleRuleStatus.bind(this)
+    this.handleDeleteRule = ::this.handleDeleteRule
+    this.handleRuleStatus = ::this.handleRuleStatus
   }
 
   componentDidMount() {

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -1,17 +1,16 @@
-import React, {PropTypes} from 'react';
-import {connect} from 'react-redux';
-import {bindActionCreators} from 'redux';
-import {Link} from 'react-router';
-import {getKapacitor} from 'src/shared/apis';
-import * as kapacitorActionCreators from '../actions/view';
-import NoKapacitorError from '../../shared/components/NoKapacitorError';
+import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+import {getKapacitor} from 'src/shared/apis'
+import * as kapacitorActionCreators from '../actions/view'
+import KapacitorRules from 'src/kapacitor/components/KapacitorRules'
 
 const {
   arrayOf,
   func,
   shape,
   string,
-} = PropTypes;
+} = PropTypes
 
 export const KapacitorRulesPage = React.createClass({
   propTypes: {
@@ -41,6 +40,7 @@ export const KapacitorRulesPage = React.createClass({
     return {
       hasKapacitor: false,
       loading: true,
+      fooRule: 'HAI',
     };
   },
 
@@ -58,111 +58,28 @@ export const KapacitorRulesPage = React.createClass({
     actions.deleteRule(rule);
   },
 
-  handleRuleStatus(e, rule) {
-    const {actions} = this.props;
-    const status = e.target.checked ? 'enabled' : 'disabled';
+  handleRuleStatus(rule) {
+    const {actions} = this.props
+    const status = rule.status === 'enabled' ? 'disabled' : 'enabled'
 
-    actions.updateRuleStatusSuccess(rule.id, status);
-    actions.updateRuleStatus(rule, {status});
-  },
-
-  renderSubComponent() {
-    const {source} = this.props;
-    const {hasKapacitor, loading} = this.state;
-
-    let component;
-    if (loading) {
-      component = (<p>Loading...</p>);
-    } else if (hasKapacitor) {
-      component = (
-        <div className="panel panel-minimal">
-          <div className="panel-heading u-flex u-ai-center u-jc-space-between">
-            <h2 className="panel-title">Alert Rules</h2>
-            <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-sm btn-primary">Create New Rule</Link>
-          </div>
-          <div className="panel-body">
-            <table className="table v-center">
-              <thead>
-                <tr>
-                  <th>Name</th>
-                  <th>Trigger</th>
-                  <th>Message</th>
-                  <th>Alerts</th>
-                  <th className="text-center">Enabled</th>
-                  <th></th>
-                </tr>
-              </thead>
-              <tbody>
-                {this.renderAlertsTableRows()}
-              </tbody>
-            </table>
-          </div>
-        </div>
-      );
-    } else {
-      component = <NoKapacitorError source={source} />;
-    }
-    return component;
+    actions.updateRuleStatus(rule, status)
+    actions.updateRuleStatusSuccess(rule.id, status)
   },
 
   render() {
+    const {source, rules} = this.props
+    const {hasKapacitor, loading} = this.state
+
     return (
-      <div className="page">
-        <div className="page-header">
-          <div className="page-header__container">
-            <div className="page-header__left">
-              <h1>Kapacitor Rules</h1>
-            </div>
-          </div>
-        </div>
-        <div className="page-contents">
-          <div className="container-fluid">
-            {this.renderSubComponent()}
-          </div>
-        </div>
-      </div>
-    );
-  },
-
-  renderAlertsTableRows() {
-    const {rules, source} = this.props;
-    const numRules = rules.length;
-
-    if (numRules === 0) {
-      return (
-        <tr className="table-empty-state">
-          <th colSpan="5">
-            <p>You don&#39;t have any Kapacitor<br/>Rules, why not create one?</p>
-            <Link to={`/sources/${source.id}/alert-rules/new`} className="btn btn-primary">Create New Rule</Link>
-          </th>
-        </tr>
-      );
-    }
-
-    return rules.map((rule) => {
-      return (
-        <tr key={rule.id}>
-          <td className="monotype"><Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>{rule.name}</Link></td>
-          <td className="monotype">{rule.trigger}</td>
-          <td className="monotype">{rule.message}</td>
-          <td className="monotype">{rule.alerts.join(', ')}</td>
-          <td className="monotype text-center">
-            <div className="dark-checkbox">
-              <input
-                id="kapacitor-enabled"
-                className="form-control-static"
-                type="checkbox"
-                ref={(r) => this.enabled = r}
-                defaultChecked={rule.status === "enabled"}
-                onClick={(e) => this.handleRuleStatus(e, rule)}
-              />
-              <label htmlFor="kapacitor-enabled"></label>
-            </div>
-          </td>
-          <td className="text-right"><button className="btn btn-danger btn-xs" onClick={() => this.handleDeleteRule(rule)}>Delete</button></td>
-        </tr>
-      );
-    });
+      <KapacitorRules
+        source={source}
+        rules={rules}
+        hasKapacitor={hasKapacitor}
+        loading={loading}
+        onDelete={this.handleDeleteRule}
+        onChangeRuleStatus={this.handleRuleStatus}
+      />
+    )
   },
 });
 

--- a/ui/src/shared/components/NoKapacitorError.js
+++ b/ui/src/shared/components/NoKapacitorError.js
@@ -1,5 +1,5 @@
-import React, {PropTypes} from 'react';
-import {Link} from 'react-router';
+import React, {PropTypes} from 'react'
+import {Link} from 'react-router'
 
 const NoKapacitorError = React.createClass({
   propTypes: {
@@ -9,14 +9,14 @@ const NoKapacitorError = React.createClass({
   },
 
   render() {
-    const path = `/sources/${this.props.source.id}/kapacitor-config`;
+    const path = `/sources/${this.props.source.id}/kapacitor-config`
     return (
       <div>
         <p>The current source does not have an associated Kapacitor instance, please configure one.</p>
         <Link to={path}>Add Kapacitor</Link>
       </div>
-    );
+    )
   },
-});
+})
 
-export default NoKapacitorError;
+export default NoKapacitorError


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #847 

### The problem
Users could only enable/disable the first rule's alerts.

### The Solution
Each checkbox's id and label was hardcoded to 'kapacitor-enabled'.  Since id's must be unique the DOM just had no idea which element we actually wanted to work on.

### Note
Also refactored this component quite a bit to conform to more modern patterns and enhance readability. 


