### PR TITLE
Allow Renaming Cells on Dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 ### Features
+  1. [#1020](https://github.com/influxdata/chronograf/pull/1020): Users can now edit cell names on dashboards
 
 ### UI Improvements
 

--- a/ui/spec/dashboards/reducers/uiSpec.js
+++ b/ui/spec/dashboards/reducers/uiSpec.js
@@ -6,6 +6,7 @@ import {
   setDashboard,
   setTimeRange,
   setEditMode,
+  updateDashboardCells,
   editCell,
   renameCell,
 } from 'src/dashboards/actions'
@@ -50,6 +51,26 @@ describe('DataExplorer.Reducers.UI', () => {
     const isEditMode = true
     const actual = reducer(state, setEditMode(isEditMode))
     expect(actual.isEditMode).to.equal(isEditMode)
+  })
+
+  it('can update dashboard cells', () => {
+    state = {
+      dashboard: d1,
+      dashboards,
+    }
+
+    const cells = [{id: 1}, {id: 2}]
+
+    const expected = {
+      id: 1,
+      cells,
+      name: 'd1',
+    }
+
+    const actual = reducer(state, updateDashboardCells(cells))
+
+    expect(actual.dashboard).to.deep.equal(expected)
+    expect(actual.dashboards[0]).to.deep.equal(expected)
   })
 
   it('can edit cell', () => {

--- a/ui/spec/dashboards/reducers/uiSpec.js
+++ b/ui/spec/dashboards/reducers/uiSpec.js
@@ -6,6 +6,8 @@ import {
   setDashboard,
   setTimeRange,
   setEditMode,
+  editCell,
+  renameCell,
 } from 'src/dashboards/actions'
 
 const noopAction = () => {
@@ -48,5 +50,51 @@ describe('DataExplorer.Reducers.UI', () => {
     const isEditMode = true
     const actual = reducer(state, setEditMode(isEditMode))
     expect(actual.isEditMode).to.equal(isEditMode)
+  })
+
+  it('can edit cell', () => {
+    const dash = {
+      id: 1,
+      cells: [{
+        x: 0,
+        y: 0,
+        w: 4,
+        h: 4,
+        id: 1,
+        isEditing: false,
+        name: "Gigawatts",
+      }],
+    }
+
+    state = {
+      dashboard: dash,
+      dashboards: [dash],
+    }
+
+    const actual = reducer(state, editCell(0, 0, true))
+    expect(actual.dashboards[0].cells[0].isEditing).to.equal(true)
+  })
+
+  it('can rename cells', () => {
+    const dash = {
+      id: 1,
+      cells: [{
+        x: 0,
+        y: 0,
+        w: 4,
+        h: 4,
+        id: 1,
+        isEditing: true,
+        name: "Gigawatts",
+      }],
+    }
+
+    state = {
+      dashboard: dash,
+      dashboards: [dash],
+    }
+
+    const actual = reducer(state, renameCell(0, 0, "Plutonium Consumption Rate (ug/sec)"))
+    expect(actual.dashboards[0].cells[0].name).to.equal("Plutonium Consumption Rate (ug/sec)")
   })
 })

--- a/ui/spec/dashboards/reducers/uiSpec.js
+++ b/ui/spec/dashboards/reducers/uiSpec.js
@@ -94,6 +94,7 @@ describe('DataExplorer.Reducers.UI', () => {
 
     const actual = reducer(state, editCell(0, 0, true))
     expect(actual.dashboards[0].cells[0].isEditing).to.equal(true)
+    expect(actual.dashboard.cells[0].isEditing).to.equal(true)
   })
 
   it('can rename cells', () => {
@@ -117,5 +118,6 @@ describe('DataExplorer.Reducers.UI', () => {
 
     const actual = reducer(state, renameCell(0, 0, "Plutonium Consumption Rate (ug/sec)"))
     expect(actual.dashboards[0].cells[0].name).to.equal("Plutonium Consumption Rate (ug/sec)")
+    expect(actual.dashboard.cells[0].name).to.equal("Plutonium Consumption Rate (ug/sec)")
   })
 })

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -39,6 +39,27 @@ export const updateDashboard = (dashboard) => ({
   },
 })
 
+export const editCell = (x, y, isEditing) => ({
+  type: 'EDIT_CELL',
+  // x and y coords are used as a alternative to cell ids, which are not
+  // universally unique, and cannot be because React depends on a
+  // quasi-predictable ID for keys. Since cells cannot overlap, coordinates act
+  // as a suitable id
+  payload: {
+    x,  // x-coord of the cell to be edited
+    y,  // y-coord of the cell to be edited
+    isEditing,
+  },
+})
+
+export const renameCell = (x, y, name) => ({
+  type: 'RENAME_CELL',
+  payload: {
+    x,  // x-coord of the cell to be renamed
+    y,  // y-coord of the cell to be renamed
+    name,
+  },
+})
 
 // Async Action Creators
 

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -39,6 +39,13 @@ export const updateDashboard = (dashboard) => ({
   },
 })
 
