### PR TITLE
Current dashboard no longer comes from local Redux store

### DIFF
--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -64,9 +64,10 @@ export const syncDashboardCell = (dashboard, cell) => ({
   },
 })
 
-export const addDashboardCell = (cell) => ({
+export const addDashboardCell = (dashboard, cell) => ({
   type: 'ADD_DASHBOARD_CELL',
   payload: {
+    dashboard,
     cell,
   },
 })
@@ -141,7 +142,7 @@ export const deleteDashboardAsync = (dashboard) => async (dispatch) => {
 export const addDashboardCellAsync = (dashboard) => async (dispatch) => {
   try {
     const {data} = await addDashboardCellAJAX(dashboard, NEW_DEFAULT_DASHBOARD_CELL)
-    dispatch(addDashboardCell(data))
+    dispatch(addDashboardCell(dashboard, data))
   } catch (error) {
     console.error(error)
     throw error

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -72,15 +72,13 @@ export default function ui(state = initialState, action) {
     }
 
     case 'ADD_DASHBOARD_CELL': {
-      const {cell} = action.payload
-      const {dashboard, dashboards} = state
+      const {cell, dashboard} = action.payload
+      const {dashboards} = state
 
       const newCells = [cell, ...dashboard.cells]
       const newDashboard = {...dashboard, cells: newCells}
       const newDashboards = dashboards.map((d) => d.id === dashboard.id ? newDashboard : d)
-      const newState = {
-        dashboards: newDashboards,
-      }
+      const newState = {dashboards: newDashboards}
 
       return {...state, ...newState}
     }


### PR DESCRIPTION
cc: @jademcgough 

  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1210

### The problem
We removed the `dashboard` key from Redux in favor of `dashboards`, which contains an array of all dashboards. Not all action creators were updated.

### The Solution
Pass the current dashboard to `addDashboardCell` around to action creators.