### PR TITLE
don't attempt to send invalid queries

### DIFF
--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -59,7 +59,8 @@ export default function AutoRefresh(ComposedComponent) {
       return _.difference(_.union(leftStrs, rightStrs), _.intersection(leftStrs, rightStrs))
     },
     executeQueries(queries) {
-      if (!queries.length) {
+      const validQueries = queries.filter((q) => q.text)
+      if (!validQueries.length) {
         this.setState({
           timeSeries: [],
         })
@@ -69,11 +70,11 @@ export default function AutoRefresh(ComposedComponent) {
       this.setState({isFetching: true})
       let count = 0
       const newSeries = []
-      queries.forEach(({host, database, rp, text}) => {
+      validQueries.forEach(({host, database, rp, text}) => {
         _fetchTimeSeries(host, database, rp, text).then((resp) => {
           newSeries.push({response: resp.data})
           count += 1
-          if (count === queries.length) {
+          if (count === validQueries.length) {
             const querySuccessful = !this._noResultsForQuery(newSeries)
             this.setState({
               lastQuerySuccessful: querySuccessful,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1126

### The problem
Some queries were being sent down that are invalid, which freezes the cell in a loading state. This is what caused #1126.

### The Solution
Filter out invalid queries.

This feels like a band-aid. If anyone else can debug deeper up the chain and figure out why these are being included in `this.props.queries`, we could fix this problem closer to the source.