### PR TITLE
Fix alert level colors, in addition to hover state color.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### UI Improvements
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
   1. [#1373](https://github.com/influxdata/chronograf/pull/1373): Re-address dashboard cell stacking contexts
+  1. [#1379](https://github.com/influxdata/chronograf/pull/1379): Re-add alert level colors on the alerts page
 
 ## v1.2.0-beta10 [2017-04-28]
 

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -462,3 +462,13 @@ input.size-49 {width: 49px;}
 .dropdown.size-106 .dropdown-toggle {width: 106px;}
 .dropdown.size-66 .dropdown-toggle {width: 66px;}
 .dropdown.size-49 .dropdown-toggle {width: 49px;}
+
+.alert-level-ok {
+  &, &:hover {color: $c-rainforest !important;}
+}
+.alert-level-warning {
+  &, &:hover {color: $c-pineapple !important;}
+}
+.alert-level-critical {
+  &, &:hover {color: $c-dreamsicle !important;}
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1345 

### The problem
The styles for alert level color were removed some time ago. In addition, there were specificity issues that could only be solved with !important, since there were already overrides of the bootstrap theme.

### The Solution
With the help of @alexpaxton, add styles back, fix specificity, and also fix hover state.