### PR TITLE
Add JWT refresh on validation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ### Features
   1. [#1232](https://github.com/influxdata/chronograf/pull/1232): Fuse the query builder and raw query editor
+  1. [#1286](https://github.com/influxdata/chronograf/pull/1286): Add refreshing JWTs for authentication
+
 
 ### UI Improvements
   1. [#1259](https://github.com/influxdata/chronograf/pull/1259): Add default display for empty dashboard

--- a/oauth2/cookies.go
+++ b/oauth2/cookies.go
@@ -56,6 +56,7 @@ func (c *cookie) Extend(ctx context.Context, w http.ResponseWriter, p Principal)
 		return Principal{}, ErrAuthentication
 	}
 
+	// Creating a new token with the extended principal
 	token, err := c.Tokens.Create(ctx, p)
 	if err != nil {
 		return Principal{}, ErrAuthentication

--- a/oauth2/cookies.go
+++ b/oauth2/cookies.go
@@ -30,10 +30,10 @@ func NewCookieJWT(secret string, lifespan time.Duration) Authenticator {
 		Name:       DefaultCookieName,
 		Lifespan:   lifespan,
 		Inactivity: DefaultInactivityDuration,
-		Now:        time.Now,
+		Now:        DefaultNowTime,
 		Tokens: &JWT{
 			Secret: secret,
-			Now:    time.Now,
+			Now:    DefaultNowTime,
 		},
 	}
 }
@@ -76,7 +76,7 @@ func (c *cookie) Validate(ctx context.Context, w http.ResponseWriter, r *http.Re
 func (c *cookie) Authorize(ctx context.Context, w http.ResponseWriter, p Principal) error {
 	// Principal will be issued at Now() and will expire
 	// c.Inactivity into the future
-	now := c.Now().UTC()
+	now := c.Now()
 	p.IssuedAt = now
 	p.ExpiresAt = now.Add(c.Inactivity)
 
@@ -104,7 +104,7 @@ func (c *cookie) setCookie(w http.ResponseWriter, value string, exp time.Time) {
 
 	// Only set a cookie to be persistent (endure beyond the browser session)
 	// if auth duration is greater than zero
-	if c.Lifespan > 0 || exp.Before(c.Now().UTC()) {
+	if c.Lifespan > 0 || exp.Before(c.Now()) {
 		cookie.Expires = exp
 	}
 
@@ -114,5 +114,5 @@ func (c *cookie) setCookie(w http.ResponseWriter, value string, exp time.Time) {
 // Expire returns a cookie that will expire an existing cookie
 func (c *cookie) Expire(w http.ResponseWriter) {
 	// to expire cookie set the time in the past
-	c.setCookie(w, "none", c.Now().UTC().Add(-1*time.Hour))
+	c.setCookie(w, "none", c.Now().Add(-1*time.Hour))
 }

--- a/oauth2/cookies.go
+++ b/oauth2/cookies.go
@@ -9,24 +9,28 @@ import (
 const (
 	// DefaultCookieName is the name of the stored cookie
 	DefaultCookieName = "session"
+	// DefaultInactivityDuration is the duration a token is valid without any new activity
+	DefaultInactivityDuration = 5 * time.Minute
 )
 
 var _ Authenticator = &cookie{}
 
 // cookie represents the location and expiration time of new cookies.
 type cookie struct {
-	Name     string
-	Duration time.Duration
-	Now      func() time.Time
-	Tokens   Tokenizer
+	Name       string        // Name is the name of the cookie stored on the browser
+	Lifespan   time.Duration // Lifespan is the expiration date of the cookie. 0 means session cookie
+	Inactivity time.Duration // Inactivity is the length of time a token is valid if there is no activity
+	Now        func() time.Time
+	Tokens     Tokenizer
 }
 
 // NewCookieJWT creates an Authenticator that uses cookies for auth
-func NewCookieJWT(secret string, duration time.Duration) Authenticator {
+func NewCookieJWT(secret string, lifespan time.Duration) Authenticator {
 	return &cookie{
-		Name:     DefaultCookieName,
-		Duration: duration,
-		Now:      time.Now,
+		Name:       DefaultCookieName,
+		Lifespan:   lifespan,
+		Inactivity: DefaultInactivityDuration,
+		Now:        time.Now,
 		Tokens: &JWT{
 			Secret: secret,
 			Now:    time.Now,
@@ -35,47 +39,80 @@ func NewCookieJWT(secret string, duration time.Duration) Authenticator {
 }
 
 // Validate returns Principal of the Cookie if the Token is valid.
-func (c *cookie) Validate(ctx context.Context, r *http.Request) (Principal, error) {
+func (c *cookie) Validate(ctx context.Context, w http.ResponseWriter, r *http.Request) (Principal, error) {
 	cookie, err := r.Cookie(c.Name)
 	if err != nil {
 		return Principal{}, ErrAuthentication
 	}
-	return c.Tokens.ValidPrincipal(ctx, Token(cookie.Value), c.Duration)
+
+	p, err := c.Tokens.ValidPrincipal(ctx, Token(cookie.Value), c.Lifespan)
+	if err != nil {
+		return Principal{}, ErrAuthentication
+	}
+
+	// Refresh the token by extending its life another Inactivity duration
+	p, err = c.Tokens.ExtendPrincipal(ctx, p, c.Inactivity)
+	if err != nil {
+		return Principal{}, ErrAuthentication
+	}
+
+	token, err := c.Tokens.Create(ctx, p)
+	if err != nil {
+		return Principal{}, ErrAuthentication
+	}
+
+	// Cookie lifespan can be indirectly figured out by taking the token's
+	// issued at time and adding the lifespan setting  The token's issued at
+	// time happens to correspond to the cookie's original issued at time.
+	exp := p.IssuedAt.Add(c.Lifespan)
+	// Once the token has been extended, write it out as a new cookie.
+	c.setCookie(w, string(token), exp)
+
+	return p, nil
 }
 
 // Authorize will create cookies containing token information.  It'll create
 // a token with cookie.Duration of life to be stored as the cookie's value.
 func (c *cookie) Authorize(ctx context.Context, w http.ResponseWriter, p Principal) error {
-	token, err := c.Tokens.Create(ctx, p, c.Duration)
+	// Principal will be issued at Now() and will expire
+	// c.Inactivity into the future
+	now := c.Now().UTC()
+	p.IssuedAt = now
+	p.ExpiresAt = now.Add(c.Inactivity)
+
+	token, err := c.Tokens.Create(ctx, p)
 	if err != nil {
 		return err
 	}
+
+	// The time when the cookie expires
+	exp := now.Add(c.Lifespan)
+	c.setCookie(w, string(token), exp)
+
+	return nil
+}
+
+// setCookie creates a cookie with value expiring at exp and writes it as a cookie into the response
+func (c *cookie) setCookie(w http.ResponseWriter, value string, exp time.Time) {
 	// Cookie has a Token baked into it
 	cookie := http.Cookie{
 		Name:     DefaultCookieName,
-		Value:    string(token),
+		Value:    value,
 		HttpOnly: true,
 		Path:     "/",
 	}
 
 	// Only set a cookie to be persistent (endure beyond the browser session)
 	// if auth duration is greater than zero
-	if c.Duration > 0 {
-		cookie.Expires = c.Now().UTC().Add(c.Duration)
+	if c.Lifespan > 0 || exp.Before(c.Now().UTC()) {
+		cookie.Expires = exp
 	}
 
 	http.SetCookie(w, &cookie)
-	return nil
 }
 
 // Expire returns a cookie that will expire an existing cookie
 func (c *cookie) Expire(w http.ResponseWriter) {
-	cookie := http.Cookie{
-		Name:     DefaultCookieName,
-		Value:    "none",
-		HttpOnly: true,
-		Path:     "/",
-		Expires:  c.Now().UTC().Add(-1 * time.Hour), // to expire cookie set the time in the past
-	}
-	http.SetCookie(w, &cookie)
+	// to expire cookie set the time in the past
+	c.setCookie(w, "none", c.Now().UTC().Add(-1*time.Hour))
 }

--- a/oauth2/cookies_test.go
+++ b/oauth2/cookies_test.go
@@ -26,7 +26,7 @@ func (m *MockTokenizer) Create(ctx context.Context, p Principal) (Token, error) 
 	return m.Token, m.CreateErr
 }
 
-func (m *MockTokenizer) ExtendPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error) {
+func (m *MockTokenizer) ExtendedPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error) {
 	return principal, nil
 }
 
@@ -138,8 +138,7 @@ func TestCookieValidate(t *testing.T) {
 				ValidErr: test.ValidErr,
 			},
 		}
-		w := httptest.NewRecorder()
-		principal, err := cook.Validate(context.Background(), w, req)
+		principal, err := cook.Validate(context.Background(), req)
 		if err != test.Err {
 			t.Errorf("Cookie extract error; expected %v  actual %v", test.Err, err)
 		}

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -44,47 +44,9 @@ func (c *Claims) Valid() error {
 	return nil
 }
 
-// EverlastingClaims extends jwt.StandardClaims' Valid to make sure claims has
-// a subject, and it ignores the expiration
-type EverlastingClaims struct {
-	gojwt.StandardClaims
-	Now func() time.Time
-}
-
-// Valid time based claims "iat, nbf".
-// There is no accounting for clock skew.
-// As well, if any of the above claims are not in the token, it will still
-// be considered a valid claim.
-func (c *EverlastingClaims) Valid() error {
-	vErr := new(gojwt.ValidationError)
-	now := c.Now().Unix()
-
-	// The claims below are optional, by default, so if they are set to the
-	// default value in Go, let's not fail the verification for them.
-
-	if c.VerifyIssuedAt(now, false) == false {
-		vErr.Inner = fmt.Errorf("Token used before issued")
-		vErr.Errors |= gojwt.ValidationErrorIssuedAt
-	}
-
-	if c.VerifyNotBefore(now, false) == false {
-		vErr.Inner = fmt.Errorf("token is not valid yet")
-		vErr.Errors |= gojwt.ValidationErrorNotValidYet
-	}
-
-	if c.Subject == "" {
-		return fmt.Errorf("claim has no subject")
-	}
-
-	if vErr.Errors > 0 {
-		return vErr
-	}
-
-	return nil
-}
-
-// ValidPrincipal checks if the jwtToken is signed correctly and validates with Claims.
-func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, duration time.Duration) (Principal, error) {
+// ValidPrincipal checks if the jwtToken is signed correctly and validates with Claims.  lifespan is the
+// maximum valid lifetime of a token.
+func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, lifespan time.Duration) (Principal, error) {
 	gojwt.TimeFunc = j.Now
 
 	// Check for expected signing method.
@@ -95,20 +57,16 @@ func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, duration time.
 		return []byte(j.Secret), nil
 	}
 
-	if duration == 0 {
-		return j.ValidEverlastingClaims(jwtToken, alg)
-	}
-
-	return j.ValidClaims(jwtToken, duration, alg)
+	return j.ValidClaims(jwtToken, lifespan, alg)
 }
 
 // ValidClaims validates a token with StandardClaims
-func (j *JWT) ValidClaims(jwtToken Token, duration time.Duration, alg gojwt.Keyfunc) (Principal, error) {
+func (j *JWT) ValidClaims(jwtToken Token, lifespan time.Duration, alg gojwt.Keyfunc) (Principal, error) {
 	// 1. Checks for expired tokens
 	// 2. Checks if time is after the issued at
 	// 3. Check if time is after not before (nbf)
 	// 4. Check if subject is not empty
-	// 5. Check if duration matches auth duration
+	// 5. Check if duration less than auth lifespan
 	token, err := gojwt.ParseWithClaims(string(jwtToken), &Claims{}, alg)
 	if err != nil {
 		return Principal{}, err
@@ -123,56 +81,35 @@ func (j *JWT) ValidClaims(jwtToken Token, duration time.Duration, alg gojwt.Keyf
 		return Principal{}, fmt.Errorf("unable to convert claims to standard claims")
 	}
 
-	if time.Duration(claims.ExpiresAt-claims.IssuedAt)*time.Second != duration {
-		return Principal{}, fmt.Errorf("claims duration is different from auth duration")
+	exp := time.Unix(claims.ExpiresAt, 0)
+	iat := time.Unix(claims.IssuedAt, 0)
+
+	// If the duration of the claim is longer than the auth lifespan then this is
+	// an invalid claim because server assumes that lifespan is the maximum possible
+	// duration
+	if exp.Sub(iat) > lifespan {
+		return Principal{}, fmt.Errorf("claims duration is different from auth lifespan")
 	}
 
 	return Principal{
-		Subject: claims.Subject,
-		Issuer:  claims.Issuer,
+		Subject:   claims.Subject,
+		Issuer:    claims.Issuer,
+		ExpiresAt: exp,
+		IssuedAt:  iat,
 	}, nil
 }
 
-// ValidEverlastingClaims validates a token with EverlastingClaims
-func (j *JWT) ValidEverlastingClaims(jwtToken Token, alg gojwt.Keyfunc) (Principal, error) {
-	// 1. Checks if time is after the issued at
-	// 2. Check if time is after not before (nbf)
-	// 3. Check if subject is not empty
-	token, err := gojwt.ParseWithClaims(string(jwtToken), &EverlastingClaims{
-		Now: j.Now,
-	}, alg)
-	if err != nil {
-		return Principal{}, err
-		// at time of this writing and researching the docs, token.Valid seems to be always true
-	} else if !token.Valid {
-		return Principal{}, err
-	}
-
-	// at time of this writing and researching the docs, there will always be claims
-	claims, ok := token.Claims.(*EverlastingClaims)
-	if !ok {
-		return Principal{}, fmt.Errorf("unable to convert claims to everlasting claims")
-	}
-
-	return Principal{
-		Subject: claims.Subject,
-		Issuer:  claims.Issuer,
-	}, nil
-}
-
-// Create creates a signed JWT token from user that expires at Now + duration
-func (j *JWT) Create(ctx context.Context, user Principal, duration time.Duration) (Token, error) {
-	gojwt.TimeFunc = j.Now
+// Create creates a signed JWT token from user that expires at Principal's ExpireAt time.
+func (j *JWT) Create(ctx context.Context, user Principal) (Token, error) {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
-	now := j.Now().UTC()
 	claims := &Claims{
 		gojwt.StandardClaims{
 			Subject:   user.Subject,
 			Issuer:    user.Issuer,
-			ExpiresAt: now.Add(duration).Unix(),
-			IssuedAt:  now.Unix(),
-			NotBefore: now.Unix(),
+			ExpiresAt: user.ExpiresAt.Unix(),
+			IssuedAt:  user.IssuedAt.Unix(),
+			NotBefore: user.IssuedAt.Unix(),
 		},
 	}
 	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
@@ -183,4 +120,13 @@ func (j *JWT) Create(ctx context.Context, user Principal, duration time.Duration
 		return "", err
 	}
 	return Token(t), nil
+}
+
+// ExtendPrincipal sets the expires at to be the current time plus the extention into the future
+func (j *JWT) ExtendPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error) {
+	// Extend the time of expiration.  Do not change IssuedAt as the
+	// lifetime of the token is extended, but, NOT the original time
+	// of issue. This is used to enforce a maximum lifetime of a token
+	principal.ExpiresAt = j.Now().UTC().Add(extension)
+	return principal, nil
 }

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -122,8 +122,8 @@ func (j *JWT) Create(ctx context.Context, user Principal) (Token, error) {
 	return Token(t), nil
 }
 
-// ExtendPrincipal sets the expires at to be the current time plus the extention into the future
-func (j *JWT) ExtendPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error) {
+// ExtendedPrincipal sets the expires at to be the current time plus the extention into the future
+func (j *JWT) ExtendedPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error) {
 	// Extend the time of expiration.  Do not change IssuedAt as the
 	// lifetime of the token is extended, but, NOT the original time
 	// of issue. This is used to enforce a maximum lifetime of a token

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -21,7 +21,7 @@ type JWT struct {
 func NewJWT(secret string) *JWT {
 	return &JWT{
 		Secret: secret,
-		Now:    time.Now,
+		Now:    DefaultNowTime,
 	}
 }
 
@@ -127,6 +127,6 @@ func (j *JWT) ExtendPrincipal(ctx context.Context, principal Principal, extensio
 	// Extend the time of expiration.  Do not change IssuedAt as the
 	// lifetime of the token is extended, but, NOT the original time
 	// of issue. This is used to enforce a maximum lifetime of a token
-	principal.ExpiresAt = j.Now().UTC().Add(extension)
+	principal.ExpiresAt = j.Now().Add(extension)
 	return principal, nil
 }

--- a/oauth2/jwt_test.go
+++ b/oauth2/jwt_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAuthenticate(t *testing.T) {
+	history := time.Unix(-446774400, 0)
 	var tests = []struct {
 		Desc      string
 		Secret    string
@@ -33,7 +34,9 @@ func TestAuthenticate(t *testing.T) {
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0Mzk5LCJuYmYiOi00NDY3NzQ0MDB9.Ga0zGXWTT2CBVnnIhIO5tUAuBEVk4bKPaT4t4MU1ngo",
 			Duration: time.Second,
 			Principal: oauth2.Principal{
-				Subject: "/chronograf/v1/users/1",
+				Subject:   "/chronograf/v1/users/1",
+				ExpiresAt: history.Add(time.Second),
+				IssuedAt:  history,
 			},
 		},
 		{
@@ -42,7 +45,9 @@ func TestAuthenticate(t *testing.T) {
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0NDAxLCJuYmYiOi00NDY3NzQ0MDB9.vWXdm0-XQ_pW62yBpSISFFJN_yz0vqT9_INcUKTp5Q8",
 			Duration: time.Second,
 			Principal: oauth2.Principal{
-				Subject: "",
+				Subject:   "",
+				ExpiresAt: history.Add(time.Second),
+				IssuedAt:  history,
 			},
 			Err: errors.New("token is expired by 1s"),
 		},
@@ -52,7 +57,9 @@ func TestAuthenticate(t *testing.T) {
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0NDAwLCJuYmYiOi00NDY3NzQzOTl9.TMGAhv57u1aosjc4ywKC7cElP1tKyQH7GmRF2ToAxlE",
 			Duration: time.Second,
 			Principal: oauth2.Principal{
-				Subject: "",
+				Subject:   "",
+				ExpiresAt: history.Add(time.Second),
+				IssuedAt:  history,
 			},
 			Err: errors.New("token is not valid yet"),
 		},
@@ -62,7 +69,9 @@ func TestAuthenticate(t *testing.T) {
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOi00NDY3NzQ0MDAsImV4cCI6LTQ0Njc3NDQwMCwibmJmIjotNDQ2Nzc0NDAwfQ.gxsA6_Ei3s0f2I1TAtrrb8FmGiO25OqVlktlF_ylhX4",
 			Duration: time.Second,
 			Principal: oauth2.Principal{
-				Subject: "",
+				Subject:   "",
+				ExpiresAt: history.Add(time.Second),
+				IssuedAt:  history,
 			},
 			Err: errors.New("claim has no subject"),
 		},
@@ -72,17 +81,11 @@ func TestAuthenticate(t *testing.T) {
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0NDAwLCJuYmYiOi00NDY3NzQ0MDB9._rZ4gOIei9PizHOABH6kLcJTA3jm8ls0YnDxtz1qeUI",
 			Duration: 500 * time.Hour,
 			Principal: oauth2.Principal{
-				Subject: "/chronograf/v1/users/1",
+				Subject:   "/chronograf/v1/users/1",
+				ExpiresAt: history,
+				IssuedAt:  history,
 			},
 			Err: errors.New("claims duration is different from auth duration"),
-		},
-		{
-			Desc:   "Test valid EverlastingClaim",
-			Secret: "secret",
-			Token:  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0Mzk5LCJuYmYiOi00NDY3NzQ0MDB9.Ga0zGXWTT2CBVnnIhIO5tUAuBEVk4bKPaT4t4MU1ngo",
-			Principal: oauth2.Principal{
-				Subject: "/chronograf/v1/users/1",
-			},
 		},
 	}
 	for _, test := range tests {
@@ -107,18 +110,20 @@ func TestAuthenticate(t *testing.T) {
 }
 
 func TestToken(t *testing.T) {
-	duration := time.Second
 	expected := oauth2.Token("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi00NDY3NzQzOTksImlhdCI6LTQ0Njc3NDQwMCwibmJmIjotNDQ2Nzc0NDAwLCJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIn0.ofQM6yTmrmve5JeEE0RcK4_euLXuZ_rdh6bLAbtbC9M")
+	history := time.Unix(-446774400, 0)
 	j := oauth2.JWT{
 		Secret: "secret",
 		Now: func() time.Time {
-			return time.Unix(-446774400, 0)
+			return history
 		},
 	}
 	p := oauth2.Principal{
-		Subject: "/chronograf/v1/users/1",
+		Subject:   "/chronograf/v1/users/1",
+		ExpiresAt: history.Add(time.Second),
+		IssuedAt:  history,
 	}
-	if token, err := j.Create(context.Background(), p, duration); err != nil {
+	if token, err := j.Create(context.Background(), p); err != nil {
 		t.Errorf("Error creating token for principal: %v", err)
 	} else if token != expected {
 		t.Errorf("Error creating token; expected: %s  actual: %s", expected, token)

--- a/oauth2/mux.go
+++ b/oauth2/mux.go
@@ -23,7 +23,7 @@ func NewAuthMux(p Provider, a Authenticator, t Tokenizer, l chronograf.Logger) *
 		Logger:     l,
 		SuccessURL: "/",
 		FailureURL: "/login",
-		Now:        time.Now,
+		Now:        DefaultNowTime,
 	}
 }
 
@@ -54,7 +54,7 @@ func (j *AuthMux) Login() http.Handler {
 		// oauth2 provider's password.
 		// If the callback is not received within 10 minutes, then authorization will fail.
 		csrf := randomString(32) // 32 is not important... just long
-		now := j.Now().UTC()
+		now := j.Now()
 
 		// This token will be valid for 10 minutes.  Any chronograf server will
 		// be able to validate this token.

--- a/oauth2/mux_test.go
+++ b/oauth2/mux_test.go
@@ -30,10 +30,11 @@ func setupMuxTest(selector func(*AuthMux) http.Handler) (*http.Client, *httptest
 	mp := &MockProvider{"biff@example.com", provider.URL}
 	mt := &YesManTokenizer{}
 	auth := &cookie{
-		Name:     DefaultCookieName,
-		Duration: 1 * time.Hour,
-		Now:      now,
-		Tokens:   mt,
+		Name:       DefaultCookieName,
+		Lifespan:   1 * time.Hour,
+		Inactivity: DefaultInactivityDuration,
+		Now:        now,
+		Tokens:     mt,
 	}
 
 	jm := NewAuthMux(mp, auth, mt, clog.New(clog.ParseLevel("debug")))

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -64,11 +64,12 @@ type Mux interface {
 // Authenticator represents a service for authenticating users.
 type Authenticator interface {
 	// Validate returns Principal associated with authenticated and authorized
-	// entity if successful.  ResponseWriter is passed if the Validation
-	// wishes to manipulate the response (i.e. refreshing a cookie)
-	Validate(context.Context, http.ResponseWriter, *http.Request) (Principal, error)
+	// entity if successful.
+	Validate(context.Context, *http.Request) (Principal, error)
 	// Authorize will grant privileges to a Principal
 	Authorize(context.Context, http.ResponseWriter, Principal) error
+	// Extend will extend the lifetime of a already validated Principal
+	Extend(context.Context, http.ResponseWriter, Principal) (Principal, error)
 	// Expire revokes privileges from a Principal
 	Expire(http.ResponseWriter)
 }
@@ -86,6 +87,6 @@ type Tokenizer interface {
 	// ValidPrincipal checks if the token has a valid Principal and requires
 	// a lifespan duration to ensure it complies with possible server runtime arguments.
 	ValidPrincipal(ctx context.Context, token Token, lifespan time.Duration) (Principal, error)
-	// ExtendPrincipal adds the extention to the principal's lifespan.
-	ExtendPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error)
+	// ExtendedPrincipal adds the extention to the principal's lifespan.
+	ExtendedPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error)
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -63,8 +63,12 @@ func (y *YesManTokenizer) ValidPrincipal(ctx context.Context, token Token, durat
 	}, nil
 }
 
-func (y *YesManTokenizer) Create(ctx context.Context, p Principal, t time.Duration) (Token, error) {
+func (y *YesManTokenizer) Create(ctx context.Context, p Principal) (Token, error) {
 	return Token("HELLO?!MCFLY?!ANYONEINTHERE?!"), nil
+}
+
+func (y *YesManTokenizer) ExtendPrincipal(ctx context.Context, p Principal, ext time.Duration) (Principal, error) {
+	return p, nil
 }
 
 func NewTestTripper(log chronograf.Logger, ts *httptest.Server, rt http.RoundTripper) (*TestTripper, error) {

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -67,7 +67,7 @@ func (y *YesManTokenizer) Create(ctx context.Context, p Principal) (Token, error
 	return Token("HELLO?!MCFLY?!ANYONEINTHERE?!"), nil
 }
 
-func (y *YesManTokenizer) ExtendPrincipal(ctx context.Context, p Principal, ext time.Duration) (Principal, error) {
+func (y *YesManTokenizer) ExtendedPrincipal(ctx context.Context, p Principal, ext time.Duration) (Principal, error) {
 	return p, nil
 }
 

--- a/oauth2/time.go
+++ b/oauth2/time.go
@@ -3,4 +3,4 @@ package oauth2
 import "time"
 
 // DefaultNowTime returns UTC time at the present moment
-const DefaultNowTime = func() time.Time { return time.Now().UTC() }
+var DefaultNowTime = func() time.Time { return time.Now().UTC() }

--- a/oauth2/time.go
+++ b/oauth2/time.go
@@ -1,0 +1,6 @@
+package oauth2
+
+import "time"
+
+// DefaultNowTime returns UTC time at the present moment
+const DefaultNowTime = func() time.Time { return time.Now().UTC() }

--- a/server/auth.go
+++ b/server/auth.go
@@ -21,11 +21,20 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 			WithField("url", r.URL)
 
 		ctx := r.Context()
-		// We do not check the validity of the principal.  Those
+		// We do not check the authorization of the principal.  Those
 		// served further down the chain should do so.
-		principal, err := auth.Validate(ctx, w, r)
+		principal, err := auth.Validate(ctx, r)
 		if err != nil {
 			log.Error("Invalid principal")
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+
+		// If the principal is valid we will extend its lifespan
+		// into the future
+		principal, err = auth.Extend(ctx, w, principal)
+		if err != nil {
+			log.Error("Unable to extend principal")
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -23,7 +23,7 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		ctx := r.Context()
 		// We do not check the validity of the principal.  Those
 		// served further down the chain should do so.
-		principal, err := auth.Validate(ctx, r)
+		principal, err := auth.Validate(ctx, w, r)
 		if err != nil {
 			log.Error("Invalid principal")
 			w.WriteHeader(http.StatusForbidden)

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -18,7 +18,7 @@ type MockAuthenticator struct {
 	Serialized  string
 }
 
-func (m *MockAuthenticator) Validate(context.Context, *http.Request) (oauth2.Principal, error) {
+func (m *MockAuthenticator) Validate(context.Context, http.ResponseWriter, *http.Request) (oauth2.Principal, error) {
 	return m.Principal, m.ValidateErr
 }
 func (m *MockAuthenticator) Authorize(ctx context.Context, w http.ResponseWriter, p oauth2.Principal) error {

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -15,19 +15,30 @@ import (
 type MockAuthenticator struct {
 	Principal   oauth2.Principal
 	ValidateErr error
+	ExtendErr   error
 	Serialized  string
 }
 
-func (m *MockAuthenticator) Validate(context.Context, http.ResponseWriter, *http.Request) (oauth2.Principal, error) {
+func (m *MockAuthenticator) Validate(context.Context, *http.Request) (oauth2.Principal, error) {
 	return m.Principal, m.ValidateErr
 }
+
+func (m *MockAuthenticator) Extend(ctx context.Context, w http.ResponseWriter, p oauth2.Principal) (oauth2.Principal, error) {
+	cookie := http.Cookie{}
+
+	http.SetCookie(w, &cookie)
+	return m.Principal, m.ExtendErr
+}
+
 func (m *MockAuthenticator) Authorize(ctx context.Context, w http.ResponseWriter, p oauth2.Principal) error {
 	cookie := http.Cookie{}
 
 	http.SetCookie(w, &cookie)
 	return nil
 }
+
 func (m *MockAuthenticator) Expire(http.ResponseWriter) {}
+
 func (m *MockAuthenticator) ValidAuthorization(ctx context.Context, serializedAuthorization string) (oauth2.Principal, error) {
 	return oauth2.Principal{}, nil
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1266 

### The problem
JWTs would last the length of the cookie.  

### The Solution

JWTs will only life five minutes into the future.  Any time
the server receives an authenticated request, the JWT's expire at time
will be extended into the future.

