### PR TITLE
Add ability to change a user's password via Admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard
+  2. [#1120](https://github.com/influxdata/chronograf/pull/1120): Allow users to update user passwords.
 
 ### UI Improvements
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -3010,14 +3010,9 @@
 			}
 		},
 		"Roles": {
-			"type": "object",
-			"properties": {
-				"roles": {
-					"type": "array",
-					"items": {
-						"$ref": "#/definitions/Role"
-					}
-				}
+			"type": "array",
+			"items": {
+				"$ref": "#/definitions/Role"
 			},
 			"example": {
 				"roles": [

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -3178,6 +3178,9 @@
 				"permissions": {
 					"$ref": "#/definitions/Permissions"
 				},
+				"roles": {
+					"$ref": "#/definitions/Roles"
+				},
 				"links": {
 					"type": "object",
 					"description": "URL relations of this user",

--- a/ui/src/admin/actions/index.js
+++ b/ui/src/admin/actions/index.js
@@ -364,7 +364,7 @@ export const updateRolePermissionsAsync = (role, permissions) => async (dispatch
     dispatch(publishAutoDismissingNotification('success', 'Role permissions updated'))
     dispatch(syncRole(role, data))
   } catch (error) {
-    dispatch(publishNotification('error', `Failed to updated role:  ${error.data.message}`))
+    dispatch(publishNotification('error', `Failed to update role:  ${error.data.message}`))
   }
 }
 
@@ -374,7 +374,7 @@ export const updateUserPermissionsAsync = (user, permissions) => async (dispatch
     dispatch(publishAutoDismissingNotification('success', 'User permissions updated'))
     dispatch(syncUser(user, data))
   } catch (error) {
-    dispatch(publishNotification('error', `Failed to updated user:  ${error.data.message}`))
+    dispatch(publishNotification('error', `Failed to update user:  ${error.data.message}`))
   }
 }
 
@@ -384,6 +384,6 @@ export const updateUserRolesAsync = (user, roles) => async (dispatch) => {
     dispatch(publishAutoDismissingNotification('success', 'User roles updated'))
     dispatch(syncUser(user, data))
   } catch (error) {
-    dispatch(publishNotification('error', `Failed to updated user:  ${error.data.message}`))
+    dispatch(publishNotification('error', `Failed to update user:  ${error.data.message}`))
   }
 }

--- a/ui/src/admin/actions/index.js
+++ b/ui/src/admin/actions/index.js
@@ -370,7 +370,7 @@ export const updateRolePermissionsAsync = (role, permissions) => async (dispatch
 
 export const updateUserPermissionsAsync = (user, permissions) => async (dispatch) => {
   try {
-    const {data} = await updateUserAJAX(user.links.self, user.roles, permissions)
+    const {data} = await updateUserAJAX(user.links.self, {permissions})
     dispatch(publishAutoDismissingNotification('success', 'User permissions updated'))
     dispatch(syncUser(user, data))
   } catch (error) {
@@ -380,8 +380,18 @@ export const updateUserPermissionsAsync = (user, permissions) => async (dispatch
 
 export const updateUserRolesAsync = (user, roles) => async (dispatch) => {
   try {
-    const {data} = await updateUserAJAX(user.links.self, roles, user.permissions)
+    const {data} = await updateUserAJAX(user.links.self, {roles})
     dispatch(publishAutoDismissingNotification('success', 'User roles updated'))
+    dispatch(syncUser(user, data))
+  } catch (error) {
+    dispatch(publishNotification('error', `Failed to update user:  ${error.data.message}`))
+  }
+}
+
+export const updateUserPasswordAsync = (user, password) => async (dispatch) => {
+  try {
+    const {data} = await updateUserAJAX(user.links.self, {password})
+    dispatch(publishNotification('success', 'User password updated'))
     dispatch(syncUser(user, data))
   } catch (error) {
     dispatch(publishNotification('error', `Failed to update user:  ${error.data.message}`))

--- a/ui/src/admin/actions/index.js
+++ b/ui/src/admin/actions/index.js
@@ -391,7 +391,7 @@ export const updateUserRolesAsync = (user, roles) => async (dispatch) => {
 export const updateUserPasswordAsync = (user, password) => async (dispatch) => {
   try {
     const {data} = await updateUserAJAX(user.links.self, {password})
-    dispatch(publishNotification('success', 'User password updated'))
+    dispatch(publishAutoDismissingNotification('success', 'User password updated'))
     dispatch(syncUser(user, data))
   } catch (error) {
     dispatch(publishNotification('error', `Failed to update user:  ${error.data.message}`))

--- a/ui/src/admin/apis/index.js
+++ b/ui/src/admin/apis/index.js
@@ -159,15 +159,12 @@ export const updateRole = async (url, users, permissions) => {
   }
 }
 
-export const updateUser = async (url, roles, permissions) => {
+export const updateUser = async (url, updates) => {
   try {
     return await AJAX({
       method: 'PATCH',
       url,
-      data: {
-        roles,
-        permissions,
-      },
+      data: updates,
     })
   } catch (error) {
     console.error(error)

--- a/ui/src/admin/components/AdminTabs.js
+++ b/ui/src/admin/components/AdminTabs.js
@@ -28,6 +28,7 @@ const AdminTabs = ({
   onUpdateRolePermissions,
   onUpdateUserRoles,
   onUpdateUserPermissions,
+  onUpdateUserPassword,
 }) => {
   let tabs = [
     {
@@ -51,6 +52,7 @@ const AdminTabs = ({
           onFilter={onFilterUsers}
           onUpdatePermissions={onUpdateUserPermissions}
           onUpdateRoles={onUpdateUserRoles}
+          onUpdatePassword={onUpdateUserPassword}
         />
       ),
     },
@@ -135,6 +137,7 @@ AdminTabs.propTypes = {
   hasRoles: bool.isRequired,
   onUpdateUserPermissions: func,
   onUpdateUserRoles: func,
+  onUpdateUserPassword: func,
 }
 
 export default AdminTabs

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -59,7 +59,7 @@ class ChangePassRow extends Component {
           autoFocus={true}
         />
         <ConfirmButtons
-          onConfirm={onSave(user)}
+          onConfirm={onSave}
           item={user}
           onCancel={this.handleCancel}
         />

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react'
 
 import OnClickOutside from 'shared/components/OnClickOutside'
-import ConfirmButtons from 'src/admin/components/ConfirmButtons'
+import ConfirmButtons from 'src/shared/components/ConfirmButtons'
 
 class ChangePassRow extends Component {
   constructor(props) {
@@ -91,4 +91,4 @@ ChangePassRow.propTypes = {
   onEdit: func.isRequired,
 }
 
-export default OnClickOutside(ChangePassRow);
+export default OnClickOutside(ChangePassRow)

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -1,0 +1,88 @@
+import React, {Component, PropTypes} from 'react'
+
+import OnClickOutside from 'shared/components/OnClickOutside'
+import ConfirmButtons from 'src/admin/components/ConfirmButtons'
+
+class ChangePassRow extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      showForm: false,
+    }
+    this.showForm = ::this.showForm
+    this.handleCancel = ::this.handleCancel
+    this.handleKeyPress = ::this.handleKeyPress
+    this.handleEdit = ::this.handleEdit
+  }
+
+  showForm() {
+    this.setState({showForm: true})
+  }
+
+  handleCancel() {
+    this.setState({showForm: false})
+  }
+
+  handleClickOutside() {
+    this.setState({showForm: false})
+  }
+
+  handleKeyPress(user) {
+    return (e) => {
+      if (e.key === 'Enter') {
+        this.props.onSave(user)
+        this.setState({showForm: false})
+      }
+    }
+  }
+
+  handleEdit(user) {
+    return (e) => {
+      this.props.onEdit(user, {[e.target.name]: e.target.value})
+    }
+  }
+
+  render() {
+    const {user, onSave} = this.props
+
+    if (this.state.showForm) {
+      return (
+        <div>
+        <input
+          className="form-control"
+          name="password"
+          type="password"
+          value={user.password || ''}
+          placeholder="Password"
+          onChange={this.handleEdit(user)}
+          onKeyPress={this.handleKeyPress(user)}
+        /> :
+        <ConfirmButtons
+          onConfirm={onSave}
+          item={user}
+          onCancel={this.handleCancel}
+        />
+        </div>
+      )
+    }
+
+    return (
+      <button
+        className="btn btn-xs btn-info admin-table--delete"
+        onClick={this.showForm}
+      >
+        Change Password
+      </button>
+    )
+  }
+}
+
+const {shape, func} = PropTypes
+
+ChangePassRow.propTypes = {
+  user: shape().isRequired,
+  onSave: func.isRequired,
+  onEdit: func.isRequired,
+}
+
+export default OnClickOutside(ChangePassRow);

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -13,6 +13,7 @@ class ChangePassRow extends Component {
     this.handleCancel = ::this.handleCancel
     this.handleKeyPress = ::this.handleKeyPress
     this.handleEdit = ::this.handleEdit
+    this.handleSubmit = ::this.handleSubmit
   }
 
   showForm() {
@@ -27,13 +28,15 @@ class ChangePassRow extends Component {
     this.setState({showForm: false})
   }
 
+  handleSubmit(user) {
+    this.props.onApply(user)
+    this.setState({showForm: false})
+  }
+
   handleKeyPress(user) {
     return (e) => {
       if (e.key === 'Enter') {
-        console.log("keypress: ", user)
-        // console.log(this.props.onSave)
-        // this.props.onSave(user)
-        // this.setState({showForm: false})
+        this.handleSubmit(user)
       }
     }
   }
@@ -45,7 +48,7 @@ class ChangePassRow extends Component {
   }
 
   render() {
-    const {user, onUpdatePassword} = this.props
+    const {user} = this.props
 
     if (this.state.showForm) {
       return (
@@ -61,7 +64,7 @@ class ChangePassRow extends Component {
           autoFocus={true}
         />
         <ConfirmButtons
-          onConfirm={onUpdatePassword}
+          onConfirm={this.handleSubmit}
           item={user}
           onCancel={this.handleCancel}
         />
@@ -84,7 +87,7 @@ const {shape, func} = PropTypes
 
 ChangePassRow.propTypes = {
   user: shape().isRequired,
-  onUpdatePassword: func.isRequired,
+  onApply: func.isRequired,
   onEdit: func.isRequired,
 }
 

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -68,7 +68,7 @@ class ChangePassRow extends Component {
 
     return (
       <button
-        className="btn btn-xs btn-info admin-table--delete"
+        className="btn btn-xs btn-info admin-table--hidden"
         onClick={this.showForm}
       >
         Change Password

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -30,8 +30,10 @@ class ChangePassRow extends Component {
   handleKeyPress(user) {
     return (e) => {
       if (e.key === 'Enter') {
-        this.props.onSave(user)
-        this.setState({showForm: false})
+        console.log("keypress: ", user)
+        // console.log(this.props.onSave)
+        // this.props.onSave(user)
+        // this.setState({showForm: false})
       }
     }
   }
@@ -43,7 +45,7 @@ class ChangePassRow extends Component {
   }
 
   render() {
-    const {user, onSave} = this.props
+    const {user, onUpdatePassword} = this.props
 
     if (this.state.showForm) {
       return (
@@ -59,7 +61,7 @@ class ChangePassRow extends Component {
           autoFocus={true}
         />
         <ConfirmButtons
-          onConfirm={onSave}
+          onConfirm={onUpdatePassword}
           item={user}
           onCancel={this.handleCancel}
         />
@@ -82,7 +84,7 @@ const {shape, func} = PropTypes
 
 ChangePassRow.propTypes = {
   user: shape().isRequired,
-  onSave: func.isRequired,
+  onUpdatePassword: func.isRequired,
   onEdit: func.isRequired,
 }
 

--- a/ui/src/admin/components/ChangePassRow.js
+++ b/ui/src/admin/components/ChangePassRow.js
@@ -56,9 +56,10 @@ class ChangePassRow extends Component {
           placeholder="Password"
           onChange={this.handleEdit(user)}
           onKeyPress={this.handleKeyPress(user)}
-        /> :
+          autoFocus={true}
+        />
         <ConfirmButtons
-          onConfirm={onSave}
+          onConfirm={onSave(user)}
           item={user}
           onCancel={this.handleCancel}
         />

--- a/ui/src/admin/components/DatabaseRow.js
+++ b/ui/src/admin/components/DatabaseRow.js
@@ -112,7 +112,7 @@ class DatabaseRow extends Component {
                 onConfirm={() => onDelete(database, retentionPolicy)}
                 onCancel={this.handleEndDelete} /> :
               <button
-                className="btn btn-xs btn-danger admin-table--delete"
+                className="btn btn-xs btn-danger admin-table--hidden"
                 style={isDeletable ? {} : {visibility: 'hidden'}}
                 onClick={this.handleStartDelete}>{`Delete ${name}`}
               </button>

--- a/ui/src/admin/components/UserRow.js
+++ b/ui/src/admin/components/UserRow.js
@@ -22,6 +22,7 @@ const UserRow = ({
   onDelete,
   onUpdatePermissions,
   onUpdateRoles,
+  onUpdatePassword,
 }) => {
   const handleUpdatePermissions = (allowed) => {
     onUpdatePermissions(user, [{scope: 'all', allowed}])
@@ -71,7 +72,7 @@ const UserRow = ({
         }
       </td>
       <td className="text-right" style={{width: "300px"}}>
-        <ChangePassRow onEdit={onEdit} onSave={onSave} user={user} />
+        <ChangePassRow onEdit={onEdit} onUpdatePassword={onUpdatePassword} user={user} />
       </td>
       <DeleteConfirmTableCell onDelete={onDelete} item={user} />
     </tr>
@@ -107,6 +108,7 @@ UserRow.propTypes = {
   onDelete: func.isRequired,
   onUpdatePermissions: func,
   onUpdateRoles: func,
+  onUpdatePassword: func,
 }
 
 export default UserRow

--- a/ui/src/admin/components/UserRow.js
+++ b/ui/src/admin/components/UserRow.js
@@ -70,7 +70,7 @@ const UserRow = ({
             /> : null
         }
       </td>
-      <td className="text-right" style={{width: "200px"}}>
+      <td className="text-right" style={{width: "300px"}}>
         <ChangePassRow onEdit={onEdit} onSave={onSave} user={user} />
       </td>
       <DeleteConfirmTableCell onDelete={onDelete} item={user} />

--- a/ui/src/admin/components/UserRow.js
+++ b/ui/src/admin/components/UserRow.js
@@ -6,6 +6,7 @@ import UserEditingRow from 'src/admin/components/UserEditingRow'
 import MultiSelectDropdown from 'shared/components/MultiSelectDropdown'
 import ConfirmButtons from 'shared/components/ConfirmButtons'
 import DeleteConfirmTableCell from 'shared/components/DeleteConfirmTableCell'
+import ChangePassRow from 'src/admin/components/ChangePassRow'
 
 const UserRow = ({
   user: {name, roles, permissions},
@@ -68,6 +69,9 @@ const UserRow = ({
               onApply={handleUpdatePermissions}
             /> : null
         }
+      </td>
+      <td className="text-right" style={{width: "200px"}}>
+        <ChangePassRow onEdit={onEdit} onSave={onSave} user={user} />
       </td>
       <DeleteConfirmTableCell onDelete={onDelete} item={user} />
     </tr>

--- a/ui/src/admin/components/UserRow.js
+++ b/ui/src/admin/components/UserRow.js
@@ -9,7 +9,7 @@ import DeleteConfirmTableCell from 'shared/components/DeleteConfirmTableCell'
 import ChangePassRow from 'src/admin/components/ChangePassRow'
 
 const UserRow = ({
-  user: {name, roles, permissions},
+  user: {name, roles, permissions, password},
   user,
   allRoles,
   allPermissions,
@@ -30,6 +30,10 @@ const UserRow = ({
 
   const handleUpdateRoles = (roleNames) => {
     onUpdateRoles(user, allRoles.filter(r => roleNames.find(rn => rn === r.name)))
+  }
+
+  const handleUpdatePassword = () => {
+    onUpdatePassword(user, password)
   }
 
   if (isEditing) {
@@ -72,7 +76,7 @@ const UserRow = ({
         }
       </td>
       <td className="text-right" style={{width: "300px"}}>
-        <ChangePassRow onEdit={onEdit} onUpdatePassword={onUpdatePassword} user={user} />
+        <ChangePassRow onEdit={onEdit} onApply={handleUpdatePassword} user={user} />
       </td>
       <DeleteConfirmTableCell onDelete={onDelete} item={user} />
     </tr>
@@ -96,6 +100,7 @@ UserRow.propTypes = {
     permissions: arrayOf(shape({
       name: string,
     })),
+    password: string,
   }).isRequired,
   allRoles: arrayOf(shape()),
   allPermissions: arrayOf(string),

--- a/ui/src/admin/components/UsersTable.js
+++ b/ui/src/admin/components/UsersTable.js
@@ -18,6 +18,7 @@ const UsersTable = ({
   onFilter,
   onUpdatePermissions,
   onUpdateRoles,
+  onUpdatePassword,
 }) => (
   <div className="panel panel-info">
     <FilterBar type="users" onFilter={onFilter} isEditing={isEditing} onClickCreate={onClickCreate} />
@@ -49,6 +50,7 @@ const UsersTable = ({
                   allPermissions={permissions}
                   onUpdatePermissions={onUpdatePermissions}
                   onUpdateRoles={onUpdateRoles}
+                  onUpdatePassword={onUpdatePassword}
                 />) :
               <EmptyRow tableName={'Users'} />
           }
@@ -89,6 +91,7 @@ UsersTable.propTypes = {
   hasRoles: bool.isRequired,
   onUpdatePermissions: func,
   onUpdateRoles: func,
+  onUpdatePassword: func,
 }
 
 export default UsersTable

--- a/ui/src/admin/containers/AdminPage.js
+++ b/ui/src/admin/containers/AdminPage.js
@@ -93,7 +93,6 @@ class AdminPage extends Component {
     if (user.isNew) {
       this.props.createUser(this.props.source.links.users, user)
     } else {
-      this.props.editUser(this.props.source.links.users, user)
       // TODO update user
     }
   }

--- a/ui/src/admin/containers/AdminPage.js
+++ b/ui/src/admin/containers/AdminPage.js
@@ -19,6 +19,7 @@ import {
   updateRolePermissionsAsync,
   updateUserPermissionsAsync,
   updateUserRolesAsync,
+  updateUserPasswordAsync,
   filterUsers as filterUsersAction,
   filterRoles as filterRolesAction,
 } from 'src/admin/actions'
@@ -54,6 +55,7 @@ class AdminPage extends Component {
     this.handleUpdateRolePermissions = ::this.handleUpdateRolePermissions
     this.handleUpdateUserPermissions = ::this.handleUpdateUserPermissions
     this.handleUpdateUserRoles = ::this.handleUpdateUserRoles
+    this.handleUpdateUserPassword = ::this.handleUpdateUserPassword
   }
 
   componentDidMount() {
@@ -91,6 +93,7 @@ class AdminPage extends Component {
     if (user.isNew) {
       this.props.createUser(this.props.source.links.users, user)
     } else {
+      this.props.editUser(this.props.source.links.users, user)
       // TODO update user
     }
   }
@@ -105,7 +108,6 @@ class AdminPage extends Component {
       this.props.createRole(this.props.source.links.roles, role)
     } else {
       // TODO update role
-      // console.log('update')
     }
   }
 
@@ -139,6 +141,10 @@ class AdminPage extends Component {
 
   handleUpdateUserRoles(user, roles) {
     this.props.updateUserRoles(user, roles)
+  }
+
+  handleUpdateUserPassword(user, password) {
+    this.props.updateUserPassword(user, password)
   }
 
   render() {
@@ -186,6 +192,7 @@ class AdminPage extends Component {
                     onUpdateRolePermissions={this.handleUpdateRolePermissions}
                     onUpdateUserPermissions={this.handleUpdateUserPermissions}
                     onUpdateUserRoles={this.handleUpdateUserRoles}
+                    onUpdateUserPassword={this.handleUpdateUserPassword}
                   /> :
                   <span>Loading...</span>
                 }
@@ -233,7 +240,11 @@ AdminPage.propTypes = {
   updateRolePermissions: func,
   updateUserPermissions: func,
   updateUserRoles: func,
+<<<<<<< HEAD
   notify: func,
+=======
+  updateUserPassword: func,
+>>>>>>> add update action for user password
 }
 
 const mapStateToProps = ({admin: {users, roles, permissions}}) => ({
@@ -262,6 +273,7 @@ const mapDispatchToProps = (dispatch) => ({
   updateRolePermissions: bindActionCreators(updateRolePermissionsAsync, dispatch),
   updateUserPermissions: bindActionCreators(updateUserPermissionsAsync, dispatch),
   updateUserRoles: bindActionCreators(updateUserRolesAsync, dispatch),
+  updateUserPassword: bindActionCreators(updateUserPasswordAsync, dispatch),
   notify: bindActionCreators(publishAutoDismissingNotification, dispatch),
 })
 

--- a/ui/src/admin/containers/AdminPage.js
+++ b/ui/src/admin/containers/AdminPage.js
@@ -239,11 +239,8 @@ AdminPage.propTypes = {
   updateRolePermissions: func,
   updateUserPermissions: func,
   updateUserRoles: func,
-<<<<<<< HEAD
-  notify: func,
-=======
   updateUserPassword: func,
->>>>>>> add update action for user password
+  notify: func,
 }
 
 const mapStateToProps = ({admin: {users, roles, permissions}}) => ({

--- a/ui/src/shared/components/DeleteConfirmButtons.js
+++ b/ui/src/shared/components/DeleteConfirmButtons.js
@@ -4,7 +4,7 @@ import OnClickOutside from 'shared/components/OnClickOutside'
 import ConfirmButtons from 'shared/components/ConfirmButtons'
 
 const DeleteButton = ({onClickDelete}) => (
-  <button className="btn btn-xs btn-danger admin-table--delete" onClick={onClickDelete}>
+  <button className="btn btn-xs btn-danger admin-table--hidden" onClick={onClickDelete}>
     Delete
   </button>
 )

--- a/ui/src/style/pages/admin.scss
+++ b/ui/src/style/pages/admin.scss
@@ -67,7 +67,7 @@
     width: 100%;
     min-width: 150px;
   }
-  .admin-table--delete {
+  .admin-table--hidden {
     visibility: hidden;
   }
   .dropdown-toggle {
@@ -83,7 +83,7 @@
   }
   .open .dropdown-toggle .multi-select-dropdown__label {left: 9px;}
   tbody tr:hover {
-    .admin-table--delete {
+    .admin-table--hidden {
       visibility: visible;
     }
     .dropdown-toggle {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #939

### The problem
Users can't change user passwords right now via the admin page.

### The Solution
Add a "change password" option to the user management page:

![screen shot 2017-03-29 at 2 26 58 pm](https://cloud.githubusercontent.com/assets/1147449/24477410/bd289132-148b-11e7-8c12-fcd08c6dc0c9.png)

### Other Comments
- I updated the swagger docs, which were missing some information for the `/users` endpoint.
- some minor refactoring of our user patching, so that we aren't patching with the entire user object but just the relevant keys to update.
- the one thing I'm not happy with is that `OnClickOutside` should be wrapping the confirm buttons, and not the entire component. The way it is right now, we have event listeners that trigger a state change for every `UserRow` whenever a user clicks anywhere on the page, because `ChangePassRow` is always being rendered, even when it isn't visible. The same is true for `DeleteRow`.
- could probably use some style cleanup >>