### PR TITLE
Fix OAuth when using a Basepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   1. [#1399](https://github.com/influxdata/chronograf/pull/1399): User can no longer create a blank template variable by clicking outside a newly added one
   1. [#1406](https://github.com/influxdata/chronograf/pull/1406): Ensure thresholds for Kapacitor Rule Alerts appear on page load
   1. [#1412](https://github.com/influxdata/chronograf/pull/1412): Check kapacitor status on configuration update
+  1. [#1407](https://github.com/influxdata/chronograf/pull/1407): Fix Authentication when using Chronograf with a basepath set
 
 ### Features
   1. [#1382](https://github.com/influxdata/chronograf/pull/1382): Add line-protocol proxy for InfluxDB data sources

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -18,6 +18,8 @@ export GH_ORGS=biffs-gang                                         # Restrict to 
 To use authentication in Chronograf, both the OAuth provider and JWT signature
 need to be configured.
 
+**Note:** If you're using the `--basepath` option when starting Chronograf, you will need to add the same basepath to the callback URL of any OAuth provider that you configure.
+
 #### Configuring JWT signature
 
 Set a [JWT](https://tools.ietf.org/html/rfc7519) signature to a random string. This is needed for all OAuth2 providers that you choose to configure. *Keep this random string around!*

--- a/oauth2/mux.go
+++ b/oauth2/mux.go
@@ -23,8 +23,8 @@ func NewAuthMux(p Provider, a Authenticator, t Tokenizer, basepath string, l chr
 		Tokens:     t,
 		SuccessURL: path.Join(basepath, "/"),
 		FailureURL: path.Join(basepath, "/login"),
-		Now:        DefaultNowTime,
-		Logger:     l,
+		Now:    DefaultNowTime,
+		Logger: l,
 	}
 }
 

--- a/oauth2/mux.go
+++ b/oauth2/mux.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/influxdata/chronograf"
@@ -15,15 +16,15 @@ var _ Mux = &AuthMux{}
 const TenMinutes = 10 * time.Minute
 
 // NewAuthMux constructs a Mux handler that checks a cookie against the authenticator
-func NewAuthMux(p Provider, a Authenticator, t Tokenizer, l chronograf.Logger) *AuthMux {
+func NewAuthMux(p Provider, a Authenticator, t Tokenizer, basepath string, l chronograf.Logger) *AuthMux {
 	return &AuthMux{
 		Provider:   p,
 		Auth:       a,
 		Tokens:     t,
-		Logger:     l,
-		SuccessURL: "/",
-		FailureURL: "/login",
+		SuccessURL: path.Join(basepath, "/"),
+		FailureURL: path.Join(basepath, "/login"),
 		Now:        DefaultNowTime,
+		Logger:     l,
 	}
 }
 

--- a/oauth2/mux_test.go
+++ b/oauth2/mux_test.go
@@ -37,7 +37,7 @@ func setupMuxTest(selector func(*AuthMux) http.Handler) (*http.Client, *httptest
 		Tokens:     mt,
 	}
 
-	jm := NewAuthMux(mp, auth, mt, clog.New(clog.ParseLevel("debug")))
+	jm := NewAuthMux(mp, auth, mt, "", clog.New(clog.ParseLevel("debug")))
 	ts := httptest.NewServer(selector(jm))
 	jar, _ := cookiejar.New(nil)
 	hc := http.Client{

--- a/server/logger.go
+++ b/server/logger.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/influxdata/chronograf"
 )
@@ -9,6 +10,7 @@ import (
 // Logger is middleware that logs the request
 func Logger(logger chronograf.Logger, next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
+		now := time.Now()
 		logger.
 			WithField("component", "server").
 			WithField("remote_addr", r.RemoteAddr).
@@ -16,6 +18,14 @@ func Logger(logger chronograf.Logger, next http.Handler) http.Handler {
 			WithField("url", r.URL).
 			Info("Request")
 		next.ServeHTTP(w, r)
+		later := time.Now()
+		elapsed := later.Sub(now)
+
+		logger.
+			WithField("component", "server").
+			WithField("remote_addr", r.RemoteAddr).
+			WithField("response_time", elapsed.String()).
+			Info("Success")
 	}
 	return http.HandlerFunc(fn)
 }

--- a/server/logout.go
+++ b/server/logout.go
@@ -1,19 +1,22 @@
 package server
 
-import "net/http"
+import (
+	"net/http"
+	"path"
+)
 
 // Logout chooses the correct provider logout route and redirects to it
-func Logout(nextURL string, routes AuthRoutes) http.HandlerFunc {
+func Logout(nextURL, basepath string, routes AuthRoutes) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		principal, err := getPrincipal(ctx)
 		if err != nil {
-			http.Redirect(w, r, nextURL, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, path.Join(basepath, nextURL), http.StatusTemporaryRedirect)
 			return
 		}
 		route, ok := routes.Lookup(principal.Issuer)
 		if !ok {
-			http.Redirect(w, r, nextURL, http.StatusTemporaryRedirect)
+			http.Redirect(w, r, path.Join(basepath, nextURL), http.StatusTemporaryRedirect)
 			return
 		}
 		http.Redirect(w, r, route.Logout, http.StatusTemporaryRedirect)

--- a/server/mountable_router.go
+++ b/server/mountable_router.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	libpath "path"
 
 	"github.com/influxdata/chronograf"
 )
@@ -18,37 +19,37 @@ type MountableRouter struct {
 // DELETE defines a route responding to a DELETE request that will be prefixed
 // with the configured route prefix
 func (mr *MountableRouter) DELETE(path string, handler http.HandlerFunc) {
-	mr.Delegate.DELETE(mr.Prefix+path, handler)
+	mr.Delegate.DELETE(libpath.Join(mr.Prefix, path), handler)
 }
 
 // GET defines a route responding to a GET request that will be prefixed
 // with the configured route prefix
 func (mr *MountableRouter) GET(path string, handler http.HandlerFunc) {
-	mr.Delegate.GET(mr.Prefix+path, handler)
+	mr.Delegate.GET(libpath.Join(mr.Prefix, path), handler)
 }
 
 // POST defines a route responding to a POST request that will be prefixed
 // with the configured route prefix
 func (mr *MountableRouter) POST(path string, handler http.HandlerFunc) {
-	mr.Delegate.POST(mr.Prefix+path, handler)
+	mr.Delegate.POST(libpath.Join(mr.Prefix, path), handler)
 }
 
 // PUT defines a route responding to a PUT request that will be prefixed
 // with the configured route prefix
 func (mr *MountableRouter) PUT(path string, handler http.HandlerFunc) {
-	mr.Delegate.PUT(mr.Prefix+path, handler)
+	mr.Delegate.PUT(libpath.Join(mr.Prefix, path), handler)
 }
 
 // PATCH defines a route responding to a PATCH request that will be prefixed
 // with the configured route prefix
 func (mr *MountableRouter) PATCH(path string, handler http.HandlerFunc) {
-	mr.Delegate.PATCH(mr.Prefix+path, handler)
+	mr.Delegate.PATCH(libpath.Join(mr.Prefix, path), handler)
 }
 
 // Handler defines a prefixed route responding to a request type specified in
 // the method parameter
 func (mr *MountableRouter) Handler(method string, path string, handler http.Handler) {
-	mr.Delegate.Handler(method, mr.Prefix+path, handler)
+	mr.Delegate.Handler(method, libpath.Join(mr.Prefix, path), handler)
 }
 
 // ServeHTTP is an implementation of http.Handler which delegates to the

--- a/server/mux.go
+++ b/server/mux.go
@@ -234,16 +234,13 @@ func AuthAPI(opts MuxOpts, router chronograf.Router) (http.Handler, AuthRoutes) 
 		})
 	}
 
-	// Y U NO WORKY WITH PATH JOIN?
-	//rootPath := path.Join(opts.Basepath, "/chronograf/v1/")
-	//logoutPath := path.Join(opts.Basepath, "/oauth/logout")
-	rootPath := opts.Basepath + "/chronograf/v1/"
-	logoutPath := opts.Basepath + "/oauth/logout"
+	rootPath := path.Join(opts.Basepath, "/chronograf/v1/")
+	logoutPath := path.Join(opts.Basepath, "/oauth/logout")
 
 	tokenMiddleware := AuthorizedToken(opts.Auth, opts.Logger, router)
 	// Wrap the API with token validation middleware.
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.HasPrefix(r.URL.Path, rootPath) || r.URL.Path == logoutPath {
+		if (strings.HasPrefix(r.URL.Path, rootPath) && len(r.URL.Path) > len(rootPath)) || r.URL.Path == logoutPath {
 			tokenMiddleware.ServeHTTP(w, r)
 			return
 		}

--- a/server/mux.go
+++ b/server/mux.go
@@ -181,6 +181,7 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.DELETE("/chronograf/v1/sources/:id/dbs/:dbid/rps/:rpid", service.DropRetentionPolicy)
 	var authRoutes AuthRoutes
 	var out http.Handler
+
 	/* Authentication */
 	logout := "/oauth/logout"
 	basepath := ""
@@ -195,9 +196,9 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 		// Create middleware to redirect to the appropriate provider logout
 		targetURL := "/"
 		router.GET(logout, Logout(targetURL, basepath, authRoutes))
-		out = Logger(opts.Logger, auth)
+		out = Logger(opts.Logger, PrefixedRedirect(opts.Basepath, auth))
 	} else {
-		out = Logger(opts.Logger, router)
+		out = Logger(opts.Logger, PrefixedRedirect(opts.Basepath, router))
 	}
 
 	router.GET("/chronograf/v1/", AllRoutes(authRoutes, path.Join(basepath, logout), opts.Logger))

--- a/server/mux.go
+++ b/server/mux.go
@@ -234,8 +234,11 @@ func AuthAPI(opts MuxOpts, router chronograf.Router) (http.Handler, AuthRoutes) 
 		})
 	}
 
-	rootPath := path.Join(opts.Basepath, "/chronograf/v1/")
-	logoutPath := path.Join(opts.Basepath, "/oauth/logout")
+	// Y U NO WORKY WITH PATH JOIN?
+	//rootPath := path.Join(opts.Basepath, "/chronograf/v1/")
+	//logoutPath := path.Join(opts.Basepath, "/oauth/logout")
+	rootPath := opts.Basepath + "/chronograf/v1/"
+	logoutPath := opts.Basepath + "/oauth/logout"
 
 	tokenMiddleware := AuthorizedToken(opts.Auth, opts.Logger, router)
 	// Wrap the API with token validation middleware.

--- a/server/prefixing_redirector.go
+++ b/server/prefixing_redirector.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+type interceptingResponseWriter struct {
+	http.ResponseWriter
+	Prefix string
+}
+
+func (i *interceptingResponseWriter) WriteHeader(status int) {
+	if status >= 300 && status < 400 {
+		location := i.ResponseWriter.Header().Get("Location")
+		if u, err := url.Parse(location); err == nil && !u.IsAbs() {
+			if !strings.HasPrefix(location, i.Prefix) {
+				i.ResponseWriter.Header().Set("Location", path.Join(i.Prefix, location)+"/")
+			}
+		}
+	}
+	i.ResponseWriter.WriteHeader(status)
+}
+
+// PrefixingRedirector alters the Location header of downstream http.Handlers
+// to include a specified prefix
+func PrefixedRedirect(prefix string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		iw := &interceptingResponseWriter{w, prefix}
+		next.ServeHTTP(iw, r)
+	})
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -29,16 +29,17 @@ func (r *AuthRoutes) Lookup(provider string) (AuthRoute, bool) {
 }
 
 type getRoutesResponse struct {
-	Layouts    string      `json:"layouts"`    // Location of the layouts endpoint
-	Mappings   string      `json:"mappings"`   // Location of the application mappings endpoint
-	Sources    string      `json:"sources"`    // Location of the sources endpoint
-	Me         string      `json:"me"`         // Location of the me endpoint
-	Dashboards string      `json:"dashboards"` // Location of the dashboards endpoint
-	Auth       []AuthRoute `json:"auth"`       // Location of all auth routes.
+	Layouts    string      `json:"layouts"`          // Location of the layouts endpoint
+	Mappings   string      `json:"mappings"`         // Location of the application mappings endpoint
+	Sources    string      `json:"sources"`          // Location of the sources endpoint
+	Me         string      `json:"me"`               // Location of the me endpoint
+	Dashboards string      `json:"dashboards"`       // Location of the dashboards endpoint
+	Auth       []AuthRoute `json:"auth"`             // Location of all auth routes.
+	Logout     *string     `json:"logout,omitempty"` // Location of the logout route for all auth routes
 }
 
 // AllRoutes returns all top level routes within chronograf
-func AllRoutes(authRoutes []AuthRoute, logger chronograf.Logger) http.HandlerFunc {
+func AllRoutes(authRoutes []AuthRoute, logout string, logger chronograf.Logger) http.HandlerFunc {
 	routes := getRoutesResponse{
 		Sources:    "/chronograf/v1/sources",
 		Layouts:    "/chronograf/v1/layouts",
@@ -46,6 +47,9 @@ func AllRoutes(authRoutes []AuthRoute, logger chronograf.Logger) http.HandlerFun
 		Mappings:   "/chronograf/v1/mappings",
 		Dashboards: "/chronograf/v1/dashboards",
 		Auth:       make([]AuthRoute, len(authRoutes)),
+	}
+	if logout != "" {
+		routes.Logout = &logout
 	}
 
 	for i, route := range authRoutes {

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestAllRoutes(t *testing.T) {
 	logger := log.New(log.DebugLevel)
-	handler := AllRoutes([]AuthRoute{}, logger)
+	handler := AllRoutes([]AuthRoute{}, "", logger)
 	req := httptest.NewRequest("GET", "http://docbrowns-inventions.com", nil)
 	w := httptest.NewRecorder()
 	handler(w, req)

--- a/server/server.go
+++ b/server/server.go
@@ -124,7 +124,7 @@ func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		Logger:       logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret)
-	ghMux := oauth2.NewAuthMux(&gh, auth, jwt, logger)
+	ghMux := oauth2.NewAuthMux(&gh, auth, jwt, s.Basepath, logger)
 	return &gh, ghMux, s.UseGithub
 }
 
@@ -138,7 +138,7 @@ func (s *Server) googleOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		Logger:       logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret)
-	goMux := oauth2.NewAuthMux(&google, auth, jwt, logger)
+	goMux := oauth2.NewAuthMux(&google, auth, jwt, s.Basepath, logger)
 	return &google, goMux, s.UseGoogle
 }
 
@@ -150,7 +150,7 @@ func (s *Server) herokuOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		Logger:        logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret)
-	hMux := oauth2.NewAuthMux(&heroku, auth, jwt, logger)
+	hMux := oauth2.NewAuthMux(&heroku, auth, jwt, s.Basepath, logger)
 	return &heroku, hMux, s.UseHeroku
 }
 
