### PR TITLE
Change behavior of Template Variables autocomplete in Query Editor to match from front of string only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
 
 ### Features
-1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Change behavior of template variable filtering in query editor to exact match from front of string
+1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Change behavior of template variable autocomplete to filter by exact match from front of string
 
 ### UI Improvements
   1. [#1451](https://github.com/influxdata/chronograf/pull/1451): Refactor scrollbars to support non-webkit browsers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
 
 ### Features
+1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Change behavior of template variable filtering in query editor to exact match from front of string
 
 ### UI Improvements
   1. [#1451](https://github.com/influxdata/chronograf/pull/1451): Refactor scrollbars to support non-webkit browsers

--- a/ui/src/data_explorer/components/QueryEditor.js
+++ b/ui/src/data_explorer/components/QueryEditor.js
@@ -163,8 +163,8 @@ class QueryEditor extends Component {
       // maintain cursor poition
       const start = this.editor.selectionStart
       const end = this.editor.selectionEnd
-      const filteredTemplates = templates.filter(t =>
-        t.tempVar.includes(matched[0].substring(1))
+      const filteredTemplates = templates.filter(
+        t => t.tempVar.indexOf(matched[0]) === 0
       )
 
       const found = filteredTemplates.find(

--- a/ui/src/data_explorer/components/QueryEditor.js
+++ b/ui/src/data_explorer/components/QueryEditor.js
@@ -163,8 +163,8 @@ class QueryEditor extends Component {
       // maintain cursor poition
       const start = this.editor.selectionStart
       const end = this.editor.selectionEnd
-      const filteredTemplates = templates.filter(
-        t => t.tempVar.indexOf(matched[0]) === 0
+      const filteredTemplates = templates.filter(t =>
+        t.tempVar.startsWith(matched[0])
       )
 
       const found = filteredTemplates.find(


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1462 

### The problem
In Query Editor, template variable autocomplete would filter based on partial string match at any location within existing template variables, ex. typing `:al` would yield options to autocomplete with `:halpmi:` and `:albertcadalbert:`

### The Solution
Filter based on exact matches from front of string only, so that `:al` would only yield `:albertcadalbert:` and would exclude `:halpmi:`.

