### PR TITLE
Fix kapacitor base64 auth as header was built incorrectly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
   1. [#1104](https://github.com/influxdata/chronograf/pull/1104): Fix windows hosts on host list
   1. [#1125](https://github.com/influxdata/chronograf/pull/1125): Fix visualizations not showing graph name
+  1. [#1133](https://github.com/influxdata/chronograf/issue/1133): Fix Enterprise Kapacitor authentication. 
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
@@ -49,9 +48,7 @@ func (h *Service) KapacitorProxy(w http.ResponseWriter, r *http.Request) {
 		// Because we are acting as a proxy, kapacitor needs to have the basic auth information set as
 		// a header directly
 		if srv.Username != "" && srv.Password != "" {
-			auth := "Basic " + srv.Username + ":" + srv.Password
-			header := base64.StdEncoding.EncodeToString([]byte(auth))
-			req.Header.Set("Authorization", header)
+			req.SetBasicAuth(srv.Username, srv.Password)
 		}
 	}
 	proxy := &httputil.ReverseProxy{


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1133

### The problem
The kapacitor authentication header is incorrect as it was base64 encoding the wrong part of the string.

### The Solution
Using the standard library basic auth generation.

