### PR TITLE
Update canned influx layout to use milliseconds of duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Make Template Variables Manager more space efficient
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Add page spinners to pages that did not have them
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Denote which source is connected in the Sources table
+  1. [#1478](https://github.com/influxdata/chronograf/pull/1478): InfluxDB dashboard uses milliseconds rather than nanoseconds
 
 ## v1.3.0 [2017-05-09]
 

--- a/canned/influxdb_queryExecutor.json
+++ b/canned/influxdb_queryExecutor.json
@@ -13,12 +13,14 @@
       "name": "InfluxDB - Query Performance",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"queryDurationNs\"), 1s) AS \"duration\" FROM \"influxdb_queryExecutor\"",
+          "query": "SELECT non_negative_derivative(max(\"queryDurationNs\"), 1s) / 1000000 AS \"duration_ms\" FROM \"influxdb_queryExecutor\"",
+          "label": "ms",
           "groupbys": [],
           "wheres": []
         },
         {
-          "query": "SELECT non_negative_derivative(max(\"queriesExecuted\"), 1s) AS \"queries_executed\" FROM \"influxdb_queryExecutor\"",
+          "query": "SELECT non_negative_derivative(max(\"queriesExecuted\"), 1s) / 1000000 AS \"queries_executed_ms\" FROM \"influxdb_queryExecutor\"",
+          "label": "ms",
           "groupbys": [],
           "wheres": []
         }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1362 

### The problem
Canned influx dashboard queries were in nanoseconds of duration
### The Solution
Update to milliseconds and add label

