### PR TITLE
Update influxql AST parsing to return full binary exprs

### DIFF
--- a/influx/query.go
+++ b/influx/query.go
@@ -178,8 +178,7 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 	// If the condition has a time range we report back its duration
 	if dur, ok := hasTimeRange(stmt.Condition); ok {
 		qc.Range = &chronograf.DurationRange{
-			Lower: shortDur(dur),
-			Upper: "now",
+			Lower: "now() - " + shortDur(dur),
 		}
 	}
 

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -59,8 +59,7 @@ func TestConvert(t *testing.T) {
 				},
 				AreTagsAccepted: false,
 				Range: &chronograf.DurationRange{
-					Lower: "15m",
-					Upper: "now",
+					Lower: "now() - 15m",
 				},
 			},
 		},
@@ -96,8 +95,7 @@ func TestConvert(t *testing.T) {
 				},
 				AreTagsAccepted: false,
 				Range: &chronograf.DurationRange{
-					Lower: "0s",
-					Upper: "now",
+					Lower: "now() - 0s",
 				},
 			},
 		},
@@ -121,8 +119,7 @@ func TestConvert(t *testing.T) {
 				},
 				AreTagsAccepted: false,
 				Range: &chronograf.DurationRange{
-					Lower: "15m",
-					Upper: "now",
+					Lower: "now() - 15m",
 				},
 			},
 		},
@@ -190,8 +187,8 @@ func TestConvert(t *testing.T) {
 				},
 				AreTagsAccepted: true,
 				Range: &chronograf.DurationRange{
-					Lower: "15m",
-					Upper: "now",
+					Lower: "now() - 15m",
+					Upper: "",
 				},
 			},
 		},
@@ -230,8 +227,7 @@ func TestConvert(t *testing.T) {
 				},
 				AreTagsAccepted: true,
 				Range: &chronograf.DurationRange{
-					Lower: "15m",
-					Upper: "now",
+					Lower: "now() - 15m",
 				},
 			},
 		},

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -284,8 +284,7 @@ func Test_newDashboardResponse(t *testing.T) {
 										Tags:            make(map[string][]string, 0),
 										AreTagsAccepted: false,
 										Range: &chronograf.DurationRange{
-											Lower: "15m",
-											Upper: "now",
+											Lower: "now() - 15m",
 										},
 									},
 								},


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1377 

### The problem
Front end does not want durations but rather entire binary expressions for time conditionals
### The Solution

Output of `/queries`

```json
{
  "queries": [
    {
      "id": "",
      "query": "SELECT \"queryFail\" FROM \"_internal\".\"monitor\".\"cq\" WHERE time > :tmpltime:",
      "queryConfig": {
        "database": "_internal",
        "measurement": "cq",
        "retentionPolicy": "monitor",
        "fields": [
          {
            "field": "queryFail",
            "funcs": []
          }
        ],
        "tags": {},
        "groupBy": {
          "time": "",
          "tags": []
        },
        "areTagsAccepted": false,
        "rawText": "SELECT \"queryFail\" FROM \"_internal\".\"monitor\".\"cq\" WHERE time > :tmpltime:",
        "range": {
          "upper": "",
          "lower": "now() - 15m"
        }
      },
      "queryAST": {
        "condition": {
          "expr": "binary",
          "op": ">",
          "lhs": {
            "expr": "reference",
            "val": "time"
          },
          "rhs": {
            "expr": "binary",
            "op": "-",
            "lhs": {
              "expr": "call",
              "name": "now"
            },
            "rhs": {
              "expr": "literal",
              "val": "15m",
              "type": "duration"
            }
          }
        },
        "fields": [
          {
            "column": {
              "expr": "reference",
              "val": "queryFail"
            }
          }
        ],
        "sources": [
          {
            "database": "_internal",
            "retentionPolicy": "monitor",
            "name": "cq",
            "type": "measurement"
          }
        ]
      },
      "queryTemplated": "SELECT \"queryFail\" FROM \"_internal\".\"monitor\".\"cq\" WHERE time > now() - 15m",
      "tempVars": [
        {
          "tempVar": ":tmpltime:",
          "values": [
            {
              "value": "now() - 15m",
              "type": "constant",
              "selected": false
            }
          ]
        }
      ]
    }
  ]
}
```

