### PR TITLE
Pare down stacking contexts in .react-grid-item

### DIFF
--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -38,10 +38,6 @@ $dash-graph-heading: 30px;
     border-radius: $radius;
     border: 2px solid $g3-castle;
     transition-property: left, top, border-color, background-color;
-
-    &:hover {
-      z-index: 8000;
-    }
   }
   .graph-empty {
     background-color: transparent;
@@ -58,10 +54,8 @@ $dash-graph-heading: 30px;
   height: 100%;
   top: 0;
   left: 0;
-  z-index: 0;
 }
 .dash-graph--container {
-  z-index: 1;
   user-select: none !important;
   -o-user-select: none !important;
   -moz-user-select: none !important;
@@ -73,7 +67,7 @@ $dash-graph-heading: 30px;
   top: $dash-graph-heading;
   left: 0;
   padding: 0;
-  
+
   & > div:not(.graph-empty) {
     position: absolute;
     left: 0;
@@ -93,7 +87,7 @@ $dash-graph-heading: 30px;
   }
 }
 .dash-graph--heading {
-  z-index: 2;
+  z-index: 1;
   user-select: none !important;
   -o-user-select: none !important;
   -moz-user-select: none !important;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

## The problem
We've seen a couple of UI issues recently that have been solved by modifying the `z-index` of a `.react-grid-item` descendant. There are a couple of remaining related UI issues, and I am resistant to adding more `z-index` bandaids -- ideally we could identify/remove one or two problematic `z-index`es, hopefully making `.react-grid-item` less hairy overall.  Specific remaining issues:

### With open menu dropdown, hover over a neighboring cell
Notice that the right side of the menu dropdown is clipped by the neighboring cell. Currently, when we hover over a cell, its `z-index` is upgraded to `8000`.
<img width="1134" alt="screen shot 2017-04-03 at 5 32 20 pm" src="https://cloud.githubusercontent.com/assets/1438089/24637125/8c3de53e-1893-11e7-9441-d7fb73d42481.png">

### CellEditorOverlay opens beneath currently hovered cell
When clicking Edit, the dropdown closes and the overlay opens. But the cell remains top of the render stack. When you move your mouse out of the cell boundary, it disappears back behind the Overlay.
<img width="1617" alt="screen shot 2017-04-03 at 5 32 27 pm" src="https://cloud.githubusercontent.com/assets/1438089/24637236/7c16d44e-1894-11e7-85fc-6c67c5fb5c80.png">

## Analysis
I drew out a `.react-grid-item`'s DOM. Black means that no new stacking context is created for the element. Red means that there is a new stacking context at that element, and the specific properties that create it are noted in brackets (i.e. `abs+1` means `position: absolute; z-index: 1;`). I've labeled each stacking context with a letter for reference.
![img_20170403_163501](https://cloud.githubusercontent.com/assets/1438089/24637270/abc1f854-1894-11e7-845f-56c10202b18e.jpg)

## The Solution
Proposed:
* Remove contexts `A`, `B`, and `E`
* Downgrade `C` to `abs+1`

Cells are not completely self-contained -- children of one cell may need to appear above a neighboring cell (e.g. cell menu dropdown, dygraph legend). By moving a cell's "root" stacking context higher up the DOM tree, we can more predictably control the interplay between these elements.