### PR TITLE
Make handleClickOutside on TemplateVariableRow work the same as handleCancelEdit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
   1. [#1364](https://github.com/influxdata/chronograf/pull/1364): Fix link to home when using the --basepath option
   1. [#1370](https://github.com/influxdata/chronograf/pull/1370): Remove notification to login outside of session timeout
   1. [#1376](https://github.com/influxdata/chronograf/pull/1376): Fix queries built in query builder with math functions in fields
+  1. [#1399](https://github.com/influxdata/chronograf/pull/1399): User can no longer create a blank template variable by clicking outside a newly added one
 
 ### Features
 ### UI Improvements

--- a/ui/src/dashboards/components/TemplateVariableRow.js
+++ b/ui/src/dashboards/components/TemplateVariableRow.js
@@ -301,7 +301,7 @@ class RowWrapper extends Component {
   }
 
   handleClickOutside() {
-    this.setState({isEditing: false})
+    this.handleCancelEdit()
   }
 
   handleStartEdit(name) {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1399 
### The problem
A user could create a blank template variable by clicking Add Variable and then clicking outside of it.

### The Solution
Have `handleClickOutside` call `handleCancelEdit`.