### PR TITLE
Update schema exploration to support non-default rp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   1. [#1164](https://github.com/influxdata/chronograf/pull/1164): Restore ability to save raw queries to a Dashboard Cell
   1. [#1115](https://github.com/influxdata/chronograf/pull/1115): Fix Basepath issue where content would fail to render under certain circumstances
   1. [#1173](https://github.com/influxdata/chronograf/pull/1173): Fix saving email in Kapacitor alerts
+  1. [#979](https://github.com/influxdata/chronograf/issues/979): Fix empty tags for non-default retention policies
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/shared/apis/metaQuery.js
+++ b/ui/src/shared/apis/metaQuery.js
@@ -1,4 +1,5 @@
 import AJAX from 'utils/ajax'
+import _ from 'lodash'
 import {buildInfluxUrl, proxy} from 'utils/queryUrlGenerator'
 
 export const showDatabases = async (source) => {
@@ -36,14 +37,15 @@ export function showMeasurements(source, db) {
 }
 
 export function showTagKeys({source, database, retentionPolicy, measurement}) {
-  const query = `SHOW TAG KEYS FROM "${retentionPolicy}"."${measurement}"`
-
+  const rp = _.toString(retentionPolicy)
+  const query = `SHOW TAG KEYS FROM "${rp}"."${measurement}"`
   return proxy({source, db: database, rp: retentionPolicy, query})
 }
 
 export function showTagValues({source, database, retentionPolicy, measurement, tagKeys}) {
   const keys = tagKeys.sort().map((k) => `"${k}"`).join(', ')
-  const query = `SHOW TAG VALUES FROM "${retentionPolicy}"."${measurement}" WITH KEY IN (${keys})`
+  const rp = _.toString(retentionPolicy)
+  const query = `SHOW TAG VALUES FROM "${rp}"."${measurement}" WITH KEY IN (${keys})`
 
   return proxy({source, db: database, rp: retentionPolicy, query})
 }

--- a/ui/src/shared/apis/metaQuery.js
+++ b/ui/src/shared/apis/metaQuery.js
@@ -36,14 +36,14 @@ export function showMeasurements(source, db) {
 }
 
 export function showTagKeys({source, database, retentionPolicy, measurement}) {
-  const query = `SHOW TAG KEYS FROM "${measurement}"`
+  const query = `SHOW TAG KEYS FROM "${retentionPolicy}"."${measurement}"`
 
   return proxy({source, db: database, rp: retentionPolicy, query})
 }
 
 export function showTagValues({source, database, retentionPolicy, measurement, tagKeys}) {
   const keys = tagKeys.sort().map((k) => `"${k}"`).join(', ')
-  const query = `SHOW TAG VALUES FROM "${measurement}" WITH KEY IN (${keys})`
+  const query = `SHOW TAG VALUES FROM "${retentionPolicy}"."${measurement}" WITH KEY IN (${keys})`
 
   return proxy({source, db: database, rp: retentionPolicy, query})
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #979 

### The problem
The `SHOW TAG` queries did not use retentionPolicies so the schema explorer would have empty tags.

### The Solution
Add retentionPolicies to 'em

However, I'm pretty sure `SHOW MEASUREMENTS` isn't working like we want it to work.  It seems to show all measurements rather than just those for a specific retention policy.  
