### PR TITLE
Admin Databases Page no longer breaks if a db is missing an rp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   1. [#1164](https://github.com/influxdata/chronograf/pull/1164): Restore ability to save raw queries to a Dashboard Cell
   1. [#1115](https://github.com/influxdata/chronograf/pull/1115): Fix Basepath issue where content would fail to render under certain circumstances
   1. [#1173](https://github.com/influxdata/chronograf/pull/1173): Fix saving email in Kapacitor alerts
+  1. [#1179](https://github.com/influxdata/chronograf/pull/1179): Admin Databases Page will render a database without retention policies
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/server/databases.go
+++ b/server/databases.go
@@ -16,12 +16,12 @@ type dbLinks struct {
 }
 
 type dbResponse struct {
-	Name          string       `json:"name"`                        // a unique string identifier for the database
-	Duration      string       `json:"duration,omitempty"`          // the duration (when creating a default retention policy)
-	Replication   int32        `json:"replication,omitempty"`       // the replication factor (when creating a default retention policy)
-	ShardDuration string       `json:"shardDuration,omitempty"`     // the shard duration (when creating a default retention policy)
-	RPs           []rpResponse `json:"retentionPolicies,omitempty"` // RPs are the retention policies for a database
-	Links         dbLinks      `json:"links"`                       // Links are URI locations related to the database
+	Name          string       `json:"name"`                    // a unique string identifier for the database
+	Duration      string       `json:"duration,omitempty"`      // the duration (when creating a default retention policy)
+	Replication   int32        `json:"replication,omitempty"`   // the replication factor (when creating a default retention policy)
+	ShardDuration string       `json:"shardDuration,omitempty"` // the shard duration (when creating a default retention policy)
+	RPs           []rpResponse `json:"retentionPolicies"`       // RPs are the retention policies for a database
+	Links         dbLinks      `json:"links"`                   // Links are URI locations related to the database
 }
 
 // newDBResponse creates the response for the /databases endpoint

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2259,6 +2259,18 @@
 				"duration": "3d",
 				"replication": 3,
 				"shardDuration": "3h",
+				"retentionPolicies": [
+					{
+						"name": "weekly",
+						"duration": "7d",
+						"replication": 1,
+						"shardDuration": "7d",
+						"default": true,
+						"links": {
+							"self": "/chronograf/v1/ousrces/1/dbs/NOAA_water_database/rps/liquid"
+						}
+					}
+				],
 				"links": {
 					"self": "/chronograf/v1/sources/1/dbs/NOAA_water_database",
 					"rps": "/chronograf/v1/sources/1/dbs/NOAA_water_database/rps"
@@ -2281,6 +2293,12 @@
 				"shardDuration": {
 					"type": "string",
 					"description": "the interval spanned by each shard group"
+				},
+				"retentionPolicies": {
+					"type": "array",
+					"items": {
+						"$ref": "#/definitions/RetentionPolicy"
+					}
 				},
 				"links": {
 					"type": "object",


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1170

### The problem
The frontend expected databases to have a `retentionPolicies` key, even if the value is an empty array. The server is omitting the key if the value is empty.

### The Solution
The server now keeps the `retentionPolicies` key, even if its value is `[]`.