### PR TITLE
Clear console error on ConfirmButtons by fixing propTypes

### DIFF
--- a/ui/src/shared/components/ConfirmButtons.js
+++ b/ui/src/shared/components/ConfirmButtons.js
@@ -19,12 +19,17 @@ const ConfirmButtons = ({onConfirm, item, onCancel}) => (
 
 const {
   func,
+  oneOfType,
   shape,
+  string,
 } = PropTypes
 
 ConfirmButtons.propTypes = {
   onConfirm: func.isRequired,
-  item: shape({}),
+  item: oneOfType([
+    shape(),
+    string,
+  ]),
   onCancel: func.isRequired,
 }
 


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1216 

### The problem
Console issued an errored when editing a Dashboard's name because ConfirmButtons component wanted an Object, and was being passed a String.

### The Solution
Make ConfirmButtons accept Objects and Strings.

