### PR TITLE
Use the Host header from the original Kapacitor URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   1. [#1095](https://github.com/influxdata/chronograf/pull/1095): Make logout button display again
   1. [#1209](https://github.com/influxdata/chronograf/pull/1209): HipChat Kapacitor config now uses only the subdomain instead of asking for the entire HipChat URL.
   1. [#1219](https://github.com/influxdata/chronograf/pull/1219): Update query for default cell in new dashboard
+  1. [#1206](https://github.com/influxdata/chronograf/issues/1206): Chronograf now proxies to kapacitors behind proxy using vhost correctly.
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -44,6 +44,9 @@ func (h *Service) KapacitorProxy(w http.ResponseWriter, r *http.Request) {
 	u.Path = path
 
 	director := func(req *http.Request) {
+		// Set the Host header of the original Kapacitor URL
+		req.Host = u.Host
+
 		req.URL = u
 		// Because we are acting as a proxy, kapacitor needs to have the basic auth information set as
 		// a header directly


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1206 

Thank you @johngilden for this patch!

### The problem
The kapacitor reverse proxy preserves the Host header from the original request,
causing issues with vhosts using SNI.

### The Solution
Use the configured kapacitor host instead of host from the original request.

For more context on this issue see https://github.com/golang/go/issues/5692
