### PR TITLE
WIP Prevent Visualization legends from falling off screen-bottom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   1. [#1426](https://github.com/influxdata/chronograf/issues/1426): Fix graph loading spinner
   1. [#1485](https://github.com/influxdata/chronograf/pull/1485): Filter out any template variable values that are empty, whitespace, or duplicates
   1. [#1484](https://github.com/influxdata/chronograf/pull/1484): Allow user to select SingleStat as Visualization Type before adding any queries and continue to be able to click Add Query
+  1. [#1505](https://github.com/influxdata/chronograf/pull/1505): Prevent Visualization legends from falling off screen-bottom
 
 ### Features
   1. [#1477](https://github.com/influxdata/chronograf/pull/1477): Add ability to log alerts

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -41,7 +41,6 @@ export default React.createClass({
       value: string,
       rangeValue: string,
     }),
-    legendOnBottom: bool,
   },
 
   getDefaultProps() {
@@ -49,7 +48,6 @@ export default React.createClass({
       containerStyle: {},
       isGraphFilled: true,
       overrideLineColors: null,
-      legendOnBottom: false,
     }
   },
 
@@ -62,7 +60,7 @@ export default React.createClass({
   componentDidMount() {
     const timeSeries = this.getTimeSeries()
     // dygraphSeries is a legend label and its corresponding y-axis e.g. {legendLabel1: 'y', legendLabel2: 'y2'};
-    const {ranges, dygraphSeries, ruleValues, legendOnBottom} = this.props
+    const {ranges, dygraphSeries, ruleValues} = this.props
 
     const refs = this.refs
     const graphContainerNode = refs.graphContainer
@@ -104,12 +102,14 @@ export default React.createClass({
         const graphRect = graphContainerNode.getBoundingClientRect()
         const legendRect = legendContainerNode.getBoundingClientRect()
         const graphWidth = graphRect.width + 32 // Factoring in padding from parent
+        const graphHeight = graphRect.height
+        const graphBottom = graphRect.bottom
         const legendWidth = legendRect.width
         const legendHeight = legendRect.height
         const screenHeight = window.innerHeight
         const legendMaxLeft = graphWidth - legendWidth / 2
         const trueGraphX = e.pageX - graphRect.left
-        let legendTop = graphRect.height + 0
+
         let legendLeft = trueGraphX
 
         // Enforcing max & min legend offsets
@@ -119,17 +119,16 @@ export default React.createClass({
           legendLeft = legendMaxLeft
         }
 
-        // Enforcing overflow of legend contents
-        if (graphRect.bottom + legendHeight > screenHeight) {
-          legendTop = graphRect.top - legendHeight
-        }
+        // Disallow screen overflow of legend
+        const legendBottomExceedsScreen =
+          graphBottom + legendHeight > screenHeight
+
+        const legendTop = legendBottomExceedsScreen
+          ? graphHeight + 8 - legendHeight
+          : graphHeight + 8
 
         legendContainerNode.style.left = `${legendLeft}px`
-        if (legendOnBottom) {
-          legendContainerNode.style.bottom = '4px'
-        } else {
-          legendContainerNode.style.top = `${legendTop}px`
-        }
+        legendContainerNode.style.top = `${legendTop}px`
 
         setMarker(points)
       },

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -105,15 +105,23 @@ export default React.createClass({
         const legendRect = legendContainerNode.getBoundingClientRect()
         const graphWidth = graphRect.width + 32 // Factoring in padding from parent
         const legendWidth = legendRect.width
+        const legendHeight = legendRect.height
+        const screenHeight = window.innerHeight
         const legendMaxLeft = graphWidth - legendWidth / 2
         const trueGraphX = e.pageX - graphRect.left
-        const legendTop = graphRect.height + 0
+        let legendTop = graphRect.height + 0
         let legendLeft = trueGraphX
+
         // Enforcing max & min legend offsets
         if (trueGraphX < legendWidth / 2) {
           legendLeft = legendWidth / 2
         } else if (trueGraphX > legendMaxLeft) {
           legendLeft = legendMaxLeft
+        }
+
+        // Enforcing overflow of legend contents
+        if (graphRect.bottom + legendHeight > screenHeight) {
+          legendTop = graphRect.top - legendHeight
         }
 
         legendContainerNode.style.left = `${legendLeft}px`

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -83,7 +83,6 @@ export default React.createClass({
       showSingleStat,
       displayOptions,
       ruleValues,
-      isInDataExplorer,
     } = this.props
     const {labels, timeSeries, dygraphSeries} = this._timeSeries
 
@@ -142,7 +141,6 @@ export default React.createClass({
           dygraphSeries={dygraphSeries}
           ranges={ranges || this.getRanges()}
           ruleValues={ruleValues}
-          legendOnBottom={isInDataExplorer}
         />
         {showSingleStat
           ? <div className="graph-single-stat single-stat">{roundedValue}</div>

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -33,6 +33,7 @@
   border-radius: 3px;
   font-weight: 600;
   line-height: 13px;
+  pointer-events: none;
 
   &.hidden {
     display: none;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1473 

### The problem
Graph legend (hover tooltip) would at times appear partly below the screen, making the data unreadable.

### The Solution
Make legends stop playing limbo.
