### PR TITLE
Home Logo Link missing basepath support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 ### Features
 
   1. [#1154](https://github.com/influxdata/chronograf/issues/1154): Add template variables to Chronograf's customized dashboards
-  1. [#1351](https://github.com/influxdata/chronograf/pull/1351): Add a canned dashboard for [phpfpm](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm) - thank you, @nickysemenza 
+  1. [#1351](https://github.com/influxdata/chronograf/pull/1351): Add a canned dashboard for [phpfpm](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm) - thank you, @nickysemenza
 
 ### UI Improvements
   1. [#1335](https://github.com/influxdata/chronograf/pull/1335): Improve UX for sanitized Kapacitor event handler settings

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.2.0 [unreleased]
 
 ### Bug Fixes
+  1. [#1364](https://github.com/influxdata/chronograf/pull/1364): Fix link to home when using the --basepath option
 ### Features
 ### UI Improvements
 

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react'
-import {withRouter} from 'react-router'
+import {withRouter, Link} from 'react-router'
 import {connect} from 'react-redux'
 
 import {
@@ -41,7 +41,7 @@ const SideNav = React.createClass({
       ? null
       : <NavBar location={location}>
           <div className="sidebar__logo">
-            <a href="/"><span className="icon cubo-uniform" /></a>
+            <Link to="/"><span className="icon cubo-uniform" /></Link>
           </div>
           <NavBlock icon="cubo-node" link={`${sourcePrefix}/hosts`}>
             <NavHeader link={`${sourcePrefix}/hosts`} title="Host List" />


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1363 

### The problem
This is basically the only link in the app not using the React Router Link component that properly prefixes basepath when a basepath is available.

### The Solution
Fix link.

### Test
```shell
make clean
make
./chronograf --basepath /chronograf --prefix-routes
```