+export const updateDashboardCells = (cells) => ({
+  type: 'UPDATE_DASHBOARD_CELLS',
+  payload: {
+    cells,
+  },
+})
+
 export const editCell = (x, y, isEditing) => ({
   type: 'EDIT_CELL',
   // x and y coords are used as a alternative to cell ids, which are not
@@ -69,7 +76,8 @@ export const getDashboards = (dashboardID) => (dispatch) => {
   })
 }
 
-export const putDashboard = (dashboard) => (dispatch) => {
+export const putDashboard = () => (dispatch, getState) => {
+  const {dashboardUI: {dashboard}} = getState()
   updateDashboardAJAX(dashboard).then(({data}) => {
     dispatch(updateDashboard(data))
   })

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -3,64 +3,53 @@ import {
   updateDashboard as updateDashboardAJAX,
 } from 'src/dashboards/apis'
 
-export function loadDashboards(dashboards, dashboardID) {
-  return {
-    type: 'LOAD_DASHBOARDS',
-    payload: {
-      dashboards,
-      dashboardID,
-    },
-  }
+export const loadDashboards = (dashboards, dashboardID) => ({
+  type: 'LOAD_DASHBOARDS',
+  payload: {
+    dashboards,
+    dashboardID,
+  },
+})
+
+export const setDashboard = (dashboardID) => ({
+  type: 'SET_DASHBOARD',
+  payload: {
+    dashboardID,
+  },
+})
+
+export const setTimeRange = (timeRange) => ({
+  type: 'SET_DASHBOARD_TIME_RANGE',
+  payload: {
+    timeRange,
+  },
+})
+
+export const setEditMode = (isEditMode) => ({
+  type: 'SET_EDIT_MODE',
+  payload: {
+    isEditMode,
+  },
+})
+
+export const updateDashboard = (dashboard) => ({
+  type: 'UPDATE_DASHBOARD',
+  payload: {
+    dashboard,
+  },
+})
+
+
+// Async Action Creators
+
+export const getDashboards = (dashboardID) => (dispatch) => {
+  getDashboardsAJAX().then(({data: {dashboards}}) => {
+    dispatch(loadDashboards(dashboards, dashboardID))
+  })
 }
 
-export function setDashboard(dashboardID) {
-  return {
-    type: 'SET_DASHBOARD',
-    payload: {
-      dashboardID,
-    },
-  }
-}
-
-export function setTimeRange(timeRange) {
-  return {
-    type: 'SET_DASHBOARD_TIME_RANGE',
-    payload: {
-      timeRange,
-    },
-  }
-}
-
-export function setEditMode(isEditMode) {
-  return {
-    type: 'SET_EDIT_MODE',
-    payload: {
-      isEditMode,
-    },
-  }
-}
-
-export function getDashboards(dashboardID) {
-  return (dispatch) => {
-    getDashboardsAJAX().then(({data: {dashboards}}) => {
-      dispatch(loadDashboards(dashboards, dashboardID))
-    });
-  }
-}
-
-export function putDashboard(dashboard) {
-  return (dispatch) => {
-    updateDashboardAJAX(dashboard).then(({data}) => {
-      dispatch(updateDashboard(data))
-    })
-  }
-}
-
-export function updateDashboard(dashboard) {
-  return {
-    type: 'UPDATE_DASHBOARD',
-    payload: {
-      dashboard,
-    },
-  }
+export const putDashboard = (dashboard) => (dispatch) => {
+  updateDashboardAJAX(dashboard).then(({data}) => {
+    dispatch(updateDashboard(data))
+  })
 }

--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -10,6 +10,8 @@ const Dashboard = ({
   inPresentationMode,
   onPositionChange,
   onEditCell,
+  onRenameCell,
+  onUpdateCell,
   source,
   autoRefresh,
   timeRange,
@@ -22,13 +24,13 @@ const Dashboard = ({
     <div className={classnames({'page-contents': true, 'presentation-mode': inPresentationMode})}>
       <div className={classnames('container-fluid full-width dashboard', {'dashboard-edit': isEditMode})}>
         {isEditMode ? <Visualizations/> : null}
-        {Dashboard.renderDashboard(dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell)}
+        {Dashboard.renderDashboard(dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell, onRenameCell, onUpdateCell)}
       </div>
     </div>
   )
 }
 
-Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell) => {
+Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell, onRenameCell, onUpdateCell) => {
   const cells = dashboard.cells.map((cell, i) => {
     i = `${i}`
     const dashboardCell = {...cell, i}
@@ -47,6 +49,8 @@ Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositi
       source={source.links.proxy}
       onPositionChange={onPositionChange}
       onEditCell={onEditCell}
+      onRenameCell={onRenameCell}
+      onUpdateCell={onUpdateCell}
     />
   )
 }
@@ -65,6 +69,8 @@ Dashboard.propTypes = {
   inPresentationMode: bool,
   onPositionChange: func,
   onEditCell: func,
+  onRenameCell: func,
+  onUpdateCell: func,
   source: shape({
     links: shape({
       proxy: string,

--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -9,6 +9,7 @@ const Dashboard = ({
   isEditMode,
   inPresentationMode,
   onPositionChange,
+  onEditCell,
   source,
   autoRefresh,
   timeRange,
@@ -21,13 +22,13 @@ const Dashboard = ({
     <div className={classnames({'page-contents': true, 'presentation-mode': inPresentationMode})}>
       <div className={classnames('container-fluid full-width dashboard', {'dashboard-edit': isEditMode})}>
         {isEditMode ? <Visualizations/> : null}
-        {Dashboard.renderDashboard(dashboard, autoRefresh, timeRange, source, onPositionChange)}
+        {Dashboard.renderDashboard(dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell)}
       </div>
     </div>
   )
 }
 
-Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositionChange) => {
+Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell) => {
   const cells = dashboard.cells.map((cell, i) => {
     i = `${i}`
     const dashboardCell = {...cell, i}
@@ -45,6 +46,7 @@ Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositi
       autoRefresh={autoRefresh}
       source={source.links.proxy}
       onPositionChange={onPositionChange}
+      onEditCell={onEditCell}
     />
   )
 }
@@ -62,6 +64,7 @@ Dashboard.propTypes = {
   isEditMode: bool,
   inPresentationMode: bool,
   onPositionChange: func,
+  onEditCell: func,
   source: shape({
     links: shape({
       proxy: string,

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -42,6 +42,8 @@ const DashboardPage = React.createClass({
       setDashboard: func.isRequired,
       setTimeRange: func.isRequired,
       setEditMode: func.isRequired,
+      editCell: func.isRequired,
+      renameCell: func.isRequired,
     }).isRequired,
     dashboards: arrayOf(shape({
       id: number.isRequired,
@@ -92,16 +94,32 @@ const DashboardPage = React.createClass({
     this.props.dashboardActions.putDashboard({...this.props.dashboard, cells})
   },
 
-  handleEditCell(cell) {
-    const {cells} = this.props.dashboard
-    const targetIdx = cells.findIndex((c) => cell.x === c.x && cell.y === c.y && cell.h === c.h && cell.w === c.w)
+  // Places cell into editing mode.
+  handleEditCell(x, y, isEditing) {
+    return () => {
+      this.props.dashboardActions.editCell(x, y, !isEditing) /* eslint-disable no-negated-condition */
+    }
+  },
 
-    const newCells = [
-      ...cells.slice(0, targetIdx),
-      cell,
-      ...cells.slice(targetIdx + 1),
-    ]
-    this.props.dashboardActions.putDashboard({...this.props.dashboard, cells: newCells})
+  handleChangeCellName(x, y) {
+    return (evt) => {
+      this.props.dashboardActions.renameCell(x, y, evt.target.value)
+    }
+  },
+
+  handleUpdateCell(newCell) {
+    return () => {
+      const {cells} = this.props.dashboard
+      const cellIdx = cells.findIndex((c) => c.x === newCell.x && c.y === newCell.y)
+
+      this.handleUpdatePosition([
+        ...cells.slice(0, cellIdx),
+        newCell,
+        ...cells.slice(cellIdx + 1),
+      ])
+
+      this.props.dashboardActions.editCell(newCell.x, newCell.y, false)
+    }
   },
 
   render() {
@@ -153,6 +171,8 @@ const DashboardPage = React.createClass({
           timeRange={timeRange}
           onPositionChange={this.handleUpdatePosition}
           onEditCell={this.handleEditCell}
+          onRenameCell={this.handleChangeCellName}
+          onUpdateCell={this.handleUpdateCell}
         />
       </div>
     );

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -91,7 +91,8 @@ const DashboardPage = React.createClass({
   },
 
   handleUpdatePosition(cells) {
-    this.props.dashboardActions.putDashboard({...this.props.dashboard, cells})
+    this.props.dashboardActions.updateDashboardCells(cells)
+    this.props.dashboardActions.putDashboard()
   },
 
   // Places cell into editing mode.
@@ -109,16 +110,8 @@ const DashboardPage = React.createClass({
 
   handleUpdateCell(newCell) {
     return () => {
-      const {cells} = this.props.dashboard
-      const cellIdx = cells.findIndex((c) => c.x === newCell.x && c.y === newCell.y)
-
-      this.handleUpdatePosition([
-        ...cells.slice(0, cellIdx),
-        newCell,
-        ...cells.slice(cellIdx + 1),
-      ])
-
       this.props.dashboardActions.editCell(newCell.x, newCell.y, false)
+      this.props.dashboardActions.putDashboard()
     }
   },
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -92,6 +92,18 @@ const DashboardPage = React.createClass({
     this.props.dashboardActions.putDashboard({...this.props.dashboard, cells})
   },
 
+  handleEditCell(cell) {
+    const {cells} = this.props.dashboard
+    const targetIdx = cells.findIndex((c) => cell.x === c.x && cell.y === c.y && cell.h === c.h && cell.w === c.w)
+
+    const newCells = [
+      ...cells.slice(0, targetIdx),
+      cell,
+      ...cells.slice(targetIdx + 1),
+    ]
+    this.props.dashboardActions.putDashboard({...this.props.dashboard, cells: newCells})
+  },
+
   render() {
     const {
       dashboards,
@@ -140,6 +152,7 @@ const DashboardPage = React.createClass({
           autoRefresh={autoRefresh}
           timeRange={timeRange}
           onPositionChange={this.handleUpdatePosition}
+          onEditCell={this.handleEditCell}
         />
       </div>
     );

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -50,6 +50,62 @@ export default function ui(state = initialState, action) {
 
       return {...state, ...newState}
     }
+
+    case 'EDIT_CELL': {
+      const {x, y, isEditing} = action.payload
+      const {dashboard} = state
+
+      const cellIdx = dashboard.cells.findIndex((cell) => cell.x === x && cell.y === y)
+
+      const newCell = {
+        ...dashboard.cells[cellIdx],
+        isEditing,
+      }
+
+      const newDashboard = {
+        ...dashboard,
+        cells: [
+          ...dashboard.cells.slice(0, cellIdx),
+          newCell,
+          ...dashboard.cells.slice(cellIdx + 1),
+        ],
+      }
+
+      const newState = {
+        newDashboard,
+        dashboards: state.dashboards.map((d) => d.id === dashboard.id ? newDashboard : d),
+      }
+
+      return {...state, ...newState}
+    }
+
+    case 'RENAME_CELL': {
+      const {x, y, name} = action.payload
+      const {dashboard} = state
+
+      const cellIdx = dashboard.cells.findIndex((cell) => cell.x === x && cell.y === y)
+
+      const newCell = {
+        ...dashboard.cells[cellIdx],
+        name,
+      }
+
+      const newDashboard = {
+        ...dashboard,
+        cells: [
+          ...dashboard.cells.slice(0, cellIdx),
+          newCell,
+          ...dashboard.cells.slice(cellIdx + 1),
+        ],
+      }
+
+      const newState = {
+        newDashboard,
+        dashboards: state.dashboards.map((d) => d.id === dashboard.id ? newDashboard : d),
+      }
+
+      return {...state, ...newState}
+    }
   }
 
   return state;

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -51,28 +51,41 @@ export default function ui(state = initialState, action) {
       return {...state, ...newState}
     }
 
+    case 'UPDATE_DASHBOARD_CELLS': {
+      const {cells} = action.payload
+      const {dashboard} = state
+
+      const newDashboard = {
+        ...dashboard,
+        cells,
+      }
+
+      const newState = {
+        dashboard: newDashboard,
+        dashboards: state.dashboards.map((d) => d.id === dashboard.id ? newDashboard : d),
+      }
+
+      return {...state, ...newState}
+    }
+
     case 'EDIT_CELL': {
       const {x, y, isEditing} = action.payload
       const {dashboard} = state
 
-      const cellIdx = dashboard.cells.findIndex((cell) => cell.x === x && cell.y === y)
+      const cell = dashboard.cells.find((c) => c.x === x && c.y === y)
 
       const newCell = {
-        ...dashboard.cells[cellIdx],
+        ...cell,
         isEditing,
       }
 
       const newDashboard = {
         ...dashboard,
-        cells: [
-          ...dashboard.cells.slice(0, cellIdx),
-          newCell,
-          ...dashboard.cells.slice(cellIdx + 1),
-        ],
+        cells: dashboard.cells.map((c) => c.x === x && c.y === y ? newCell : c),
       }
 
       const newState = {
-        newDashboard,
+        dashboard: newDashboard,
         dashboards: state.dashboards.map((d) => d.id === dashboard.id ? newDashboard : d),
       }
 
@@ -83,24 +96,20 @@ export default function ui(state = initialState, action) {
       const {x, y, name} = action.payload
       const {dashboard} = state
 
-      const cellIdx = dashboard.cells.findIndex((cell) => cell.x === x && cell.y === y)
+      const cell = dashboard.cells.find((c) => c.x === x && c.y === y)
 
       const newCell = {
-        ...dashboard.cells[cellIdx],
+        ...cell,
         name,
       }
 
       const newDashboard = {
         ...dashboard,
-        cells: [
-          ...dashboard.cells.slice(0, cellIdx),
-          newCell,
-          ...dashboard.cells.slice(cellIdx + 1),
-        ],
+        cells: dashboard.cells.map((c) => c.x === x && c.y === y ? newCell : c),
       }
 
       const newState = {
-        newDashboard,
+        dashboard: newDashboard,
         dashboards: state.dashboards.map((d) => d.id === dashboard.id ? newDashboard : d),
       }
 

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react';
 import AutoRefresh from 'shared/components/AutoRefresh';
 import LineGraph from 'shared/components/LineGraph';
 import SingleStat from 'shared/components/SingleStat';
+import NameableGraph from 'shared/components/NameableGraph';
 import ReactGridLayout, {WidthProvider} from 'react-grid-layout';
 const GridLayout = WidthProvider(ReactGridLayout);
 
@@ -94,14 +95,12 @@ export const LayoutRenderer = React.createClass({
         });
       });
 
-
       if (cell.type === 'single-stat') {
         return (
           <div key={cell.i}>
-            <h2 className="dash-graph--heading">{cell.name || `Graph`}</h2>
-            <div className="dash-graph--container">
+            <NameableGraph name={cell.name || `Graph`} layout={cells} onRename={this.handleLayoutChange} id={cell.i}>
               <RefreshingSingleStat queries={[qs[0]]} autoRefresh={autoRefresh} />
-            </div>
+            </NameableGraph>
           </div>
         );
       }
@@ -113,15 +112,14 @@ export const LayoutRenderer = React.createClass({
 
       return (
         <div key={cell.i}>
-          <h2 className="dash-graph--heading">{cell.name || `Graph`}</h2>
-          <div className="dash-graph--container">
+          <NameableGraph name={cell.name || `Graph`} layout={cells} onRename={this.handleLayoutChange} id={cell.i}>
             <RefreshingLineGraph
               queries={qs}
               autoRefresh={autoRefresh}
               showSingleStat={cell.type === "line-plus-single-stat"}
               displayOptions={displayOptions}
             />
-          </div>
+          </NameableGraph>
         </div>
       );
     });
@@ -136,7 +134,7 @@ export const LayoutRenderer = React.createClass({
 
     const newCells = this.props.cells.map((cell) => {
       const l = layout.find((ly) => ly.i === cell.i)
-      const newLayout = {x: l.x, y: l.y, h: l.h, w: l.w}
+      const newLayout = {x: l.x, y: l.y, h: l.h, w: l.w, name: l.name}
       return {...cell, ...newLayout}
     })
 

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -135,7 +135,7 @@ export const LayoutRenderer = React.createClass({
 
     const newCells = this.props.cells.map((cell) => {
       const l = layout.find((ly) => ly.i === cell.i)
-      const newLayout = {x: l.x, y: l.y, h: l.h, w: l.w, name: l.name}
+      const newLayout = {x: l.x, y: l.y, h: l.h, w: l.w}
       return {...cell, ...newLayout}
     })
 

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -52,6 +52,8 @@ export const LayoutRenderer = React.createClass({
     source: string,
     onPositionChange: func,
     onEditCell: func,
+    onRenameCell: func,
+    onUpdateCell: func,
   },
 
   buildQuery(q) {
@@ -86,7 +88,7 @@ export const LayoutRenderer = React.createClass({
   },
 
   generateVisualizations() {
-    const {autoRefresh, source, cells} = this.props;
+    const {autoRefresh, source, cells, onEditCell, onRenameCell, onUpdateCell} = this.props;
 
     return cells.map((cell) => {
       const qs = cell.queries.map((q) => {
@@ -99,7 +101,12 @@ export const LayoutRenderer = React.createClass({
       if (cell.type === 'single-stat') {
         return (
           <div key={cell.i}>
-            <NameableGraph cell={cell} onRename={this.props.onEditCell}>
+            <NameableGraph
+              onEditCell={onEditCell}
+              onRenameCell={onRenameCell}
+              onUpdateCell={onUpdateCell}
+              cell={cell}
+            >
               <RefreshingSingleStat queries={[qs[0]]} autoRefresh={autoRefresh} />
             </NameableGraph>
           </div>
@@ -113,7 +120,12 @@ export const LayoutRenderer = React.createClass({
 
       return (
         <div key={cell.i}>
-          <NameableGraph cell={cell} onRename={this.props.onEditCell}>
+          <NameableGraph
+            onEditCell={onEditCell}
+            onRenameCell={onRenameCell}
+            onUpdateCell={onUpdateCell}
+            cell={cell}
+          >
             <RefreshingLineGraph
               queries={qs}
               autoRefresh={autoRefresh}

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -51,6 +51,7 @@ export const LayoutRenderer = React.createClass({
     host: string,
     source: string,
     onPositionChange: func,
+    onEditCell: func,
   },
 
   buildQuery(q) {
@@ -98,7 +99,7 @@ export const LayoutRenderer = React.createClass({
       if (cell.type === 'single-stat') {
         return (
           <div key={cell.i}>
-            <NameableGraph name={cell.name || `Graph`} layout={cells} onRename={this.handleLayoutChange} id={cell.i}>
+            <NameableGraph cell={cell} onRename={this.props.onEditCell}>
               <RefreshingSingleStat queries={[qs[0]]} autoRefresh={autoRefresh} />
             </NameableGraph>
           </div>
@@ -112,7 +113,7 @@ export const LayoutRenderer = React.createClass({
 
       return (
         <div key={cell.i}>
-          <NameableGraph name={cell.name || `Graph`} layout={cells} onRename={this.handleLayoutChange} id={cell.i}>
+          <NameableGraph cell={cell} onRename={this.props.onEditCell}>
             <RefreshingLineGraph
               queries={qs}
               autoRefresh={autoRefresh}

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -23,6 +23,11 @@ const NameableGraph = ({
         autoFocus={true}
         onChange={onRenameCell(x, y)}
         onBlur={onUpdateCell(cell)}
+        onKeyUp={(evt) => {
+          if (evt.key === 'Enter') {
+            onUpdateCell(cell)()
+          }
+        }}
       />
     )
   } else {

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -1,58 +1,61 @@
 import React, {PropTypes} from 'react'
 
-const NameableGraph = React.createClass({
-  propTypes: {
-    cell: PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      id: PropTypes.string.isRequired,
-    }).isRequired,
-    children: PropTypes.node.isRequired,
-    onRename: PropTypes.func.isRequired,
+const NameableGraph = ({
+  cell: {
+    name,
+    isEditing,
+    x,
+    y,
   },
+  cell,
+  children,
+  onEditCell,
+  onRenameCell,
+  onUpdateCell,
+}) => {
+  let nameOrField
 
-  getInitialState() {
-    return {
-      editing: false,
-      name: this.props.cell.name,
-    }
-  },
+  if (isEditing) {
+    nameOrField = (
+      <input
+        type="text"
+        value={name}
+        autoFocus={true}
+        onChange={onRenameCell(x, y)}
+        onBlur={onUpdateCell(cell)}
+      />
+    )
+  } else {
+    nameOrField = name
+  }
 
-  handleClick() {
-    this.setState({
-      editing: !this.state.editing, /* eslint-disable no-negated-condition */
-    });
-  },
-
-  handleChangeName() {
-    this.props.onRename({
-      ...this.props.cell,
-      name: this.state.name,
-    })
-  },
-
-  handleChange(evt) {
-    this.setState({
-      name: evt.target.value,
-    })
-  },
-
-  render() {
-    let nameOrField
-    if (!this.state.editing) {
-      nameOrField = this.props.cell.name
-    } else {
-      nameOrField = <input type="text" value={this.state.name} autoFocus={true} onChange={this.handleChange} onBlur={this.handleChangeName}></input>
-    }
-
-    return (
-      <div>
-        <h2 className="dash-graph--heading" onClick={this.handleClick}>{nameOrField}</h2>
-        <div className="dash-graph--container">
-          {this.props.children}
-        </div>
+  return (
+    <div>
+      <h2 className="dash-graph--heading" onClick={onEditCell(x, y, isEditing)}>{nameOrField}</h2>
+      <div className="dash-graph--container">
+        {children}
       </div>
-    );
-  },
-});
+    </div>
+  )
+}
+
+const {
+  func,
+  node,
+  shape,
+  string,
+} = PropTypes
+
+NameableGraph.propTypes = {
+  cell: shape({
+    name: string.isRequired,
+    x: string.isRequired,
+    y: string.isRequired,
+  }).isRequired,
+  children: node.isRequired,
+  onEditCell: func.isRequired,
+  onRenameCell: func.isRequired,
+  onUpdateCell: func.isRequired,
+}
 
 export default NameableGraph;

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -2,17 +2,17 @@ import React, {PropTypes} from 'react'
 
 const NameableGraph = React.createClass({
   propTypes: {
-    name: PropTypes.string.isRequired,
-    id: PropTypes.string.isRequired,
+    cell: PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+    }).isRequired,
     children: PropTypes.node.isRequired,
-    layout: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     onRename: PropTypes.func.isRequired,
   },
 
   getInitialState() {
     return {
       editing: false,
-      name: this.props.name,
     }
   },
 
@@ -23,32 +23,18 @@ const NameableGraph = React.createClass({
   },
 
   handleChangeName(evt) {
-    const {editing, name: oldName} = this.state
-    const newName = evt.target.value
-    const {layout, id, onRename} = this.props
-
-    if (editing && newName !== oldName) {
-      const newLayout = layout.map((cell) => {
-        if (cell.i === id) {
-          const ret = Object.assign({}, cell)
-          ret.name = newName
-          return ret
-        }
-        return cell
-      })
-      onRename(newLayout)
-      this.setState({
-        name: newName,
-      });
-    }
+    this.props.onRename({
+      ...this.props.cell,
+      name: evt.target.value,
+    })
   },
 
   render() {
     let nameOrField
     if (!this.state.editing) {
-      nameOrField = this.state.name
+      nameOrField = this.props.cell.name
     } else {
-      nameOrField = <input type="text" value={this.state.name} autoFocus={true} onChange={this.handleChangeName}></input>
+      nameOrField = <input type="text" value={this.props.cell.name} autoFocus={true} onChange={this.handleChangeName}></input>
     }
 
     return (

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -13,6 +13,7 @@ const NameableGraph = React.createClass({
   getInitialState() {
     return {
       editing: false,
+      name: this.props.cell.name,
     }
   },
 
@@ -22,9 +23,15 @@ const NameableGraph = React.createClass({
     });
   },
 
-  handleChangeName(evt) {
+  handleChangeName() {
     this.props.onRename({
       ...this.props.cell,
+      name: this.state.name,
+    })
+  },
+
+  handleChange(evt) {
+    this.setState({
       name: evt.target.value,
     })
   },
@@ -34,7 +41,7 @@ const NameableGraph = React.createClass({
     if (!this.state.editing) {
       nameOrField = this.props.cell.name
     } else {
-      nameOrField = <input type="text" value={this.props.cell.name} autoFocus={true} onChange={this.handleChangeName}></input>
+      nameOrField = <input type="text" value={this.state.name} autoFocus={true} onChange={this.handleChange} onBlur={this.handleChangeName}></input>
     }
 
     return (

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -1,0 +1,65 @@
+import React, {PropTypes} from 'react'
+
+const NameableGraph = React.createClass({
+  propTypes: {
+    name: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    children: PropTypes.node.isRequired,
+    layout: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
+    onRename: PropTypes.func.isRequired,
+  },
+
+  getInitialState() {
+    return {
+      editing: false,
+      name: this.props.name,
+    }
+  },
+
+  handleClick() {
+    this.setState({
+      editing: !this.state.editing, /* eslint-disable no-negated-condition */
+    });
+  },
+
+  handleChangeName(evt) {
+    const {editing, name: oldName} = this.state
+    const newName = evt.target.value
+    const {layout, id, onRename} = this.props
+
+    if (editing && newName !== oldName) {
+      const newLayout = layout.map((cell) => {
+        if (cell.i === id) {
+          const ret = Object.assign({}, cell)
+          ret.name = newName
+          return ret
+        }
+        return cell
+      })
+      onRename(newLayout)
+      this.setState({
+        name: newName,
+      });
+    }
+  },
+
+  render() {
+    let nameOrField
+    if (!this.state.editing) {
+      nameOrField = this.state.name
+    } else {
+      nameOrField = <input type="text" value={this.state.name} autoFocus={true} onChange={this.handleChangeName}></input>
+    }
+
+    return (
+      <div>
+        <h2 className="dash-graph--heading" onClick={this.handleClick}>{nameOrField}</h2>
+        <div className="dash-graph--container">
+          {this.props.children}
+        </div>
+      </div>
+    );
+  },
+});
+
+export default NameableGraph;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #954 

### The problem

Users weren't able to edit the name of their cells on dashboards, so they all had the name "Graph"

### The Solution

Users are now able to edit cells by clicking on the title, changing the name and either clicking elsewhere or hitting "Enter" to submit changes to the cell's name.

