### PR TITLE
Bugfix/no apps for hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,12 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
+  1. [#1337](https://github.com/influxdata/chronograf/pull/1337): Fix no apps for hosts false negative
 
 ### Features
 
 ### UI Improvements
+  1. [#1335](https://github.com/influxdata/chronograf/pull/1335): Improve UX for sanitized kapacitor settings
 
 ## v1.2.0-beta9 [2017-04-21]
 
@@ -14,7 +16,6 @@
   1. [#1269](https://github.com/influxdata/chronograf/issues/1269): Add more functionality to the explorer's query generation process
   1. [#1318](https://github.com/influxdata/chronograf/issues/1318): Fix JWT refresh for auth-durations of zero and less than five minutes
   1. [#1332](https://github.com/influxdata/chronograf/pull/1332): Remove table toggle from dashboard visualization
-  1. [#1335](https://github.com/influxdata/chronograf/pull/1335): Improve UX for sanitized kapacitor settings
 
 ### Features
   1. [#1232](https://github.com/influxdata/chronograf/pull/1232): Fuse the query builder and raw query editor

--- a/ui/src/hosts/apis/index.js
+++ b/ui/src/hosts/apis/index.js
@@ -108,6 +108,7 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
     appMappings.map(m => m.measurement),
     appMappings.map(m => m.name)
   )
+
   return proxy({
     source: proxyLink,
     query: `show series from /${measurements}/`,
@@ -119,6 +120,7 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
       ['data', 'results', '0', 'series', '0', 'values'],
       []
     )
+
     allSeries.forEach(([series]) => {
       const seriesObj = parseSeries(series)
       const measurement = seriesObj.measurement
@@ -127,12 +129,15 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
       if (!newHosts[host]) {
         return
       }
+
       if (!newHosts[host].apps) {
         newHosts[host].apps = []
       }
+
       if (!newHosts[host].tags) {
         newHosts[host].tags = {}
       }
+
       newHosts[host].apps = _.uniq(
         newHosts[host].apps.concat(measurementsToApps[measurement])
       )

--- a/ui/src/hosts/apis/index.js
+++ b/ui/src/hosts/apis/index.js
@@ -124,7 +124,7 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
     allSeries.forEach(([series]) => {
       const seriesObj = parseSeries(series)
       const measurement = seriesObj.measurement
-      const host = seriesObj.tags.host
+      const host = _.get(seriesObj, ['tags', 'host'], '')
 
       if (!newHosts[host]) {
         return

--- a/ui/src/hosts/apis/index.js
+++ b/ui/src/hosts/apis/index.js
@@ -7,7 +7,7 @@ export function getCpuAndLoadForHosts(proxyLink, telegrafDB) {
     source: proxyLink,
     query: 'select mean(usage_user) from cpu where cpu = \'cpu-total\' and time > now() - 10m group by host; select mean("load1") from "system" where time > now() - 10m group by host;  select mean("Percent_Processor_Time") from win_cpu where time > now() - 10m group by host; select mean("Processor_Queue_Length") from win_system where time > now() - 10s group by host; select non_negative_derivative(mean(uptime)) as deltaUptime from "system" where time > now() - 10m group by host, time(1m) fill(0); show tag values from /win_system|system/ with key = "host"',
     db: telegrafDB,
-  }).then((resp) => {
+  }).then(resp => {
     const hosts = {}
     const precision = 100
     const cpuSeries = _.get(resp, ['data', 'results', '0', 'series'], [])
@@ -17,9 +17,9 @@ export function getCpuAndLoadForHosts(proxyLink, telegrafDB) {
     const uptimeSeries = _.get(resp, ['data', 'results', '4', 'series'], [])
     const allHostsSeries = _.get(resp, ['data', 'results', '5', 'series'], [])
 
-    allHostsSeries.forEach((s) => {
-      const hostnameIndex = s.columns.findIndex((col) => col === 'value')
-      s.values.forEach((v) => {
+    allHostsSeries.forEach(s => {
+      const hostnameIndex = s.columns.findIndex(col => col === 'value')
+      s.values.forEach(v => {
         const hostname = v[hostnameIndex]
         hosts[hostname] = {
           name: hostname,
@@ -30,35 +30,38 @@ export function getCpuAndLoadForHosts(proxyLink, telegrafDB) {
       })
     })
 
-    cpuSeries.forEach((s) => {
-      const meanIndex = s.columns.findIndex((col) => col === 'mean')
+    cpuSeries.forEach(s => {
+      const meanIndex = s.columns.findIndex(col => col === 'mean')
       hosts[s.tags.host] = {
         name: s.tags.host,
-        cpu: (Math.round(s.values[0][meanIndex] * precision) / precision),
+        cpu: Math.round(s.values[0][meanIndex] * precision) / precision,
       }
     })
 
-    loadSeries.forEach((s) => {
-      const meanIndex = s.columns.findIndex((col) => col === 'mean')
-      hosts[s.tags.host].load = (Math.round(s.values[0][meanIndex] * precision) / precision)
+    loadSeries.forEach(s => {
+      const meanIndex = s.columns.findIndex(col => col === 'mean')
+      hosts[s.tags.host].load =
+        Math.round(s.values[0][meanIndex] * precision) / precision
     })
 
-    uptimeSeries.forEach((s) => {
-      const uptimeIndex = s.columns.findIndex((col) => col === 'deltaUptime')
-      hosts[s.tags.host].deltaUptime = s.values[s.values.length - 1][uptimeIndex]
+    uptimeSeries.forEach(s => {
+      const uptimeIndex = s.columns.findIndex(col => col === 'deltaUptime')
+      hosts[s.tags.host].deltaUptime =
+        s.values[s.values.length - 1][uptimeIndex]
     })
 
-    winCPUSeries.forEach((s) => {
-      const meanIndex = s.columns.findIndex((col) => col === 'mean')
+    winCPUSeries.forEach(s => {
+      const meanIndex = s.columns.findIndex(col => col === 'mean')
       hosts[s.tags.host] = {
         name: s.tags.host,
-        cpu: (Math.round(s.values[0][meanIndex] * precision) / precision),
+        cpu: Math.round(s.values[0][meanIndex] * precision) / precision,
       }
     })
 
-    winLoadSeries.forEach((s) => {
-      const meanIndex = s.columns.findIndex((col) => col === 'mean')
-      hosts[s.tags.host].load = (Math.round(s.values[0][meanIndex] * precision) / precision)
+    winLoadSeries.forEach(s => {
+      const meanIndex = s.columns.findIndex(col => col === 'mean')
+      hosts[s.tags.host].load =
+        Math.round(s.values[0][meanIndex] * precision) / precision
     })
 
     return hosts
@@ -75,9 +78,9 @@ export async function getAllHosts(proxyLink, telegrafDB) {
     const hosts = {}
     const allHostsSeries = _.get(resp, ['data', 'results', '0', 'series'], [])
 
-    allHostsSeries.forEach((s) => {
-      const hostnameIndex = s.columns.findIndex((col) => col === 'value')
-      s.values.forEach((v) => {
+    allHostsSeries.forEach(s => {
+      const hostnameIndex = s.columns.findIndex(col => col === 'value')
+      s.values.forEach(v => {
         const hostname = v[hostnameIndex]
         hosts[hostname] = {
           name: hostname,
@@ -100,15 +103,22 @@ export function getMappings() {
 }
 
 export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
-  const measurements = appMappings.map((m) => `^${m.measurement}$`).join('|')
-  const measurementsToApps = _.zipObject(appMappings.map(m => m.measurement), appMappings.map(m => m.name))
+  const measurements = appMappings.map(m => `^${m.measurement}$`).join('|')
+  const measurementsToApps = _.zipObject(
+    appMappings.map(m => m.measurement),
+    appMappings.map(m => m.name)
+  )
   return proxy({
     source: proxyLink,
     query: `show series from /${measurements}/`,
     db: telegrafDB,
-  }).then((resp) => {
+  }).then(resp => {
     const newHosts = Object.assign({}, hosts)
-    const allSeries = _.get(resp, ['data', 'results', '0', 'series', '0', 'values'], [])
+    const allSeries = _.get(
+      resp,
+      ['data', 'results', '0', 'series', '0', 'values'],
+      []
+    )
     allSeries.forEach(([series]) => {
       const seriesObj = parseSeries(series)
       const measurement = seriesObj.measurement
@@ -123,7 +133,9 @@ export function getAppsForHosts(proxyLink, hosts, appMappings, telegrafDB) {
       if (!newHosts[host].tags) {
         newHosts[host].tags = {}
       }
-      newHosts[host].apps = _.uniq(newHosts[host].apps.concat(measurementsToApps[measurement]))
+      newHosts[host].apps = _.uniq(
+        newHosts[host].apps.concat(measurementsToApps[measurement])
+      )
       _.assign(newHosts[host].tags, seriesObj.tags)
     })
 
@@ -142,7 +154,7 @@ export function getMeasurementsForHost(source, host) {
     }
 
     const series = data.results[0].series[0]
-    return series.values.map((measurement) => {
+    return series.values.map(measurement => {
       return measurement[0]
     })
   })

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -31,38 +31,42 @@ export const HostsPage = React.createClass({
     Promise.all([
       getCpuAndLoadForHosts(source.links.proxy, source.telegraf),
       getMappings(),
-      new Promise((resolve) => {
+      new Promise(resolve => {
         this.setState({hostsLoading: true})
         resolve()
       }),
-    ]).then(([hosts, {data: {mappings}}]) => {
-      this.setState({
-        hosts,
-        hostsLoading: false,
-      })
-      getAppsForHosts(source.links.proxy, hosts, mappings, source.telegraf).then((newHosts) => {
+    ])
+      .then(([hosts, {data: {mappings}}]) => {
         this.setState({
-          hosts: newHosts,
-          hostsError: '',
+          hosts,
           hostsLoading: false,
         })
-      }).catch(() => {
-        const reason = 'Unable to get apps for hosts'
-        addFlashMessage({type: 'error', text: reason})
+        getAppsForHosts(source.links.proxy, hosts, mappings, source.telegraf)
+          .then(newHosts => {
+            this.setState({
+              hosts: newHosts,
+              hostsError: '',
+              hostsLoading: false,
+            })
+          })
+          .catch(() => {
+            const reason = 'Unable to get apps for hosts'
+            addFlashMessage({type: 'error', text: reason})
+            this.setState({
+              hostsError: reason,
+              hostsLoading: false,
+            })
+          })
+      })
+      .catch(reason => {
         this.setState({
-          hostsError: reason,
+          hostsError: reason.toString(),
           hostsLoading: false,
         })
+        // TODO: this isn't reachable at the moment, because getCpuAndLoadForHosts doesn't fail when it should.
+        // (like with a bogus proxy link). We should provide better messaging to the user in this catch after that's fixed.
+        console.error(reason) // eslint-disable-line no-console
       })
-    }).catch((reason) => {
-      this.setState({
-        hostsError: reason.toString(),
-        hostsLoading: false,
-      })
-      // TODO: this isn't reachable at the moment, because getCpuAndLoadForHosts doesn't fail when it should.
-      // (like with a bogus proxy link). We should provide better messaging to the user in this catch after that's fixed.
-      console.error(reason) // eslint-disable-line no-console
-    })
   },
 
   render() {

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -49,7 +49,8 @@ export const HostsPage = React.createClass({
               hostsLoading: false,
             })
           })
-          .catch(() => {
+          .catch(error => {
+            console.error(error)
             const reason = 'Unable to get apps for hosts'
             addFlashMessage({type: 'error', text: reason})
             this.setState({


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1307 

### The problem
The "Unable to get apps for hosts" error message was a false negative.  The real issue, which @zodman pointed out (ty!).  Is that on [this line](https://github.com/influxdata/chronograf/pull/1337/commits/beb5052b9173c422765dd28ee68b4ba4070a00ce) we were assuming that a host is always set in telegraf.  This is not the case.  It is possible in your telegraf config to set a host name to `""`.  Unfortunately if host is `""`, `SHOW SERIES` omits the host key altogether. 

### The Solution
Guard against the assumption that there is always a host key returned.  


