### PR TITLE
Add ability to log alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
 
 ### Features
+  1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts
 
 ### UI Improvements
   1. [#1451](https://github.com/influxdata/chronograf/pull/1451): Refactor scrollbars to support non-webkit browsers

--- a/kapacitor/alerts.go
+++ b/kapacitor/alerts.go
@@ -21,7 +21,7 @@ func kapaHandler(handler string) (string, error) {
 		return "email", nil
 	case "http":
 		return "post", nil
-	case "alerta", "sensu", "slack", "email", "talk", "telegram", "post", "tcp", "exec":
+	case "alerta", "sensu", "slack", "email", "talk", "telegram", "post", "tcp", "exec", "log":
 		return handler, nil
 	default:
 		return "", fmt.Errorf("Unsupported alert handler %s", handler)

--- a/kapacitor/alerts_test.go
+++ b/kapacitor/alerts_test.go
@@ -96,6 +96,31 @@ func TestAlertServices(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Test log",
+			rule: chronograf.AlertRule{
+				AlertNodes: []chronograf.KapacitorNode{
+					{
+						Name: "log",
+						Args: []string{"/tmp/alerts.log"},
+					},
+				},
+			},
+			want: `alert()
+        .log('/tmp/alerts.log')
+`,
+		},
+		{
+			name: "Test log no argument",
+			rule: chronograf.AlertRule{
+				AlertNodes: []chronograf.KapacitorNode{
+					{
+						Name: "log",
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Test tcp no argument with other services",
 			rule: chronograf.AlertRule{
 				Alerts: []string{"slack", "tcp", "email"},

--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -493,6 +493,7 @@ func extractAlertNodes(p *pipeline.Pipeline, rule *chronograf.AlertRule) {
 			extractTalk(t, rule)
 			extractTelegram(t, rule)
 			extractTCP(t, rule)
+			extractLog(t, rule)
 			extractExec(t, rule)
 		}
 		return nil
@@ -796,6 +797,23 @@ func extractTCP(node *pipeline.AlertNode, rule *chronograf.AlertRule) {
 
 	if t.Address != "" {
 		alert.Args = []string{t.Address}
+	}
+
+	rule.AlertNodes = append(rule.AlertNodes, alert)
+}
+
+func extractLog(node *pipeline.AlertNode, rule *chronograf.AlertRule) {
+	if node.LogHandlers == nil {
+		return
+	}
+	rule.Alerts = append(rule.Alerts, "log")
+	log := node.LogHandlers[0]
+	alert := chronograf.KapacitorNode{
+		Name: "log",
+	}
+
+	if log.FilePath != "" {
+		alert.Args = []string{log.FilePath}
 	}
 
 	rule.AlertNodes = append(rule.AlertNodes, alert)

--- a/kapacitor/ast_test.go
+++ b/kapacitor/ast_test.go
@@ -59,12 +59,13 @@ func TestReverse(t *testing.T) {
 															.slack()
 															.victorOps()
 															.email('howdy@howdy.com')
+															.log('/tmp/alerts.log')
 															`),
 
 			want: chronograf.AlertRule{
 				Name:    "name",
 				Trigger: "threshold",
-				Alerts:  []string{"victorops", "smtp", "slack"},
+				Alerts:  []string{"victorops", "smtp", "slack", "log"},
 				AlertNodes: []chronograf.KapacitorNode{
 					{
 						Name: "victorops",
@@ -75,6 +76,10 @@ func TestReverse(t *testing.T) {
 					},
 					{
 						Name: "slack",
+					},
+					{
+						Name: "log",
+						Args: []string{"/tmp/alerts.log"},
 					},
 				},
 				TriggerValues: chronograf.TriggerValues{

--- a/ui/src/kapacitor/constants/index.js
+++ b/ui/src/kapacitor/constants/index.js
@@ -74,12 +74,13 @@ export const RULE_MESSAGE_TEMPLATES = {
   },
 }
 
-export const DEFAULT_ALERTS = ['http', 'tcp', 'exec']
+export const DEFAULT_ALERTS = ['http', 'tcp', 'exec', 'log']
 
 export const DEFAULT_ALERT_LABELS = {
   http: 'URL:',
   tcp: 'Address:',
   exec: 'Add Command (Arguments separated by Spaces):',
+  log: 'File',
   smtp: 'Email Addresses (Separated by Spaces):',
   slack: 'Send alerts to Slack channel:',
   alerta: 'Paste Alerta TICKscript:',
@@ -88,6 +89,7 @@ export const DEFAULT_ALERT_PLACEHOLDERS = {
   http: 'Ex: http://example.com/api/alert',
   tcp: 'Ex: exampleendpoint.com:5678',
   exec: 'Ex: woogie boogie',
+  log: 'Ex: /tmp/alerts.log',
   smtp: 'Ex: benedict@domain.com delaney@domain.com susan@domain.com',
   slack: '#alerts',
   alerta: 'alerta()',
@@ -97,6 +99,7 @@ export const ALERT_NODES_ACCESSORS = {
   http: rule => _.get(rule, 'alertNodes[0].args[0]', ''),
   tcp: rule => _.get(rule, 'alertNodes[0].args[0]', ''),
   exec: rule => _.get(rule, 'alertNodes[0].args', []).join(' '),
+  log: rule => _.get(rule, 'alertNodes[0].args[0]', ''),
   smtp: rule => _.get(rule, 'alertNodes[0].args', []).join(' '),
   slack: rule => _.get(rule, 'alertNodes[0].properties[0].args', ''),
   alerta: rule =>

--- a/ui/src/kapacitor/reducers/rules.js
+++ b/ui/src/kapacitor/reducers/rules.js
@@ -81,6 +81,7 @@ export default function rules(state = {}, action) {
       switch (alertType) {
         case 'http':
         case 'tcp':
+        case 'log':
           alertNodesByType = [
             {
               name: alertType,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [X] Rebased/mergable
  - [X] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem

Kapacitor alerts cannot be set up to write to a log file.

The log alert type is especially useful when experimenting with things locally as it is really cheap to set up.

### The Solution

Add the ability to send alerts to a log file

![image](https://cloud.githubusercontent.com/assets/4132322/26021631/af780b8e-375f-11e7-9b65-7b5ee79430ef.png)

