### PR TITLE
Dropdown Autocomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Add page spinners to pages that did not have them
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Denote which source is connected in the Sources table
   1. [#1478](https://github.com/influxdata/chronograf/pull/1478): InfluxDB dashboard uses milliseconds rather than nanoseconds
+  1. [#1500](https://github.com/influxdata/chronograf/pull/1500): Add autocomplete functionality to Template Variable dropdowns
 
 ## v1.3.0 [2017-05-09]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@
 
 ### Features
   1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts
-  1. [#1474](https://github.com/influxdata/chronograf/pull/1474): Change behavior of template variable autocomplete to filter by exact match from front of string
   1. [#1491](https://github.com/influxdata/chronograf/pull/1491): Update go vendoring to dep and committed vendor directory
+  1. [#1500](https://github.com/influxdata/chronograf/pull/1500): Add autocomplete functionality to Template Variable dropdowns
 
 ### UI Improvements
   1. [#1451](https://github.com/influxdata/chronograf/pull/1451): Refactor scrollbars to support non-webkit browsers
@@ -19,7 +19,6 @@
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Add page spinners to pages that did not have them
   1. [#1464](https://github.com/influxdata/chronograf/pull/1464): Denote which source is connected in the Sources table
   1. [#1478](https://github.com/influxdata/chronograf/pull/1478): InfluxDB dashboard uses milliseconds rather than nanoseconds
-  1. [#1500](https://github.com/influxdata/chronograf/pull/1500): Add autocomplete functionality to Template Variable dropdowns
 
 ## v1.3.0 [2017-05-09]
 

--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -34,15 +34,16 @@ const AlertsTable = React.createClass({
 
   filterAlerts(searchTerm, newAlerts) {
     const alerts = newAlerts || this.props.alerts
+    const filterText = searchTerm.toLowerCase()
     const filteredAlerts = alerts.filter(h => {
       if (h.host === null || h.name === null || h.level === null) {
         return false
       }
 
       return (
-        h.name.toLowerCase().search(searchTerm.toLowerCase()) !== -1 ||
-        h.host.toLowerCase().search(searchTerm.toLowerCase()) !== -1 ||
-        h.level.toLowerCase().search(searchTerm.toLowerCase()) !== -1
+        h.name.toLowerCase().includes(filterText) ||
+        h.host.toLowerCase().includes(filterText) ||
+        h.level.toLowerCase().includes(filterText)
       )
     })
     this.setState({searchTerm, filteredAlerts})

--- a/ui/src/dashboards/components/TemplateControlBar.js
+++ b/ui/src/dashboards/components/TemplateControlBar.js
@@ -24,7 +24,7 @@ const TemplateControlBar = ({
             <Dropdown
               items={items}
               buttonSize="btn-xs"
-              hasAutoComplete={true}
+              useAutoComplete={true}
               selected={selectedText || 'Loading...'}
               onChoose={item =>
                 onSelectTemplate(id, [item].map(x => omit(x, 'text')))}

--- a/ui/src/dashboards/components/TemplateControlBar.js
+++ b/ui/src/dashboards/components/TemplateControlBar.js
@@ -24,6 +24,7 @@ const TemplateControlBar = ({
             <Dropdown
               items={items}
               buttonSize="btn-xs"
+              hasAutoComplete={true}
               selected={selectedText || 'Loading...'}
               onChoose={item =>
                 onSelectTemplate(id, [item].map(x => omit(x, 'text')))}

--- a/ui/src/data_explorer/components/MeasurementList.js
+++ b/ui/src/data_explorer/components/MeasurementList.js
@@ -115,8 +115,9 @@ const MeasurementList = React.createClass({
       )
     }
 
+    const filterText = this.state.filterText.toLowerCase()
     const measurements = this.state.measurements.filter(m =>
-      m.match(this.state.filterText)
+      m.toLowerCase().includes(filterText)
     )
 
     return (

--- a/ui/src/data_explorer/components/QueryEditor.js
+++ b/ui/src/data_explorer/components/QueryEditor.js
@@ -162,9 +162,12 @@ class QueryEditor extends Component {
     if (matched && !_.isEmpty(templates)) {
       // maintain cursor poition
       const start = this.editor.selectionStart
+
       const end = this.editor.selectionEnd
+      const filterText = matched[0].substr(1).toLowerCase()
+
       const filteredTemplates = templates.filter(t =>
-        t.tempVar.startsWith(matched[0])
+        t.tempVar.toLowerCase().includes(filterText)
       )
 
       const found = filteredTemplates.find(

--- a/ui/src/data_explorer/components/TagListItem.js
+++ b/ui/src/data_explorer/components/TagListItem.js
@@ -52,7 +52,8 @@ const TagListItem = React.createClass({
       return <div>no tag values</div>
     }
 
-    const filtered = tagValues.filter(v => v.match(this.state.filterText))
+    const filterText = this.state.filterText.toLowerCase()
+    const filtered = tagValues.filter(v => v.toLowerCase().includes(filterText))
 
     return (
       <div className="query-builder--sub-list">

--- a/ui/src/hosts/components/HostsTable.js
+++ b/ui/src/hosts/components/HostsTable.js
@@ -35,20 +35,21 @@ const HostsTable = React.createClass({
   },
 
   filter(allHosts, searchTerm) {
+    const filterText = searchTerm.toLowerCase()
     return allHosts.filter(h => {
       const apps = h.apps ? h.apps.join(', ') : ''
       // search each tag for the presence of the search term
       let tagResult = false
       if (h.tags) {
         tagResult = Object.keys(h.tags).reduce((acc, key) => {
-          return acc || h.tags[key].search(searchTerm) !== -1
+          return acc || h.tags[key].toLowerCase().includes(filterText)
         }, false)
       } else {
         tagResult = false
       }
       return (
-        h.name.search(searchTerm) !== -1 ||
-        apps.search(searchTerm) !== -1 ||
+        h.name.toLowerCase().includes(filterText) ||
+        apps.toLowerCase().includes(filterText) ||
         tagResult
       )
     })

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -8,12 +8,6 @@ import {
   DROPDOWN_MENU_ITEM_THRESHOLD,
 } from 'shared/constants/index'
 
-// State for index of highlighted item
-// If there are filtered items, set highlighted item index to 0, otherwise set to null
-// Arrow keys will increment or decrement the highlighted item index (without going out of bounds)
-// Hitting enter will pass the highlighted item to this.props.onChoose
-// Hitting escape will reset highlightedItemIndex to null
-
 class Dropdown extends Component {
   constructor(props) {
     super(props)

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -138,6 +138,7 @@ class Dropdown extends Component {
       menuWidth,
       menuLabel,
       useAutoComplete,
+      selected,
     } = this.props
     const {filteredItems, highlightedItemIndex} = this.state
     const menuItems = useAutoComplete ? filteredItems : items
@@ -157,7 +158,8 @@ class Dropdown extends Component {
           return (
             <li
               className={classnames('dropdown-item', {
-                active: i === highlightedItemIndex,
+                highlight: i === highlightedItemIndex,
+                active: item.text === selected,
               })}
               key={i}
             >
@@ -208,6 +210,7 @@ class Dropdown extends Component {
       menuWidth,
       menuLabel,
       useAutoComplete,
+      selected,
     } = this.props
     const {filteredItems, highlightedItemIndex} = this.state
     const menuItems = useAutoComplete ? filteredItems : items
@@ -228,7 +231,8 @@ class Dropdown extends Component {
             return (
               <li
                 className={classnames('dropdown-item', {
-                  active: i === highlightedItemIndex,
+                  highlight: i === highlightedItemIndex,
+                  active: item.text === selected,
                 })}
                 key={i}
               >

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -34,7 +34,7 @@ class Dropdown extends Component {
     buttonSize: 'btn-sm',
     buttonColor: 'btn-info',
     menuWidth: '100%',
-    hasAutoComplete: false,
+    useAutoComplete: false,
   }
 
   handleClickOutside() {
@@ -137,15 +137,15 @@ class Dropdown extends Component {
       items,
       menuWidth,
       menuLabel,
-      hasAutoComplete,
+      useAutoComplete,
     } = this.props
     const {filteredItems, highlightedItemIndex} = this.state
-    const menuItems = hasAutoComplete ? filteredItems : items
+    const menuItems = useAutoComplete ? filteredItems : items
 
     return (
       <ul
         className={classnames('dropdown-menu', {
-          'dropdown-menu--no-highlight': hasAutoComplete,
+          'dropdown-menu--no-highlight': useAutoComplete,
         })}
         style={{width: menuWidth}}
       >
@@ -207,15 +207,15 @@ class Dropdown extends Component {
       items,
       menuWidth,
       menuLabel,
-      hasAutoComplete,
+      useAutoComplete,
     } = this.props
     const {filteredItems, highlightedItemIndex} = this.state
-    const menuItems = hasAutoComplete ? filteredItems : items
+    const menuItems = useAutoComplete ? filteredItems : items
 
     return (
       <ul
         className={classnames('dropdown-menu', {
-          'dropdown-menu--no-highlight': hasAutoComplete,
+          'dropdown-menu--no-highlight': useAutoComplete,
         })}
         style={{width: menuWidth, height: DROPDOWN_MENU_MAX_HEIGHT}}
       >
@@ -280,17 +280,17 @@ class Dropdown extends Component {
       iconName,
       buttonSize,
       buttonColor,
-      hasAutoComplete,
+      useAutoComplete,
     } = this.props
     const {isOpen, searchTerm, filteredItems} = this.state
-    const menuItems = hasAutoComplete ? filteredItems : items
+    const menuItems = useAutoComplete ? filteredItems : items
 
     return (
       <div
         onClick={this.handleClick}
         className={classnames(`dropdown ${className}`, {open: isOpen})}
       >
-        {hasAutoComplete && isOpen
+        {useAutoComplete && isOpen
           ? <div
               className={`dropdown-autocomplete dropdown-toggle ${buttonSize} ${buttonColor}`}
             >
@@ -358,7 +358,7 @@ Dropdown.propTypes = {
   buttonColor: string,
   menuWidth: string,
   menuLabel: string,
-  hasAutoComplete: bool,
+  useAutoComplete: bool,
 }
 
 export default OnClickOutside(Dropdown)

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -79,7 +79,7 @@ class Dropdown extends Component {
   handleFilterKeyPress(e) {
     const {filteredItems, highlightedItemIndex} = this.state
 
-    if (e.key === 'Enter' && filteredItems.length > 0) {
+    if (e.key === 'Enter' && filteredItems.length) {
       this.setState({isOpen: false})
       this.props.onChoose(filteredItems[highlightedItemIndex])
     }
@@ -89,18 +89,13 @@ class Dropdown extends Component {
     if (e.key === 'ArrowUp' && highlightedItemIndex > 0) {
       this.setState({highlightedItemIndex: highlightedItemIndex - 1})
     }
-    if (
-      e.key === 'ArrowDown' &&
-      highlightedItemIndex < filteredItems.length - 1
-    ) {
-      this.setState({highlightedItemIndex: highlightedItemIndex + 1})
-    }
-    if (
-      e.key === 'ArrowDown' &&
-      highlightedItemIndex === null &&
-      filteredItems.length
-    ) {
-      this.setState({highlightedItemIndex: 0})
+    if (e.key === 'ArrowDown') {
+      if (highlightedItemIndex < filteredItems.length - 1) {
+        this.setState({highlightedItemIndex: highlightedItemIndex + 1})
+      }
+      if (highlightedItemIndex === null && filteredItems.length) {
+        this.setState({highlightedItemIndex: 0})
+      }
     }
   }
 
@@ -325,7 +320,7 @@ class Dropdown extends Component {
         {isOpen && menuItems.length >= DROPDOWN_MENU_ITEM_THRESHOLD
           ? this.renderLongMenu()
           : null}
-        {isOpen && menuItems.length === 0
+        {isOpen && !menuItems.length
           ? <ul className="dropdown-menu">
               <li className="dropdown-empty">No matching items</li>
             </ul>

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -120,11 +120,11 @@ class Dropdown extends Component {
 
   applyFilter(searchTerm) {
     const {items} = this.props
-    const matchingItems = items.filter(item => {
-      if (item.text === null) {
-        return false
-      }
-      return item.text.toLowerCase().search(searchTerm.toLowerCase()) !== -1
+    const filterText = searchTerm.toLowerCase()
+    const matchingItems = items.filter(item =>
+      item.text.toLowerCase().includes(filterText)
+    )
+
     })
     this.setState({filteredItems: matchingItems})
     this.setState({highlightedItemIndex: 0})

--- a/ui/src/shared/components/Dropdown.js
+++ b/ui/src/shared/components/Dropdown.js
@@ -125,9 +125,10 @@ class Dropdown extends Component {
       item.text.toLowerCase().includes(filterText)
     )
 
+    this.setState({
+      filteredItems: matchingItems,
+      highlightedItemIndex: 0,
     })
-    this.setState({filteredItems: matchingItems})
-    this.setState({highlightedItemIndex: 0})
   }
 
   renderShortMenu() {

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -16,43 +16,9 @@ $dropdown-menu-max-height: 270px;
 .dropdown .dropdown-autocomplete {
   width: 120px; /* Default width */
 }
-.dropdown {
-  &-80 .dropdown-toggle,
-  &-80 .dropdown-autocomplete {width: 80px;}
-  &-90 .dropdown-toggle,
-  &-90 .dropdown-autocomplete {width: 90px;}
-  &-100 .dropdown-toggle,
-  &-100 .dropdown-autocomplete {width: 100px;}
-  &-110 .dropdown-toggle,
-  &-110 .dropdown-autocomplete {width: 110px;}
-  &-120 .dropdown-toggle,
-  &-120 .dropdown-autocomplete {width: 120px;}
-  &-130 .dropdown-toggle,
-  &-130 .dropdown-autocomplete {width: 130px;}
-  &-140 .dropdown-toggle,
-  &-140 .dropdown-autocomplete {width: 140px;}
-  &-150 .dropdown-toggle,
-  &-150 .dropdown-autocomplete {width: 150px;}
-  &-160 .dropdown-toggle,
-  &-160 .dropdown-autocomplete {width: 160px;}
-  &-170 .dropdown-toggle,
-  &-170 .dropdown-autocomplete {width: 170px;}
-  &-180 .dropdown-toggle,
-  &-180 .dropdown-autocomplete {width: 180px;}
-  &-190 .dropdown-toggle,
-  &-190 .dropdown-autocomplete {width: 190px;}
-  &-200 .dropdown-toggle,
-  &-200 .dropdown-autocomplete {width: 200px;}
-  &-210 .dropdown-toggle,
-  &-210 .dropdown-autocomplete {width: 210px;}
-  &-220 .dropdown-toggle,
-  &-220 .dropdown-autocomplete {width: 220px;}
-  &-230 .dropdown-toggle,
-  &-230 .dropdown-autocomplete {width: 230px;}
-  &-240 .dropdown-toggle,
-  &-240 .dropdown-autocomplete {width: 240px;}
-  &-250 .dropdown-toggle,
-  &-250 .dropdown-autocomplete {width: 250px;}
+@for $i from 8 through 30 {
+  &-#{$i * 10} .dropdown-toggle,
+  &-#{$i * 10} .dropdown-autocomplete { width: #{$i * 10}px; }
 }
 
 .dropdown-toggle {
@@ -109,13 +75,12 @@ $dropdown-menu-max-height: 270px;
   border: 0;
   color: $g20-white;
   padding: 0;
-  font-size: inherit;
   font-weight: 600;
 
-  .btn-xs & {padding: 0 18px 0 9px;}
-  .btn-sm & {padding: 0 18px 0 9px;}
-  .btn-md & {padding: 0 34px 0 17px;}
-  .btn-lg & {padding: 0 48px 0 24px;}
+  .btn-xs & {padding: 0 18px 0 9px; font-size: 12px;}
+  .btn-sm & {padding: 0 18px 0 9px; font-size: 13px;}
+  .btn-md & {padding: 0 34px 0 17px; font-size: 14px;}
+  .btn-lg & {padding: 0 48px 0 24px; font-size: 18px;}
 
   &::-webkit-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
   &::-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -84,7 +84,7 @@ $dropdown-menu-max-height: 270px;
 .dropdown .dropdown-toggle.btn-xs {
   height: 22px !important;
   line-height: 22px !important;
-  padding: 0 9px !important;
+  padding: 0 9px;
 }
 
 /*
@@ -93,7 +93,7 @@ $dropdown-menu-max-height: 270px;
 */
 .dropdown-autocomplete {
   position: relative;
-  padding: 0;
+  padding: 0 !important;
 
   &.btn-xs {height: 22px;}
   &.btn-sm {height: 30px;}
@@ -125,6 +125,14 @@ $dropdown-menu-max-height: 270px;
   &:focus {
     color: $g20-white;
   }
+}
+.dropdown-empty {
+  padding: 7px 9px;
+  font-size: 13px;
+  color: rgba(255,255,255,0.4);
+  font-weight: 500;
+  line-height: 15px;
+  @include no-user-select();
 }
 
 /*
@@ -242,6 +250,24 @@ $dropdown-menu-max-height: 270px;
   }
 }
 
+/*
+    Dropdown Menu (only js highlighting, works with autocomplete feature)
+    ----------------------------------------------
+*/
+.dropdown-menu.dropdown-menu--no-highlight {
+  li.dropdown-item {
+
+    &:hover {
+      background: none;
+      background-color: transparent;
+    }
+  }
+  li.dropdown-item.active {
+    &, &:hover {
+      @include gradient-h($c-laser, $c-pool);
+    }
+  }
+}
 /*
     Dropdown Header
     ----------------------------------------------

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -16,11 +16,12 @@ $dropdown-menu-max-height: 270px;
 .dropdown .dropdown-autocomplete {
   width: 120px; /* Default width */
 }
-@for $i from 8 through 30 {
-  &-#{$i * 10} .dropdown-toggle,
-  &-#{$i * 10} .dropdown-autocomplete { width: #{$i * 10}px; }
+.dropdown {
+  @for $i from 8 through 30 {
+    &-#{$i * 10} .dropdown-toggle,
+    &-#{$i * 10} .dropdown-autocomplete { width: #{$i * 10}px; }
+  }
 }
-
 .dropdown-toggle {
   position: relative;
   text-align: left;

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -75,17 +75,17 @@ $dropdown-menu-max-height: 270px;
   border: 0;
   color: $g20-white;
   padding: 0;
-  font-weight: 600;
+  font-weight: 500;
 
   .btn-xs & {padding: 0 18px 0 9px; font-size: 12px;}
   .btn-sm & {padding: 0 18px 0 9px; font-size: 13px;}
   .btn-md & {padding: 0 34px 0 17px; font-size: 14px;}
   .btn-lg & {padding: 0 48px 0 24px; font-size: 18px;}
 
-  &::-webkit-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
-  &::-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
-  &:-ms-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
-  &:-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
+  &::-webkit-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 500 !important; }
+  &::-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 500 !important; }
+  &:-ms-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 500 !important; }
+  &:-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 500 !important; }
 
   &:focus {
     color: $g20-white;
@@ -118,6 +118,9 @@ $dropdown-menu-max-height: 270px;
     position: relative;
     width: 100%;
 
+    &.active {
+      @include gradient-h($c-sapphire, $c-pool);
+    }
     &:hover {
       @include gradient-h($c-laser, $c-pool);
     }
@@ -150,7 +153,7 @@ $dropdown-menu-max-height: 270px;
       @include gradient-h($c-ocean, $c-pool);
     }
   }
-  li.dropdown-item.active {
+  li.dropdown-item.highlight {
     &, &:hover {
       @include gradient-h($c-laser, $c-pool);
     }
@@ -179,7 +182,7 @@ $dropdown-menu-max-height: 270px;
       color: $g20-white !important;
     }
   }
-  li.dropdown-item.active {
+  li.dropdown-item.highlight {
     &, &:hover {
       @include gradient-h($c-laser, $c-rainforest);
     }
@@ -203,7 +206,7 @@ $dropdown-menu-max-height: 270px;
       color: $g20-white !important;
     }
   }
-  li.dropdown-item.active {
+  li.dropdown-item.highlight {
     &, &:hover {
       @include gradient-h($c-laser, $c-comet);
     }
@@ -227,7 +230,7 @@ $dropdown-menu-max-height: 270px;
       background-color: transparent;
     }
   }
-  li.dropdown-item.active {
+  li.dropdown-item.highlight {
     &, &:hover {
       @include gradient-h($c-laser, $c-pool);
     }

--- a/ui/src/style/components/dropdown.scss
+++ b/ui/src/style/components/dropdown.scss
@@ -12,28 +12,47 @@ $dropdown-menu-max-height: 270px;
     Generic width modifiers
     Use instead of creating new classes if possible
 */
-.dropdown .dropdown-toggle {
+.dropdown .dropdown-toggle,
+.dropdown .dropdown-autocomplete {
   width: 120px; /* Default width */
 }
 .dropdown {
-  &-80 .dropdown-toggle {width: 80px;}
-  &-90 .dropdown-toggle {width: 90px;}
-  &-100 .dropdown-toggle {width: 100px;}
-  &-110 .dropdown-toggle {width: 110px;}
-  &-120 .dropdown-toggle {width: 120px;}
-  &-130 .dropdown-toggle {width: 130px;}
-  &-140 .dropdown-toggle {width: 140px;}
-  &-150 .dropdown-toggle {width: 150px;}
-  &-160 .dropdown-toggle {width: 160px;}
-  &-170 .dropdown-toggle {width: 170px;}
-  &-180 .dropdown-toggle {width: 180px;}
-  &-190 .dropdown-toggle {width: 190px;}
-  &-200 .dropdown-toggle {width: 200px;}
-  &-210 .dropdown-toggle {width: 210px;}
-  &-220 .dropdown-toggle {width: 220px;}
-  &-230 .dropdown-toggle {width: 230px;}
-  &-240 .dropdown-toggle {width: 240px;}
-  &-250 .dropdown-toggle {width: 250px;}
+  &-80 .dropdown-toggle,
+  &-80 .dropdown-autocomplete {width: 80px;}
+  &-90 .dropdown-toggle,
+  &-90 .dropdown-autocomplete {width: 90px;}
+  &-100 .dropdown-toggle,
+  &-100 .dropdown-autocomplete {width: 100px;}
+  &-110 .dropdown-toggle,
+  &-110 .dropdown-autocomplete {width: 110px;}
+  &-120 .dropdown-toggle,
+  &-120 .dropdown-autocomplete {width: 120px;}
+  &-130 .dropdown-toggle,
+  &-130 .dropdown-autocomplete {width: 130px;}
+  &-140 .dropdown-toggle,
+  &-140 .dropdown-autocomplete {width: 140px;}
+  &-150 .dropdown-toggle,
+  &-150 .dropdown-autocomplete {width: 150px;}
+  &-160 .dropdown-toggle,
+  &-160 .dropdown-autocomplete {width: 160px;}
+  &-170 .dropdown-toggle,
+  &-170 .dropdown-autocomplete {width: 170px;}
+  &-180 .dropdown-toggle,
+  &-180 .dropdown-autocomplete {width: 180px;}
+  &-190 .dropdown-toggle,
+  &-190 .dropdown-autocomplete {width: 190px;}
+  &-200 .dropdown-toggle,
+  &-200 .dropdown-autocomplete {width: 200px;}
+  &-210 .dropdown-toggle,
+  &-210 .dropdown-autocomplete {width: 210px;}
+  &-220 .dropdown-toggle,
+  &-220 .dropdown-autocomplete {width: 220px;}
+  &-230 .dropdown-toggle,
+  &-230 .dropdown-autocomplete {width: 230px;}
+  &-240 .dropdown-toggle,
+  &-240 .dropdown-autocomplete {width: 240px;}
+  &-250 .dropdown-toggle,
+  &-250 .dropdown-autocomplete {width: 250px;}
 }
 
 .dropdown-toggle {
@@ -69,6 +88,46 @@ $dropdown-menu-max-height: 270px;
 }
 
 /*
+    AutoComplete Field
+    ----------------------------------------------
+*/
+.dropdown-autocomplete {
+  position: relative;
+  padding: 0;
+
+  &.btn-xs {height: 22px;}
+  &.btn-sm {height: 30px;}
+  &.btn-md {height: 36px;}
+  &.btn-lg {height: 50px;}
+}
+.dropdown-autocomplete--input {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  outline: none;
+  background-color: transparent;
+  border: 0;
+  color: $g20-white;
+  padding: 0;
+  font-size: inherit;
+  font-weight: 600;
+
+  .btn-xs & {padding: 0 18px 0 9px;}
+  .btn-sm & {padding: 0 18px 0 9px;}
+  .btn-md & {padding: 0 34px 0 17px;}
+  .btn-lg & {padding: 0 48px 0 24px;}
+
+  &::-webkit-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
+  &::-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
+  &:-ms-input-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
+  &:-moz-placeholder { color: rgba(255,255,255,0.5); font-weight: 600 !important; }
+
+  &:focus {
+    color: $g20-white;
+  }
+}
+
+/*
     Dropdown Menu
     ----------------------------------------------
 */
@@ -99,7 +158,7 @@ $dropdown-menu-max-height: 270px;
     padding: 7px 9px;
     font-size: 13px;
     line-height: 15px;
-    font-weight: 500;
+    font-weight: 500 !important;
     color: $c-yeti !important;
     background-color: transparent;
     transition:
@@ -116,6 +175,16 @@ $dropdown-menu-max-height: 270px;
     }
     &:focus {
       @include gradient-h($c-ocean, $c-pool);
+    }
+  }
+  li.dropdown-item.active {
+    &, &:hover {
+      @include gradient-h($c-laser, $c-pool);
+    }
+    > a {
+      background: none;
+      background-color: transparent;
+      color: $g20-white;
     }
   }
 }
@@ -137,6 +206,16 @@ $dropdown-menu-max-height: 270px;
       color: $g20-white !important;
     }
   }
+  li.dropdown-item.active {
+    &, &:hover {
+      @include gradient-h($c-laser, $c-rainforest);
+    }
+    > a {
+      background: none;
+      background-color: transparent;
+      color: $g20-white;
+    }
+  }
 }
 .dropdown.dropdown-chronograf .dropdown-menu {
   @include custom-scrollbar($c-comet, $c-potassium);
@@ -149,6 +228,16 @@ $dropdown-menu-max-height: 270px;
     color: $c-twilight !important;
     &:hover {
       color: $g20-white !important;
+    }
+  }
+  li.dropdown-item.active {
+    &, &:hover {
+      @include gradient-h($c-laser, $c-comet);
+    }
+    > a {
+      background: none;
+      background-color: transparent;
+      color: $g20-white;
     }
   }
 }

--- a/ui/src/style/components/template-control-bar.scss
+++ b/ui/src/style/components/template-control-bar.scss
@@ -68,6 +68,14 @@ $template-control--min-height: 52px;
       font-size: 12px;
       font-family: $code-font;
     }
+    li.dropdown-item.active {
+      &, &:hover {@include gradient-h($c-comet,$c-pool);}
+      > a {
+        color: $g20-white;
+        background: none;
+        background-color: transparent;
+      }
+    }
   }
 }
 .template-control--label {

--- a/ui/src/style/components/template-control-bar.scss
+++ b/ui/src/style/components/template-control-bar.scss
@@ -57,13 +57,13 @@ $template-control--min-height: 52px;
   }
   .dropdown-menu {
     @include gradient-h($c-star,$c-pool);
-    @include custom-scrollbar-round($c-pool,$c-laser);
 
     li.dropdown-item {
       &, &:hover {
         background: none;
         background-color: transparent;
       }
+      &.active {@include gradient-h($c-amethyst,$c-pool);}
     }
     li.dropdown-item > a {
       &, &:focus {background: none;}
@@ -71,7 +71,7 @@ $template-control--min-height: 52px;
       font-size: 12px;
       font-family: $code-font;
     }
-    li.dropdown-item.active {
+    li.dropdown-item.highlight {
       &, &:hover {@include gradient-h($c-comet,$c-pool);}
       > a {
         color: $g20-white;

--- a/ui/src/style/components/template-control-bar.scss
+++ b/ui/src/style/components/template-control-bar.scss
@@ -60,7 +60,10 @@ $template-control--min-height: 52px;
     @include custom-scrollbar-round($c-pool,$c-laser);
 
     li.dropdown-item {
-      &:hover {@include gradient-h($c-comet,$c-pool);}
+      &, &:hover {
+        background: none;
+        background-color: transparent;
+      }
     }
     li.dropdown-item > a {
       &, &:focus {background: none;}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1462 

### The problem
- Sometimes a dropdown will have a large amount of items in the list, and manually scrolling is frustrating
- Also, there was some confusion between #1462 and the PR #1474 that got merged, so this PR also reverts those changes and then updates them to be consistent with how filtering is now being done app-wide.

### The Solution
- Option for any dropdown to use autocomplete
- Switches to a text input on click, matches as you type
- Can use up/down arrows to change selection
- Esc cancels the action
- Enter confirms selection (if there is one)

**Thanks to @jaredscheib for helping me do the javascripts for this one**

![tempvar-autocomplete](https://cloud.githubusercontent.com/assets/2433762/26180035/cc9771e0-3b1b-11e7-81ac-85a0a1b94bd0.gif)


