### PR TITLE
Promote dash-graph--options, demote dash-graph--container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 ### UI Improvements
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
+  1. [#1373](https://github.com/influxdata/chronograf/pull/1373): Re-address dashboard cell stacking contexts
 
 ## v1.2.0-beta10 [2017-04-28]
 

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -86,7 +86,6 @@ $dash-graph-options-arrow: 8px;
   top: $dash-graph-heading;
   left: 0;
   padding: 0;
-  z-index: 0;
 
   & > div:not(.graph-empty) {
     position: absolute;
@@ -164,7 +163,7 @@ $dash-graph-options-arrow: 8px;
 .dash-graph--options {
   width: $dash-graph-heading;
   position: absolute;
-  z-index: 1;
+  z-index: 11;
   right: 0px;
   top: 0px;
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
Menu Options looks ok above a second Y-axis:
<img width="541" alt="screen shot 2017-05-01 at 3 43 31 pm" src="https://cloud.githubusercontent.com/assets/1438089/25597676/00162bf4-2e85-11e7-9ee6-fb3597035ddf.png">

But I overlooked that the legend was clipping behind other graphs:
<img width="633" alt="screen shot 2017-05-01 at 3 45 29 pm" src="https://cloud.githubusercontent.com/assets/1438089/25597708/3b0c470c-2e85-11e7-8b9d-7ee4d2b23422.png">

### The Solution
Promote the Menu Options in z-index
Remove the stacking context from `.dash-graph--container`

<img width="544" alt="screen shot 2017-05-01 at 3 50 17 pm" src="https://cloud.githubusercontent.com/assets/1438089/25597823/e6bf2920-2e85-11e7-9da0-654087a93cf7.png">

<img width="587" alt="screen shot 2017-05-01 at 3 49 54 pm" src="https://cloud.githubusercontent.com/assets/1438089/25597815/d8ebe70c-2e85-11e7-8fb5-7793b7e6731c.png">
