### PR TITLE
Terminology Terminus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   1. [#1378](https://github.com/influxdata/chronograf/pull/1378): Save query time range for dashboards
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
   1. [#1373](https://github.com/influxdata/chronograf/pull/1373): Re-address dashboard cell stacking contexts
+  1. [#602](https://github.com/influxdata/chronograf/pull/602): Normalize terminology in app
 
 ## v1.2.0-beta10 [2017-04-28]
 

--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -262,7 +262,7 @@ const SearchBar = React.createClass({
         <input
           type="text"
           className="form-control"
-          placeholder="Filter by Hostname..."
+          placeholder="Filter by Host..."
           ref="searchInput"
           onChange={this.handleChange}
         />

--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -129,7 +129,7 @@ const HostsTable = React.createClass({
                   onClick={() => this.updateSort('name')}
                   className={this.sortableClasses('name')}
                 >
-                  Hostname
+                  Host
                 </th>
                 <th
                   onClick={() => this.updateSort('deltaUptime')}

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -152,7 +152,7 @@ export const KapacitorRule = React.createClass({
     }
 
     if (this.thresholdValueEmpty() || this.relativeValueEmpty()) {
-      return 'Please enter a value in the Values section'
+      return 'Please enter a value in the Rule Conditions section'
     }
 
     return ''

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -28,11 +28,11 @@ const KapacitorRules = ({
       </PageContents>
     )
   }
-
+  const tableHeader = rules.length === 1 ? '1 Alert Rule' : `${rules.length} Alert Rules`
   return (
     <PageContents source={source}>
       <div className="panel-heading u-flex u-ai-center u-jc-space-between">
-        <h2 className="panel-title">Alert Rules</h2>
+        <h2 className="panel-title">{tableHeader}</h2>
         <Link
           to={`/sources/${source.id}/alert-rules/new`}
           className="btn btn-sm btn-primary"
@@ -55,7 +55,7 @@ const PageContents = ({children, source}) => (
     <div className="page-header">
       <div className="page-header__container">
         <div className="page-header__left">
-          <h1 className="page-header__title">Kapacitor Rules</h1>
+          <h1 className="page-header__title">Alert Rules</h1>
         </div>
         <div className="page-header__right">
           <SourceIndicator sourceName={source && source.name} />

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -8,7 +8,7 @@ const KapacitorRulesTable = ({source, rules, onDelete, onChangeRuleStatus}) => {
         <thead>
           <tr>
             <th>Name</th>
-            <th>Trigger</th>
+            <th>Rule Type</th>
             <th>Message</th>
             <th>Alerts</th>
             <th className="text-center">Enabled</th>

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -23,7 +23,7 @@ export const ValuesSection = React.createClass({
 
     return (
       <div className="kapacitor-rule-section">
-        <h3 className="rule-section-heading">Values</h3>
+        <h3 className="rule-section-heading">Rule Conditions</h3>
         <div className="rule-section-body">
           <Tabs initialIndex={initialIndex} onSelect={this.handleChooseTrigger}>
             <TabList isKapacitorTabs="true">

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -65,7 +65,7 @@ const SideNav = React.createClass({
               Alert History
             </NavListItem>
             <NavListItem link={`${sourcePrefix}/alert-rules`}>
-              Kapacitor Rules
+              Alert Rules
             </NavListItem>
           </NavBlock>
           <NavBlock icon="crown2" link={`${sourcePrefix}/admin`}>


### PR DESCRIPTION
Fix for #602 

- Alerts Rules Page
  - Changed `Trigger` to `Rule Type` in the alert rules table
  - Title bar changed from `Kapacitor Rules` to `Alert Rules`
- Changed Side nav item `Kapacitor Rules` to `Alert Rules`
- Alert Config page
  - Changed `Values` to `Rule Conditions`
  - Changed empty state text to `Please enter a value in the Rule Conditions section`
- Host List page
  - Changed `Hostname` to `Host` in table header
  - Changed `Filter by Hostname...` to `Filter by Host`