### PR TITLE
Prevent Blur when Clicking Inside Graph Name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   1. [#1173](https://github.com/influxdata/chronograf/pull/1173): Fix saving email in Kapacitor alerts
   1. [#979](https://github.com/influxdata/chronograf/issues/979): Fix empty tags for non-default retention policies
   1. [#1179](https://github.com/influxdata/chronograf/pull/1179): Admin Databases Page will render a database without retention policies
+  1. [#1189](https://github.com/influxdata/chronograf/pull/1189): Clicking inside the graph header edit box will no longer blur the field. Use the Escape key for that behavior instead.
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -80,6 +80,9 @@ const NameableGraph = React.createClass({
             if (evt.key === 'Enter') {
               onUpdateCell(cell)()
             }
+            if (evt.key === 'Escape') {
+              onEditCell(x, y, false)()
+            }
           }}
         />
       )
@@ -88,7 +91,7 @@ const NameableGraph = React.createClass({
     }
 
     let onClickHandler
-    if (isEditable) {
+    if (!isEditing && isEditable) {
       onClickHandler = onEditCell
     } else {
       onClickHandler = () => {

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -81,7 +81,7 @@ const NameableGraph = React.createClass({
               onUpdateCell(cell)()
             }
             if (evt.key === 'Escape') {
-              onEditCell(x, y, false)()
+              onEditCell(x, y, true)()
             }
           }}
         />


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1146 

### The problem
If a user were to click on the cell header when editing, they would get kicked out of edit mode, which prevents text selection.

### The Solution
Prevent kicking out of edit mode if the cell is being edited.

Also, add a blur feature with the escape key. It doesn't cancel and reset to prior state, however. That should be addressed in the separate issue, #1188 
