### PR TITLE
Fix AST influxql for parsing binary expressions in fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
   1. [#1364](https://github.com/influxdata/chronograf/pull/1364): Fix link to home when using the --basepath option
   1. [#1370](https://github.com/influxdata/chronograf/pull/1370): Remove notification to login outside of session timeout
+  1. [#1376](https://github.com/influxdata/chronograf/pull/1376): Fix queries built in query builder with math functions in fields
 
 ### Features
 ### UI Improvements

--- a/influx/query.go
+++ b/influx/query.go
@@ -102,6 +102,8 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 	fields := map[string][]string{}
 	for _, fld := range stmt.Fields {
 		switch f := fld.Expr.(type) {
+		default:
+			return raw, nil
 		case *influxql.Call:
 			// only support certain query config functions
 			if _, ok := supportedFuncs[f.Name]; !ok {

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -27,6 +27,18 @@ func TestConvert(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Test math",
+			influxQL: `SELECT count("event_id")/3 as "event_count_id" from discource.autogen.discourse_events where time > now() - 7d group by time(1d), "event_type"`,
+			RawText:  `SELECT count("event_id")/3 as "event_count_id" from discource.autogen.discourse_events where time > now() - 7d group by time(1d), "event_type"`,
+			want: chronograf.QueryConfig{
+				Fields: []chronograf.Field{},
+				Tags:   map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1325 

### The problem
In parsing InfluxQL binary expressions in the fields were considered valid.
An example would be to divide the fields by 3 in #1325.

### The Solution
If the fields are not `Varref` or `Call` then the parsing will use RawText.

