### PR TITLE
Need RangeValue to correctly calculate Alert graph range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   1. [#1370](https://github.com/influxdata/chronograf/pull/1370): Remove notification to login outside of session timeout
   1. [#1376](https://github.com/influxdata/chronograf/pull/1376): Fix queries built in query builder with math functions in fields
   1. [#1399](https://github.com/influxdata/chronograf/pull/1399): User can no longer create a blank template variable by clicking outside a newly added one
+  1. [#1406](https://github.com/influxdata/chronograf/pull/1406): Ensure thresholds for Kapacitor Rule Alerts appear on page load
 
 ### Features
   1. [#1382](https://github.com/influxdata/chronograf/pull/1382): Add line-protocol proxy for InfluxDB data sources

--- a/chronograf.go
+++ b/chronograf.go
@@ -269,12 +269,12 @@ type Ticker interface {
 
 // TriggerValues specifies the alerting logic for a specific trigger type
 type TriggerValues struct {
-	Change     string `json:"change,omitempty"`     // Change specifies if the change is a percent or absolute
-	Period     string `json:"period,omitempty"`     // Period length of time before deadman is alerted
-	Shift      string `json:"shift,omitempty"`      // Shift is the amount of time to look into the past for the alert to compare to the present
-	Operator   string `json:"operator,omitempty"`   // Operator for alert comparison
-	Value      string `json:"value,omitempty"`      // Value is the boundary value when alert goes critical
-	RangeValue string `json:"rangeValue,omitempty"` // RangeValue is an optional value for range comparisons
+	Change     string `json:"change,omitempty"`   // Change specifies if the change is a percent or absolute
+	Period     string `json:"period,omitempty"`   // Period length of time before deadman is alerted
+	Shift      string `json:"shift,omitempty"`    // Shift is the amount of time to look into the past for the alert to compare to the present
+	Operator   string `json:"operator,omitempty"` // Operator for alert comparison
+	Value      string `json:"value,omitempty"`    // Value is the boundary value when alert goes critical
+	RangeValue string `json:"rangeValue"`         // RangeValue is an optional value for range comparisons
 }
 
 // Field represent influxql fields and functions from the UI


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1041

### The problem
LineGraph and Dygraphs were depending on `ruleValues` having a `rangeValue` to ensure that the y-axis was large enough to encompass a defined threshold. If this value was omitted when empty, Dygraphs seems to respect only the range of data. Thus, with a defined threshold far above or below the nominal range of data, the threshold overlay was being hidden.

### The Solution
Don't omit when empty. On a fresh page load, the threshold now appears:

![screen shot 2017-05-05 at 2 34 57 pm](https://cloud.githubusercontent.com/assets/1438089/25765102/0a532130-31a0-11e7-8591-89dfe137e046.png)