### PR TITLE
Mellow Yellow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### UI Improvements
   1. [#1259](https://github.com/influxdata/chronograf/pull/1259): Add default display for empty dashboard
   1. [#1258](https://github.com/influxdata/chronograf/pull/1258): Display Kapacitor alert endpoint options as radio button group
+  1. [#1321](https://github.com/influxdata/chronograf/pull/1321): Add yellow color to UI, Query Editor warnings are now appropriately colored
 
 ## v1.2.0-beta8 [2017-04-07]
 

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -141,7 +141,7 @@ $dropdown-menu-max-height: 290px;
     @include gradient-h($c-laser, $c-comet);
   }
   > li > a {
-    color: $c-cremedeviolette !important;
+    color: $c-twilight !important;
     &:hover {
       color: $g20-white !important;
     }

--- a/ui/src/style/components/query-maker.scss
+++ b/ui/src/style/components/query-maker.scss
@@ -43,7 +43,7 @@ $query-editor--status-height: 34px;
 /* ^ These 2 should total 86px */
 $query-editor--status-default: $g11-sidewalk;
 $query-editor--status-success: $c-rainforest;
-$query-editor--status-warning: $c-comet;
+$query-editor--status-warning: $c-mango;
 $query-editor--status-error: $c-dreamsicle;
 $query-editor--templates-width: 135px;
 $query-editor--templates-height: 22px;

--- a/ui/src/style/components/query-maker.scss
+++ b/ui/src/style/components/query-maker.scss
@@ -43,7 +43,7 @@ $query-editor--status-height: 34px;
 /* ^ These 2 should total 86px */
 $query-editor--status-default: $g11-sidewalk;
 $query-editor--status-success: $c-rainforest;
-$query-editor--status-warning: $c-mango;
+$query-editor--status-warning: $c-pineapple;
 $query-editor--status-error: $c-dreamsicle;
 $query-editor--templates-width: 135px;
 $query-editor--templates-height: 22px;

--- a/ui/src/style/modules/influx-colors.scss
+++ b/ui/src/style/modules/influx-colors.scss
@@ -72,3 +72,13 @@ $c-honeydew:						#7CE490;
 $c-krypton:							#A5F3B4;
 $c-wasabi:							#C6FFD0;
 $c-mint:							#F2FFF4;
+
+// Warnings (Dark to Light)
+$c-oak:								#3F241F;
+$c-topaz:							#E85B1C;
+$c-tiger:							#F48D38;
+$c-mango:							#FFB94A;
+$c-thunder:							#FFD255;
+$c-sulfur:							#FFE480;
+$c-daisy:							#FFF6B8;
+$c-banana:							#FFFDDE;

--- a/ui/src/style/modules/influx-colors.scss
+++ b/ui/src/style/modules/influx-colors.scss
@@ -77,7 +77,7 @@ $c-mint:							#F2FFF4;
 $c-oak:								#3F241F;
 $c-topaz:							#E85B1C;
 $c-tiger:							#F48D38;
-$c-mango:							#FFB94A;
+$c-pineapple:						#FFB94A;
 $c-thunder:							#FFD255;
 $c-sulfur:							#FFE480;
 $c-daisy:							#FFF6B8;

--- a/ui/src/style/modules/influx-colors.scss
+++ b/ui/src/style/modules/influx-colors.scss
@@ -52,14 +52,14 @@ $c-yeti:							#F0FCFF;
 // Chronograf (Dark to Light)
 $c-shadow:							#1F2039;
 $c-void:							#311F94;
-$c-planet:							#513CC6;
-$c-planet-disabled:					#484281;
+$c-amethyst:						#513CC6;
+$c-amethyst-disabled:				#484281;
 $c-star:							#7A65F2;
 $c-star-disabled:					#D6D5ED;
 $c-comet:							#9394FF;
 $c-potassium:						#B1B6FF;
 $c-moonstone:						#C9D0FF;
-$c-cremedeviolette:					#F2F4FF;
+$c-twilight:						#F2F4FF;
 
 // Kapacitor (Dark to Light)
 $c-gypsy:							#152B2D;


### PR DESCRIPTION
### Problem
There was no yellow spectrum in the color palette. Was using purple as the color for warnings in the Query Editor and it felt mismatched. Purple is used on other non-warning contexts so this is a little odd.

### Solution
There is a yellow spectrum. Currently using yellow for Query Editor warnings, but I am sure we will need these colors in the future. Taste the rainbow.

<img width="645" alt="screen shot 2017-04-20 at 5 43 05 pm" src="https://cloud.githubusercontent.com/assets/2433762/25257970/d9181e8c-25f0-11e7-9255-f78df4546545.png">

<img width="579" alt="screen shot 2017-04-20 at 5 32 52 pm" src="https://cloud.githubusercontent.com/assets/2433762/25257972/dc89bc38-25f0-11e7-9654-e1b5b6c4b52d.png">
