### PR TITLE
Fix bug on selecting single-stat Visualization Type when no queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   1. [#1455](https://github.com/influxdata/chronograf/issues/1455): Fix backwards sort arrows in tables
   1. [#1423](https://github.com/influxdata/chronograf/issues/1423): Make logout nav item consistent with design
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
+  1. [#1484](https://github.com/influxdata/chronograf/issues/1484): Allow user to select SingleStat as Visualization Type before adding any queries and continue to be able to click Add Query
 
 ### Features
   1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts

--- a/ui/src/data_explorer/components/VisView.js
+++ b/ui/src/data_explorer/components/VisView.js
@@ -43,7 +43,7 @@ const VisView = ({
   if (cellType === 'single-stat') {
     return (
       <RefreshingSingleStat
-        queries={[queries[0]]}
+        queries={queries.length ? [queries[0]] : []}
         autoRefresh={autoRefresh}
         templates={templates}
       />


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1463 

### The problem
When no queries had been entered and the Visualization Type `SingleStat` was selected in Cell Editor Overlay, the user could not then click the `Add Query` button -- rather, it would do nothing. Whereas, when the user would select another Visualization Type without any queries, the `Add Query` button would still work.

### The Solution
Clean up the input to `queries` in the <VisView> component for when there are not yet any queries.

