### PR TITLE
Fix dashboards to use specified database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
   1. [#936](https://github.com/influxdata/chronograf/pull/936): Fix leaking sockets for InfluxQL queries
+  1. [#968](https://github.com/influxdata/chronograf/issue/968): Fix wrong database used in dashboards
 
 ### Features
 

--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -33,7 +33,7 @@ Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositi
     const dashboardCell = {...cell, i}
     dashboardCell.queries.forEach((q) => {
       q.text = q.query;
-      q.database = source.telegraf;
+      q.database = q.db;
     });
     return dashboardCell;
   })


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #968

### The problem
Dashboard defaulted to use the telegraf db.

### The Solution
Dashboard queries now use the database specified in the dashboard resource.

Used this command to test:

```sh
curl -X POST -H "Content-Type: application/json" -d '{
  "cells": [
    {
      "name": "Write Errors",
      "queries": [
        {
          "db": "_internal",
          "rp": "monitor",
          "label": "count",
          "query": "SELECT max(\"writeFailures\") AS \"max_writeFailures\" FROM \"_internal\".\"monitor\".\"subscriber\"",
          "wheres": [],
          "groupbys": []
        }
      ],
      "type": "line"
    }
  ],
  "name": "internal subscriber test"
}' "http://localhost:8888/chronograf/v1/dashboards"
```