### PR TITLE
Bugfix/1111 kapacitor form

### DIFF
--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -104,7 +104,7 @@ const KapacitorForm = React.createClass({
                       </div>
 
                       <div className="form-group form-group-submit col-xs-12 text-center">
-                        <button className="btn btn-info" onClick={onReset}>Reset to Default</button>
+                        <button className="btn btn-info" type="button" onClick={onReset}>Reset to Default</button>
                         <button className="btn btn-success" type="submit">Connect Kapacitor</button>
                       </div>
                     </form>

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -70,11 +70,10 @@ export const KapacitorPage = React.createClass({
   },
 
   handleInputChange(e) {
-    const val = e.target.value
-    const name = e.target.name
+    const {value, name} = e.target
 
     this.setState((prevState) => {
-      const update = {[name]: val.trim()}
+      const update = {[name]: value.trim()}
       return {kapacitor: {...prevState.kapacitor, ...update}}
     })
   },


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1111 

### The problem
The Kapacitor setup page wound up clearing the form when the enter key was pressed.

### The Solution
Turns out, the reset button was being set as the default instead of the submit button. Clarified to the form DOM that the reset button is not a submit button.