### PR TITLE
Notify user via UI if their local storage is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
   1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts
   1. [#1474](https://github.com/influxdata/chronograf/pull/1474): Change behavior of template variable autocomplete to filter by exact match from front of string
   1. [#1491](https://github.com/influxdata/chronograf/pull/1491): Update go vendoring to dep and committed vendor directory
+  1. [#1498](https://github.com/influxdata/chronograf/pull/1498): Notify user via UI when local settings are cleared
 
 ### UI Improvements
   1. [#1451](https://github.com/influxdata/chronograf/pull/1451): Refactor scrollbars to support non-webkit browsers

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -40,6 +40,8 @@ import 'src/style/chronograf.scss'
 
 import {HEARTBEAT_INTERVAL} from 'shared/constants'
 
+const errorsQueue = []
+
 const rootNode = document.getElementById('react-root')
 
 const basepath = rootNode.dataset.basepath || ''
@@ -48,7 +50,7 @@ const browserHistory = useRouterHistory(createHistory)({
   basename: basepath, // this is written in when available by the URL prefixer middleware
 })
 
-const store = configureStore(loadLocalStorage(), browserHistory)
+const store = configureStore(loadLocalStorage(errorsQueue), browserHistory)
 const {dispatch} = store
 
 browserHistory.listen(() => {
@@ -67,6 +69,7 @@ const history = syncHistoryWithStore(browserHistory, store)
 
 const Root = React.createClass({
   componentWillMount() {
+    this.flushErrorsQueue()
     this.checkAuth()
   },
 
@@ -96,6 +99,14 @@ const Root = React.createClass({
       }, HEARTBEAT_INTERVAL)
     } catch (error) {
       dispatch(errorThrown(error))
+    }
+  },
+
+  flushErrorsQueue() {
+    if (errorsQueue.length) {
+      errorsQueue.forEach(errorText => {
+        dispatch(errorThrown({status: 0, auth: null}, errorText, 'warning'))
+      })
     }
   },
 

--- a/ui/src/localStorage.js
+++ b/ui/src/localStorage.js
@@ -1,4 +1,4 @@
-export const loadLocalStorage = () => {
+export const loadLocalStorage = errorsQueue => {
   try {
     const serializedState = localStorage.getItem('state')
 
@@ -6,8 +6,12 @@ export const loadLocalStorage = () => {
 
     // eslint-disable-next-line no-undef
     if (state.VERSION !== VERSION) {
-      // eslint-disable-next-line no-console
-      console.log('New version detected. Clearing old settings.')
+      const errorText =
+        'New version of Chronograf detected. Local settings cleared.'
+
+      console.log(errorText) // eslint-disable-line no-console
+      errorsQueue.push(errorText)
+
       window.localStorage.removeItem('state')
       return {}
     }
@@ -15,9 +19,12 @@ export const loadLocalStorage = () => {
     delete state.VERSION
 
     return state || {}
-  } catch (err) {
-    // eslint-disable-line no-console
-    console.error(`Loading persisted state failed: ${err}`)
+  } catch (error) {
+    const errorText = `Loading local settings failed: ${error}`
+
+    console.error(errorText) // eslint-disable-line no-console
+    errorsQueue.push(errorText)
+
     return {}
   }
 }

--- a/ui/src/shared/actions/errors.js
+++ b/ui/src/shared/actions/errors.js
@@ -1,5 +1,6 @@
-export const errorThrown = (error, altText) => ({
+export const errorThrown = (error, altText, alertType) => ({
   type: 'ERROR_THROWN',
   error,
   altText,
+  alertType,
 })

--- a/ui/src/shared/middleware/errors.js
+++ b/ui/src/shared/middleware/errors.js
@@ -17,7 +17,7 @@ const errorsMiddleware = store => next => action => {
   const {auth: {me}} = store.getState()
 
   if (action.type === 'ERROR_THROWN') {
-    const {error: {status, auth}, altText} = action
+    const {error: {status, auth}, altText, alertType = 'error'} = action
 
     if (status === HTTP_FORBIDDEN) {
       const wasSessionTimeout = me !== null
@@ -26,7 +26,7 @@ const errorsMiddleware = store => next => action => {
 
       if (wasSessionTimeout) {
         store.dispatch(
-          notify('error', 'Session timed out. Please login again.')
+          notify(alertType, 'Session timed out. Please login again.')
         )
 
         allowNotifications = false
@@ -35,9 +35,9 @@ const errorsMiddleware = store => next => action => {
         }, notificationsBlackoutDuration)
       }
     } else if (altText) {
-      store.dispatch(notify('error', altText))
+      store.dispatch(notify(alertType, altText))
     } else {
-      store.dispatch(notify('error', 'Cannot communicate with server.'))
+      store.dispatch(notify(alertType, 'Cannot communicate with server.'))
     }
   }
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1498 #1443 #1458

### The problem
User's localStorage would be cleared on Chronograf version upgrade with only a console notification, so they may be confused as to why they no longer have their queries in Data Explorer and other user settings (time range, auto refresh) are no longer there.

### The Solution
Notify the user via the UI (purple `warning` notification) when local settings have been cleared.

<img width="1440" alt="screen shot 2017-05-17 at 1 32 26 pm" src="https://cloud.githubusercontent.com/assets/6403018/26174763/4a951780-3b05-11e7-8dcc-bb5db830b51a.png">