### PR TITLE
Fix saving email in Kapacitor alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   1. [#1051](https://github.com/influxdata/chronograf/issue/1051): Exit presentation mode when using the browser back button
   1. [#1123](https://github.com/influxdata/chronograf/issue/1123): Widen single column results in data explorer
   1. [#1115](https://github.com/influxdata/chronograf/pull/1115): Fix Basepath issue where content would fail to render under certain circumstances
+  1. [#1173](https://github.com/influxdata/chronograf/pull/1173): Fix saving email in Kapacitor alerts
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/kapacitor/components/RuleMessageAlertConfig.js
+++ b/ui/src/kapacitor/components/RuleMessageAlertConfig.js
@@ -25,8 +25,7 @@ const RuleMessageAlertConfig = ({
         className="form-control size-486"
         type="text"
         placeholder={DEFAULT_ALERT_PLACEHOLDERS[alert]}
-        name="alertProperty"
-        onChange={(evt) => updateAlertNodes(rule.id, alert, evt.target.form.alertProperty.value)}
+        onChange={(e) => updateAlertNodes(rule.id, alert, e.target.value)}
         value={ALERT_NODES_ACCESSORS[alert](rule)}
       />
     </div>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1100 #1156 

### The problem
Kapacitor alerts failed to save email address entered by user.

### The Solution
Fix how form data is captured.

