### PR TITLE
After the query is parsed, return query string to :dashboardTime:

### DIFF
--- a/influx/query.go
+++ b/influx/query.go
@@ -21,6 +21,10 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 		return chronograf.QueryConfig{}, err
 	}
 
+	if itsDashboardTime {
+		influxQL = strings.Replace(influxQL, "now() - 15m", ":dashboardTime:", 1)
+	}
+
 	raw := chronograf.QueryConfig{
 		RawText: &influxQL,
 		Fields:  []chronograf.Field{},


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1502

### The problem
While we were putting `:dashboardTime:` back in the queryConfig, we were neglecting to replace it in the original query string. Turns out the original query string is what eventually becomes `rawText`.

### The Solution
Replace `now() - 15m` with `:dashboardTime:` in the original string as well