### PR TITLE
Add ability to delete a dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   1. [#1104](https://github.com/influxdata/chronograf/pull/1104): Fix windows hosts on host list
 
 ### Features
+  1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard
+
 ### UI Improvements
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip
 

--- a/ui/spec/dashboards/reducers/uiSpec.js
+++ b/ui/spec/dashboards/reducers/uiSpec.js
@@ -1,9 +1,13 @@
+import _ from 'lodash'
+
 import reducer from 'src/dashboards/reducers/ui'
 import timeRanges from 'hson!src/shared/data/timeRanges.hson';
 
 import {
   loadDashboards,
   setDashboard,
+  deleteDashboard,
+  deleteDashboardFailed,
   setTimeRange,
   updateDashboardCells,
   editDashboardCell,
@@ -48,6 +52,25 @@ describe('DataExplorer.Reducers.UI', () => {
     const actual = reducer(loadedState, setDashboard(d2.id))
 
     expect(actual.dashboard).to.deep.equal(d2)
+  })
+
+  it('can handle a successful dashboard deletion', () => {
+    const loadedState = reducer(state, loadDashboards(dashboards))
+    const expected = [d1]
+    const actual = reducer(loadedState, deleteDashboard(d2))
+
+    expect(actual.dashboards).to.deep.equal(expected)
+  })
+
+  it('can handle a failed dashboard deletion', () => {
+    const loadedState = reducer(state, loadDashboards([d1]))
+    const actual = reducer(loadedState, deleteDashboardFailed(d2))
+    const actualFirst = _.first(actual.dashboards)
+
+    expect(actual.dashboards).to.have.length(2)
+    _.forOwn(d2, (v, k) => {
+      expect(actualFirst[k]).to.deep.equal(v)
+    })
   })
 
   it('can set the time range', () => {

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -106,10 +106,9 @@ export const deleteDashboardCell = (cell) => ({
 
 // Async Action Creators
 
-export const getDashboards = (dashboardID) => (dispatch) => {
-  getDashboardsAJAX().then(({data: {dashboards}}) => {
-    dispatch(loadDashboards(dashboards, dashboardID))
-  })
+export const getDashboardsAsync = (dashboardID) => async (dispatch) => {
+  const {data: {dashboards}} = await getDashboardsAJAX()
+  dispatch(loadDashboards(dashboards, dashboardID))
 }
 
 export const putDashboard = () => (dispatch, getState) => {

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -1,10 +1,13 @@
 import {
   getDashboards as getDashboardsAJAX,
   updateDashboard as updateDashboardAJAX,
+  deleteDashboard as deleteDashboardAJAX,
   updateDashboardCell as updateDashboardCellAJAX,
   addDashboardCell as addDashboardCellAJAX,
   deleteDashboardCell as deleteDashboardCellAJAX,
 } from 'src/dashboards/apis'
+
+import {publishNotification} from 'src/shared/actions/notifications';
 
 import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants'
 
@@ -32,6 +35,20 @@ export const setTimeRange = (timeRange) => ({
 
 export const updateDashboard = (dashboard) => ({
   type: 'UPDATE_DASHBOARD',
+  payload: {
+    dashboard,
+  },
+})
+
+export const deleteDashboard = (dashboard) => ({
+  type: 'DELETE_DASHBOARD',
+  payload: {
+    dashboard,
+  },
+})
+
+export const undoDeleteDashboard = (dashboard) => ({
+  type: 'UNDO_DELETE_DASHBOARD',
   payload: {
     dashboard,
   },
@@ -107,6 +124,17 @@ export const updateDashboardCell = (cell) => (dispatch) => {
   .then(({data}) => {
     dispatch(syncDashboardCell(data))
   })
+}
+
+export const deleteDashboardAsync = (dashboard) => async (dispatch) => {
+  dispatch(deleteDashboard(dashboard))
+  try {
+    await deleteDashboardAJAX(dashboard)
+    dispatch(publishNotification('success', 'Dashboard deleted successfully.'))
+  } catch (error) {
+    dispatch(undoDeleteDashboard(dashboard)) // undo optimistic update
+    dispatch(publishNotification('error', `Failed to delete dashboard: ${error.data.message}.`))
+  }
 }
 
 export const addDashboardCellAsync = (dashboard) => async (dispatch) => {

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -47,8 +47,8 @@ export const deleteDashboard = (dashboard) => ({
   },
 })
 
-export const undoDeleteDashboard = (dashboard) => ({
-  type: 'UNDO_DELETE_DASHBOARD',
+export const deleteDashboardFailed = (dashboard) => ({
+  type: 'DELETE_DASHBOARD_FAILED',
   payload: {
     dashboard,
   },
@@ -131,7 +131,7 @@ export const deleteDashboardAsync = (dashboard) => async (dispatch) => {
     await deleteDashboardAJAX(dashboard)
     dispatch(publishNotification('success', 'Dashboard deleted successfully.'))
   } catch (error) {
-    dispatch(undoDeleteDashboard(dashboard)) // undo optimistic update
+    dispatch(deleteDashboardFailed(dashboard))
     dispatch(publishNotification('error', `Failed to delete dashboard: ${error.data.message}.`))
   }
 }

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -107,8 +107,13 @@ export const deleteDashboardCell = (cell) => ({
 // Async Action Creators
 
 export const getDashboardsAsync = (dashboardID) => async (dispatch) => {
-  const {data: {dashboards}} = await getDashboardsAJAX()
-  dispatch(loadDashboards(dashboards, dashboardID))
+  try {
+    const {data: {dashboards}} = await getDashboardsAJAX()
+    dispatch(loadDashboards(dashboards, dashboardID))
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
 }
 
 export const putDashboard = () => (dispatch, getState) => {

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -7,8 +7,9 @@ import {
   deleteDashboardCell as deleteDashboardCellAJAX,
 } from 'src/dashboards/apis'
 
-import {publishNotification} from 'src/shared/actions/notifications';
+import {publishNotification, delayDismissNotification} from 'src/shared/actions/notifications'
 
+import {SHORT_NOTIFICATION_DISAPPEARING_DELAY} from 'shared/constants'
 import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants'
 
 export const loadDashboards = (dashboards, dashboardID) => ({
@@ -135,6 +136,7 @@ export const deleteDashboardAsync = (dashboard) => async (dispatch) => {
   try {
     await deleteDashboardAJAX(dashboard)
     dispatch(publishNotification('success', 'Dashboard deleted successfully.'))
+    dispatch(delayDismissNotification('success', SHORT_NOTIFICATION_DISAPPEARING_DELAY))
   } catch (error) {
     dispatch(deleteDashboardFailed(dashboard))
     dispatch(publishNotification('error', `Failed to delete dashboard: ${error.data.message}.`))

--- a/ui/src/dashboards/apis/index.js
+++ b/ui/src/dashboards/apis/index.js
@@ -36,6 +36,18 @@ export const createDashboard = async (dashboard) => {
   }
 }
 
+export const deleteDashboard = async (dashboard) => {
+  try {
+    return await AJAX({
+      method: 'DELETE',
+      url: dashboard.links.self,
+    })
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}
+
 export const addDashboardCell = async (dashboard, cell) => {
   try {
     return await AJAX({

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -39,7 +39,7 @@ const DashboardPage = React.createClass({
     }).isRequired,
     dashboardActions: shape({
       putDashboard: func.isRequired,
-      getDashboards: func.isRequired,
+      getDashboardsAsync: func.isRequired,
       setDashboard: func.isRequired,
       setTimeRange: func.isRequired,
       addDashboardCellAsync: func.isRequired,
@@ -84,10 +84,10 @@ const DashboardPage = React.createClass({
   componentDidMount() {
     const {
       params: {dashboardID},
-      dashboardActions: {getDashboards},
+      dashboardActions: {getDashboardsAsync},
     } = this.props;
 
-    getDashboards(dashboardID)
+    getDashboardsAsync(dashboardID)
   },
 
   componentWillReceiveProps(nextProps) {

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -24,10 +24,10 @@ const {
 
 const DashboardPage = React.createClass({
   propTypes: {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        proxy: PropTypes.string,
-        self: PropTypes.string,
+    source: shape({
+      links: shape({
+        proxy: string,
+        self: string,
       }),
     }),
     params: shape({
@@ -49,11 +49,11 @@ const DashboardPage = React.createClass({
     dashboards: arrayOf(shape({
       id: number.isRequired,
       cells: arrayOf(shape({})).isRequired,
-    })).isRequired,
+    })),
     dashboard: shape({
       id: number.isRequired,
       cells: arrayOf(shape({})).isRequired,
-    }).isRequired,
+    }),
     handleChooseAutoRefresh: func.isRequired,
     autoRefresh: number.isRequired,
     timeRange: shape({}).isRequired,
@@ -224,30 +224,38 @@ const DashboardPage = React.createClass({
               onAddCell={this.handleAddCell}
               onEditDashboard={this.handleEditDashboard}
             >
-              {(dashboards).map((d, i) => {
-                return (
-                  <li key={i}>
-                    <Link to={`/sources/${sourceID}/dashboards/${d.id}`} className="role-option">
-                      {d.name}
-                    </Link>
-                  </li>
-                );
-              })}
+              {
+                dashboards ?
+                dashboards.map((d, i) => {
+                  return (
+                    <li key={i}>
+                      <Link to={`/sources/${sourceID}/dashboards/${d.id}`} className="role-option">
+                        {d.name}
+                      </Link>
+                    </li>
+                  );
+                }) :
+                null
+              }
             </Header>
         }
-        <Dashboard
-          dashboard={dashboard}
-          inPresentationMode={inPresentationMode}
-          source={source}
-          autoRefresh={autoRefresh}
-          timeRange={timeRange}
-          onPositionChange={this.handleUpdatePosition}
-          onEditCell={this.handleEditDashboardCell}
-          onRenameCell={this.handleRenameDashboardCell}
-          onUpdateCell={this.handleUpdateDashboardCell}
-          onDeleteCell={this.handleDeleteDashboardCell}
-          onSummonOverlayTechnologies={this.handleSummonOverlayTechnologies}
-        />
+        {
+          dashboard ?
+          <Dashboard
+            dashboard={dashboard}
+            inPresentationMode={inPresentationMode}
+            source={source}
+            autoRefresh={autoRefresh}
+            timeRange={timeRange}
+            onPositionChange={this.handleUpdatePosition}
+            onEditCell={this.handleEditDashboardCell}
+            onRenameCell={this.handleRenameDashboardCell}
+            onUpdateCell={this.handleUpdateDashboardCell}
+            onDeleteCell={this.handleDeleteDashboardCell}
+            onSummonOverlayTechnologies={this.handleSummonOverlayTechnologies}
+          /> :
+          null
+        }
       </div>
     );
   },

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -1,8 +1,14 @@
 import React, {PropTypes} from 'react'
 import {Link, withRouter} from 'react-router'
-import SourceIndicator from '../../shared/components/SourceIndicator'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+
+import SourceIndicator from 'shared/components/SourceIndicator'
+import DeleteConfirmTableCell from 'shared/components/DeleteConfirmTableCell'
 
 import {getDashboards, createDashboard} from '../apis'
+import {deleteDashboardAsync} from 'src/dashboards/actions'
+
 import {NEW_DASHBOARD} from 'src/dashboards/constants'
 
 const {
@@ -26,6 +32,7 @@ const DashboardsPage = React.createClass({
       push: func.isRequired,
     }).isRequired,
     addFlashMessage: func,
+    handleDeleteDashboard: func.isRequired,
   },
 
   getInitialState() {
@@ -48,6 +55,10 @@ const DashboardsPage = React.createClass({
     const {source: {id}, router: {push}} = this.props
     const {data} = await createDashboard(NEW_DASHBOARD)
     push(`/sources/${id}/dashboards/${data.id}`)
+  },
+
+  handleDeleteDashboard(dashboard) {
+    this.props.handleDeleteDashboard(dashboard)
   },
 
   render() {
@@ -95,12 +106,13 @@ const DashboardsPage = React.createClass({
                           {
                             this.state.dashboards.map((dashboard) => {
                               return (
-                                <tr key={dashboard.id}>
+                                <tr key={dashboard.id} className="">
                                   <td className="monotype">
                                     <Link to={`${dashboardLink}/dashboards/${dashboard.id}`}>
                                       {dashboard.name}
                                     </Link>
                                   </td>
+                                  <DeleteConfirmTableCell onDelete={this.handleDeleteDashboard} item={dashboard} />
                                 </tr>
                               );
                             })
@@ -125,4 +137,8 @@ const DashboardsPage = React.createClass({
   },
 })
 
-export default withRouter(DashboardsPage)
+const mapDispatchToProps = (dispatch) => ({
+  handleDeleteDashboard: bindActionCreators(deleteDashboardAsync, dispatch),
+})
+
+export default connect(null, mapDispatchToProps)(withRouter(DashboardsPage))

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -53,7 +53,7 @@ const DashboardsPage = React.createClass({
   },
 
   render() {
-    const {dashboards: dashboards} = this.props
+    const {dashboards} = this.props
     const dashboardLink = `/sources/${this.props.source.id}`
     let tableHeader
     if (dashboards === null) {

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -5,7 +5,7 @@ import timeRanges from 'hson!../../shared/data/timeRanges.hson';
 const {lower, upper} = timeRanges[1]
 
 const initialState = {
-  dashboards: [],
+  dashboards: null,
   dashboard: EMPTY_DASHBOARD,
   timeRange: {lower, upper},
   isEditMode: false,

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -57,7 +57,7 @@ export default function ui(state = initialState, action) {
       return {...state, ...newState}
     }
 
-    case 'UNDO_DELETE_DASHBOARD': {
+    case 'DELETE_DASHBOARD_FAILED': {
       const {dashboard} = action.payload
       const newState = {
         dashboards: [

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -48,6 +48,26 @@ export default function ui(state = initialState, action) {
       return {...state, ...newState}
     }
 
+    case 'DELETE_DASHBOARD': {
+      const {dashboard} = action.payload
+      const newState = {
+        dashboards: state.dashboards.filter((d) => d.id !== dashboard.id),
+      }
+
+      return {...state, ...newState}
+    }
+
+    case 'UNDO_DELETE_DASHBOARD': {
+      const {dashboard} = action.payload
+      const newState = {
+        dashboards: [
+          _.cloneDeep(dashboard),
+          ...state.dashboards,
+        ],
+      }
+      return {...state, ...newState}
+    }
+
     case 'UPDATE_DASHBOARD_CELLS': {
       const {cells} = action.payload
       const {dashboard} = state

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -471,6 +471,8 @@ export const STROKE_WIDTH = {
 export const PRESENTATION_MODE_ANIMATION_DELAY = 0 // In milliseconds.
 export const PRESENTATION_MODE_NOTIFICATION_DELAY = 2000 // In milliseconds.
 
+export const SHORT_NOTIFICATION_DISAPPEARING_DELAY = 1500 // in milliseconds
+
 export const RES_UNAUTHORIZED = 401
 
 export const AUTOREFRESH_DEFAULT = 15000 // in milliseconds


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1080 

### The problem
User could not delete a dashboard via the UI.

### The Solution
Add UI button, action creators, reducers, and tests for dashboard deletion and error handling. This required some refactoring of DashboardsPage to load `dashboards` and `dashboard` from redux state.

<img width="1241" alt="screen shot 2017-03-28 at 8 04 42 pm" src="https://cloud.githubusercontent.com/assets/6403018/24436747/1d6902b0-13f2-11e7-9bc4-0cff2e9eb4e3.png">
<img width="1249" alt="screen shot 2017-03-28 at 8 05 07 pm" src="https://cloud.githubusercontent.com/assets/6403018/24436746/1d68190e-13f2-11e7-9df7-3cb36ef1ee0e.png">
<img width="1234" alt="screen shot 2017-03-28 at 8 07 36 pm" src="https://cloud.githubusercontent.com/assets/6403018/24436770/374c827e-13f2-11e7-9c95-dfb8d77e83dd.png">