### PR TITLE
Kapacitor UI/UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### UI Improvements
   1. [#1508](https://github.com/influxdata/chronograf/pull/1508): The enter and escape keys now perform as expected when renaming dashboard headers.
+  1. [#1524](https://github.com/influxdata/chronograf/pull/1524): Rewrite UI copy in Kapacitor Node configuration to be more clear
 
 ## v1.3.1 [unreleased]
 

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -5,7 +5,7 @@ import FancyScrollbar from 'shared/components/FancyScrollbar'
 
 class KapacitorForm extends Component {
   render() {
-    const {onInputChange, onReset, kapacitor, onSubmit} = this.props
+    const {onInputChange, onReset, kapacitor, onSubmit, exists} = this.props
     const {url, name, username, password} = kapacitor
 
     return (
@@ -90,7 +90,7 @@ class KapacitorForm extends Component {
                           Reset
                         </button>
                         <button className="btn btn-success" type="submit">
-                          Connect
+                          {exists ? 'Connect' : 'Update'}
                         </button>
                       </div>
                     </form>

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -90,7 +90,7 @@ class KapacitorForm extends Component {
                           Reset
                         </button>
                         <button className="btn btn-success" type="submit">
-                          {exists ? 'Connect' : 'Update'}
+                          {exists ? 'Update' : 'Connect'}
                         </button>
                       </div>
                     </form>

--- a/ui/src/kapacitor/components/config/AlertaConfig.js
+++ b/ui/src/kapacitor/components/config/AlertaConfig.js
@@ -79,7 +79,7 @@ const AlertaConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update Alerta Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/AlertaConfig.js
+++ b/ui/src/kapacitor/components/config/AlertaConfig.js
@@ -77,9 +77,9 @@ const AlertaConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/HipChatConfig.js
+++ b/ui/src/kapacitor/components/config/HipChatConfig.js
@@ -76,9 +76,9 @@ const HipchatConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/HipChatConfig.js
+++ b/ui/src/kapacitor/components/config/HipChatConfig.js
@@ -78,7 +78,7 @@ const HipchatConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update HipChat Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/OpsGenieConfig.js
+++ b/ui/src/kapacitor/components/config/OpsGenieConfig.js
@@ -97,9 +97,9 @@ const OpsGenieConfig = React.createClass({
           tags={currentRecipients}
         />
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/OpsGenieConfig.js
+++ b/ui/src/kapacitor/components/config/OpsGenieConfig.js
@@ -99,7 +99,7 @@ const OpsGenieConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update OpsGenie Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/PagerDutyConfig.js
+++ b/ui/src/kapacitor/components/config/PagerDutyConfig.js
@@ -58,9 +58,9 @@ const PagerDutyConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/PagerDutyConfig.js
+++ b/ui/src/kapacitor/components/config/PagerDutyConfig.js
@@ -60,7 +60,7 @@ const PagerDutyConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update PagerDuty Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SMTPConfig.js
+++ b/ui/src/kapacitor/components/config/SMTPConfig.js
@@ -91,7 +91,7 @@ const SMTPConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update SMTP Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SMTPConfig.js
+++ b/ui/src/kapacitor/components/config/SMTPConfig.js
@@ -89,9 +89,9 @@ const SMTPConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SensuConfig.js
+++ b/ui/src/kapacitor/components/config/SensuConfig.js
@@ -51,7 +51,7 @@ const SensuConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update Sensu Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SensuConfig.js
+++ b/ui/src/kapacitor/components/config/SensuConfig.js
@@ -49,9 +49,9 @@ const SensuConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SlackConfig.js
+++ b/ui/src/kapacitor/components/config/SlackConfig.js
@@ -79,7 +79,7 @@ const SlackConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update Slack Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/SlackConfig.js
+++ b/ui/src/kapacitor/components/config/SlackConfig.js
@@ -61,7 +61,7 @@ const SlackConfig = React.createClass({
           <RedactedInput
             defaultValue={url}
             id="url"
-            refFunc={r => this.url = r}
+            refFunc={r => (this.url = r)}
           />
         </div>
 
@@ -72,14 +72,14 @@ const SlackConfig = React.createClass({
             id="slack-channel"
             type="text"
             placeholder="#alerts"
-            ref={r => this.channel = r}
+            ref={r => (this.channel = r)}
             defaultValue={channel || ''}
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/TalkConfig.js
+++ b/ui/src/kapacitor/components/config/TalkConfig.js
@@ -53,7 +53,7 @@ const TalkConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update Talk Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/TalkConfig.js
+++ b/ui/src/kapacitor/components/config/TalkConfig.js
@@ -51,9 +51,9 @@ const TalkConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/TelegramConfig.js
+++ b/ui/src/kapacitor/components/config/TelegramConfig.js
@@ -161,7 +161,7 @@ const TelegramConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update Telegram Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/TelegramConfig.js
+++ b/ui/src/kapacitor/components/config/TelegramConfig.js
@@ -159,9 +159,9 @@ const TelegramConfig = React.createClass({
           </div>
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/VictorOpsConfig.js
+++ b/ui/src/kapacitor/components/config/VictorOpsConfig.js
@@ -65,9 +65,9 @@ const VictorOpsConfig = React.createClass({
           />
         </div>
 
-        <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3">
-          <button className="btn btn-block btn-primary" type="submit">
-            Save
+        <div className="form-group-submit col-xs-12 text-center">
+          <button className="btn btn-primary" type="submit">
+            Update Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/components/config/VictorOpsConfig.js
+++ b/ui/src/kapacitor/components/config/VictorOpsConfig.js
@@ -67,7 +67,7 @@ const VictorOpsConfig = React.createClass({
 
         <div className="form-group-submit col-xs-12 text-center">
           <button className="btn btn-primary" type="submit">
-            Update Config
+            Update VictorOps Config
           </button>
         </div>
       </form>

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -93,7 +93,7 @@ class KapacitorPage extends Component {
           router.push(`/sources/${source.id}/kapacitors/${data.id}/edit`)
           addFlashMessage({
             type: 'success',
-            text: 'Kapacitor Created! Configuring endpoints is optional',
+            text: 'Kapacitor Created! Configuring endpoints is optional.',
           })
         })
         .catch(() => {

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -91,7 +91,10 @@ class KapacitorPage extends Component {
           this.setState({kapacitor: data})
           this.checkKapacitorConnection(data)
           router.push(`/sources/${source.id}/kapacitors/${data.id}/edit`)
-          addFlashMessage({type: 'success', text: 'Kapacitor Created!'})
+          addFlashMessage({
+            type: 'success',
+            text: 'Kapacitor Created! Configuring endpoints is optional',
+          })
         })
         .catch(() => {
           addFlashMessage({


### PR DESCRIPTION
  - [x] CHANGELOG.md updated
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1496 

### The problem
- Language in the UI is a little confusing

### The Solution
- Followed @nhaugo's suggestions and rewrote the micro copy
- Success alert now reads `Kapacitor Created! Configuring endpoints is optional`
- When creating a new kapacitor, the connection details button reads `Connect`, when editing a kapacitor the button reads `Update`
- Instead of the giant blue `Save` button, it now reads (for example) `Update OpsGenie Config` which more accurately describes what the button does

