### PR TITLE
Replace Kapacitor Alert Endpoint Dropdown with Radio Buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.2.0 [unreleased]
+### Bug Fixes
+### Features
+### UI Improvements
+  1. [#1258](https://github.com/influxdata/chronograf/pull/1258): Display Kapacitor alert endpoint options as radio button group
+
 ## v1.2.0-beta8 [2017-04-07]
 
 ### Bug Fixes
@@ -23,7 +29,7 @@
   1. [#1209](https://github.com/influxdata/chronograf/pull/1209): Ask for the HipChat subdomain instead of the entire HipChat URL in the HipChat Kapacitor configuration
   1. [#1223](https://github.com/influxdata/chronograf/pull/1223): Use vhost as Chronograf's proxy to Kapacitor
   1. [#1205](https://github.com/influxdata/chronograf/pull/1205): Allow initial source to be an InfluxEnterprise source
-  1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret 
+  1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,9 @@
 ## v1.2.0 [unreleased]
+
 ### Bug Fixes
 ### Features
 ### UI Improvements
   1. [#1258](https://github.com/influxdata/chronograf/pull/1258): Display Kapacitor alert endpoint options as radio button group
-
-## v1.2.0 [unreleased]
-
-### Bug Fixes
-### Features
-### UI Improvements
 
 ## v1.2.0-beta8 [2017-04-07]
 

--- a/ui/src/kapacitor/components/RuleMessage.js
+++ b/ui/src/kapacitor/components/RuleMessage.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
+import classnames from 'classnames'
 import ReactTooltip from 'react-tooltip'
 
-import Dropdown from 'shared/components/Dropdown'
 import RuleMessageAlertConfig from 'src/kapacitor/components/RuleMessageAlertConfig'
 
 import {
@@ -55,17 +55,25 @@ export const RuleMessage = React.createClass({
       return {text, ruleID: rule.id}
     }).concat(defaultAlertEndpoints)
 
-    const selectedAlert = rule.alerts[0]
+    const selectedAlert = rule.alerts[0] || alerts[0].text
 
     return (
       <div className="kapacitor-rule-section">
         <h3 className="rule-section-heading">Alert Message</h3>
         <div className="rule-section-body">
-          <div className="rule-section--item alert-message--endpoint">
-            <div>
-              <p>Send this Alert to:</p>
-              <Dropdown className="dropdown-kapacitor size-136" selected={selectedAlert || 'Choose an output'} items={alerts} onChoose={this.handleChooseAlert} />
-            </div>
+          <div className="kapacitor-values-tabs">
+            <p>Send this Alert to:</p>
+            <ul className="btn-group btn-group-lg tab-group">
+              {alerts.map(alert =>
+                <li
+                  key={alert.text}
+                  className={classnames('btn tab', {active: alert.text === selectedAlert})}
+                  onClick={() => this.handleChooseAlert(alert)}
+                >
+                  {alert.text}
+                </li>
+              )}
+            </ul>
           </div>
           <RuleMessageAlertConfig
             updateAlertNodes={actions.updateAlertNodes}

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -511,6 +511,7 @@ div.qeditor.kapacitor-metric-selector {
 }
 
 .kapacitor-values-tabs,
+.kapacitor-alert-message,
 .value-selector {
   background-color: $kapacitor-graphic-color;
   padding: ($kap-padding-sm - 2px) $kap-padding-lg;
@@ -556,11 +557,14 @@ div.qeditor.kapacitor-metric-selector {
   }
 }
 
-.kapacitor-values-tabs {
+.kapacitor-values-tabs,
+.kapacitor-alert-message, {
   border-radius: $kap-radius-lg $kap-radius-lg 0 0;
   border-bottom: 2px solid $kapacitor-divider-color;
 
   .tab-group {
+    padding: 0;
+
     > .btn.tab {
       padding: 0 $kap-padding-md;
       height: $kap-input-height;
@@ -627,8 +631,8 @@ div.qeditor.kapacitor-metric-selector {
       color: $c-honeydew !important;
     }
   }
-  
-  
+
+
   .size-486 {
     width: 486px;
   }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #982 

### The problem
See #982

### The Solution
We replace the vertical Dropdown with a horizontal Radio Button Group:
<img width="1104" alt="screen shot 2017-04-11 at 4 36 51 pm" src="https://cloud.githubusercontent.com/assets/1438089/24935176/2843f490-1ed5-11e7-923f-4d96f1070462.png">



