### PR TITLE
Resolve CHANGELOG.md conflicts by keeping both changes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union


### PR DESCRIPTION
## The problem
Even with the team converging on true Markdown numbering (i.e all `1`s instead of `1`, `2`, etc.), we still seem to be running into per-PR merge conflicts in our CHANGELOG. This is still happening because:

#### Base
```
1. one
1. two
1. three
```

#### Left Branch
```
1. one
1. two
1. three
1. four
```

#### Right Branch
```
1. one
1. two
1. three
1. five
```

The default merge strategy sees `1. four` and `1. five` occupying the same spot, and it doesn't know which to choose. So it delegates to a human to decide. We can do better.

## The Solution
For `CHANGELOG.md` ONLY, use the `union` merge strategy. This will identify two conflicting changes:
`1. four`
`1. five`

And keep them both, though their order is not guaranteed.