### PR TITLE
EditDashboardCell now requires dashboard be provided

### DIFF
--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -142,7 +142,7 @@ const DashboardPage = React.createClass({
 
   handleUpdateDashboardCell(newCell) {
     return () => {
-      this.props.dashboardActions.editDashboardCell(newCell.x, newCell.y, false)
+      this.props.dashboardActions.editDashboardCell(this.getActiveDashboard(), newCell.x, newCell.y, false)
       this.props.dashboardActions.putDashboard(this.getActiveDashboard())
     }
   },


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
The current dashboard wasn't being passed into `editDashboardCell`, which now required it as a parameter. As a result, pressing enter or clicking out of the name input field would not save the name. The input would remain present.

### The Solution
Pass it