### PR TITLE
Bugfix/no active query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 ### Bug Fixes
   1. [#1337](https://github.com/influxdata/chronograf/pull/1337): Fix no apps for hosts false negative
+  1. [#1340](https://github.com/influxdata/chronograf/pull/1340): Fix no active query in DE and Cell editing
 
 ### Features
 
 ### UI Improvements
   1. [#1335](https://github.com/influxdata/chronograf/pull/1335): Improve UX for sanitized kapacitor settings
+  1. [#1340](https://github.com/influxdata/chronograf/pull/1340): Automatically switch to table view if meta query
 
 ## v1.2.0-beta9 [2017-04-21]
 

--- a/ui/src/data_explorer/components/Visualization.js
+++ b/ui/src/data_explorer/components/Visualization.js
@@ -4,8 +4,10 @@ import classNames from 'classnames'
 import VisHeader from 'src/data_explorer/components/VisHeader'
 import VisView from 'src/data_explorer/components/VisView'
 import {GRAPH, TABLE} from 'src/shared/constants'
+import _ from 'lodash'
 
 const {arrayOf, func, number, shape, string} = PropTypes
+const META_QUERY_REGEX = /^show/i
 
 const Visualization = React.createClass({
   propTypes: {
@@ -33,15 +35,37 @@ const Visualization = React.createClass({
   },
 
   getInitialState() {
-    return {
-      view: GRAPH,
-    }
+    const {activeQueryIndex, queryConfigs} = this.props
+    const activeQueryText = this.getQueryText(queryConfigs, activeQueryIndex)
+
+    return activeQueryText.match(META_QUERY_REGEX)
+      ? {view: TABLE}
+      : {view: GRAPH}
   },
 
   getDefaultProps() {
     return {
       cellName: '',
     }
+  },
+
+  componentWillReceiveProps(nextProps) {
+    const {activeQueryIndex, queryConfigs} = nextProps
+    const nextQueryText = this.getQueryText(queryConfigs, activeQueryIndex)
+    const queryText = this.getQueryText(
+      this.props.queryConfigs,
+      this.props.activeQueryIndex
+    )
+
+    if (queryText === nextQueryText) {
+      return
+    }
+
+    if (!nextQueryText.match(META_QUERY_REGEX)) {
+      return this.setState({view: GRAPH})
+    }
+
+    this.setState({view: TABLE})
   },
 
   handleToggleView(view) {
@@ -99,6 +123,11 @@ const Visualization = React.createClass({
         </div>
       </div>
     )
+  },
+
+  getQueryText(queryConfigs, index) {
+    // rawText can be null
+    return _.get(queryConfigs, [`${index}`, 'rawText'], '') || ''
   },
 })
 

--- a/ui/src/data_explorer/components/Visualization.js
+++ b/ui/src/data_explorer/components/Visualization.js
@@ -33,39 +33,14 @@ const Visualization = React.createClass({
   },
 
   getInitialState() {
-    const {queryConfigs, activeQueryIndex} = this.props
-    if (!queryConfigs.length || activeQueryIndex === null) {
-      return {
-        view: GRAPH,
-      }
-    }
-
     return {
-      view: typeof queryConfigs[activeQueryIndex].rawText === 'string'
-        ? TABLE
-        : GRAPH,
+      view: GRAPH,
     }
   },
 
   getDefaultProps() {
     return {
       cellName: '',
-    }
-  },
-
-  componentWillReceiveProps(nextProps) {
-    const {queryConfigs, activeQueryIndex} = nextProps
-    if (
-      !queryConfigs.length ||
-      activeQueryIndex === null ||
-      activeQueryIndex === this.props.activeQueryIndex
-    ) {
-      return
-    }
-
-    const activeQuery = queryConfigs[activeQueryIndex]
-    if (activeQuery && typeof activeQuery.rawText === 'string') {
-      return this.setState({view: TABLE})
     }
   },
 

--- a/ui/src/data_explorer/components/Visualization.js
+++ b/ui/src/data_explorer/components/Visualization.js
@@ -61,11 +61,11 @@ const Visualization = React.createClass({
       return
     }
 
-    if (!nextQueryText.match(META_QUERY_REGEX)) {
-      return this.setState({view: GRAPH})
+    if (nextQueryText.match(META_QUERY_REGEX)) {
+      return this.setState({view: TABLE})
     }
 
-    this.setState({view: TABLE})
+    this.setState({view: GRAPH})
   },
 
   handleToggleView(view) {

--- a/ui/src/data_explorer/containers/DataExplorer.js
+++ b/ui/src/data_explorer/containers/DataExplorer.js
@@ -57,7 +57,7 @@ const DataExplorer = React.createClass({
 
   getInitialState() {
     return {
-      activeQueryIndex: null,
+      activeQueryIndex: 0,
     }
   },
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1228 
Connect #1291 

### The problem
`activeQueryIndex` was set to null in order to make it a trinary.  With the new `/query` endpoint the logic that supported this was no longer needed or helpful.  The logic in `Visualizations` `getInitialState` and `componentDidUpdate` directly effected #1228, so I decided to combine stories.

### The Solution
Solving the active query bug was as trivial as changing initial state to 0. 


