### PR TITLE
Fall back to useRouterHistory method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v1.3.0~rc2 [unreleased]
+
+### Bug Fixes
+  1. [#1433](https://github.com/influxdata/chronograf/pull/1433): Fix router bug introduced by upgrading to react-router v3.0.
+
 ## v1.3.0~rc1 [2017-05-08]
 
 ### Bug Fixes

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import {render} from 'react-dom'
 import {Provider} from 'react-redux'
-import {Router, Route} from 'react-router'
-import {createHistory, useBasename} from 'history'
+import {Router, Route, useRouterHistory} from 'react-router'
+import {createHistory} from 'history'
 import {syncHistoryWithStore} from 'react-router-redux'
 
 import App from 'src/App'
@@ -42,11 +42,18 @@ import {HEARTBEAT_INTERVAL} from 'shared/constants'
 
 const rootNode = document.getElementById('react-root')
 
+let browserHistory
 const basepath = rootNode.dataset.basepath || ''
 window.basepath = basepath
-const browserHistory = useBasename(createHistory)({
-  basename: basepath, // basepath is written in when available by the URL prefixer middleware
-})
+if (basepath) {
+  browserHistory = useRouterHistory(createHistory)({
+    basename: basepath, // this is written in when available by the URL prefixer middleware
+  })
+} else {
+  browserHistory = useRouterHistory(createHistory)({
+    basename: '',
+  })
+}
 
 const store = configureStore(loadLocalStorage(), browserHistory)
 const {dispatch} = store

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -42,18 +42,11 @@ import {HEARTBEAT_INTERVAL} from 'shared/constants'
 
 const rootNode = document.getElementById('react-root')
 
-let browserHistory
 const basepath = rootNode.dataset.basepath || ''
 window.basepath = basepath
-if (basepath) {
-  browserHistory = useRouterHistory(createHistory)({
-    basename: basepath, // this is written in when available by the URL prefixer middleware
-  })
-} else {
-  browserHistory = useRouterHistory(createHistory)({
-    basename: '',
-  })
-}
+const browserHistory = useRouterHistory(createHistory)({
+  basename: basepath, // this is written in when available by the URL prefixer middleware
+})
 
 const store = configureStore(loadLocalStorage(), browserHistory)
 const {dispatch} = store


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1418 

### The problem
Modern react-router / history usage breaks the app currently because they deprecated a feature that turned a search string into a query object. See: https://github.com/ReactTraining/react-router/issues/4410

### The Solution
Revert to old usage pattern. If we want to use the new pattern, we'll need to add a new package that parses search strings to query objects. There are also a variety of ways to do that, and we'll want to decide on one.