### PR TITLE
Bypass URLPrefixer if http.Flusher is unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   1. [#1106](https://github.com/influxdata/chronograf/issues/1106): Fix obscured legends in dashboards
   1. [#1051](https://github.com/influxdata/chronograf/issue/1051): Exit presentation mode when using the browser back button
   1. [#1123](https://github.com/influxdata/chronograf/issue/1123): Widen single column results in data explorer
+  1. [#1115](https://github.com/influxdata/chronograf/pull/1115): Fix Basepath issue where content would fail to render under certain circumstances
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/server/builders_test.go
+++ b/server/builders_test.go
@@ -1,0 +1,30 @@
+package server_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/chronograf/server"
+)
+
+func TestLayoutBuilder(t *testing.T) {
+	var l server.LayoutBuilder = &server.MultiLayoutBuilder{}
+	layout, err := l.Build(nil)
+	if err != nil {
+		t.Fatalf("MultiLayoutBuilder can't build a MultiLayoutStore: %v", err)
+	}
+
+	if layout == nil {
+		t.Fatal("LayoutBuilder should have built a layout")
+	}
+}
+
+func TestSourcesStoresBuilder(t *testing.T) {
+	var b server.SourcesBuilder = &server.MultiSourceBuilder{}
+	sources, err := b.Build(nil)
+	if err != nil {
+		t.Fatalf("MultiSourceBuilder can't build a MultiSourcesStore: %v", err)
+	}
+	if sources == nil {
+		t.Fatal("SourcesBuilder should have built a MultiSourceStore")
+	}
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,26 +1,74 @@
-package server
+package server_test
 
-import "testing"
+import (
+	"fmt"
+	"io"
 
-func TestLayoutBuilder(t *testing.T) {
-	var l LayoutBuilder = &MultiLayoutBuilder{}
-	layout, err := l.Build(nil)
-	if err != nil {
-		t.Fatalf("MultiLayoutBuilder can't build a MultiLayoutStore: %v", err)
-	}
+	"github.com/influxdata/chronograf"
+)
 
-	if layout == nil {
-		t.Fatal("LayoutBuilder should have built a layout")
-	}
+type LogMessage struct {
+	Level string
+	Body  string
 }
 
-func TestSourcesStoresBuilder(t *testing.T) {
-	var b SourcesBuilder = &MultiSourceBuilder{}
-	sources, err := b.Build(nil)
-	if err != nil {
-		t.Fatalf("MultiSourceBuilder can't build a MultiSourcesStore: %v", err)
+// TestLogger is a chronograf.Logger which allows assertions to be made on the
+// contents of its messages.
+type TestLogger struct {
+	Messages []LogMessage
+}
+
+func (tl *TestLogger) Debug(args ...interface{}) {
+	tl.Messages = append(tl.Messages, LogMessage{"debug", tl.stringify(args...)})
+}
+
+func (tl *TestLogger) Info(args ...interface{}) {
+	tl.Messages = append(tl.Messages, LogMessage{"info", tl.stringify(args...)})
+}
+
+func (tl *TestLogger) Error(args ...interface{}) {
+	tl.Messages = append(tl.Messages, LogMessage{"error", tl.stringify(args...)})
+}
+
+func (tl *TestLogger) WithField(key string, value interface{}) chronograf.Logger {
+	return tl
+}
+
+func (tl *TestLogger) Writer() *io.PipeWriter {
+	_, write := io.Pipe()
+	return write
+}
+
+// HasMessage will return true if the TestLogger has been called with an exact
+// match of a particular log message at a particular log level
+func (tl *TestLogger) HasMessage(level string, body string) bool {
+	for _, msg := range tl.Messages {
+		if msg.Level == level && msg.Body == body {
+			return true
+		}
 	}
-	if sources == nil {
-		t.Fatal("SourcesBuilder should have built a MultiSourceStore")
+	return false
+}
+
+func (tl *TestLogger) stringify(args ...interface{}) string {
+	out := []byte{}
+	for _, arg := range args[:len(args)-1] {
+		out = append(out, tl.stringifyArg(arg)...)
+		out = append(out, []byte(" ")...)
+	}
+	out = append(out, tl.stringifyArg(args[len(args)-1])...)
+	return string(out)
+}
+
+func (tl *TestLogger) stringifyArg(arg interface{}) []byte {
+	switch a := arg.(type) {
+	case fmt.Stringer:
+		return []byte(a.String())
+	case error:
+		return []byte(a.Error())
+	case string:
+		return []byte(a)
+	default:
+		return []byte("UNKNOWN")
 	}
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [X] Rebased/mergable
  - [x] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #972

In certain situations, the http.ResponseWriter passed to the URLPrefixer
may not be an http.Flusher. A simple case where this may occur is if the
Prefixer has been wrapped up in a middleware where the above middleware
wraps the ResponseWriter in a ResponseWriter that doesn't implement the
Flush method.

Previously, the Prefixer would error, which would cause the request to
fail with a 500. Instead, the condition is logged and the request is
passed unmodified to the next middleware in the chain. This effectively
disables prefixing for requests where the above ResponseWriter is not an
http.Flusher.


