### PR TITLE
add canned dashboard for phpfpm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
   1. [#1340](https://github.com/influxdata/chronograf/pull/1340): Fix no active query in DE and Cell editing
   1. [#1338](https://github.com/influxdata/chronograf/pull/1338): Require url and name when adding a new source
   1. [#1348](https://github.com/influxdata/chronograf/pull/1348): Fix broken 'Add Kapacitor' Link
-  1. [#1348](https://github.com/influxdata/chronograf/pull/1350): Add a canned dashboard for phpfpm
+  1. [#1351](https://github.com/influxdata/chronograf/pull/1350): Add a canned dashboard for phpfpm
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   1. [#1340](https://github.com/influxdata/chronograf/pull/1340): Fix no active query in DE and Cell editing
   1. [#1338](https://github.com/influxdata/chronograf/pull/1338): Require url and name when adding a new source
   1. [#1348](https://github.com/influxdata/chronograf/pull/1348): Fix broken 'Add Kapacitor' Link
+  1. [#1348](https://github.com/influxdata/chronograf/pull/1350): Add a canned dashboard for phpfpm
 
 ### Features
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Currently, Chronograf offers dashboard templates for the following Telegraf inpu
 * Network
 * [NGINX](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nginx)
 * [NSQ](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/nsq)
+* [PHPfpm](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/phpfpm)
 * [Ping](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/ping)
 * [PostgreSQL](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/postgresql)
 * Processes

--- a/canned/phpfpm.json
+++ b/canned/phpfpm.json
@@ -1,0 +1,76 @@
+{
+  "id": "e6b69c66-6183-4728-9f1d-1b0f1fc01b7d",
+  "measurement": "phpfpm",
+  "app": "phpfpm",
+  "autoflow": true,
+  "cells": [
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "da42044d-8d10-4e3c-a0a2-41512266fd00",
+      "name": "phpfpm – Accepted Connections",
+      "queries": [
+        {
+          "query": "SELECT non_negative_derivative(mean(\"accepted_conn\"),1s) FROM \"phpfpm\"",
+          "label": "count",
+          "groupbys": [
+            "\"pool\""
+          ]
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "7aae5ec6-dbaf-4926-b922-d585e6a869be",
+      "name": "phpfpm – Processes",
+      "queries": [
+        {
+          "query": "SELECT mean(\"active_processes\") as \"active\",mean(\"idle_processes\") as \"idle\"  FROM \"phpfpm\"",
+          "label": "count",
+          "groupbys": [
+            "\"pool\""
+          ]
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "e4de9091-7250-4634-bf38-81a441ef0f27",
+      "name": "phpfpm – Slow Requests",
+      "queries": [
+        {
+          "query": "SELECT non_negative_derivative(mean(\"slow_requests\"),1s) FROM \"phpfpm\"",
+          "label": "count",
+          "groupbys": [
+            "\"pool\""
+          ]
+        }
+      ]
+    },
+    {
+      "x": 0,
+      "y": 0,
+      "w": 4,
+      "h": 4,
+      "i": "7ed72ef0-a429-4edd-9c8e-a11625a279c2",
+      "name": "phpfpm – Max Children Reached",
+      "queries": [
+        {
+          "query": "SELECT mean(\"max_children_reached\") FROM \"phpfpm\"",
+          "label": "count",
+          "groupbys": [
+            "\"pool\""
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
No phpfpm canned dashboard 😢 
### The Solution
Added a phpfpm dash 😄 

![image](https://cloud.githubusercontent.com/assets/707582/25544141/2707fe64-2c27-11e7-8fc7-04ae053f2be5.png)


