### PR TITLE
Active sidebar items should have a blue indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,15 @@
 
 ### Bug Fixes
   1. [#1104](https://github.com/influxdata/chronograf/pull/1104): Fix windows hosts on host list
-  2. [#1125](https://github.com/influxdata/chronograf/pull/1125): Fix visualizations not showing graph name
+  1. [#1125](https://github.com/influxdata/chronograf/pull/1125): Fix visualizations not showing graph name
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard
-  2. [#1120](https://github.com/influxdata/chronograf/pull/1120): Allow users to update user passwords.
+  1. [#1120](https://github.com/influxdata/chronograf/pull/1120): Allow users to update user passwords.
 
 ### UI Improvements
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip
-  2. [#1132](https://github.com/influxdata/chronograf/pull/1132): All sidebar items show activity with a blue strip
+  1. [#1132](https://github.com/influxdata/chronograf/pull/1132): All sidebar items show activity with a blue strip
 
 ## v1.2.0-beta7 [2017-03-28]
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### UI Improvements
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip
+  2. [#1132](https://github.com/influxdata/chronograf/pull/1132): All sidebar items show activity with a blue strip
 
 ## v1.2.0-beta7 [2017-03-28]
 ### Bug Fixes

--- a/ui/src/side_nav/components/NavItems.js
+++ b/ui/src/side_nav/components/NavItems.js
@@ -47,7 +47,7 @@ const NavBlock = React.createClass({
     const {location, className, wrapperClassName} = this.props
 
     const isActive = React.Children.toArray(this.props.children).find((child) => {
-      return child.type === NavListItem && location.startsWith(child.props.link)
+      return location.startsWith(child.props.link)
     })
 
     const children = React.Children.map((this.props.children), (child) => {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1040

### The problem
A `NavBlock` determines whether to apply the `active` by comparing the current browser location to the links attached to its `NavLinkItem` children. This assumes that all `NavBlocks` in the sidebar will contain at least one `NavLinkItem` child, which isn't the case currently. It is also valid for a `NavBlock` to contain a single child of type `NavHeader`. Clicking on that `NavHeader` should activate the `NavBlock`. 

### The Solution
Remove the `NavListItem` type check