### PR TITLE
Remove notification to login outside of session timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
   1. [#1364](https://github.com/influxdata/chronograf/pull/1364): Fix link to home when using the --basepath option
+  1. [#1370](https://github.com/influxdata/chronograf/pull/1370): Remove notification to login outside of session timeout
+
 ### Features
 ### UI Improvements
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host

--- a/ui/src/shared/middleware/errors.js
+++ b/ui/src/shared/middleware/errors.js
@@ -33,8 +33,6 @@ const errorsMiddleware = store => next => action => {
         setTimeout(() => {
           allowNotifications = true
         }, notificationsBlackoutDuration)
-      } else {
-        store.dispatch(notify('error', 'Please login to use Chronograf.'))
       }
     } else if (altText) {
       store.dispatch(notify('error', altText))


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1336 

### The problem
User was receiving an error notification to "Please login to use Chronograf." if they had not logged in yet, on the Login page.

### The Solution
Remove that notification. The only remaining notification related to session is for session timeouts.

