### PR TITLE
Fix function application bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   1. [#1223](https://github.com/influxdata/chronograf/pull/1223): Use vhost as Chronograf's proxy to Kapacitor
   1. [#1205](https://github.com/influxdata/chronograf/pull/1205): Allow initial source to be an InfluxEnterprise source
   1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret
+  1. [#1257](https://github.com/influxdata/chronograf/issues/1257): Fix function selection in query builder
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
+  1. [#1257](https://github.com/influxdata/chronograf/issues/1257): Fix function selection in query builder
+  1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret
+  1. [#1269](https://github.com/influxdata/chronograf/issues/1269): Add more functionality to query config generation
+
 ### Features
+  1. [#1232](https://github.com/influxdata/chronograf/pull/1232): Fuse the query builder and raw query editor
+
 ### UI Improvements
   1. [#1259](https://github.com/influxdata/chronograf/pull/1259): Add default display for empty dashboard
   1. [#1258](https://github.com/influxdata/chronograf/pull/1258): Display Kapacitor alert endpoint options as radio button group
@@ -31,8 +37,6 @@
   1. [#1209](https://github.com/influxdata/chronograf/pull/1209): Ask for the HipChat subdomain instead of the entire HipChat URL in the HipChat Kapacitor configuration
   1. [#1223](https://github.com/influxdata/chronograf/pull/1223): Use vhost as Chronograf's proxy to Kapacitor
   1. [#1205](https://github.com/influxdata/chronograf/pull/1205): Allow initial source to be an InfluxEnterprise source
-  1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret
-  1. [#1257](https://github.com/influxdata/chronograf/issues/1257): Fix function selection in query builder
 
 ### Features
   1. [#1112](https://github.com/influxdata/chronograf/pull/1112): Add ability to delete a dashboard
@@ -46,7 +50,6 @@
   1. [#1212](https://github.com/influxdata/chronograf/pull/1212): Add meta query templates and loading animation to the RawQueryEditor
   1. [#1221](https://github.com/influxdata/chronograf/pull/1221): Remove the default query from empty cells on dashboards
   1. [#1101](https://github.com/influxdata/chronograf/pull/1101): Compress InfluxQL responses with gzip
-  1. [#1232](https://github.com/influxdata/chronograf/pull/1232): Fuse the query builder and raw query editor
 
 ### UI Improvements
   1. [#1132](https://github.com/influxdata/chronograf/pull/1132): Show blue strip next to active tab on the sidebar

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ define CHRONOGIRAFFE
           ,""      _\_
         ,"  ## |   0 0.
       ," ##   ,-\__    `.
-    ,"       /     `--._;)
+    ,"       /     `--._;) - "HAI, I'm Chronogiraffe.  Will you be my friend?"
   ,"     ## /
 ,"   ##    /
 endef

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -30,14 +30,6 @@ class MultiSelectDropdown extends Component {
     this.onApplyFunctions = ::this.onApplyFunctions
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!_.isEqual(this.state.localSelectedItems, nextProps.selectedItems)) {
-      this.setState({
-        localSelectedItems: nextProps.selectedItems,
-      })
-    }
-  }
-
   handleClickOutside() {
     this.setState({isOpen: false})
   }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1257 
Connect #1269 

### The problem
1) In the multi-select dropdown, it was not possible to select multiple items. This was because `componentWillReceiveProps` was unnecessarily setting the localSelectedItems state. Specifically, the `nextProps.selectedItems` collection will always be blank until onApplyFunctions is called. 

2) If a user typed a syntactically valid, fully qualified SELECT statement without an RP, Chronograf had no idea how to parse that into a query config.

### The Solution
1) The setState in `componentWillReceiveProps` was unnecessary because as soon as onApplyFunctions is called, the selection state is persisted via the query string and query config. Experimented with other uses of the multiSelectDropdown in admin UI and it works 👍 

2) Add default RP to queryConfig when no RP is present.  This will only happen if the qC is fully qualified.  A fully qualified query is one that has a db, measurement, and field.



