### PR TITLE
Actually dedupe and remove whitespace characters from Template Variable input (and selectors)

### DIFF
--- a/ui/src/dashboards/components/TemplateControlBar.js
+++ b/ui/src/dashboards/components/TemplateControlBar.js
@@ -25,7 +25,7 @@ const TemplateControlBar = ({
               items={items}
               buttonSize="btn-xs"
               useAutoComplete={true}
-              selected={selectedText || 'Loading...'}
+              selected={selectedText || '(No values)'}
               onChoose={item =>
                 onSelectTemplate(id, [item].map(x => omit(x, 'text')))}
             />

--- a/ui/src/dashboards/components/TemplateVariableRow.js
+++ b/ui/src/dashboards/components/TemplateVariableRow.js
@@ -25,6 +25,8 @@ import generateTemplateVariableQuery
 import {errorThrown as errorThrownAction} from 'shared/actions/errors'
 import {publishAutoDismissingNotification} from 'shared/dispatchers'
 
+const compact = values => uniq(values).filter(value => /\S/.test(value))
+
 const RowValues = ({
   selectedType,
   values = [],
@@ -296,10 +298,7 @@ class RowWrapper extends Component {
           parsedData = await this.runTemplateVariableQuery(source, queryConfig)
         }
 
-        const sanitize = values =>
-          uniq(values).filter(value => /\S/.test(value))
-
-        onRunQuerySuccess(template, queryConfig, sanitize(parsedData), tempVar)
+        onRunQuerySuccess(template, queryConfig, compact(parsedData), tempVar)
       } catch (error) {
         onRunQueryFailure(error)
       }

--- a/ui/src/dashboards/components/TemplateVariableRow.js
+++ b/ui/src/dashboards/components/TemplateVariableRow.js
@@ -32,9 +32,7 @@ const RowValues = ({
   onStartEdit,
   autoFocusTarget,
 }) => {
-  const _values = uniq(values.map(({value}) => value))
-    .filter(value => /\S/.test(value))
-    .join(', ')
+  const _values = values.map(v => v.value).join(', ')
 
   if (selectedType === 'csv') {
     return (
@@ -297,7 +295,11 @@ class RowWrapper extends Component {
         } else {
           parsedData = await this.runTemplateVariableQuery(source, queryConfig)
         }
-        onRunQuerySuccess(template, queryConfig, parsedData, tempVar)
+
+        const sanitize = values =>
+          uniq(values).filter(value => /\S/.test(value))
+
+        onRunQuerySuccess(template, queryConfig, sanitize(parsedData), tempVar)
       } catch (error) {
         onRunQueryFailure(error)
       }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1415

### The problem
User could input whitespace and duplicate values into CSV when adding a Template Variable. The Previous PR (#1485) did not actually prevent the values from being saved, rather just removed them from view in the Template Variable Manager.

### The Solution
- Actually remove the values from their respective data set altogether.
<img width="297" alt="screen shot 2017-05-18 at 3 20 28 pm" src="https://cloud.githubusercontent.com/assets/6403018/26225761/b1d0d6cc-3bdd-11e7-8c95-599af0f2eef6.png">
<img width="99" alt="screen shot 2017-05-18 at 3 20 33 pm" src="https://cloud.githubusercontent.com/assets/6403018/26225760/b1d004c2-3bdd-11e7-85ce-1969078d7317.png">
<img width="160" alt="screen shot 2017-05-18 at 3 20 40 pm" src="https://cloud.githubusercontent.com/assets/6403018/26225759/b1cd7e82-3bdd-11e7-9ca3-b8042f0bef33.png">

- Changes the `Loading...` text in an empty TV selector to `(No values)`
<img width="166" alt="screen shot 2017-05-18 at 3 21 26 pm" src="https://cloud.githubusercontent.com/assets/6403018/26225755/ad5c4310-3bdd-11e7-91c1-caa7d5ee73b9.png">

- Makes the `v => v.value` syntax change requested by @lukevmorris in the previous PR.