### PR TITLE
validate kapacitor connection after updating config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   1. [#1376](https://github.com/influxdata/chronograf/pull/1376): Fix queries built in query builder with math functions in fields
   1. [#1399](https://github.com/influxdata/chronograf/pull/1399): User can no longer create a blank template variable by clicking outside a newly added one
   1. [#1406](https://github.com/influxdata/chronograf/pull/1406): Ensure thresholds for Kapacitor Rule Alerts appear on page load
+  1. [#1412](https://github.com/influxdata/chronograf/pull/1412): Check kapacitor status on configuration update
 
 ### Features
   1. [#1382](https://github.com/influxdata/chronograf/pull/1382): Add line-protocol proxy for InfluxDB data sources

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -127,7 +127,7 @@ class KapacitorForm extends Component {
         <div className="panel-body">
           <br />
           <p className="text-center">
-            Set your Kapacitor connection info to configure alerting endpoints.
+            Connect to an active Kapacitor instance to configure alerting endpoints.
           </p>
         </div>
       </div>

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -87,7 +87,6 @@ class KapacitorPage extends Component {
       createKapacitor(source, kapacitor)
         .then(({data}) => {
           // need up update kapacitor with info from server to AlertOutputs
-          router.push(`/sources/${source.id}/kapacitors/${data.id}/edit`)
           this.setState({kapacitor: data}, () =>
             this.checkKapacitorConnection(data)
           )

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -1,4 +1,6 @@
 import React, {Component, PropTypes} from 'react'
+import {withRouter} from 'react-router'
+
 import {
   getKapacitor,
   createKapacitor,
@@ -66,10 +68,10 @@ class KapacitorPage extends Component {
 
   handleSubmit(e) {
     e.preventDefault()
-    const {addFlashMessage, source} = this.props
-    const {kapacitor, exists} = this.state
+    const {addFlashMessage, source, params, router} = this.props
+    const {kapacitor} = this.state
 
-    if (exists) {
+    if (params.id) {
       updateKapacitor(kapacitor)
         .then(({data}) => {
           this.setState({kapacitor: data})
@@ -88,6 +90,7 @@ class KapacitorPage extends Component {
           // need up update kapacitor with info from server to AlertOutputs
           this.setState({kapacitor: data})
           this.checkKapacitorConnection(data)
+          router.push(`/sources/${source.id}/kapacitors/${data.id}/edit`)
           addFlashMessage({type: 'success', text: 'Kapacitor Created!'})
         })
         .catch(() => {
@@ -143,10 +146,13 @@ KapacitorPage.propTypes = {
   params: shape({
     id: string,
   }).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
   source: shape({
     id: string.isRequired,
     url: string.isRequired,
   }),
 }
 
-export default KapacitorPage
+export default withRouter(KapacitorPage)

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -72,9 +72,8 @@ class KapacitorPage extends Component {
     if (exists) {
       updateKapacitor(kapacitor)
         .then(({data}) => {
-          this.setState({kapacitor: data}, () =>
-            this.checkKapacitorConnection(data)
-          )
+          this.setState({kapacitor: data})
+          this.checkKapacitorConnection(data)
           addFlashMessage({type: 'success', text: 'Kapacitor Updated!'})
         })
         .catch(() => {
@@ -87,9 +86,8 @@ class KapacitorPage extends Component {
       createKapacitor(source, kapacitor)
         .then(({data}) => {
           // need up update kapacitor with info from server to AlertOutputs
-          this.setState({kapacitor: data}, () =>
-            this.checkKapacitorConnection(data)
-          )
+          this.setState({kapacitor: data})
+          this.checkKapacitorConnection(data)
           addFlashMessage({type: 'success', text: 'Kapacitor Created!'})
         })
         .catch(() => {

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -39,22 +39,22 @@ class KapacitorPage extends Component {
     }
 
     getKapacitor(source, id).then(kapacitor => {
-      this.setState({kapacitor}, () => this.checkKapacitorConnection(kapacitor))
+      this.setState({kapacitor})
+      this.checkKapacitorConnection(kapacitor)
     })
   }
 
-  checkKapacitorConnection(kapacitor) {
-    pingKapacitor(kapacitor)
-      .then(() => {
-        this.setState({exists: true})
+  async checkKapacitorConnection(kapacitor) {
+    try {
+      await pingKapacitor(kapacitor)
+      this.setState({exists: true})
+    } catch (error) {
+      this.setState({exists: false})
+      this.props.addFlashMessage({
+        type: 'error',
+        text: 'Could not connect to Kapacitor. Check settings.',
       })
-      .catch(() => {
-        this.setState({exists: false})
-        this.props.addFlashMessage({
-          type: 'error',
-          text: 'Could not connect to Kapacitor. Check settings.',
-        })
-      })
+    }
   }
 
   handleInputChange(e) {

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -146,8 +146,8 @@ KapacitorPage.propTypes = {
   params: shape({
     id: string,
   }).isRequired,
-  router: PropTypes.shape({
-    push: PropTypes.func.isRequired,
+  router: shape({
+    push: func.isRequired,
   }).isRequired,
   source: shape({
     id: string.isRequired,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1271

When previously invalid kapacitor configuration is updated, the alerts section doesn't show until after a refresh. This fixes that.