### PR TITLE
Change default global time range to past 1 hour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
   1. [#1365](https://github.com/influxdata/chronograf/pull/1365): Show red indicator on Hosts Page for an offline host
   1. [#1373](https://github.com/influxdata/chronograf/pull/1373): Re-address dashboard cell stacking contexts
   1. [#602](https://github.com/influxdata/chronograf/pull/602): Normalize terminology in app
+  1. [#1395](https://github.com/influxdata/chronograf/pull/1395): Change default global time range to past 1 hour
 
 ## v1.2.0-beta10 [2017-04-28]
 

--- a/ui/spec/data_explorer/reducers/timeRangeSpec.js
+++ b/ui/spec/data_explorer/reducers/timeRangeSpec.js
@@ -1,8 +1,6 @@
 import reducer from 'src/data_explorer/reducers/timeRange'
 
-import {
-  setTimeRange,
-} from 'src/data_explorer/actions/view'
+import {setTimeRange} from 'src/data_explorer/actions/view'
 
 const noopAction = () => {
   return {type: 'NOOP'}
@@ -12,7 +10,7 @@ describe('DataExplorer.Reducers.TimeRange', () => {
   it('it sets the default timeRange', () => {
     const state = reducer(undefined, noopAction())
     const expected = {
-      lower: 'now() - 15m',
+      lower: 'now() - 1h',
       upper: null,
     }
 

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -1,7 +1,7 @@
 import _ from 'lodash'
 import timeRanges from 'hson!../../shared/data/timeRanges.hson'
 
-const {lower, upper} = timeRanges[1]
+const {lower, upper} = timeRanges[2]
 
 const initialState = {
   dashboards: [],

--- a/ui/src/data_explorer/actions/view/index.js
+++ b/ui/src/data_explorer/actions/view/index.js
@@ -97,10 +97,12 @@ export function editRawText(queryId, rawText) {
   }
 }
 
-export function setTimeRange(range) {
+export function setTimeRange(bounds) {
   return {
     type: 'SET_TIME_RANGE',
-    payload: range,
+    payload: {
+      bounds,
+    },
   }
 }
 

--- a/ui/src/data_explorer/reducers/timeRange.js
+++ b/ui/src/data_explorer/reducers/timeRange.js
@@ -1,23 +1,18 @@
 import timeRanges from 'hson!../../shared/data/timeRanges.hson'
 
-const initialLower = timeRanges[1].lower
-const initialUpper = timeRanges[1].upper
+const {lower, upper} = timeRanges[2]
 
 const initialState = {
-  upper: initialUpper,
-  lower: initialLower,
+  upper,
+  lower,
 }
 
 export default function timeRange(state = initialState, action) {
   switch (action.type) {
     case 'SET_TIME_RANGE': {
-      const {upper, lower} = action.payload
-      const newState = {
-        upper,
-        lower,
-      }
+      const {bounds} = action.payload
 
-      return {...state, ...newState}
+      return {...state, ...bounds}
     }
   }
   return state

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -45,12 +45,12 @@ export const HostPage = React.createClass({
   },
 
   getInitialState() {
-    const fifteenMinutesIndex = 1
+    const timeRange = timeRanges[2]
 
     return {
       layouts: [],
       hosts: [],
-      timeRange: timeRanges[fifteenMinutesIndex],
+      timeRange,
     }
   },
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1389 

### The problem
Default timeRange in a Host Page, Data Explorer, or Dashboard was `now() - 15m`. This is shorter than would be expected.

### The Solution
Make the default timeRange `now() - 1 hour`.

