### PR TITLE
bugfix/ent validation

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -47,6 +47,28 @@ type Assets interface {
 	Handler() http.Handler
 }
 
+// Supported time-series databases
+const (
+	// InfluxDB is the open-source time-series database
+	InfluxDB = "influx"
+	// InfluxEnteprise is the clustered HA time-series database
+	InfluxEnterprise = "influx-enterprise"
+	// InfluxRelay is the basic HA layer over InfluxDB
+	InfluxRelay = "influx-relay"
+)
+
+// TSDBStatus represents the current status of a time series database
+type TSDBStatus interface {
+	// Connect will connect to the time series using the information in `Source`.
+	Connect(ctx context.Context, src *Source) error
+	// Ping returns version and TSDB type of time series database if reachable.
+	Ping(context.Context) error
+	// Version returns the version of the TSDB database
+	Version(context.Context) (string, error)
+	// Type returns the type of the TSDB database
+	Type(context.Context) (string, error)
+}
+
 // TimeSeries represents a queryable time series database.
 type TimeSeries interface {
 	// Query retrieves time series data from the database.

--- a/server/service.go
+++ b/server/service.go
@@ -43,7 +43,7 @@ type InfluxClient struct{}
 
 // New creates a client to connect to OSS or enterprise
 func (c *InfluxClient) New(src chronograf.Source, logger chronograf.Logger) (chronograf.TimeSeries, error) {
-	if src.Type == "influx-enterprise" && src.MetaURL != "" {
+	if src.Type == chronograf.InfluxEnterprise && src.MetaURL != "" {
 		dataNode := &influx.Client{
 			Logger: logger,
 		}

--- a/server/sources.go
+++ b/server/sources.go
@@ -276,8 +276,8 @@ func (h *Service) UpdateSource(w http.ResponseWriter, r *http.Request) {
 // ValidSourceRequest checks if name, url and type are valid
 func ValidSourceRequest(s chronograf.Source) error {
 	// Name and URL areq required
-	if s.Name == "" || s.URL == "" {
-		return fmt.Errorf("name and url required")
+	if s.URL == "" {
+		return fmt.Errorf("url required")
 	}
 	// Type must be influx or influx-enterprise
 	if s.Type != "" {

--- a/server/sources.go
+++ b/server/sources.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/influx"
 )
 
 type sourceLinks struct {
@@ -45,7 +46,7 @@ func newSourceResponse(src chronograf.Source) sourceResponse {
 		},
 	}
 
-	if src.Type == "influx-enterprise" {
+	if src.Type == chronograf.InfluxEnterprise {
 		res.Links.Roles = fmt.Sprintf("%s/%d/roles", httpAPISrcs, src.ID)
 	}
 	return res
@@ -69,8 +70,15 @@ func (h *Service) NewSource(w http.ResponseWriter, r *http.Request) {
 		src.Telegraf = "telegraf"
 	}
 
-	var err error
-	if src, err = h.SourcesStore.Add(r.Context(), src); err != nil {
+	ctx := r.Context()
+	dbType, err := h.tsdbType(ctx, &src)
+	if err != nil {
+		Error(w, http.StatusBadRequest, "Error contacting source", h.Logger)
+		return
+	}
+
+	src.Type = dbType
+	if src, err = h.SourcesStore.Add(ctx, src); err != nil {
 		msg := fmt.Errorf("Error storing source %v: %v", src, err)
 		unknownErrorWithMessage(w, msg, h.Logger)
 		return
@@ -79,6 +87,16 @@ func (h *Service) NewSource(w http.ResponseWriter, r *http.Request) {
 	res := newSourceResponse(src)
 	w.Header().Add("Location", res.Links.Self)
 	encodeJSON(w, http.StatusCreated, res, h.Logger)
+}
+
+func (h *Service) tsdbType(ctx context.Context, src *chronograf.Source) (string, error) {
+	cli := &influx.Client{
+		Logger: h.Logger,
+	}
+	if err := cli.Connect(ctx, src); err != nil {
+		return "", err
+	}
+	return cli.Type(ctx)
 }
 
 type getSourcesResponse struct {
@@ -240,6 +258,13 @@ func (h *Service) UpdateSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	dbType, err := h.tsdbType(ctx, &src)
+	if err != nil {
+		Error(w, http.StatusBadRequest, "Error contacting source", h.Logger)
+		return
+	}
+	src.Type = dbType
+
 	if err := h.SourcesStore.Update(ctx, src); err != nil {
 		msg := fmt.Sprintf("Error updating source ID %d", id)
 		Error(w, http.StatusInternalServerError, msg, h.Logger)
@@ -256,7 +281,7 @@ func ValidSourceRequest(s chronograf.Source) error {
 	}
 	// Type must be influx or influx-enterprise
 	if s.Type != "" {
-		if s.Type != "influx" && s.Type != "influx-enterprise" {
+		if s.Type != chronograf.InfluxDB && s.Type != chronograf.InfluxEnterprise && s.Type != chronograf.InfluxRelay {
 			return fmt.Errorf("invalid source type %s", s.Type)
 		}
 	}

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2400,9 +2400,11 @@
 				"type": {
 					"type": "string",
 					"description": "Format of the data source",
+					"readOnly": true,
 					"enum": [
 						"influx",
-						"influx-enterprise"
+						"influx-enterprise",
+						"influx-relay"
 					]
 				},
 				"username": {

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2384,7 +2384,6 @@
 				}
 			},
 			"required": [
-				"name",
 				"url"
 			],
 			"properties": {

--- a/ui/src/admin/components/UserEditingRow.js
+++ b/ui/src/admin/components/UserEditingRow.js
@@ -42,7 +42,7 @@ class UserEditingRow extends Component {
               <input
                 className="form-control"
                 name="password"
-                type="text"
+                type="password"
                 value={user.password || ''}
                 placeholder="Password"
                 onChange={this.handleEdit(user)}

--- a/ui/src/side_nav/components/SideNav.js
+++ b/ui/src/side_nav/components/SideNav.js
@@ -42,13 +42,13 @@ const SideNav = React.createClass({
           <NavListItem link={`${sourcePrefix}/alerts`}>Alert History</NavListItem>
           <NavListItem link={`${sourcePrefix}/alert-rules`}>Kapacitor Rules</NavListItem>
         </NavBlock>
+        <NavBlock icon="crown" link={`${sourcePrefix}/admin`}>
+          <NavHeader link={`${sourcePrefix}/admin`} title="Admin" />
+        </NavBlock>
         <NavBlock icon="cog-thick" link={`${sourcePrefix}/manage-sources`}>
           <NavHeader link={`${sourcePrefix}/manage-sources`} title="Configuration" />
           <NavListItem link={`${sourcePrefix}/manage-sources`}>InfluxDB</NavListItem>
           <NavListItem link={`${sourcePrefix}/kapacitor-config`}>Kapacitor</NavListItem>
-        </NavBlock>
-        <NavBlock icon="crown" link={`${sourcePrefix}/admin`}>
-          <NavHeader link={`${sourcePrefix}/admin`} title="Admin" />
         </NavBlock>
         {loggedIn ? (
         <NavBlock icon="user-outline" className="sidebar__square-last">

--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -16,7 +16,6 @@ export const SourceForm = React.createClass({
     updateSourceAction: func,
     source: shape({}).isRequired,
     editMode: bool.isRequired,
-    canConnect: bool,
     onInputChange: func.isRequired,
     onSubmit: func.isRequired,
     onBlurSourceURL: func.isRequired,
@@ -34,7 +33,6 @@ export const SourceForm = React.createClass({
       telegraf: this.sourceTelegraf.value,
       insecureSkipVerify: this.sourceInsecureSkipVerify ? this.sourceInsecureSkipVerify.checked : false,
       metaUrl: this.metaUrl.value.trim(),
-      type: this.metaUrl.value.trim() ? 'influx-enterprise' : null,
     }
 
     this.props.onSubmit(newSource)
@@ -99,6 +97,11 @@ export const SourceForm = React.createClass({
                         <label htmlFor="password">Password</label>
                         <input type="password" name="password" ref={(r) => this.sourcePassword = r} className="form-control" id="password" onChange={onInputChange} value={source.password || ''}></input>
                       </div>
+                      {_.get(source, 'type', '').includes("enterprise") ?
+                          <div className="form-group col-xs-12">
+                            <label htmlFor="meta-url">Meta Service Connection URL</label>
+                            <input type="text" name="metaUrl" ref={(r) => this.metaUrl = r} className="form-control" id="meta-url" placeholder="http://localhost:8091" onChange={onInputChange} value={source.metaUrl || ''}></input>
+                          </div> : null}
                       <div className="form-group col-xs-12">
                         <label htmlFor="telegraf">Telegraf database</label>
                         <input type="text" name="telegraf" ref={(r) => this.sourceTelegraf = r} className="form-control" id="telegraf" onChange={onInputChange} value={source.telegraf || 'telegraf'}></input>
@@ -117,23 +120,6 @@ export const SourceForm = React.createClass({
                           </div>
                           <label className="form-helper">{insecureSkipVerifyText}</label>
                         </div> : null}
-                      <div className="form-group col-xs-12">
-                        <div className="panel-collapse panel-collapse-sm form-control-static">
-                          <h2 className="panel-title" style={{margin: '0 0 6px'}}>
-                            <a role="button" data-toggle="collapse" className="collapsed" href="#meta-service" style={{fontSize: '14px', fontWeight: 600}}>
-                              <span className="caret"></span>Add Influx Enterprise Meta Service
-                            </a>
-                          </h2>
-                          <div className="collapse" id="meta-service" style={{height: '0px'}}>
-                            <div className="panel-body" style={{padding: '10px 10px 21px'}}>
-                              <div className="form-group col-xs-12 col-sm-6">
-                                <label htmlFor="meta-url">Meta Service Connection URL</label>
-                                <input type="text" name="metaUrl" ref={(r) => this.metaUrl = r} className="form-control" id="meta-url" placeholder="http://localhost:8091" onChange={onInputChange} value={source.metaUrl || ''}></input>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
                       <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
                         <button className={classNames('btn btn-block', {'btn-primary': editMode, 'btn-success': !editMode})} type="submit">{editMode ? "Save Changes" : "Add Source"}</button>
                       </div>

--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -32,7 +32,7 @@ export const SourceForm = React.createClass({
       'default': this.sourceDefault.checked,
       telegraf: this.sourceTelegraf.value,
       insecureSkipVerify: this.sourceInsecureSkipVerify ? this.sourceInsecureSkipVerify.checked : false,
-      metaUrl: this.metaUrl.value.trim(),
+      metaUrl: this.metaUrl && this.metaUrl.value.trim(),
     }
 
     this.props.onSubmit(newSource)

--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -1,13 +1,13 @@
-import React, {PropTypes} from 'react';
-import classNames from 'classnames';
-import {insecureSkipVerifyText} from 'src/shared/copy/tooltipText';
-import _ from 'lodash';
+import React, {PropTypes} from 'react'
+import classNames from 'classnames'
+import {insecureSkipVerifyText} from 'src/shared/copy/tooltipText'
+import _ from 'lodash'
 
 const {
   bool,
   func,
   shape,
-} = PropTypes;
+} = PropTypes
 
 export const SourceForm = React.createClass({
   propTypes: {
@@ -16,13 +16,16 @@ export const SourceForm = React.createClass({
     updateSourceAction: func,
     source: shape({}).isRequired,
     editMode: bool.isRequired,
+    canConnect: bool,
     onInputChange: func.isRequired,
     onSubmit: func.isRequired,
+    onBlurSourceURL: func.isRequired,
   },
 
   handleSubmitForm(e) {
-    e.preventDefault();
-    const newSource = {...this.props.source,
+    e.preventDefault()
+    const newSource = {
+      ...this.props.source,
       url: this.sourceURL.value.trim(),
       name: this.sourceName.value,
       username: this.sourceUsername.value,
@@ -31,15 +34,32 @@ export const SourceForm = React.createClass({
       telegraf: this.sourceTelegraf.value,
       insecureSkipVerify: this.sourceInsecureSkipVerify ? this.sourceInsecureSkipVerify.checked : false,
       metaUrl: this.metaUrl.value.trim(),
-    };
-    this.props.onSubmit(newSource);
+      type: this.metaUrl.value.trim() ? 'influx-enterprise' : null,
+    }
+
+    this.props.onSubmit(newSource)
+  },
+
+  handleBlurSourceURL() {
+    const url = this.sourceURL.value.trim()
+
+    if (!url) {
+      return
+    }
+
+    const newSource = {
+      ...this.props.source,
+      url: this.sourceURL.value.trim(),
+    }
+
+    this.props.onBlurSourceURL(newSource)
   },
 
   render() {
     const {source, editMode, onInputChange} = this.props;
 
     if (editMode && !source.id) {
-      return <div className="page-spinner"></div>;
+      return <div className="page-spinner"></div>
     }
 
     return (
@@ -64,8 +84,8 @@ export const SourceForm = React.createClass({
 
                     <form onSubmit={this.handleSubmitForm}>
                       <div className="form-group col-xs-12 col-sm-6">
-                        <label htmlFor="connect-string">Connection String</label>
-                        <input type="text" name="url" ref={(r) => this.sourceURL = r} className="form-control" id="connect-string" placeholder="http://localhost:8086" onChange={onInputChange} value={source.url || ''}></input>
+                        <label htmlFor="connect-string"> Connection String</label>
+                        <input type="text" name="url" ref={(r) => this.sourceURL = r} className="form-control" id="connect-string" placeholder="http://localhost:8086" onChange={onInputChange} value={source.url || ''} onBlur={this.handleBlurSourceURL}></input>
                       </div>
                       <div className="form-group col-xs-12 col-sm-6">
                         <label htmlFor="name">Name</label>
@@ -125,8 +145,8 @@ export const SourceForm = React.createClass({
           </div>
         </div>
       </div>
-    );
+    )
   },
-});
+})
 
-export default SourceForm;
+export default SourceForm

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -61,6 +61,20 @@ export const SourcePage = React.createClass({
     });
   },
 
+  handleBlurSourceURL(newSource) {
+    if (this.state.editMode) {
+      return
+    }
+
+    if (!newSource.url) {
+      return
+    }
+
+    createSource(newSource).then(({data: sourceFromServer}) => {
+      this.props.addSourceAction(sourceFromServer)
+    })
+  },
+
   handleSubmit(newSource) {
     const {router, params, addFlashMessage} = this.props;
     if (this.state.editMode) {
@@ -99,6 +113,7 @@ export const SourcePage = React.createClass({
         updateSourceAction={updateSourceAction}
         onInputChange={this.handleInputChange}
         onSubmit={this.handleSubmit}
+        onBlurSourceURL={this.handleBlurSourceURL}
       />
     );
   },

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -78,23 +78,13 @@ export const SourcePage = React.createClass({
 
   handleSubmit(newSource) {
     const {router, params, addFlashMessage} = this.props;
-    if (this.state.editMode) {
-      updateSource(newSource).then(({data: sourceFromServer}) => {
-        this.props.updateSourceAction(sourceFromServer);
-        router.push(`/sources/${params.sourceID}/manage-sources`);
-        addFlashMessage({type: 'success', text: 'The source was successfully updated'});
-      }).catch(() => {
-        addFlashMessage({type: 'error', text: 'There was a problem updating the source. Check the settings'});
-      });
-    } else {
-      createSource(newSource).then(({data: sourceFromServer}) => {
-        this.props.addSourceAction(sourceFromServer);
-        router.push(`/sources/${params.sourceID}/manage-sources`);
-        addFlashMessage({type: 'success', text: 'The source was successfully created'});
-      }).catch(() => {
-        addFlashMessage({type: 'error', text: 'There was a problem creating the source. Check the settings'});
-      });
-    }
+    updateSource(newSource).then(({data: sourceFromServer}) => {
+      this.props.updateSourceAction(sourceFromServer);
+      router.push(`/sources/${params.sourceID}/manage-sources`);
+      addFlashMessage({type: 'success', text: 'The source info saved'});
+    }).catch(() => {
+      addFlashMessage({type: 'error', text: 'There was a problem updating the source. Check the settings'});
+    });
   },
 
 

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -38,6 +38,7 @@ export const SourcePage = React.createClass({
     return {
       source: {},
       editMode: this.props.params.id !== undefined,
+      error: '',
     };
   },
 
@@ -70,20 +71,34 @@ export const SourcePage = React.createClass({
       return
     }
 
+    // if there is a type on source it has already been created
+    if (newSource.type) {
+      return
+    }
+
     createSource(newSource).then(({data: sourceFromServer}) => {
       this.props.addSourceAction(sourceFromServer)
       this.setState({source: sourceFromServer})
+    }).catch(({data: error}) => {
+      // dont want to flash this until they submit
+      this.setState({error: error.message})
     })
   },
 
   handleSubmit(newSource) {
-    const {router, params, addFlashMessage} = this.props;
+    const {router, params, addFlashMessage} = this.props
+    const {error} = this.state
+
+    if (error) {
+      return addFlashMessage({type: 'error', text: error})
+    }
+
     updateSource(newSource).then(({data: sourceFromServer}) => {
       this.props.updateSourceAction(sourceFromServer);
       router.push(`/sources/${params.sourceID}/manage-sources`);
-      addFlashMessage({type: 'success', text: 'The source info saved'});
+      addFlashMessage({type: 'success', text: 'The source info saved'})
     }).catch(() => {
-      addFlashMessage({type: 'error', text: 'There was a problem updating the source. Check the settings'});
+      addFlashMessage({type: 'error', text: 'There was a problem updating the source. Check the settings'})
     });
   },
 

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -72,6 +72,7 @@ export const SourcePage = React.createClass({
 
     createSource(newSource).then(({data: sourceFromServer}) => {
       this.props.addSourceAction(sourceFromServer)
+      this.setState({source: sourceFromServer})
     })
   },
 


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1009
Connect #1006 
Connect #1007

### The problem
When connecting to an enterprise source, we were not informing the server of the server-type.  The cause the incorrect permissions / roles to populate the frontend.  Also, it was unclear to users when to input a metaURL.  

### The Solution
We 'create' a source as soon as the user blurs our of the sourceURL input.  This allows us to check the type of the InfluxDB instance, set the server type, and conditionally display the metaURL input.