### PR TITLE
Enable expected Enter/Escape keys on Dashboard rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.3.2 [unreleased]
+
+### Bug Fixes
+
+### Features
+
+### UI Improvements
+  1. [#1508](https://github.com/influxdata/chronograf/pull/1508): The enter and escape keys now perform as expected when renaming dashboard headers.
+
 ## v1.3.1 [unreleased]
 
 ### Bug Fixes

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -8,10 +8,26 @@ class DashboardEditHeader extends Component {
     const {dashboard: {name}} = props
     this.state = {name}
     this.handleChange = ::this.handleChange
+    this.handleFormSubmit = ::this.handleFormSubmit
+    this.handleKeyUp = ::this.handleKeyUp
   }
 
   handleChange(name) {
     this.setState({name})
+  }
+
+  handleFormSubmit(e) {
+    e.preventDefault()
+    const name = e.target.name.value
+    this.props.onSave(name)
+  }
+
+  handleKeyUp(e) {
+    const {dashboard: {name}, onCancel} = this.props
+    if (e.key === 'Escape') {
+      this.setState({name})
+      onCancel()
+    }
   }
 
   render() {
@@ -21,15 +37,17 @@ class DashboardEditHeader extends Component {
     return (
       <div className="page-header full-width">
         <div className="page-header__container">
-          <div className="page-header__left">
+          <form className="page-header__left" onSubmit={this.handleFormSubmit}>
             <input
               className="page-header--editing"
+              name="name"
               autoFocus={true}
               value={name}
               placeholder="Name this Dashboard"
               onChange={e => this.handleChange(e.target.value)}
+              onKeyUp={this.handleKeyUp}
             />
-          </div>
+          </form>
           <ConfirmButtons item={name} onConfirm={onSave} onCancel={onCancel} />
         </div>
       </div>

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -23,9 +23,8 @@ class DashboardEditHeader extends Component {
   }
 
   handleKeyUp(e) {
-    const {dashboard: {name}, onCancel} = this.props
+    const {onCancel} = this.props
     if (e.key === 'Escape') {
-      this.setState({name})
       onCancel()
     }
   }

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -46,6 +46,7 @@ class DashboardEditHeader extends Component {
               placeholder="Name this Dashboard"
               onChange={e => this.handleChange(e.target.value)}
               onKeyUp={this.handleKeyUp}
+              autoComplete="off"
             />
           </form>
           <ConfirmButtons item={name} onConfirm={onSave} onCancel={onCancel} />


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1420 #1421 

### The problem
Pressing escape for cancel or enter for submit doesn't do the expected thing when renaming a dashboard.

### The Solution
Use a form and onSubmit handler for the title, and add a onKeyUp handler that detects escape and returns the contents of the component to its original state while canceling editing.
