### PR TITLE
Fix DB manager table column sizing

### DIFF
--- a/ui/src/admin/components/DatabaseRow.js
+++ b/ui/src/admin/components/DatabaseRow.js
@@ -34,6 +34,7 @@ class DatabaseRow extends Component {
       retentionPolicy,
       database,
       onDelete,
+      isDeletable,
       isRFDisplayed,
     } = this.props
     const {isEditing, isDeleting} = this.state
@@ -107,23 +108,17 @@ class DatabaseRow extends Component {
         <td className="text-right">
           {
             isDeleting ?
-              <YesNoButtons onConfirm={() => onDelete(database, retentionPolicy)} onCancel={this.handleEndDelete} /> :
-              this.renderDeleteButton()
+              <YesNoButtons
+                onConfirm={() => onDelete(database, retentionPolicy)}
+                onCancel={this.handleEndDelete} /> :
+              <button
+                className="btn btn-xs btn-danger admin-table--delete"
+                style={isDeletable ? {} : {visibility: 'hidden'}}
+                onClick={this.handleStartDelete}>{`Delete ${name}`}
+              </button>
           }
         </td>
       </tr>
-    )
-  }
-
-  renderDeleteButton() {
-    if (!this.props.isDeletable) {
-      return
-    }
-
-    return (
-      <button className="btn btn-xs btn-danger admin-table--delete" onClick={this.handleStartDelete}>
-        {`Delete ${name}`}
-      </button>
     )
   }
 


### PR DESCRIPTION
The delete RP button was not rendered if
there was only one RP for that RP's database.
This caused the table columns to render in different
sizes.  Hiding the button keep the same functionality but
preserves the sizing for the table.


