### PR TITLE
Filter out any template variable values that are empty, whitespace, or duplicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   1. [#1455](https://github.com/influxdata/chronograf/issues/1455): Fix backwards sort arrows in tables
   1. [#1423](https://github.com/influxdata/chronograf/issues/1423): Make logout nav item consistent with design
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
+  1. [#1485](https://github.com/influxdata/chronograf/issues/1485): Filter out any template variable values that are empty, whitespace, or duplicates
 
 ### Features
   1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts

--- a/ui/src/dashboards/components/TemplateVariableRow.js
+++ b/ui/src/dashboards/components/TemplateVariableRow.js
@@ -2,6 +2,8 @@ import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 
+import uniq from 'lodash/uniq'
+
 import OnClickOutside from 'react-onclickoutside'
 import classnames from 'classnames'
 
@@ -30,7 +32,9 @@ const RowValues = ({
   onStartEdit,
   autoFocusTarget,
 }) => {
-  const _values = values.map(({value}) => value).join(', ')
+  const _values = uniq(values.map(({value}) => value))
+    .filter(value => /\S/.test(value))
+    .join(', ')
 
   if (selectedType === 'csv') {
     return (


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1415 

### The problem
User could enter empty, whitespace, or duplicate CSV values in template variable manager.

### The Solution
Make entered values a set (uniques only) and remove whitespace entries. This also applies to any values returned via meta queries for the other template variable types (i.e. `Databases`, `Measurements`, `Field Keys`, etc.).

