### PR TITLE
Fix Kapacitor Telegram config to display correct disableNotification setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   1. [#1104](https://github.com/influxdata/chronograf/pull/1104): Fix windows hosts on host list
   1. [#1125](https://github.com/influxdata/chronograf/pull/1125): Fix visualizations not showing graph name
   1. [#1133](https://github.com/influxdata/chronograf/issue/1133): Fix Enterprise Kapacitor authentication.
+  1. [#1142](https://github.com/influxdata/chronograf/issue/1142): Fix Kapacitor Telegram config to display correct disableNotification setting
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/kapacitor/components/TelegramConfig.js
+++ b/ui/src/kapacitor/components/TelegramConfig.js
@@ -42,7 +42,7 @@ const TelegramConfig = React.createClass({
     const {options} = this.props.config
     const {url, token} = options
     const chatID = options['chat-id']
-    const disableNotification = options['chat-id']
+    const disableNotification = options['disable-notification']
     const disableWebPagePreview = options['disable-web-page-preview']
     const parseMode = options['parse-mode']
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #862 

### The problem
Telegram config was always showing `Disable Notification` to be checked after saving, regardless of whether it was checked when saved.

### The Solution
Assign `disableNotification` the proper `options` value from the Telegram config section.

