### PR TITLE
Fix broken link to add a Kapacitor when none exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   1. [#1337](https://github.com/influxdata/chronograf/pull/1337): Fix no apps for hosts false negative
   1. [#1340](https://github.com/influxdata/chronograf/pull/1340): Fix no active query in DE and Cell editing
   1. [#1338](https://github.com/influxdata/chronograf/pull/1338): Require url and name when adding a new source
+  1. [#1348](https://github.com/influxdata/chronograf/pull/1348): Fix broken 'Add Kapacitor' Link
 
 ### Features
 

--- a/ui/src/shared/components/NoKapacitorError.js
+++ b/ui/src/shared/components/NoKapacitorError.js
@@ -9,7 +9,7 @@ const NoKapacitorError = React.createClass({
   },
 
   render() {
-    const path = `/sources/${this.props.source.id}/kapacitor-config`
+    const path = `/sources/${this.props.source.id}/kapacitors/new`
     return (
       <div>
         <p>The current source does not have an associated Kapacitor instance, please configure one.</p>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
The Link on the view presented to the Alerts page when no Kapacitors exist is broken
### The Solution
Update the link to point to the correct route.


