### PR TITLE
Add Range.Lower and Range.Upper to query config to persist custom ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Features
 ### UI Improvements
+  1. [#1378](https://github.com/influxdata/chronograf/pull/1378): Save query time range for dashboards
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
   1. [#1373](https://github.com/influxdata/chronograf/pull/1373): Re-address dashboard cell stacking contexts
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -289,6 +289,12 @@ type GroupBy struct {
 	Tags []string `json:"tags"`
 }
 
+// DurationRange represents the lower and upper durations of the query config
+type DurationRange struct {
+	Upper string `json:"upper"`
+	Lower string `json:"lower"`
+}
+
 // QueryConfig represents UI query from the data explorer
 type QueryConfig struct {
 	ID              string              `json:"id,omitempty"`
@@ -300,6 +306,7 @@ type QueryConfig struct {
 	GroupBy         GroupBy             `json:"groupBy"`
 	AreTagsAccepted bool                `json:"areTagsAccepted"`
 	RawText         *string             `json:"rawText"`
+	Range           *DurationRange      `json:"range"`
 }
 
 // KapacitorNode adds arguments and properties to an alert

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -151,6 +151,26 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name:     "Test with no where clauses",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				Tags: map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+			},
+		},
+		{
 			name:     "Test tags accepted",
 			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" = 'myhost' and time > now() - 15m`,
 			want: chronograf.QueryConfig{

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -39,6 +39,182 @@ func TestConvert(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Test range",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time > now() - 15m`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				Tags: map[string][]string{"host": []string{"myhost"}},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+				AreTagsAccepted: false,
+				Range: &chronograf.DurationRange{
+					Lower: "15m",
+					Upper: "now",
+				},
+			},
+		},
+		{
+			name:     "Test invalid range",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time > now() - 15`,
+			RawText:  `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time > now() - 15`,
+			want: chronograf.QueryConfig{
+				Fields: []chronograf.Field{},
+				Tags:   map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
+		{
+			name:     "Test range with no duration",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time > now()`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				Tags: map[string][]string{"host": []string{"myhost"}},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+				AreTagsAccepted: false,
+				Range: &chronograf.DurationRange{
+					Lower: "0s",
+					Upper: "now",
+				},
+			},
+		},
+		{
+			name:     "Test range with no tags",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where time > now() - 15m`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Tags:            map[string][]string{},
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+				AreTagsAccepted: false,
+				Range: &chronograf.DurationRange{
+					Lower: "15m",
+					Upper: "now",
+				},
+			},
+		},
+		{
+			name:     "Test range with no tags nor duration",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where time`,
+			RawText:  `SELECT usage_user from telegraf.autogen.cpu where time`,
+			want: chronograf.QueryConfig{
+				Fields: []chronograf.Field{},
+				Tags:   map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
+		{
+			name:     "Test with no time range",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time`,
+			RawText:  `SELECT usage_user from telegraf.autogen.cpu where "host" != 'myhost' and time`,
+			want: chronograf.QueryConfig{
+				Fields: []chronograf.Field{},
+				Tags:   map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
+		{
+			name:     "Test tags accepted",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where "host" = 'myhost' and time > now() - 15m`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				Tags: map[string][]string{"host": []string{"myhost"}},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+				AreTagsAccepted: true,
+				Range: &chronograf.DurationRange{
+					Lower: "15m",
+					Upper: "now",
+				},
+			},
+		},
+		{
+			name:     "Test mixed tag logic",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where ("host" = 'myhost' or "this" = 'those') and ("howdy" != 'doody') and time > now() - 15m`,
+			RawText:  `SELECT usage_user from telegraf.autogen.cpu where ("host" = 'myhost' or "this" = 'those') and ("howdy" != 'doody') and time > now() - 15m`,
+			want: chronograf.QueryConfig{
+				Fields: []chronograf.Field{},
+				Tags:   map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
+		{
+			name:     "Test tags accepted",
+			influxQL: `SELECT usage_user from telegraf.autogen.cpu where ("host" = 'myhost' OR "host" = 'yourhost') and ("these" = 'those') and time > now() - 15m`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Field: "usage_user",
+						Funcs: []string{},
+					},
+				},
+				Tags: map[string][]string{
+					"host":  []string{"myhost", "yourhost"},
+					"these": []string{"those"},
+				},
+				GroupBy: chronograf.GroupBy{
+					Time: "",
+					Tags: []string{},
+				},
+				AreTagsAccepted: true,
+				Range: &chronograf.DurationRange{
+					Lower: "15m",
+					Upper: "now",
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -49,6 +225,11 @@ func TestConvert(t *testing.T) {
 			}
 			if tt.RawText != "" {
 				tt.want.RawText = &tt.RawText
+				if got.RawText == nil {
+					t.Errorf("Convert() = nil, want %s", tt.RawText)
+				} else if *got.RawText != tt.RawText {
+					t.Errorf("Convert() = %s, want %s", *got.RawText, tt.RawText)
+				}
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("Convert() = %#v, want %#v", got, tt.want)

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -283,6 +283,10 @@ func Test_newDashboardResponse(t *testing.T) {
 										},
 										Tags:            make(map[string][]string, 0),
 										AreTagsAccepted: false,
+										Range: &chronograf.DurationRange{
+											Lower: "15m",
+											Upper: "now",
+										},
 									},
 								},
 							},
@@ -299,7 +303,7 @@ func Test_newDashboardResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		if got := newDashboardResponse(tt.d); !reflect.DeepEqual(got, tt.want) {
-			t.Errorf("%q. newDashboardResponse() = \n%+v\n\n, want\n\n%+v", tt.name, got, tt.want)
+			t.Errorf("%q. newDashboardResponse() = \n%#v\n\n, want\n\n%#v", tt.name, got, tt.want)
 		}
 	}
 }

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2536,7 +2536,11 @@
 					"time": "10m",
 					"tags": []
 				},
-				"areTagsAccepted": true
+				"areTagsAccepted": true,
+				"range": {
+					"lower": "15m",
+					"upper": "now"
+				}
 			},
 			"properties": {
 				"id": {
@@ -2598,6 +2602,21 @@
 							"funcs"
 						]
 					}
+				},
+				"range": {
+					"type": "object",
+					"properties": {
+						"lower": {
+							"type": "string"
+						},
+						"upper": {
+							"type": "string"
+						}
+					},
+					"required": [
+						"lower",
+						"upper"
+					]
 				}
 			},
 			"required": [


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1377

### The problem
The legacy `queryConfig` data structure does not support time ranges for queries.  
### The Solution
Extend `queryConfig` with `range`.

Here is the queryConfig fragment from the `/queries` endpoint for the query `select usage_user from howdy where time > now() - 15m`: 
```json
...
      "queryConfig": {
        "database": "",
        "measurement": "howdy",
        "retentionPolicy": "",
        "fields": [
          {
            "field": "usage_user",
            "funcs": []
          }
        ],
        "tags": {},
        "groupBy": {
          "time": "",
          "tags": []
        },
        "areTagsAccepted": false,
        "rawText": null,
        "range": {
          "upper": "now",
          "lower": "15m"
        }
...
```


