### PR TITLE
Redirect to default source when deleting sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
-  1. [#1065](https://github.com/influxdata/chronograf/pull/1065): Save and Cancel edits to a Dashboard name
-  2. [#1069](https://github.com/influxdata/chronograf/pull/1069): Graphs are no longer editable from a Host Page
-  3. [#1074](https://github.com/influxdata/chronograf/pull/1074): Fix unexpected redirection to create sources page when deleting a source
+  1. [#1074](https://github.com/influxdata/chronograf/pull/1074): Fix unexpected redirection to create sources page when deleting a source
 ### Features
 ### UI Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Bug Fixes
   1. [#1065](https://github.com/influxdata/chronograf/pull/1065): Save and Cancel edits to a Dashboard name
   2. [#1069](https://github.com/influxdata/chronograf/pull/1069): Graphs are no longer editable from a Host Page
+  3. [#1074](https://github.com/influxdata/chronograf/pull/1074): Fix unexpected redirection to create sources page when deleting a source
 
 ## v1.2.0-beta6 [2017-03-24]
 

--- a/server/sources.go
+++ b/server/sources.go
@@ -155,7 +155,11 @@ func (h *Service) RemoveSource(w http.ResponseWriter, r *http.Request) {
 	src := chronograf.Source{ID: id}
 	ctx := r.Context()
 	if err = h.SourcesStore.Delete(ctx, src); err != nil {
-		unknownErrorWithMessage(w, err, h.Logger)
+		if err == chronograf.ErrSourceNotFound {
+			notFound(w, id, h.Logger)
+		} else {
+			unknownErrorWithMessage(w, err, h.Logger)
+		}
 		return
 	}
 

--- a/ui/spec/shared/reducers/sourcesSpec.js
+++ b/ui/spec/shared/reducers/sourcesSpec.js
@@ -3,7 +3,6 @@ import reducer from 'src/shared/reducers/sources';
 import {
   loadSources,
   updateSource,
-  removeSource,
   addSource,
 } from 'src/shared/actions/sources';
 

--- a/ui/src/CheckSources.js
+++ b/ui/src/CheckSources.js
@@ -45,7 +45,12 @@ const CheckSources = React.createClass({
     const {router, location, params, addFlashMessage, sources} = nextProps;
     const {isFetching} = nextState;
     const source = sources.find((s) => s.id === params.sourceID);
+    const defaultSource = sources.find((s) => s.default === true)
     if (!isFetching && !source) {
+      if (defaultSource) {
+        const rest = location.pathname.match(/\/sources\/\d+?\/(.+)/)
+        return router.push(`/sources/${defaultSource.id}/${rest[1]}`)
+      }
       return router.push(`/sources/new?redirectPath=${location.pathname}`);
     }
 

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -24,14 +24,13 @@ export const addSource = (source) => ({
 
 // Async action creators
 
-export const removeAndLoadSources = (source, sources) => async (dispatch) => {
+export const removeAndLoadSources = (source) => async (dispatch) => {
   try {
     try {
       await deleteSource(source)
     } catch (err) {
-      // A 404 means that a concurrent write occurred, since the above
-      // assertion was successful. It's safe to pretend the delete was
-      // successful and reload sources.
+      // A 404 means that either a concurrent write occurred or the source
+      // passed to this action creator doesn't exist (or is undefined)
       if (err.status !== 404) { // eslint-disable-line no-magic-numbers
         throw (err)
       }

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -25,11 +25,6 @@ export const addSource = (source) => ({
 // Async action creators
 
 export const removeAndLoadSources = (source, sources) => async (dispatch) => {
-  // Assert that the caller is sane by ensuring that source is among the provided sources
-  if (!sources.find(({id}) => source.id === id)) {
-    throw new Error("Assertion failed: provided source not in sources")
-  }
-
   try {
     try {
       await deleteSource(source)

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -1,35 +1,37 @@
-export function loadSources(sources) {
-  return {
-    type: 'LOAD_SOURCES',
-    payload: {
-      sources,
-    },
-  };
-}
+import {deleteSource, getSources} from 'src/shared/apis'
 
-export function updateSource(source) {
-  return {
-    type: 'SOURCE_UPDATED',
-    payload: {
-      source,
-    },
-  };
-}
+export const loadSources = (sources) => ({
+  type: 'LOAD_SOURCES',
+  payload: {
+    sources,
+  },
+})
 
-export function removeSource(source) {
-  return {
-    type: 'SOURCE_REMOVED',
-    payload: {
-      source,
-    },
-  };
-}
+export const updateSource = (source) => ({
+  type: 'SOURCE_UPDATED',
+  payload: {
+    source,
+  },
+})
 
-export function addSource(source) {
-  return {
-    type: 'SOURCE_ADDED',
-    payload: {
-      source,
-    },
-  };
+export const removeSource = (source) => ({
+  type: 'SOURCE_REMOVED',
+  payload: {
+    source,
+  },
+})
+
+export const addSource = (source) => ({
+  type: 'SOURCE_ADDED',
+  payload: {
+    source,
+  },
+})
+
+// Async action creators
+
+export const removeAndLoadSources = (source) => async (dispatch) => {
+  await deleteSource(source)
+  const sources = await getSources()
+  dispatch(loadSources(sources.data.sources))
 }

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -1,4 +1,5 @@
 import {deleteSource, getSources} from 'src/shared/apis'
+import {publishNotification} from './notifications'
 
 export const loadSources = (sources) => ({
   type: 'LOAD_SOURCES',
@@ -23,8 +24,27 @@ export const addSource = (source) => ({
 
 // Async action creators
 
-export const removeAndLoadSources = (source) => async (dispatch) => {
-  await deleteSource(source)
-  const sources = await getSources()
-  dispatch(loadSources(sources.data.sources))
+export const removeAndLoadSources = (source, sources) => async (dispatch) => {
+  // Assert that the caller is sane by ensuring that source is among the provided sources
+  if (!sources.find(({id}) => source.id === id)) {
+    throw new Error("Assertion failed: provided source not in sources")
+  }
+
+  try {
+    try {
+      await deleteSource(source)
+    } catch (err) {
+      // A 404 means that a concurrent write occurred, since the above
+      // assertion was successful. It's safe to pretend the delete was
+      // successful and reload sources.
+      if (err.status !== 404) { // eslint-disable-line no-magic-numbers
+        throw (err)
+      }
+    }
+
+    const {data: {sources: newSources}} = await getSources()
+    dispatch(loadSources(newSources))
+  } catch (err) {
+    dispatch(publishNotification("error", "Internal Server Error. Check API Logs"))
+  }
 }

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -14,13 +14,6 @@ export const updateSource = (source) => ({
   },
 })
 
-export const removeSource = (source) => ({
-  type: 'SOURCE_REMOVED',
-  payload: {
-    source,
-  },
-})
-
 export const addSource = (source) => ({
   type: 'SOURCE_ADDED',
   payload: {

--- a/ui/src/shared/reducers/sources.js
+++ b/ui/src/shared/reducers/sources.js
@@ -14,12 +14,6 @@ export default function sources(state = [], action) {
       return updatedSources;
     }
 
-    case 'SOURCE_REMOVED': {
-      const {source} = action.payload;
-      const updatedSources = state.filter((s) => s.id !== source.id);
-      return updatedSources;
-    }
-
     case 'SOURCE_ADDED': {
       const {source} = action.payload;
       const updatedSources = source.default ? state.map((s) => {

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -1,29 +1,33 @@
 import React, {PropTypes} from 'react';
 import {withRouter, Link} from 'react-router';
-import {getKapacitor, deleteSource} from 'shared/apis';
-import {
-  loadSources as loadSourcesAction,
-  removeSource as removeSourceAction,
-} from 'src/shared/actions/sources';
+import {getKapacitor} from 'shared/apis';
+import {removeAndLoadSources} from 'src/shared/actions/sources';
 import {connect} from 'react-redux';
+
+const {
+  array,
+  func,
+  shape,
+  string,
+} = PropTypes
 
 export const ManageSources = React.createClass({
   propTypes: {
-    location: PropTypes.shape({
-      pathname: PropTypes.string.isRequired,
+    location: shape({
+      pathname: string.isRequired,
     }).isRequired,
-    source: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-      links: PropTypes.shape({
-        proxy: PropTypes.string.isRequired,
-        self: PropTypes.string.isRequired,
+    source: shape({
+      id: string.isRequired,
+      links: shape({
+        proxy: string.isRequired,
+        self: string.isRequired,
       }),
     }),
-    sources: PropTypes.array,
-    addFlashMessage: PropTypes.func,
-    loadSourcesAction: PropTypes.func.isRequired,
-    removeSourceAction: PropTypes.func.isRequired,
+    sources: array,
+    addFlashMessage: func,
+    removeAndLoadSources: func,
   },
+
   getInitialState() {
     return {
       kapacitors: {},
@@ -47,12 +51,11 @@ export const ManageSources = React.createClass({
   handleDeleteSource(source) {
     const {addFlashMessage} = this.props;
 
-    deleteSource(source).then(() => {
-      this.props.removeSourceAction(source);
-      addFlashMessage({type: 'success', text: 'Source removed from Chronograf'});
-    }).catch(() => {
+    try {
+      this.props.removeAndLoadSources(source)
+    } catch (e) {
       addFlashMessage({type: 'error', text: 'Could not remove source from Chronograf'});
-    });
+    }
   },
 
   render() {
@@ -130,4 +133,4 @@ function mapStateToProps(state) {
   };
 }
 
-export default connect(mapStateToProps, {loadSourcesAction, removeSourceAction})(withRouter(ManageSources));
+export default connect(mapStateToProps, {removeAndLoadSources})(withRouter(ManageSources));

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -49,10 +49,10 @@ export const ManageSources = React.createClass({
   },
 
   handleDeleteSource(source) {
-    const {addFlashMessage, sources} = this.props;
+    const {addFlashMessage} = this.props;
 
     try {
-      this.props.removeAndLoadSources(source, sources)
+      this.props.removeAndLoadSources(source)
     } catch (e) {
       addFlashMessage({type: 'error', text: 'Could not remove source from Chronograf'});
     }

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -49,10 +49,10 @@ export const ManageSources = React.createClass({
   },
 
   handleDeleteSource(source) {
-    const {addFlashMessage} = this.props;
+    const {addFlashMessage, sources} = this.props;
 
     try {
-      this.props.removeAndLoadSources(source)
+      this.props.removeAndLoadSources(source, sources)
     } catch (e) {
       addFlashMessage({type: 'error', text: 'Could not remove source from Chronograf'});
     }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [X] Rebased/mergable
  - [x] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1008 

### The problem

Users that deleted a source they were connected to would be unexpectedly redirected to the create sources page.

### The Solution

Users are redirected to the default source when deleting sources. If the default source is deleted, the API chooses a new default source and the user is directed to that one. If all sources are deleted, the user is prompted to create a new one.