### PR TITLE
Move Rename Cell functionality to ContextMenu dropdown; Restyle cell header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
   1. [#1079](https://github.com/influxdata/chronograf/issues/1079): Remove series highlighting in line graphs
   1. [#1124](https://github.com/influxdata/chronograf/pull/1124): Polished dashboard cell drag interaction, use Hover-To-Reveal UI pattern in all tables, Source Indicator & Graph Tips are no longer misleading, and aesthetic improvements to the DB Management page
   1. [#1185](https://github.com/influxdata/chronograf/pull/1185): Alphabetically sort Admin Database Page
+  1. [#1199](https://github.com/influxdata/chronograf/pull/1199): Move Rename Cell functionality to ContextMenu dropdown
 
 ## v1.2.0-beta7 [2017-03-28]
 ### Bug Fixes

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -187,7 +187,7 @@ export const LayoutRenderer = React.createClass({
         useCSSTransforms={false}
         onResize={this.triggerWindowResize}
         onLayoutChange={this.handleLayoutChange}
-        draggableHandle={'.dash-graph--drag-handle'}
+        draggableHandle={'.dash-graph--name'}
         isDraggable={isDashboard}
         isResizable={isDashboard}
       >

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -84,7 +84,7 @@ const NameableGraph = React.createClass({
         />
       )
     } else {
-      nameOrField = (<span className={classnames("dash-graph--name", {editable: !shouldNotBeEditable})}>{name}</span>)
+      nameOrField = (<span className="dash-graph--name">{name}</span>)
     }
 
     let onStartRenaming
@@ -98,25 +98,20 @@ const NameableGraph = React.createClass({
 
     return (
       <div className="dash-graph">
-        <div className="dash-graph--heading">
-          <div className="dash-graph--name-container">
-            {nameOrField}
-          </div>
-          {shouldNotBeEditable ? null : <div className="dash-graph--drag-handle"></div>}
-          {
-            shouldNotBeEditable ?
-              null :
-              <ContextMenu
-                isOpen={this.state.isMenuOpen}
-                toggleMenu={this.toggleMenu}
-                onEdit={onSummonOverlayTechnologies}
-                onRename={onStartRenaming}
-                onDelete={onDeleteCell}
-                cell={cell}
-                handleClickOutside={this.closeMenu}
-              />
-          }
-        </div>
+        <div className={classnames("dash-graph--heading", {"dash-graph--heading-draggable": !shouldNotBeEditable})}>{nameOrField}</div>
+        {
+          shouldNotBeEditable ?
+          null :
+          <ContextMenu
+            isOpen={this.state.isMenuOpen}
+            toggleMenu={this.toggleMenu}
+            onEdit={onSummonOverlayTechnologies}
+            onRename={onStartRenaming}
+            onDelete={onDeleteCell}
+            cell={cell}
+            handleClickOutside={this.closeMenu}
+          />
+        }
         <div className="dash-graph--container">
           {children}
         </div>

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -87,11 +87,11 @@ const NameableGraph = React.createClass({
       nameOrField = (<span className={classnames("dash-graph--name", {editable: !shouldNotBeEditable})}>{name}</span>)
     }
 
-    let onClickHandler
+    let onStartRenaming
     if (isEditable) {
-      onClickHandler = onEditCell
+      onStartRenaming = onEditCell
     } else {
-      onClickHandler = () => {
+      onStartRenaming = () => {
         // no-op
       }
     }
@@ -99,7 +99,9 @@ const NameableGraph = React.createClass({
     return (
       <div className="dash-graph">
         <div className="dash-graph--heading">
-          <div className="dash-graph--name-container" onClick={onClickHandler(x, y, isEditing)}>{nameOrField}</div>
+          <div className="dash-graph--name-container">
+            {nameOrField}
+          </div>
           {shouldNotBeEditable ? null : <div className="dash-graph--drag-handle"></div>}
           {
             shouldNotBeEditable ?
@@ -108,6 +110,7 @@ const NameableGraph = React.createClass({
                 isOpen={this.state.isMenuOpen}
                 toggleMenu={this.toggleMenu}
                 onEdit={onSummonOverlayTechnologies}
+                onRename={onStartRenaming}
                 onDelete={onDeleteCell}
                 cell={cell}
                 handleClickOutside={this.closeMenu}
@@ -122,13 +125,14 @@ const NameableGraph = React.createClass({
   },
 })
 
-const ContextMenu = OnClickOutside(({isOpen, toggleMenu, onEdit, onDelete, cell}) => (
+const ContextMenu = OnClickOutside(({isOpen, toggleMenu, onEdit, onRename, onDelete, cell}) => (
   <div className={classnames("dash-graph--options", {"dash-graph--options-show": isOpen})} onClick={toggleMenu}>
     <button className="btn btn-info btn-xs">
       <span className="icon caret-down"></span>
     </button>
     <ul className="dash-graph--options-menu">
       <li onClick={() => onEdit(cell)}>Edit</li>
+      <li onClick={onRename(cell.x, cell.y, cell.isEditing)}>Rename</li>
       <li onClick={() => onDelete(cell)}>Delete</li>
     </ul>
   </div>

--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -99,7 +99,7 @@ const NameableGraph = React.createClass({
     return (
       <div className="dash-graph">
         <div className="dash-graph--heading">
-          <div onClick={onClickHandler(x, y, isEditing)}>{nameOrField}</div>
+          <div className="dash-graph--name-container" onClick={onClickHandler(x, y, isEditing)}>{nameOrField}</div>
           {shouldNotBeEditable ? null : <div className="dash-graph--drag-handle"></div>}
           {
             shouldNotBeEditable ?

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -3,7 +3,8 @@
   ------------------------------------------------------
 */
 $dash-graph-heading: 30px;
-
+$dash-graph-heading-context: $dash-graph-heading - 8px;
+$dash-graph-options-arrow: 8px;
 
 /*
   Animations
@@ -98,115 +99,64 @@ $dash-graph-heading: 30px;
   left: 0;
   width: 100%;
   height: $dash-graph-heading;
-  padding: 0 16px;
   margin: 0;
   display: flex;
   align-items: center;
   justify-content: space-between;
-  border-radius: $radius;
+  border-radius: $radius-small;
   font-weight: 600;
   font-size: 13px;
   color: $g14-chromium;
   transition:
     color 0.25s ease,
     background-color 0.25s ease;
-  &:hover {
-    cursor: default;
-  }
-}
-.dash-graph--drag-handle {
-  height: $dash-graph-heading;
-  flex: 1 0 0;
-
-  &:before {
-    content: '';
-    position: absolute;
-    width: 100%;
-    left: 0;
-    height: $dash-graph-heading;
-    background-color: $g5-pepper;
-    border-radius: 3px;
-    z-index: -1;
-    opacity: 0;
-    transition: opacity 0.25s ease;
-  }
-  &:hover {
+  &.dash-graph--heading-draggable:hover {
     cursor: move;
+    background-color: $g5-pepper;
   }
-  &:hover:before {
-    opacity: 1;
-  }
-}
-.dash-graph--name-container {
-  flex: 0 0 70%;
-  overflow: hidden;
 }
 .dash-graph--name-edit,
 .dash-graph--name {
-  display: inline-block;
-  padding: 0 6px;
-  height: 26px !important;
-  line-height: (26px - 4px) !important;
   font-size: 13px;
   font-weight: 600;
-  position: relative;
-  left: -6px;
   border-radius: $radius;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  width: 100%;
 }
 .dash-graph--name {
+  height: $dash-graph-heading;
+  line-height: $dash-graph-heading;
+  width: calc(100% - 50px);
+  margin-left: 16px;
   transition:
     color 0.25s ease,
     background-color 0.25s ease,
     border-color 0.25s ease;
-  border: 2px solid transparent;
-  top: 2px;
-
-  &.editable {
-    &:after {
-      display: inline-block;
-      content: "\f058";
-      font-family: 'icomoon' !important;
-      font-style: normal;
-      font-weight: normal;
-      font-variant: normal;
-      line-height: 1;
-      text-transform: none;
-      color: $g11-sidewalk;
-      font-size: 14px;
-      opacity: 0;
-      transition: opacity 0.25s ease;
-      margin-left: 5px;
-    }
-
-    &:hover {
-      cursor: text;
-      color: $g20-white;
-
-      &:after {
-        opacity: 1;
-      }
-    }
-  }
 }
 .dash-graph--name-edit {
-  top: -1px;
+  margin-left: 8px;
+  padding: 0 6px;
+  width: calc(100% - 42px);
+  height: 26px !important;
+  line-height: (26px - 4px) !important;
+  position: relative;
+  top: -1px; // Fix for slight offset
 }
 .dash-graph--options {
-  flex: 0 0 22px;
-  position: relative;
-  right: -6px;
+  width: $dash-graph-heading;
+  position: absolute;
+  z-index: 2;
+  right: 0px;
+  top: 0px;
 
   > .btn {
     background-color: transparent !important;
     padding: 0;
     margin: 4px 0;
-    height: ($dash-graph-heading - 8px);
-    width: ($dash-graph-heading - 8px);
-    line-height: ($dash-graph-heading - 8px);
+    height: $dash-graph-heading-context;
+    width: $dash-graph-heading-context;
+    line-height: $dash-graph-heading-context;
     transition:
       background-color 0.25s ease,
       color 0.25s ease !important;
@@ -217,7 +167,6 @@ $dash-graph-heading: 30px;
     }
   }
 }
-$dash-graph-options-arrow: 8px;
 
 .presentation-mode .dash-graph--options {
   display: none;
@@ -354,9 +303,8 @@ $dash-graph-options-arrow: 8px;
       cursor: move;
     }
 
-    .dash-graph--drag-handle:before,
-    .dash-graph--drag-handle:hover:before {
-      opacity: 1 !important;
+    .dash-graph--heading {
+      background-color: $g5-pepper;
       cursor: move;
     }
   }

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -116,7 +116,7 @@ $dash-graph-heading: 30px;
 }
 .dash-graph--drag-handle {
   height: $dash-graph-heading;
-  width: 100%;
+  flex: 1 0 0;
 
   &:before {
     content: '';
@@ -137,6 +137,10 @@ $dash-graph-heading: 30px;
     opacity: 1;
   }
 }
+.dash-graph--name-container {
+  flex: 0 0 70%;
+  overflow: hidden;
+}
 .dash-graph--name-edit,
 .dash-graph--name {
   display: inline-block;
@@ -151,6 +155,7 @@ $dash-graph-heading: 30px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  width: 100%;
 }
 .dash-graph--name {
   transition:
@@ -189,12 +194,10 @@ $dash-graph-heading: 30px;
 }
 .dash-graph--name-edit {
   top: -1px;
-  width: 190px;
 }
 .dash-graph--options {
-  height: $dash-graph-heading;
+  flex: 0 0 22px;
   position: relative;
-  width: ($dash-graph-heading - 8px);
   right: -6px;
 
   > .btn {


### PR DESCRIPTION
cc: @alexpaxton 


  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1194

### The problem
When
1) A user enters a super long name for a cell
2) A user enters a reasonable name for a cell, and then makes the cell smaller
the name of the cell will overflow its reserved space, and push the ContextMenu carat off to the right.
![before](http://g.recordit.co/Wm02QAM5wM.gif)

And so we tried to rework the spacing in the header, but it turns out that the header is really too busy and should be simplified. Namely,
1. The header needs to have a clickable area for the ContextMenu dropdown. When clicking this area, a user should not be able to drag the cell
2. The header needs a clickable area for the name -- clicking the name enters you into a "rename" mode. Clicking out, or pressing enter, will return you to "normal" mode.
3. The header needs a clickable area for a drag handle. Hovering over this will turn the cursor to a "move" symbol, and the entire header will highlight, indicating that the user can grab it.

It's a lot to manage, and satisfying all conditions above meant tackling quite a few edge cases.

### The Solution
Instead, we opted to move the Rename functionality to the ContextMenu dropdown. And the drag handle for the cell was expanded to cover everything except for the dropdown carat.
![after-1](http://g.recordit.co/L4JMdX84pK.gif)

This made it much simpler to solve for #1194 and similar edge cases:
![after-2](http://g.recordit.co/LKYTxhHqBF.gif)