@@ -167,7 +167,7 @@ func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticato
 		Logger:         logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret)
-	genMux := oauth2.NewAuthMux(&gen, auth, jwt, logger)
+	genMux := oauth2.NewAuthMux(&gen, auth, jwt, s.Basepath, logger)
 	return &gen, genMux, s.UseGenericOAuth2
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -236,6 +236,11 @@ func (s *Server) Serve(ctx context.Context) error {
 	}
 	service := openService(ctx, s.BoltPath, layoutBuilder, sourcesBuilder, kapacitorBuilder, logger, s.useAuth())
 	basepath = s.Basepath
+	if basepath != "" && s.PrefixRoutes == false {
+		logger.
+			WithField("component", "server").
+			Info("Note: you may want to use --prefix-routes with --basepath. Try `./chronograf --help` for more info.")
+	}
 
 	providerFuncs := []func(func(oauth2.Provider, oauth2.Mux)){}
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -32,6 +32,7 @@ import {
   authReceived,
   meRequested,
   meReceived,
+  logoutLinkReceived,
 } from 'shared/actions/auth'
 import {errorThrown} from 'shared/actions/errors'
 
@@ -79,10 +80,11 @@ const Root = React.createClass({
 
   async startHeartbeat({shouldDispatchResponse}) {
     try {
-      const {data: me, auth} = await getMe()
+      const {data: me, auth, logoutLink} = await getMe()
       if (shouldDispatchResponse) {
         dispatch(authReceived(auth))
         dispatch(meReceived(me))
+        dispatch(logoutLinkReceived(logoutLink))
       }
 
       setTimeout(() => {

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import {render} from 'react-dom'
 import {Provider} from 'react-redux'
-import {Router, Route, useRouterHistory} from 'react-router'
-import {createHistory} from 'history'
+import {Router, Route} from 'react-router'
+import {createHistory, useBasename} from 'history'
 import {syncHistoryWithStore} from 'react-router-redux'
 
 import App from 'src/App'
@@ -41,9 +41,9 @@ import {HEARTBEAT_INTERVAL} from 'shared/constants'
 
 const rootNode = document.getElementById('react-root')
 
-const basepath = rootNode.dataset.basepath
+const basepath = rootNode.dataset.basepath || ''
 window.basepath = basepath
-const browserHistory = useRouterHistory(createHistory)({
+const browserHistory = useBasename(createHistory)({
   basename: basepath, // basepath is written in when available by the URL prefixer middleware
 })
 
@@ -100,12 +100,12 @@ const Root = React.createClass({
       <Provider store={store}>
         <Router history={history}>
           <Route path="/" component={UserIsAuthenticated(CheckSources)} />
-          <Route path="login" component={UserIsNotAuthenticated(Login)} />
+          <Route path="/login" component={UserIsNotAuthenticated(Login)} />
           <Route
-            path="sources/new"
+            path="/sources/new"
             component={UserIsAuthenticated(CreateSource)}
           />
-          <Route path="sources/:sourceID" component={UserIsAuthenticated(App)}>
+          <Route path="/sources/:sourceID" component={UserIsAuthenticated(App)}>
             <Route component={CheckSources}>
               <Route path="manage-sources" component={ManageSources} />
               <Route path="manage-sources/new" component={SourcePage} />

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -41,18 +41,11 @@ import {HEARTBEAT_INTERVAL} from 'shared/constants'
 
 const rootNode = document.getElementById('react-root')
 
-let browserHistory
 const basepath = rootNode.dataset.basepath
 window.basepath = basepath
-if (basepath) {
-  browserHistory = useRouterHistory(createHistory)({
-    basename: basepath, // this is written in when available by the URL prefixer middleware
-  })
-} else {
-  browserHistory = useRouterHistory(createHistory)({
-    basename: '',
-  })
-}
+const browserHistory = useRouterHistory(createHistory)({
+  basename: basepath, // basepath is written in when available by the URL prefixer middleware
+})
 
 const store = configureStore(loadLocalStorage(), browserHistory)
 const {dispatch} = store

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -26,3 +26,10 @@ export const meReceived = me => ({
     me,
   },
 })
+
+export const logoutLinkReceived = logoutLink => ({
+  type: 'LOGOUT_LINK_RECEIVED',
+  payload: {
+    logoutLink,
+  },
+})

--- a/ui/src/shared/reducers/auth.js
+++ b/ui/src/shared/reducers/auth.js
@@ -3,6 +3,7 @@ const getInitialState = () => ({
   me: null,
   isMeLoading: false,
   isAuthLoading: false,
+  logoutLink: null,
 })
 
 export const initialState = getInitialState()
@@ -26,6 +27,10 @@ const authReducer = (state = initialState, action) => {
     case 'ME_RECEIVED': {
       const {me} = action.payload
       return {...state, me, isMeLoading: false}
+    }
+    case 'LOGOUT_LINK_RECEIVED': {
+      const {logoutLink} = action.payload
+      return {...state, logoutLink}
     }
   }
 

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -23,6 +23,7 @@ const SideNav = React.createClass({
       email: string,
     }),
     isHidden: bool.isRequired,
+    logoutLink: string,
   },
 
   render() {
@@ -31,6 +32,7 @@ const SideNav = React.createClass({
       params: {sourceID},
       location: {pathname: location},
       isHidden,
+      logoutLink,
     } = this.props
 
     const sourcePrefix = `/sources/${sourceID}`
@@ -79,7 +81,7 @@ const SideNav = React.createClass({
           </NavBlock>
           {showLogout
             ? <NavBlock icon="user-outline" className="sidebar__square-last">
-                <a className="sidebar__menu-item" href="/oauth/logout">
+                <a className="sidebar__menu-item" href={logoutLink}>
                   Logout
                 </a>
               </NavBlock>
@@ -89,11 +91,12 @@ const SideNav = React.createClass({
 })
 
 const mapStateToProps = ({
-  auth: {me},
+  auth: {me, logoutLink},
   app: {ephemeral: {inPresentationMode}},
 }) => ({
   me,
   isHidden: inPresentationMode,
+  logoutLink,
 })
 
 export default connect(mapStateToProps)(withRouter(SideNav))

--- a/ui/src/utils/ajax.js
+++ b/ui/src/utils/ajax.js
@@ -44,7 +44,7 @@ export default async function AJAX({
     return {
       ...response,
       auth: {links: auth},
-      logout: links.logout,
+      logoutLink: links.logout,
     }
   } catch (error) {
     const {response} = error

--- a/ui/src/utils/ajax.js
+++ b/ui/src/utils/ajax.js
@@ -25,8 +25,6 @@ export default async function AJAX({
       links = linksRes.data
     }
 
-    const {auth} = links
-
     if (resource) {
       url = id
         ? `${basepath}${links[resource]}/${id}`
@@ -41,9 +39,11 @@ export default async function AJAX({
       headers,
     })
 
+    const {auth} = links
+
     return {
-      auth,
       ...response,
+      auth: {links: auth},
     }
   } catch (error) {
     const {response} = error

--- a/ui/src/utils/ajax.js
+++ b/ui/src/utils/ajax.js
@@ -44,11 +44,12 @@ export default async function AJAX({
     return {
       ...response,
       auth: {links: auth},
+      logout: links.logout,
     }
   } catch (error) {
     const {response} = error
 
     const {auth} = links
-    throw {...response, auth: {links: auth}} // eslint-disable-line no-throw-literal
+    throw {...response, auth: {links: auth}, logout: links.logout} // eslint-disable-line no-throw-literal
   }
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1369 

### The problem

The `--basepath` option didn't work with authentication enabled.

### The Solution

There were several issues with this. The first is that in many places, we were performing string concatenation of paths, which caused strange and unexpected behavior. This can happen with trailing slashes on URLs, and when concatenating fragments like `/foo/` and `/bar/` to yield `/foo//bar/`. The places where we used string concatenation or `fmt.Sprintf` to build paths have been eliminated with extreme prejudice and replaced with `path.Join`.

There's still some situations where the `bouk/httprouter` cares about trailing slashes, and it mostly deals with them by itself. However, because it's unaware of any prefixing that we do, a middleware needed to be added to prefix the `Location` header of 3XX class responses that came back from it.

Finally, the logout route didn't work because the correct link wasn't being propagated to it. This is now done by carrying the link from one of the initial requests into the Redux store so that it can be picked up by the `SideNav`. This isn't the greatest solution, but @jaredscheib and I concluded that a larger refactoring effort needs to take place to better support `basepath`. Notably in that effort will be the modernization of many of the older components in the application (e.g. `HostPage`, `HostsPage`, etc. These currently don't work with `basepath`) that use older patterns. These issues will be addressed in another issue to come.

