### PR TITLE
(Fix) Graphs are now resizable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
   1. [#1065](https://github.com/influxdata/chronograf/pull/1065): Add functionality to the `save` and `cancel` buttons on editable dashboards
   2. [#1069](https://github.com/influxdata/chronograf/pull/1069): Make graphs on pre-created dashboards un-editable
+  3. [#1085](https://github.com/influxdata/chronograf/pull/1085): Make graphs resizable again
 
 ### Features
   1. [#1056](https://github.com/influxdata/chronograf/pull/1056): Add ability to add a dashboard cell

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -54,6 +54,7 @@ $dash-graph-heading: 30px;
   height: 100%;
   top: 0;
   left: 0;
+  z-index: 0;
 }
 .dash-graph--container {
   z-index: 1;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1078 

### The problem
Dashboard cells became unresizable, despite the handle for it at the bottom-right corner.

### The Solution
Change the z-index of the new `dash-graph` container `div` in the recently added NameableGraph component.

