### PR TITLE
Update roles to check if role already exists

### DIFF
--- a/server/roles.go
+++ b/server/roles.go
@@ -34,6 +34,11 @@ func (h *Service) NewRole(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if _, err := roles.Get(ctx, req.Name); err == nil {
+		Error(w, http.StatusBadRequest, fmt.Sprintf("Source %d already has role %s", srcID, req.Name), h.Logger)
+		return
+	}
+
 	res, err := roles.Add(ctx, &req.Role)
 	if err != nil {
 		Error(w, http.StatusBadRequest, err.Error(), h.Logger)

--- a/server/roles_test.go
+++ b/server/roles_test.go
@@ -156,6 +156,9 @@ func TestService_NewSourceRole(t *testing.T) {
 							AddF: func(ctx context.Context, u *chronograf.Role) (*chronograf.Role, error) {
 								return nil, fmt.Errorf("server had and issue")
 							},
+							GetF: func(ctx context.Context, name string) (*chronograf.Role, error) {
+								return nil, fmt.Errorf("No such role")
+							},
 						}, nil
 					},
 				},
@@ -196,6 +199,9 @@ func TestService_NewSourceRole(t *testing.T) {
 						return &mocks.RolesStore{
 							AddF: func(ctx context.Context, u *chronograf.Role) (*chronograf.Role, error) {
 								return u, nil
+							},
+							GetF: func(ctx context.Context, name string) (*chronograf.Role, error) {
+								return nil, fmt.Errorf("no such role")
 							},
 						}, nil
 					},


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #984

### The problem
Appears as if plutonium does not check if role already exists (or doesn't send an error)

### The Solution
Get the role first to check if it exists.

