### PR TITLE
Show red indicator when a host is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 ### Features
 ### UI Improvements
+  1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
 
 ## v1.2.0-beta10 [2017-04-28]
 
@@ -15,7 +16,7 @@
 ### Features
 
   1. [#1154](https://github.com/influxdata/chronograf/issues/1154): Add template variables to Chronograf's customized dashboards
-  1. [#1351](https://github.com/influxdata/chronograf/pull/1351): Add a canned dashboard for [phpfpm](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm) - thank you, @nickysemenza 
+  1. [#1351](https://github.com/influxdata/chronograf/pull/1351): Add a canned dashboard for [phpfpm](https://github.com/influxdata/telegraf/tree/master/plugins/inputs/phpfpm) - thank you, @nickysemenza
 
 ### UI Improvements
   1. [#1335](https://github.com/influxdata/chronograf/pull/1335): Improve UX for sanitized Kapacitor event handler settings

--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -1,6 +1,9 @@
 import React, {PropTypes} from 'react'
-import shallowCompare from 'react-addons-shallow-compare'
 import {Link} from 'react-router'
+
+import shallowCompare from 'react-addons-shallow-compare'
+import classnames from 'classnames'
+
 import _ from 'lodash'
 
 const {arrayOf, bool, number, shape, string} = PropTypes
@@ -187,19 +190,19 @@ const HostRow = React.createClass({
     const {host, source} = this.props
     const {name, cpu, load, apps = []} = host
 
-    let stateStr = ''
-    if (host.deltaUptime > 0) {
-      stateStr = 'table-dot dot-success'
-    } else {
-      stateStr = 'table-dot dot-critical'
-    }
-
     return (
       <tr>
         <td className="monotype">
           <Link to={`/sources/${source.id}/hosts/${name}`}>{name}</Link>
         </td>
-        <td style={{width: '74px'}}><div className={stateStr} /></td>
+        <td style={{width: '74px'}}>
+          <div
+            className={classnames(
+              'table-dot',
+              host.deltaUptime > 0 ? 'dot-success' : 'dot-critical'
+            )}
+          />
+        </td>
         <td className="monotype" style={{width: '70px'}}>
           {isNaN(cpu) ? 'N/A' : `${cpu.toFixed(2)}%`}
         </td>

--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -188,10 +188,10 @@ const HostRow = React.createClass({
     const {name, cpu, load, apps = []} = host
 
     let stateStr = ''
-    if (host.deltaUptime < 0) {
-      stateStr = 'table-dot dot-critical'
-    } else if (host.deltaUptime > 0) {
+    if (host.deltaUptime > 0) {
       stateStr = 'table-dot dot-success'
+    } else {
+      stateStr = 'table-dot dot-critical'
     }
 
     return (


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1346

![screen shot 2017-05-01 at 11 33 07 am](https://cloud.githubusercontent.com/assets/1438089/25589952/6846ea5a-2e63-11e7-8ebd-1cd939ed6a94.png)

### The problem
The Hosts Page would display a critical (red) indicator for an offline host if that host had a _negative_ uptime value. Not sure that can happen in the first place (@rkuchan reports that the query includes a `non_negative_derivative`). But even if it could, an uptime value of 0 should also result in a critical indicator.

### The Solution
Report green if uptime is positive. Otherwise, report red.