### PR TITLE
Redirect to default source on invalid source ID

### DIFF
--- a/ui/src/CheckSources.js
+++ b/ui/src/CheckSources.js
@@ -45,7 +45,11 @@ const CheckSources = React.createClass({
     const {router, location, params, addFlashMessage, sources} = nextProps;
     const {isFetching} = nextState;
     const source = sources.find((s) => s.id === params.sourceID);
+    const defaultSource = sources.find((s) => s.default === true)
     if (!isFetching && !source) {
+      if (defaultSource) {
+        return router.push(location.pathname.replace(/\/sources\/\d+\//, defaultSource.id));
+      }
       return router.push(`/sources/new?redirectPath=${location.pathname}`);
     }
 


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1008 

When supplied with an invalid source ID, the CheckSources component
would redirect the user to a "Create Source" page. This caused
surprising behavior when a source was deleted because that source ID
would become invalid. The effect being that deleting a source brought
users immediately to the create source page, rather than back to the
sources list.

This instead redirects users to the default source when provided an
invalid source id. The backend automatically re-assigns the "default"
source, so this will always succeed, since sources are fetched again
from the backend.

The regex used is slightly dependent on URL structure that has been
stable over the lifetime of this project. Also it relies on URL
structure more than the previous redirecting implementation.

