### PR TITLE
Dump localStorage state on any error

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -57,7 +57,7 @@ window.addEventListener('keyup', (event) => {
 console.error = (error) => {
   console.warn(error)
   localStorage.removeItem('state')
-};
+}
 
 const Root = React.createClass({
   getInitialState() {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -55,7 +55,7 @@ window.addEventListener('keyup', (event) => {
 
 // Dump localStorage state on any error
 console.error = (error) => {
-  console.warn(error)
+  console.warn(error) // eslint-disable-line no-console
   localStorage.removeItem('state')
 }
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -53,6 +53,12 @@ window.addEventListener('keyup', (event) => {
   }
 })
 
+// Dump localStorage state on any error
+console.error = (error) => {
+  console.warn(error)
+  localStorage.removeItem('state')
+};
+
 const Root = React.createClass({
   getInitialState() {
     return {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1285 

### The problem
I don't know about you, but I've been getting a lot of weird errors about how old localStorage state is conflicting with the shape of in-memory application state.

### The Solution
I we just purge localStorage state on error. It doesn't actually affect frontend application state at all, and it just kinda... Magically fixes a lot of shape-of-old-state issues when persisted state was introduced.