### PR TITLE
support escaping from presentation mode with safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   1. [#1406](https://github.com/influxdata/chronograf/pull/1406): Ensure thresholds for Kapacitor Rule Alerts appear on page load
   1. [#1412](https://github.com/influxdata/chronograf/pull/1412): Check kapacitor status on configuration update
   1. [#1407](https://github.com/influxdata/chronograf/pull/1407): Fix Authentication when using Chronograf with a basepath set
+  1. [#1417](https://github.com/influxdata/chronograf/pull/1417): Support escaping from presentation mode with safari
 
 ### Features
   1. [#1382](https://github.com/influxdata/chronograf/pull/1382): Add line-protocol proxy for InfluxDB data sources

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -57,7 +57,7 @@ browserHistory.listen(() => {
 
 window.addEventListener('keyup', event => {
   const escapeKeyCode = 27
-  if (event.keyCode === escapeKeyCode) {
+  if (event.key === 'Escape' || event.which === escapeKeyCode) {
     dispatch(disablePresentationMode())
   }
 })

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -57,6 +57,7 @@ browserHistory.listen(() => {
 
 window.addEventListener('keyup', event => {
   const escapeKeyCode = 27
+  // fallback for browsers that don't support event.key
   if (event.key === 'Escape' || event.keyCode === escapeKeyCode) {
     dispatch(disablePresentationMode())
   }

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -56,7 +56,8 @@ browserHistory.listen(() => {
 })
 
 window.addEventListener('keyup', event => {
-  if (event.key === 'Escape') {
+  const escapeKeyCode = 27
+  if (event.keyCode === escapeKeyCode) {
     dispatch(disablePresentationMode())
   }
 })

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -57,7 +57,7 @@ browserHistory.listen(() => {
 
 window.addEventListener('keyup', event => {
   const escapeKeyCode = 27
-  if (event.key === 'Escape' || event.which === escapeKeyCode) {
+  if (event.key === 'Escape' || event.keyCode === escapeKeyCode) {
     dispatch(disablePresentationMode())
   }
 })


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1393 

### The problem
Escape does not exit presentation mode when using the safari brower.

### The Solution
Safari `keyup` events do not include a `key` key. To ensure better browser compatibility, we should use the keycode for escape.

