### PR TITLE
Restore ability to save raw queries to a Dashboard Cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   1. [#1106](https://github.com/influxdata/chronograf/issues/1106): Fix obscured legends in dashboards
   1. [#1051](https://github.com/influxdata/chronograf/issue/1051): Exit presentation mode when using the browser back button
   1. [#1123](https://github.com/influxdata/chronograf/issue/1123): Widen single column results in data explorer
+  1. [#1164](https://github.com/influxdata/chronograf/issue/1164): Restore ability to save raw queries to a Dashboard Cell
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -69,7 +69,7 @@ class CellEditorOverlay extends Component {
     newCell.type = cellWorkingType
     newCell.queries = queriesWorkingDraft.map((q) => {
       const query = q.rawText || buildInfluxQLQuery(timeRange, q)
-      const label = `${q.measurement}.${q.fields[0].field}`
+      const label = q.rawText || `${q.measurement}.${q.fields[0].field}`
 
       return {
         queryConfig: q,

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -69,7 +69,9 @@ class CellEditorOverlay extends Component {
     newCell.type = cellWorkingType
     newCell.queries = queriesWorkingDraft.map((q) => {
       const query = q.rawText || buildInfluxQLQuery(timeRange, q)
-      const label = q.rawText || `${q.measurement}.${q.fields[0].field}`
+      const label = q.rawText ?
+        "" :
+        `${q.measurement}.${q.fields[0].field}`
 
       return {
         queryConfig: q,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1105

### The problem
Queries added via the InfluxQL mode will lack a queryConfig representation, having only a `rawText` value to send to the server. In these cases, we can't craft a Cell Label by inspecting a queryConfig.

### The Solution
If `rawText` is all we have to go on, we should provide a blank Cell Label to the server.