### PR TITLE
Add simple loading spinner to Alert History page.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard
-  2. [#1120](https://github.com/influxdata/chronograf/pull/1120): Allow users to update user passwords.
+  1. [#1120](https://github.com/influxdata/chronograf/pull/1120): Allow users to update user passwords.
+  1. [#1130](https://github.com/influxdata/chronograf/pull/1130): Add loading spinner to Alert History page.
 
 ### UI Improvements
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip

--- a/ui/src/alerts/containers/AlertsApp.js
+++ b/ui/src/alerts/containers/AlertsApp.js
@@ -91,6 +91,12 @@ const AlertsApp = React.createClass({
 
   render() {
     const {source} = this.props
+    const {loading} = this.state
+
+    if (loading || !source) {
+      return <div className="page-spinner" />
+    }
+
     return (
       // I stole this from the Hosts page.
       // Perhaps we should create an abstraction?


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1054 

### The problem
The Alert History page does not show a spinner when the data is loading.

### The Solution
Add a spinner to the component.

