### PR TITLE
Flip the Data Explorer

### DIFF
--- a/ui/src/data_explorer/components/FieldList.js
+++ b/ui/src/data_explorer/components/FieldList.js
@@ -98,11 +98,11 @@ const FieldList = React.createClass({
 
     return (
       <ul className="qeditor--list">
-        {this.state.fields.map((fieldFunc, i) => {
+        {this.state.fields.map((fieldFunc) => {
           const selectedField = this.props.query.fields.find((f) => f.field === fieldFunc.field)
           return (
             <FieldListItem
-              key={fieldFunc.field + i}
+              key={fieldFunc.field}
               onToggleField={this.props.onToggleField}
               onApplyFuncsToField={this.props.applyFuncsToField}
               isSelected={!!selectedField}

--- a/ui/src/data_explorer/components/FieldList.js
+++ b/ui/src/data_explorer/components/FieldList.js
@@ -98,11 +98,11 @@ const FieldList = React.createClass({
 
     return (
       <ul className="qeditor--list">
-        {this.state.fields.map((fieldFunc) => {
+        {this.state.fields.map((fieldFunc, i) => {
           const selectedField = this.props.query.fields.find((f) => f.field === fieldFunc.field)
           return (
             <FieldListItem
-              key={fieldFunc.field}
+              key={fieldFunc.field + i}
               onToggleField={this.props.onToggleField}
               onApplyFuncsToField={this.props.applyFuncsToField}
               isSelected={!!selectedField}

--- a/ui/src/data_explorer/components/Visualization.js
+++ b/ui/src/data_explorer/components/Visualization.js
@@ -112,7 +112,7 @@ const Visualization = React.createClass({
 
   renderTable(query, heightPixels, onEditRawStatus) {
     if (!query) {
-      return <div className="generic-empty-state">Enter your query below</div>
+      return <div className="generic-empty-state">Enter your query above</div>
     }
 
     return <Table query={query} height={heightPixels} onEditRawStatus={onEditRawStatus} />

--- a/ui/src/data_explorer/containers/DataExplorer.js
+++ b/ui/src/data_explorer/containers/DataExplorer.js
@@ -83,22 +83,22 @@ const DataExplorer = React.createClass({
           timeRange={timeRange}
         />
         <ResizeContainer>
-          <Visualization
+          <QueryBuilder
+            queries={queryConfigs}
+            actions={queryConfigActions}
             autoRefresh={autoRefresh}
             timeRange={timeRange}
-            queryConfigs={queryConfigs}
+            setActiveQueryIndex={this.handleSetActiveQueryIndex}
+            onDeleteQuery={this.handleDeleteQuery}
             activeQueryIndex={activeQueryIndex}
-            onEditRawStatus={queryConfigActions.editRawQueryStatus}
           />
           <ResizeBottom>
-            <QueryBuilder
-              queries={queryConfigs}
-              actions={queryConfigActions}
+            <Visualization
               autoRefresh={autoRefresh}
               timeRange={timeRange}
-              setActiveQueryIndex={this.handleSetActiveQueryIndex}
-              onDeleteQuery={this.handleDeleteQuery}
+              queryConfigs={queryConfigs}
               activeQueryIndex={activeQueryIndex}
+              onEditRawStatus={queryConfigActions.editRawQueryStatus}
             />
           </ResizeBottom>
         </ResizeContainer>

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -119,7 +119,7 @@ export default React.createClass({
           dygraphSeries={dygraphSeries}
           ranges={ranges || this.getRanges()}
           ruleValues={ruleValues}
-          legendOnBottom={isInDataExplorer ? true : null}
+          legendOnBottom={isInDataExplorer}
         />
         {showSingleStat ? <div className="graph-single-stat single-stat">{roundedValue}</div> : null}
       </div>

--- a/ui/src/shared/components/ResizeContainer.js
+++ b/ui/src/shared/components/ResizeContainer.js
@@ -83,9 +83,12 @@ const ResizeContainer = React.createClass({
   },
 })
 
-const ResizeBottom = (props) => (
-  <div className="resize-bottom" style={{height: props.height}}>
-    {props.children}
+export const ResizeBottom = ({
+  height,
+  children,
+}) => (
+  <div className="resize-bottom" style={{height}}>
+    {children}
   </div>
 )
 
@@ -93,7 +96,5 @@ ResizeBottom.propTypes = {
   children: node.isRequired,
   height: string,
 }
-
-export {ResizeBottom}
 
 export default ResizeContainer

--- a/ui/src/shared/components/ResizeContainer.js
+++ b/ui/src/shared/components/ResizeContainer.js
@@ -81,7 +81,7 @@ const ResizeContainer = React.createClass({
       bottomHeightPixels,
     } = this.state
     const top = React.cloneElement(this.props.children[0], {height: topHeight, heightPixels: topHeightPixels})
-    const bottom = React.cloneElement(this.props.children[1], {height: bottomHeightPixels})
+    const bottom = React.cloneElement(this.props.children[1], {height: `${bottomHeightPixels}px`})
     return (
       <div className="resize-container page-contents" onMouseLeave={this.handleMouseLeave} onMouseUp={this.handleStopDrag} onMouseMove={this.handleDrag} ref="resizeContainer" >
         {top}

--- a/ui/src/shared/components/ResizeContainer.js
+++ b/ui/src/shared/components/ResizeContainer.js
@@ -59,7 +59,12 @@ const ResizeContainer = React.createClass({
       return
     }
 
-    this.setState({topHeight: `${(newTopPanelPercent)}%`, bottomHeight: `${(newBottomPanelPercent)}%`, topHeightPixels})
+    this.setState({
+      topHeight: `${(newTopPanelPercent)}%`,
+      bottomHeight: `${(newBottomPanelPercent)}%`,
+      topHeightPixels,
+      bottomHeightPixels,
+    })
   },
 
   renderHandle() {
@@ -70,9 +75,13 @@ const ResizeContainer = React.createClass({
   },
 
   render() {
-    const {topHeight, topHeightPixels, bottomHeight} = this.state
+    const {
+      topHeight,
+      topHeightPixels,
+      bottomHeightPixels,
+    } = this.state
     const top = React.cloneElement(this.props.children[0], {height: topHeight, heightPixels: topHeightPixels})
-    const bottom = React.cloneElement(this.props.children[1], {height: bottomHeight})
+    const bottom = React.cloneElement(this.props.children[1], {height: bottomHeightPixels})
     return (
       <div className="resize-container page-contents" onMouseLeave={this.handleMouseLeave} onMouseUp={this.handleStopDrag} onMouseMove={this.handleDrag} ref="resizeContainer" >
         {top}
@@ -86,11 +95,14 @@ const ResizeContainer = React.createClass({
 export const ResizeBottom = ({
   height,
   children,
-}) => (
-  <div className="resize-bottom" style={{height}}>
-    {children}
-  </div>
-)
+}) => {
+  const child = React.cloneElement(children, {height})
+  return (
+    <div className="resize-bottom" style={{height}}>
+      {child}
+    </div>
+  )
+}
 
 ResizeBottom.propTypes = {
   children: node.isRequired,

--- a/ui/src/style/components/resizer.scss
+++ b/ui/src/style/components/resizer.scss
@@ -19,7 +19,7 @@ $resizer-color-active: $c-pool;
   z-index: 2;
   user-select: none;
   -webkit-user-select: none;
-  position: relative;
+  position: absolute;
 
   // Psuedo element for handle
   &:before {

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -444,7 +444,7 @@ $overlay-bg: rgba($c-pool, 0.7);
   margin-top: 2px;
 }
 .overlay-technology .query-builder--tabs,
-.overlay-technology .query-builder--tab-contents
+.overlay-technology .query-builder--tab-contents,
 .overlay-technology .qeditor--empty {
   margin: 0;
 }

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -369,11 +369,6 @@ $overlay-bg: rgba($c-pool, 0.7);
     border: 0;
     border-radius: $radius;
     @include gradient-h($g3-castle,$overlay-controls-bg);
-
-    /* Hack for making the adjacent query builder have less margin on top */
-    & + .query-builder {
-      margin-top: 2px;
-    }
   }
   .overlay-controls--right {
     display: flex;
@@ -442,4 +437,14 @@ $overlay-bg: rgba($c-pool, 0.7);
 .overlay-technology .dash-graph--container {
   height: calc(100% - #{$dash-graph-heading});
   top: $dash-graph-heading;
+}
+.overlay-technology .query-builder {
+  flex: 1 0 0;
+  margin-bottom: 16px;
+  margin-top: 2px;
+}
+.overlay-technology .query-builder--tabs,
+.overlay-technology .query-builder--tab-contents
+.overlay-technology .qeditor--empty {
+  margin: 0;
 }

--- a/ui/src/style/pages/data-explorer/font-scale.scss
+++ b/ui/src/style/pages/data-explorer/font-scale.scss
@@ -88,13 +88,11 @@ $breakpoint-c: 2100px;
     .query-builder--tabs {
       width: 372px;
     }
-    .query-builder--tab-label {
-      width: (373px - 8px - 16px - 16px);
-    }
     .qeditor--list-item {
       letter-spacing: 0.3px;
     }
     .query-builder--tab-label {
+      width: (373px - 8px - 16px - 16px);
       font-size: 16px;
     }
     .query-builder--tab {

--- a/ui/src/style/pages/data-explorer/font-scale.scss
+++ b/ui/src/style/pages/data-explorer/font-scale.scss
@@ -26,6 +26,9 @@ $breakpoint-c: 2100px;
     .query-builder--tabs {
       width: 320px;
     }
+    .query-builder--tab-label {
+      width: (320px - 8px - 16px - 16px);
+    }
     .qeditor--list-item,
     .query-builder--tab-label {
       font-size: 15px;
@@ -84,6 +87,9 @@ $breakpoint-c: 2100px;
   .data-explorer {
     .query-builder--tabs {
       width: 372px;
+    }
+    .query-builder--tab-label {
+      width: (373px - 8px - 16px - 16px);
     }
     .qeditor--list-item {
       letter-spacing: 0.3px;

--- a/ui/src/style/pages/data-explorer/query-builder.scss
+++ b/ui/src/style/pages/data-explorer/query-builder.scss
@@ -4,8 +4,6 @@ $query-builder-tabs-width: 210px;
 
 .query-builder {
   position: relative;
-  flex: 1 0 0;
-  margin: 16px 0;
   width: calc(100% - #{($explorer-page-padding * 2)});
   left: $explorer-page-padding;
   border: 0;
@@ -16,6 +14,7 @@ $query-builder-tabs-width: 210px;
 
 // Tabs
 .query-builder--tabs {
+  margin: 16px 0;
   display: flex;
   width: $query-builder-tabs-width;
   flex-direction: column;
@@ -149,7 +148,8 @@ $query-builder--preview-height: 60px;
 $query-builder--column-heading-height: 50px;
 
 .query-builder--tab-contents {
-  width: 100%;
+  flex: 1 0 0;
+  margin: 16px 0;
   background-color: $g4-onyx;
   border-radius: 0 $radius $radius 0;
   overflow: hidden;

--- a/ui/src/style/pages/data-explorer/query-builder.scss
+++ b/ui/src/style/pages/data-explorer/query-builder.scss
@@ -1,3 +1,7 @@
+/* Variables */
+$query-builder-tabs-width: 210px;
+
+
 .query-builder {
   position: relative;
   flex: 1 0 0;
@@ -13,10 +17,10 @@
 // Tabs
 .query-builder--tabs {
   display: flex;
-  width: 250px;
+  width: $query-builder-tabs-width;
   flex-direction: column;
   align-items: stretch;
-  @include gradient-v($g3-castle,$g1-raven);
+  background-color: $g3-castle;
   border-radius: $radius 0 0 $radius;
 }
 .query-builder--tabs-heading {
@@ -132,7 +136,7 @@
   font-weight: 600;
   white-space: nowrap;
   overflow: hidden;
-  width: 90%;
+  width: ($query-builder-tabs-width - 8px - 16px - 16px);
   text-overflow: ellipsis;
   @include no-user-select();
 }

--- a/ui/src/style/pages/data-explorer/query-builder.scss
+++ b/ui/src/style/pages/data-explorer/query-builder.scss
@@ -223,6 +223,7 @@ $query-builder--column-heading-height: 50px;
     background-color: $g4-onyx;
   }
   .qeditor--empty {
+    width: 100%;
     margin-top: 0;
     height: calc(100% - #{$query-builder--column-heading-height});
     position: absolute;

--- a/ui/src/style/pages/data-explorer/query-editor.scss
+++ b/ui/src/style/pages/data-explorer/query-editor.scss
@@ -163,7 +163,8 @@
 .qeditor--empty {
   text-align: center;
   color: $g10-wolf;
-  width: 100%;
+  flex: 1 0 0;
+  margin: 16px 0;
   padding: 0;
   display: flex;
   flex-direction: column;

--- a/ui/src/style/pages/data-explorer/visualization.scss
+++ b/ui/src/style/pages/data-explorer/visualization.scss
@@ -4,6 +4,10 @@
   width: calc(100% - #{($explorer-page-padding * 2)});
   left: $explorer-page-padding;
 }
+/* Special rule for when the graph is in the bottom of resizer */
+.resize-bottom .graph {
+  height: 100%;
+}
 .graph-heading {
   position: relative;
   top: $de-vertical-margin;


### PR DESCRIPTION
### Problem
All the important UI is at the bottom, graph is over-emphasized

### Solution
Flip the halves of the DE such that the query builder is on top. Draws a lot more attention to the query box, and editor as a whole

![screen shot 2017-04-06 at 1 03 49 pm](https://cloud.githubusercontent.com/assets/2433762/24775085/4f9b2116-1ad0-11e7-965c-d0e6eeac0398.png)