### PR TITLE
Escape presentation when using back button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   1. [#1125](https://github.com/influxdata/chronograf/pull/1125): Fix visualizations not showing graph name
   1. [#1133](https://github.com/influxdata/chronograf/issue/1133): Fix Enterprise Kapacitor authentication.
   1. [#1142](https://github.com/influxdata/chronograf/issue/1142): Fix Kapacitor Telegram config to display correct disableNotification setting
+  1. [#1051](https://github.com/influxdata/chronograf/issue/1051): Exit presentation mode when using the browser back button
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -28,6 +28,8 @@ import 'src/style/chronograf.scss'
 const store = configureStore(loadLocalStorage())
 const rootNode = document.getElementById('react-root')
 
+// c
+
 let browserHistory
 const basepath = rootNode.dataset.basepath
 window.basepath = basepath
@@ -40,6 +42,9 @@ if (basepath) {
     basename: "",
   })
 }
+browserHistory.listen(_ => {
+  store.dispatch(disablePresentationMode())
+})
 
 window.addEventListener('keyup', (event) => {
   if (event.key === 'Escape') {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -40,7 +40,7 @@ if (basepath) {
     basename: "",
   })
 }
-browserHistory.listen(_ => {
+browserHistory.listen(() => {
   store.dispatch(disablePresentationMode())
 })
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -28,8 +28,6 @@ import 'src/style/chronograf.scss'
 const store = configureStore(loadLocalStorage())
 const rootNode = document.getElementById('react-root')
 
-// c
-
 let browserHistory
 const basepath = rootNode.dataset.basepath
 window.basepath = basepath


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1051

### The problem
When a user clicks the back button while in presentation mode, presentation mode does not end.

### The Solution
Watch changes to the location and disable presentation mode when it changes.

This could be improved upon by only registering the listener when presentation mode becomes active.
