### PR TITLE
Fix/jwt duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   1. [#1257](https://github.com/influxdata/chronograf/issues/1257): Fix function selection in query builder
   1. [#1244](https://github.com/influxdata/chronograf/pull/1244): Fix env var name for Google client secret
   1. [#1269](https://github.com/influxdata/chronograf/issues/1269): Add more functionality to query config generation
+  1. [#1318](https://github.com/influxdata/chronograf/issues/1318): Fix JWT refresh for auth-duration zero and less than 5 min
 
 ### Features
   1. [#1232](https://github.com/influxdata/chronograf/pull/1232): Fuse the query builder and raw query editor

--- a/oauth2/cookies_test.go
+++ b/oauth2/cookies_test.go
@@ -152,9 +152,25 @@ func TestCookieValidate(t *testing.T) {
 }
 
 func TestNewCookieJWT(t *testing.T) {
-	auth := NewCookieJWT("secret", time.Second)
-	if _, ok := auth.(*cookie); !ok {
+	auth := NewCookieJWT("secret", 2*time.Second)
+	if cookie, ok := auth.(*cookie); !ok {
 		t.Errorf("NewCookieJWT() did not create cookie Authenticator")
+	} else if cookie.Inactivity != time.Second {
+		t.Errorf("NewCookieJWT() inactivity was not two seconds: %s", cookie.Inactivity)
+	}
+
+	auth = NewCookieJWT("secret", time.Hour)
+	if cookie, ok := auth.(*cookie); !ok {
+		t.Errorf("NewCookieJWT() did not create cookie Authenticator")
+	} else if cookie.Inactivity != DefaultInactivityDuration {
+		t.Errorf("NewCookieJWT() inactivity was not five minutes: %s", cookie.Inactivity)
+	}
+
+	auth = NewCookieJWT("secret", 0)
+	if cookie, ok := auth.(*cookie); !ok {
+		t.Errorf("NewCookieJWT() did not create cookie Authenticator")
+	} else if cookie.Inactivity != DefaultInactivityDuration {
+		t.Errorf("NewCookieJWT() inactivity was not five minutes: %s", cookie.Inactivity)
 	}
 }
 

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -3,7 +3,6 @@ package oauth2
 import (
 	"context"
 	"fmt"
-	"log"
 	"time"
 
 	gojwt "github.com/dgrijalva/jwt-go"
@@ -46,7 +45,7 @@ func (c *Claims) Valid() error {
 }
 
 // ValidPrincipal checks if the jwtToken is signed correctly and validates with Claims.  lifespan is the
-// maximum valid lifetime of a token.
+// maximum valid lifetime of a token.  If the lifespan is 0 then the auth lifespan duration is not checked.
 func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, lifespan time.Duration) (Principal, error) {
 	gojwt.TimeFunc = j.Now
 
@@ -87,9 +86,9 @@ func (j *JWT) ValidClaims(jwtToken Token, lifespan time.Duration, alg gojwt.Keyf
 
 	// If the duration of the claim is longer than the auth lifespan then this is
 	// an invalid claim because server assumes that lifespan is the maximum possible
-	// duration
-	if exp.Sub(iat) > lifespan {
-		log.Printf("IAT %s LIFESPAN %s", iat, lifespan)
+	// duration.  However, a lifespan of zero means that the duration comparison
+	// against the auth duration is not needed.
+	if lifespan > 0 && exp.Sub(iat) > lifespan {
 		return Principal{}, fmt.Errorf("claims duration is different from auth lifespan")
 	}
 

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -3,6 +3,7 @@ package oauth2
 import (
 	"context"
 	"fmt"
+	"log"
 	"time"
 
 	gojwt "github.com/dgrijalva/jwt-go"
@@ -88,6 +89,7 @@ func (j *JWT) ValidClaims(jwtToken Token, lifespan time.Duration, alg gojwt.Keyf
 	// an invalid claim because server assumes that lifespan is the maximum possible
 	// duration
 	if exp.Sub(iat) > lifespan {
+		log.Printf("IAT %s LIFESPAN %s", iat, lifespan)
 		return Principal{}, fmt.Errorf("claims duration is different from auth lifespan")
 	}
 

--- a/oauth2/jwt_test.go
+++ b/oauth2/jwt_test.go
@@ -79,14 +79,14 @@ func TestAuthenticate(t *testing.T) {
 		{
 			Desc:     "Test jwt duration matches auth duration",
 			Secret:   "secret",
-			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIvY2hyb25vZ3JhZi92MS91c2Vycy8xIiwibmFtZSI6IkRvYyBCcm93biIsImlhdCI6LTQ0Njc3NDQwMCwiZXhwIjotNDQ2Nzc0NDAwLCJuYmYiOi00NDY3NzQ0MDB9._rZ4gOIei9PizHOABH6kLcJTA3jm8ls0YnDxtz1qeUI",
-			Duration: 500 * time.Hour,
+			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi00NDY3NzQzMDAsImlhdCI6LTQ0Njc3NDQwMCwiaXNzIjoiaGlsbHZhbGxleSIsIm5iZiI6LTQ0Njc3NDQwMCwic3ViIjoibWFydHlAcGluaGVhZC5uZXQifQ.njEjstpuIDnghSR7VyPPB9QlvJ6Q5JpR3ZEZ_8vGYfA",
+			Duration: time.Second,
 			Principal: oauth2.Principal{
-				Subject:   "/chronograf/v1/users/1",
+				Subject:   "marty@pinhead.net",
 				ExpiresAt: history,
-				IssuedAt:  history,
+				IssuedAt:  history.Add(100 * time.Second),
 			},
-			Err: errors.New("claims duration is different from auth duration"),
+			Err: errors.New("claims duration is different from auth lifespan"),
 		},
 	}
 	for _, test := range tests {
@@ -97,6 +97,9 @@ func TestAuthenticate(t *testing.T) {
 			},
 		}
 		principal, err := j.ValidPrincipal(context.Background(), test.Token, test.Duration)
+		if test.Err != nil && err == nil {
+			t.Fatalf("Expected err %s", test.Err.Error())
+		}
 		if err != nil {
 			if test.Err == nil {
 				t.Errorf("Error in test %s authenticating with bad token: %v", test.Desc, err)

--- a/server/auth.go
+++ b/server/auth.go
@@ -26,6 +26,7 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		principal, err := auth.Validate(ctx, r)
 		if err != nil {
 			log.Error("Invalid principal")
+			log.Debug("Invalid principal error %v", err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
@@ -35,6 +36,7 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		principal, err = auth.Extend(ctx, w, principal)
 		if err != nil {
 			log.Error("Unable to extend principal")
+			log.Debug("Extension error principal error %v", err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -26,7 +26,6 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		principal, err := auth.Validate(ctx, r)
 		if err != nil {
 			log.Error("Invalid principal")
-			log.Debug("Invalid principal error %v", err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}
@@ -36,7 +35,6 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		principal, err = auth.Extend(ctx, w, principal)
 		if err != nil {
 			log.Error("Unable to extend principal")
-			log.Debug("Extension error principal error %v", err)
 			w.WriteHeader(http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1266

### The problem

    If a server had an auth_duration of 0 then JWTs would not be refreshed.
    if a server had an auth_duration of less than 5 minutes the JWT would not be extendable.

### The Solution
If the auth_duration is less than five minutes but greater than the magic value of zero (MORE ON THAT LATER) then the JWT will be extended a fraction of the auth-duration so it can be extended at least once.

If the auth-duration is zero JWTs now understand that zero is a magic value meaning, the cookie has now lifespan.
