### PR TITLE
Bugfix/threshold value

### DIFF
--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -44,7 +44,9 @@ describe('getRangeForDygraphSpec', () => {
   describe('when user provides a Kapacitor rule value', () => {
     const defaultMax = 20
     const defaultMin = -10
+    const positiveMin = 10
     const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]]
+    const timeSeries1 = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), positiveMin]]
 
     it('can pad positive values', () => {
       const kapacitorRuleValues = {value: 20, rangeValue: "", operator: null}
@@ -62,8 +64,17 @@ describe('getRangeForDygraphSpec', () => {
       expect(max).to.equal(defaultMax)
     })
 
-    it('subtracts from positive values if Kapactior operator is "lower than"', () => {
-      // TODO: go home
+    describe('when Kapacitor operator is "lower than" and value is outiside the range', () => {
+      it('subtracts from a positive value', () => {
+        const value = 5
+        const rangeValue = ""
+        const operator = "lower than"
+        const kapacitorRuleValues = {value, rangeValue, operator}
+
+        const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
+        expect(min).to.be.lessThan(value)
+        expect(max).to.equal(defaultMax)
+      })
     })
   })
 

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -41,44 +41,48 @@ describe('getRangeForDygraphSpec', () => {
     expect(actual).to.deep.equal(expected)
   })
 
-  describe('when user provides a rule value', () => {
+  describe('when user provides a Kapacitor rule value', () => {
     const defaultMax = 20
     const defaultMin = -10
     const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]]
 
     it('can pad positive values', () => {
-      const value = 20
-      const [min, max] = getRange(timeSeries, undefined, value)
+      const kapacitorRuleValues = {value: 20, rangeValue: "", operator: null}
+      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
 
       expect(min).to.equal(defaultMin)
       expect(max).to.be.above(defaultMax)
     })
 
     it('can pad negative values', () => {
-      const value = -10
-      const [min, max] = getRange(timeSeries, undefined, value)
+      const kapacitorRuleValues = {value: -10, rangeValue: "", operator: null}
+      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
 
       expect(min).to.be.below(defaultMin)
       expect(max).to.equal(defaultMax)
     })
+
+    it('subtracts from positive values if Kapactior operator is "lower than"', () => {
+      // TODO: go home
+    })
   })
 
-  describe('when user provides a rule range value', () => {
+  describe('when user provides a Kapacitor rule rangeValue', () => {
     const defaultMax = 20
     const defaultMin = -10
     const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]]
 
     it('can pad positive values', () => {
-      const rangeValue = 20
-      const [min, max] = getRange(timeSeries, undefined, 0, rangeValue)
+      const kapacitorRuleValues = {value: null, rangeValue: 20, operator: null}
+      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
 
       expect(min).to.equal(defaultMin)
       expect(max).to.be.above(defaultMax)
     })
 
     it('can pad negative values', () => {
-      const rangeValue = -10
-      const [min, max] = getRange(timeSeries, undefined, 0, rangeValue)
+      const kapacitorRuleValues = {value: null, rangeValue: -10, operator: null}
+      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
 
       expect(min).to.be.below(defaultMin)
       expect(max).to.equal(defaultMax)

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -1,18 +1,22 @@
 import getRange from 'shared/parsing/getRangeForDygraph'
 
+const date = new Date()
+const max = 20
+const mid = 10
+const min = 5
+const kapacitor = {value: null, rangeValue: null, operator: null}
+
 describe('getRangeForDygraphSpec', () => {
   it('gets the range for one timeSeries', () => {
-    const timeSeries = [[new Date(1000), 1], [new Date(2000), 2], [new Date(3000), 3]]
-
+    const timeSeries = [[date, min], [date, mid], [date, max]]
     const actual = getRange(timeSeries)
-    const expected = [1, 3]
+    const expected = [min, max]
 
     expect(actual).to.deep.equal(expected)
   })
 
   it('does not get range when a range is provided', () => {
-    const timeSeries = [[new Date(1000), 1], [new Date(2000), 2], [new Date(3000), 3]]
-
+    const timeSeries = [[date, min], [date, max], [date, mid]]
     const providedRange = [0, 4]
     const actual = getRange(timeSeries, providedRange)
 
@@ -20,21 +24,15 @@ describe('getRangeForDygraphSpec', () => {
   })
 
   it('gets the range for multiple timeSeries', () => {
-    const timeSeries = [
-      [new Date(1000), null, 1],
-      [new Date(1000), 100, 1],
-      [new Date(2000), null, 2],
-      [new Date(3000), 200, 3],
-    ]
-
+    const timeSeries = [[date, null, min], [date, max, mid], [date, null, mid]]
     const actual = getRange(timeSeries)
-    const expected = [1, 200]
+    const expected = [min, max]
 
     expect(actual).to.deep.equal(expected)
   })
 
   it('returns a null array of two elements when min and max are equal', () => {
-    const timeSeries = [[new Date(1000), 1], [new Date(2000), 1], [new Date(3000), 1]]
+    const timeSeries = [[date, max], [date, max], [date, max]]
     const actual = getRange(timeSeries)
     const expected = [null, null]
 
@@ -42,61 +40,49 @@ describe('getRangeForDygraphSpec', () => {
   })
 
   describe('when user provides a Kapacitor rule value', () => {
-    const defaultMax = 20
-    const defaultMin = -10
-    const positiveMin = 10
-    const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]]
-    const timeSeries1 = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), positiveMin]]
+    const timeSeries = [[date, max], [date, mid], [date, min]]
 
     it('can pad positive values', () => {
-      const kapacitorRuleValues = {value: 20, rangeValue: "", operator: null}
-      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
+      const [actualMin, actualMax] = getRange(timeSeries, undefined, {...kapacitor, value: 20})
 
-      expect(min).to.equal(defaultMin)
-      expect(max).to.be.above(defaultMax)
+      expect(actualMin).to.equal(min)
+      expect(actualMax).to.be.above(max)
     })
 
     it('can pad negative values', () => {
-      const kapacitorRuleValues = {value: -10, rangeValue: "", operator: null}
-      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
+      const [actualMin, actualMax] = getRange(timeSeries, undefined, {...kapacitor, value: -10})
 
-      expect(min).to.be.below(defaultMin)
-      expect(max).to.equal(defaultMax)
+      expect(actualMin).to.be.below(min)
+      expect(actualMax).to.equal(max)
     })
 
     describe('when Kapacitor operator is "lower than" and value is outiside the range', () => {
       it('subtracts from a positive value', () => {
-        const value = 5
-        const rangeValue = ""
-        const operator = "lower than"
-        const kapacitorRuleValues = {value, rangeValue, operator}
+        const value = 2
+        const opAndValue = {operator: 'less than', value}
+        const [actualMin, actualMax] = getRange(timeSeries, undefined, {...kapacitor, ...opAndValue})
 
-        const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
-        expect(min).to.be.lessThan(value)
-        expect(max).to.equal(defaultMax)
+        expect(actualMin).to.be.lessThan(value)
+        expect(actualMax).to.equal(max)
       })
     })
   })
 
   describe('when user provides a Kapacitor rule rangeValue', () => {
-    const defaultMax = 20
-    const defaultMin = -10
-    const timeSeries = [[new Date(1000), defaultMax], [new Date(2000), 1], [new Date(3000), defaultMin]]
+    const timeSeries = [[date, max], [date, min], [date, mid]]
 
     it('can pad positive values', () => {
-      const kapacitorRuleValues = {value: null, rangeValue: 20, operator: null}
-      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
+      const [actualMin, actualMax] = getRange(timeSeries, undefined, {...kapacitor, rangeValue: 20})
 
-      expect(min).to.equal(defaultMin)
-      expect(max).to.be.above(defaultMax)
+      expect(actualMin).to.equal(min)
+      expect(actualMax).to.be.above(max)
     })
 
     it('can pad negative values', () => {
-      const kapacitorRuleValues = {value: null, rangeValue: -10, operator: null}
-      const [min, max] = getRange(timeSeries, undefined, kapacitorRuleValues)
+      const [actualMin, actualMax] = getRange(timeSeries, undefined, {...kapacitor, rangeValue: -10})
 
-      expect(min).to.be.below(defaultMin)
-      expect(max).to.equal(defaultMax)
+      expect(actualMin).to.be.below(min)
+      expect(actualMax).to.equal(max)
     })
   })
 })

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -2,7 +2,6 @@
 import React, {PropTypes} from 'react'
 import Dygraph from '../../external/dygraph'
 import getRange from 'src/shared/parsing/getRangeForDygraph'
-import _ from 'lodash'
 
 const {
   array,
@@ -10,6 +9,7 @@ const {
   number,
   bool,
   shape,
+  string,
 } = PropTypes
 
 const LINE_COLORS = [
@@ -43,7 +43,11 @@ export default React.createClass({
     isGraphFilled: bool,
     overrideLineColors: array,
     dygraphSeries: shape({}).isRequired,
-    ruleValues: shape({}),
+    ruleValues: shape({
+      operator: string,
+      value: string,
+      rangeValue: string,
+    }),
   },
 
   getDefaultProps() {
@@ -90,7 +94,7 @@ export default React.createClass({
       series: dygraphSeries,
       axes: {
         y: {
-          valueRange: getRange(timeSeries, ranges.y, _.get(ruleValues, 'value', null), _.get(ruleValues, 'rangeValue', null)),
+          valueRange: getRange(timeSeries, ranges.y, ruleValues),
         },
         y2: {
           valueRange: getRange(timeSeries, ranges.y2),
@@ -159,7 +163,7 @@ export default React.createClass({
       file: timeSeries,
       axes: {
         y: {
-          valueRange: getRange(timeSeries, ranges.y, _.get(ruleValues, 'value', null), _.get(ruleValues, 'rangeValue', null)),
+          valueRange: getRange(timeSeries, ranges.y, ruleValues),
         },
         y2: {
           valueRange: getRange(timeSeries, ranges.y2),

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -1,9 +1,11 @@
 const PADDING_FACTOR = 0.1
 
-export default function getRange(timeSeries, override, value = null, rangeValue = null) {
+export default function getRange(timeSeries, override, ruleValues = {value: null, rangeValue: null}) {
   if (override) {
     return override
   }
+
+  const {value, rangeValue, operator} = ruleValues
 
   const subtractPadding = (val) => +val - Math.abs(val * PADDING_FACTOR)
   const addPadding = (val) => +val + Math.abs(val * PADDING_FACTOR)
@@ -11,6 +13,10 @@ export default function getRange(timeSeries, override, value = null, rangeValue 
   const pad = (val) => {
     if (val === null || val === '') {
       return null
+    }
+
+    if (operator === 'less than') {
+      return val < 0 ? addPadding(val) : subtractPadding(val)
     }
 
     return val < 0 ? subtractPadding(val) : addPadding(val)


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1041 

### The problem
When a user provided a "less than" threshold value that was far below the minimum range of a time series, the threshold highlighting would not appear.  For example, a series with a range of [90, 100], and a "less than" threshold value of 78 would create a highlight out of view.
![](http://g.recordit.co/f1juFH2IgR.gif)

This was due to us applying incorrect padding to numbers 

### The Solution
When the threshold value is supposed to be the new min for graph view range (as is the case when "less than" is selected) subtract padding from the view.  This increases the view range:

![](http://g.recordit.co/SnGGal2zUk.gif)

### Notes
Refactored the `getRangeForDygraphSpec`.  Please see [this commit](https://github.com/influxdata/chronograf/pull/1151/commits/6e2672d5209a6722ab56a4fd7ee183fbab1e2f23) for the relevant test