### PR TITLE
Submit tvars when asking for a queryConfig

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -13,6 +13,7 @@ import defaultQueryConfig from 'src/utils/defaultQueryConfig'
 import buildInfluxQLQuery from 'utils/influxql'
 import {getQueryConfig} from 'shared/apis'
 import {MINIMUM_HEIGHTS} from 'src/data_explorer/constants'
+import {removeUnselectedTemplateValues} from 'src/dashboards/constants'
 
 class CellEditorOverlay extends Component {
   constructor(props) {
@@ -114,9 +115,11 @@ class CellEditorOverlay extends Component {
   }
 
   async handleEditRawText(url, id, text) {
+    const templates = removeUnselectedTemplateValues(this.props.templates)
+
     // use this as the handler passed into fetchTimeSeries to update a query status
     try {
-      const {data} = await getQueryConfig(url, [{query: text, id}])
+      const {data} = await getQueryConfig(url, [{query: text, id}], templates)
       const config = data.queries.find(q => q.id === id)
       const nextQueries = this.state.queriesWorkingDraft.map(
         q => (q.id === id ? config.queryConfig : q)

--- a/ui/src/dashboards/constants/index.js
+++ b/ui/src/dashboards/constants/index.js
@@ -86,3 +86,10 @@ export const insertTempVar = (query, tempVar) => {
 export const unMask = query => {
   return query.replace(/😸/g, ':')
 }
+
+export const removeUnselectedTemplateValues = templates => {
+  return templates.map(template => {
+    const selectedValues = template.values.filter(value => value.selected)
+    return {...template, values: selectedValues}
+  })
+}

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -163,9 +163,11 @@ export function updateKapacitorConfigSection(kapacitor, section, properties) {
 }
 
 export function testAlertOutput(kapacitor, outputName, properties) {
-  return kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/service-tests').then(({
-    data: {services},
-  }) => {
+  return kapacitorProxy(
+    kapacitor,
+    'GET',
+    '/kapacitor/v1/service-tests'
+  ).then(({data: {services}}) => {
     const service = services.find(s => s.name === outputName)
     return kapacitorProxy(
       kapacitor,
@@ -213,9 +215,9 @@ export function kapacitorProxy(kapacitor, method, path, body) {
   })
 }
 
-export const getQueryConfig = (url, queries) =>
+export const getQueryConfig = (url, queries, tempVars) =>
   AJAX({
     url,
     method: 'POST',
-    data: {queries},
+    data: {queries, tempVars},
   })

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react'
 import _ from 'lodash'
 import {fetchTimeSeriesAsync} from 'shared/actions/timeSeries'
+import {removeUnselectedTemplateValues} from 'src/dashboards/constants'
 
 const {
   arrayOf,
@@ -111,11 +112,6 @@ const AutoRefresh = ComposedComponent => {
 
       this.setState({isFetching: true})
 
-      const selectedTempVarTemplates = templates.map(template => {
-        const selectedValues = template.values.filter(value => value.selected)
-        return {...template, values: selectedValues}
-      })
-
       const timeSeriesPromises = queries.map(query => {
         const {host, database, rp} = query
         return fetchTimeSeriesAsync(
@@ -124,7 +120,7 @@ const AutoRefresh = ComposedComponent => {
             db: database,
             rp,
             query,
-            tempVars: selectedTempVarTemplates,
+            tempVars: removeUnselectedTemplateValues(templates),
           },
           editQueryStatus
         )


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
If a query contains a template variable (e.g. `SELECT :tvar: FROM db.rp.meas ...`), then when we ask the server for its queryConfig, we must also provide the current values for those template variables. Otherwise the server understandably can't parse the query in the first place, and returns a syntax error. (Even though the following `proxy` request will succeed, and the user will get data back.)

### The Solution
Submit tvar values along with the query when requesting a queryConfig