### PR TITLE
Fix dropdown text typo

### DIFF
--- a/ui/src/data_explorer/constants/index.js
+++ b/ui/src/data_explorer/constants/index.js
@@ -42,7 +42,7 @@ export const QUERY_TEMPLATES = [
   },
   {text: `${SEPARATOR}`},
   {
-    text: 'Show Continuos Queries',
+    text: 'Show Continuous Queries',
     query: 'SHOW CONTINUOUS QUERIES',
   },
   {


### PR DESCRIPTION
### The problem
Typo in `Query Templates` dropdown.
<img width="216" alt="screen shot 2017-05-01 at 2 44 29 pm" src="https://cloud.githubusercontent.com/assets/6403018/25596178/c8fb415c-2e7c-11e7-873e-c5c859bb2488.png">

### The Solution
Fix typo.
<img width="206" alt="screen shot 2017-05-01 at 2 46 10 pm" src="https://cloud.githubusercontent.com/assets/6403018/25596211/f1436e64-2e7c-11e7-9e5d-c9f7e47ae95c.png">
