### PR TITLE
Update query config field ordering to always match input query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.2.0 [unreleased]
 
 ### Bug Fixes
+1. [#1530](https://github.com/influxdata/chronograf/pull/1530): Update query config field ordering to always match input query
 
 ### Features
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1158 

### The problem
Query config fields were assumed to remain in the same order as they were submitted, but their order could arbitrarily change.

### The Solution
Server now preserves the order of the field keys by preserving the initial order of the field keys instead of using a `map`, which randomly reorders.