### PR TITLE
Use Cell ID returned by the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@
   1. [#1187](https://github.com/influxdata/chronograf/pull/1187): Replace Kill Query confirmation modal with ConfirmButtons
   1. [#1185](https://github.com/influxdata/chronograf/pull/1185): Alphabetically sort Admin Database Page
   1. [#1199](https://github.com/influxdata/chronograf/pull/1199): Move Rename Cell functionality to ContextMenu dropdown
+  1. [#1222](https://github.com/influxdata/chronograf/pull/1222): Isolate cell repositioning to just those affected by adding a new cell
 
 ## v1.2.0-beta7 [2017-03-28]
 ### Bug Fixes

--- a/chronograf.go
+++ b/chronograf.go
@@ -380,7 +380,7 @@ type Dashboard struct {
 
 // DashboardCell holds visual and query information for a cell
 type DashboardCell struct {
-	ID      string           `json:"-"`
+	ID      string           `json:"i"`
 	X       int32            `json:"x"`
 	Y       int32            `json:"y"`
 	W       int32            `json:"w"`

--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -31,9 +31,8 @@ const Dashboard = ({
 }
 
 Dashboard.renderDashboard = (dashboard, autoRefresh, timeRange, source, onPositionChange, onEditCell, onRenameCell, onUpdateCell, onDeleteCell, onSummonOverlayTechnologies) => {
-  const cells = dashboard.cells.map((cell, i) => {
-    i = `${i}`
-    const dashboardCell = {...cell, i}
+  const cells = dashboard.cells.map((cell) => {
+    const dashboardCell = {...cell}
     dashboardCell.queries = dashboardCell.queries.map(({label, query, queryConfig, db}) =>
       ({
         label,


### PR DESCRIPTION
- [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
Seen below. A cell element's `key` was calculated anew per `LayoutRenderer.render()` execution as we mapped over the dashboard's cells. This means the `key` was not guaranteed to be an invariant. And so if the key value changes, then the `GridLayout` component may decide to reposition more than it has to.
![before](http://g.recordit.co/8tKtSrXImv.gif)

### The Solution
Each cell has an ID on the server -- use this value instead of the cell's index in the array. This should be relatively more invariant.
![after](http://g.recordit.co/w5dtZtMaUk.gif)