### PR TITLE
Add structured logging to underlying http server

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -2,6 +2,7 @@ package chronograf
 
 import (
 	"context"
+	"io"
 	"net/http"
 )
 
@@ -32,12 +33,13 @@ func (e Error) Error() string {
 type Logger interface {
 	Debug(...interface{})
 	Info(...interface{})
-	Warn(...interface{})
 	Error(...interface{})
-	Fatal(...interface{})
-	Panic(...interface{})
 
 	WithField(string, interface{}) Logger
+
+	// Logger can be transformed into an io.Writer.
+	// That writer is the end of an io.Pipe and it is your responsibility to close it.
+	Writer() *io.PipeWriter
 }
 
 // Assets returns a handler to serve the website.

--- a/kapacitor/validate.go
+++ b/kapacitor/validate.go
@@ -3,7 +3,6 @@ package kapacitor
 import (
 	"bytes"
 	"fmt"
-	"log"
 	"time"
 
 	"github.com/influxdata/chronograf"
@@ -25,7 +24,6 @@ func ValidateAlert(service string) error {
 func formatTick(tickscript string) (chronograf.TICKScript, error) {
 	node, err := ast.Parse(tickscript)
 	if err != nil {
-		log.Fatalf("parse execution: %s", err)
 		return "", err
 	}
 

--- a/log/log.go
+++ b/log/log.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"io"
 	"os"
 
 	"github.com/Sirupsen/logrus"
@@ -79,6 +80,10 @@ func (ll *logrusLogger) Panic(items ...interface{}) {
 
 func (ll *logrusLogger) WithField(key string, value interface{}) chronograf.Logger {
 	return &logrusLogger{ll.l.WithField(key, value)}
+}
+
+func (ll *logrusLogger) Writer() *io.PipeWriter {
+	return ll.l.Logger.WriterLevel(logrus.ErrorLevel)
 }
 
 // New wraps a logrus Logger

--- a/server/url_prefixer.go
+++ b/server/url_prefixer.go
@@ -80,9 +80,9 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	// extract the flusher for flushing chunks
 	flusher, ok := rw.(http.Flusher)
 	if !ok {
-		up.Logger.
-			WithField("component", "prefixer").
-			Fatal("Expected http.ResponseWriter to be an http.Flusher, but wasn't")
+		msg := "Expected http.ResponseWriter to be an http.Flusher, but wasn't"
+		Error(rw, http.StatusInternalServerError, msg, up.Logger)
+		return
 	}
 
 	nextRead, nextWrite := io.Pipe()


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
We weren't logging internal `http.Server` errors.

### The Solution
Get `io.PipeWriter` from logrus and send to `http.Server`


