### PR TITLE
Enforce Kapacitor alert schema agreement between client and server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#1530](https://github.com/influxdata/chronograf/pull/1530): Update query config field ordering to always match input query
+1. [#1535](https://github.com/influxdata/chronograf/pull/1535): Fix add field functions to existing Kapacitor rules
 
 ### Features
 

--- a/server/kapacitors.go
+++ b/server/kapacitors.go
@@ -451,8 +451,7 @@ func (h *Service) KapacitorRulesPut(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusInternalServerError, err.Error(), h.Logger)
 		return
 	}
-
-	res := newAlertResponse(req, task.TICKScript, task.Href, task.HrefOutput, "enabled", srv.SrcID, srv.ID)
+	res := newAlertResponse(task.Rule, task.TICKScript, task.Href, task.HrefOutput, "enabled", srv.SrcID, srv.ID)
 	encodeJSON(w, http.StatusOK, res, h.Logger)
 }
 

--- a/server/kapacitors_test.go
+++ b/server/kapacitors_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/influxdata/chronograf"
+)
+
+func TestValidRuleRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		rule    chronograf.AlertRule
+		wantErr bool
+	}{
+		{
+			name: "No every with functions",
+			rule: chronograf.AlertRule{
+				Query: &chronograf.QueryConfig{
+					Fields: []chronograf.Field{
+						{
+							Field: "oldmanpeabody",
+							Funcs: []string{"max"},
+						},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "With every",
+			rule: chronograf.AlertRule{
+				Every: "10s",
+				Query: &chronograf.QueryConfig{
+					Fields: []chronograf.Field{
+						{
+							Field: "oldmanpeabody",
+							Funcs: []string{"max"},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "No query config",
+			rule:    chronograf.AlertRule{},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidRuleRequest(tt.rule); (err != nil) != tt.wantErr {
+				t.Errorf("ValidRuleRequest() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/ui/spec/kapacitor/reducers/rulesSpec.js
+++ b/ui/spec/kapacitor/reducers/rulesSpec.js
@@ -4,6 +4,8 @@ import {ALERT_NODES_ACCESSORS} from 'src/kapacitor/constants'
 
 import {
   chooseTrigger,
+  addEvery,
+  removeEvery,
   updateRuleValues,
   updateDetails,
   updateMessage,
@@ -38,6 +40,23 @@ describe('Kapacitor.Reducers.rules', () => {
     expect(newState[ruleID].values).to.equal(defaultRuleConfigs.threshold)
   })
 
+  it('can update the every', () => {
+    const ruleID = 1
+    const initialState = {
+      [ruleID]: {
+        id: ruleID,
+        queryID: 988,
+        every: null,
+      },
+    }
+
+    let newState = reducer(initialState, addEvery(ruleID, '30s'))
+    expect(newState[ruleID].every).to.equal('30s')
+
+    newState = reducer(initialState, removeEvery(ruleID))
+    expect(newState[ruleID].every).to.equal(null)
+  })
+
   it('can update the values', () => {
     const ruleID = 1
     const initialState = {
@@ -50,11 +69,17 @@ describe('Kapacitor.Reducers.rules', () => {
     }
 
     const newDeadmanValues = {duration: '5m'}
-    const newState = reducer(initialState, updateRuleValues(ruleID, 'deadman', newDeadmanValues))
+    const newState = reducer(
+      initialState,
+      updateRuleValues(ruleID, 'deadman', newDeadmanValues)
+    )
     expect(newState[ruleID].values).to.equal(newDeadmanValues)
 
     const newRelativeValues = {func: 'max', change: 'change'}
-    const finalState = reducer(newState, updateRuleValues(ruleID, 'relative', newRelativeValues))
+    const finalState = reducer(
+      newState,
+      updateRuleValues(ruleID, 'relative', newRelativeValues)
+    )
     expect(finalState[ruleID].trigger).to.equal('relative')
     expect(finalState[ruleID].values).to.equal(newRelativeValues)
   })
@@ -110,7 +135,10 @@ describe('Kapacitor.Reducers.rules', () => {
           .services('a b c')
     `
 
-    let newState = reducer(initialState, updateAlertNodes(ruleID, 'alerta', tickScript))
+    let newState = reducer(
+      initialState,
+      updateAlertNodes(ruleID, 'alerta', tickScript)
+    )
     const expectedStr = `alerta().resource('Hostname or service').event('Something went wrong').environment('Development').group('Dev. Servers').services('a b c')`
     let actualStr = ALERT_NODES_ACCESSORS.alerta(newState[ruleID])
 
@@ -184,7 +212,10 @@ describe('Kapacitor.Reducers.rules', () => {
       },
     }
 
-    const newState = reducer(initialState, updateRuleStatusSuccess(ruleID, status))
+    const newState = reducer(
+      initialState,
+      updateRuleStatusSuccess(ruleID, status)
+    )
     expect(newState[ruleID].status).to.equal(status)
   })
 })

--- a/ui/spec/kapacitor/reducers/rulesSpec.js
+++ b/ui/spec/kapacitor/reducers/rulesSpec.js
@@ -53,7 +53,7 @@ describe('Kapacitor.Reducers.rules', () => {
     let newState = reducer(initialState, addEvery(ruleID, '30s'))
     expect(newState[ruleID].every).to.equal('30s')
 
-    newState = reducer(initialState, removeEvery(ruleID))
+    newState = reducer(newState, removeEvery(ruleID))
     expect(newState[ruleID].every).to.equal(null)
   })
 

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -71,6 +71,21 @@ export function chooseTrigger(ruleID, trigger) {
   }
 }
 
+export const everyAdded = (ruleID, frequency) => ({
+  type: 'EVERY_ADDED',
+  payload: {
+    ruleID,
+    frequency,
+  },
+})
+
+export const everyRemoved = ruleID => ({
+  type: 'EVERY_REMOVED',
+  payload: {
+    ruleID,
+  },
+})
+
 export function updateRuleValues(ruleID, trigger, values) {
   return {
     type: 'UPDATE_RULE_VALUES',

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -71,16 +71,16 @@ export function chooseTrigger(ruleID, trigger) {
   }
 }
 
-export const everyAdded = (ruleID, frequency) => ({
-  type: 'EVERY_ADDED',
+export const addEvery = (ruleID, frequency) => ({
+  type: 'ADD_EVERY',
   payload: {
     ruleID,
     frequency,
   },
 })
 
-export const everyRemoved = ruleID => ({
-  type: 'EVERY_REMOVED',
+export const removeEvery = ruleID => ({
+  type: 'REMOVE_EVERY',
   payload: {
     ruleID,
   },

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -6,6 +6,8 @@ import DatabaseList from '../../data_explorer/components/DatabaseList'
 import MeasurementList from '../../data_explorer/components/MeasurementList'
 import FieldList from '../../data_explorer/components/FieldList'
 
+import {defaultEveryFrequency} from 'src/kapacitor/constants'
+
 export const DataSection = React.createClass({
   propTypes: {
     source: PropTypes.shape({
@@ -21,6 +23,8 @@ export const DataSection = React.createClass({
       chooseNamespace: PropTypes.func.isRequired,
       chooseMeasurement: PropTypes.func.isRequired,
       applyFuncsToField: PropTypes.func.isRequired,
+      everyAdded: PropTypes.func.isRequired,
+      everyRemoved: PropTypes.func.isRequired,
       chooseTag: PropTypes.func.isRequired,
       groupByTag: PropTypes.func.isRequired,
       toggleField: PropTypes.func.isRequired,
@@ -53,6 +57,11 @@ export const DataSection = React.createClass({
 
   handleToggleField(field) {
     this.props.actions.toggleField(this.props.query.id, field, true)
+    // Every is only added when a function has been added to a field.
+    // Here, the field is selected without a function.
+    this.props.actions.everyRemoved(this.props.query.id)
+    // Because there are no functions there is no group by time.
+    this.props.actions.groupByTime(this.props.query.id, null)
   },
 
   handleGroupByTime(time) {
@@ -61,6 +70,7 @@ export const DataSection = React.createClass({
 
   handleApplyFuncsToField(fieldFunc) {
     this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc)
+    this.props.actions.everyAdded(this.props.query.id, defaultEveryFrequency)
   },
 
   handleChooseTag(tag) {

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -23,14 +23,14 @@ export const DataSection = React.createClass({
       chooseNamespace: PropTypes.func.isRequired,
       chooseMeasurement: PropTypes.func.isRequired,
       applyFuncsToField: PropTypes.func.isRequired,
-      everyAdded: PropTypes.func.isRequired,
-      everyRemoved: PropTypes.func.isRequired,
       chooseTag: PropTypes.func.isRequired,
       groupByTag: PropTypes.func.isRequired,
       toggleField: PropTypes.func.isRequired,
       groupByTime: PropTypes.func.isRequired,
       toggleTagAcceptance: PropTypes.func.isRequired,
     }).isRequired,
+    onAddEvery: PropTypes.func.isRequired,
+    onRemoveEvery: PropTypes.func.isRequired,
     timeRange: PropTypes.shape({}).isRequired,
   },
 
@@ -59,7 +59,7 @@ export const DataSection = React.createClass({
     this.props.actions.toggleField(this.props.query.id, field, true)
     // Every is only added when a function has been added to a field.
     // Here, the field is selected without a function.
-    this.props.actions.everyRemoved(this.props.query.id)
+    this.props.onRemoveEvery()
     // Because there are no functions there is no group by time.
     this.props.actions.groupByTime(this.props.query.id, null)
   },
@@ -70,7 +70,7 @@ export const DataSection = React.createClass({
 
   handleApplyFuncsToField(fieldFunc) {
     this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc)
-    this.props.actions.everyAdded(this.props.query.id, defaultEveryFrequency)
+    this.props.onAddEvery(defaultEveryFrequency)
   },
 
   handleChooseTag(tag) {

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -70,6 +70,8 @@ export const KapacitorRule = React.createClass({
                     source={source}
                     query={query}
                     actions={queryActions}
+                    onAddEvery={this.handleAddEvery}
+                    onRemoveEvery={this.handleRemoveEvery}
                   />
                   <ValuesSection
                     rule={rule}
@@ -147,6 +149,16 @@ export const KapacitorRule = React.createClass({
           text: 'There was a problem updating the rule',
         })
       })
+  },
+
+  handleAddEvery(frequency) {
+    const {rule: {id: ruleID}, kapacitorActions: {addEvery}} = this.props
+    addEvery(ruleID, frequency)
+  },
+
+  handleRemoveEvery() {
+    const {rule: {id: ruleID}, kapacitorActions: {removeEvery}} = this.props
+    removeEvery(ruleID)
   },
 
   validationError() {

--- a/ui/src/kapacitor/constants/index.js
+++ b/ui/src/kapacitor/constants/index.js
@@ -19,6 +19,8 @@ export const defaultRuleConfigs = {
   },
 }
 
+export const defaultEveryFrequency = '30s'
+
 export const OPERATORS = [
   'greater than',
   'equal to or greater',

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -2,12 +2,8 @@ import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 
-import * as kapacitorActionCreators from '../actions/view'
-import * as queryActionCreators from '../../data_explorer/actions/view'
-import {
-  everyAdded as everyAddedAction,
-  everyRemoved as everyRemovedAction,
-} from 'src/kapacitor/actions/view'
+import * as kapacitorActionCreators from 'src/kapacitor/actions/view'
+import * as queryActionCreators from 'src/data_explorer/actions/view'
 
 import {bindActionCreators} from 'redux'
 import {getActiveKapacitor, getKapacitorConfig} from 'shared/apis/index'
@@ -29,14 +25,16 @@ export const KapacitorRulePage = React.createClass({
       loadDefaultRule: PropTypes.func.isRequired,
       fetchRule: PropTypes.func.isRequired,
       chooseTrigger: PropTypes.func.isRequired,
+      addEvery: PropTypes.func.isRequired,
+      removeEvery: PropTypes.func.isRequired,
       updateRuleValues: PropTypes.func.isRequired,
       updateMessage: PropTypes.func.isRequired,
       updateAlerts: PropTypes.func.isRequired,
       updateRuleName: PropTypes.func.isRequired,
     }).isRequired,
     queryActions: PropTypes.shape({}).isRequired,
-    everyAdded: PropTypes.func.isRequired,
-    everyRemoved: PropTypes.func.isRequired,
+    addEvery: PropTypes.func.isRequired,
+    removeEvery: PropTypes.func.isRequired,
     params: PropTypes.shape({
       ruleID: PropTypes.string,
     }).isRequired,
@@ -84,7 +82,7 @@ export const KapacitorRulePage = React.createClass({
         .catch(() => {
           addFlashMessage({
             type: 'error',
-            text: 'We couldn\'t find a configured Kapacitor for this source',
+            text: "We couldn't find a configured Kapacitor for this source", // eslint-disable-line quotes
           })
         })
     })
@@ -98,8 +96,6 @@ export const KapacitorRulePage = React.createClass({
       kapacitorActions,
       source,
       queryActions,
-      everyAdded,
-      everyRemoved,
       addFlashMessage,
       router,
     } = this.props
@@ -120,7 +116,7 @@ export const KapacitorRulePage = React.createClass({
         rule={rule}
         query={query}
         queryConfigs={queryConfigs}
-        queryActions={{...queryActions, everyAdded, everyRemoved}}
+        queryActions={queryActions}
         kapacitorActions={kapacitorActions}
         addFlashMessage={addFlashMessage}
         enabledAlerts={enabledAlerts}
@@ -148,8 +144,6 @@ function mapDispatchToProps(dispatch) {
   return {
     kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
     queryActions: bindActionCreators(queryActionCreators, dispatch),
-    everyAdded: bindActionCreators(everyAddedAction, dispatch),
-    everyRemoved: bindActionCreators(everyRemovedAction, dispatch),
   }
 }
 

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -33,8 +33,6 @@ export const KapacitorRulePage = React.createClass({
       updateRuleName: PropTypes.func.isRequired,
     }).isRequired,
     queryActions: PropTypes.shape({}).isRequired,
-    addEvery: PropTypes.func.isRequired,
-    removeEvery: PropTypes.func.isRequired,
     params: PropTypes.shape({
       ruleID: PropTypes.string,
     }).isRequired,

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -1,8 +1,14 @@
 import React, {PropTypes} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
+
 import * as kapacitorActionCreators from '../actions/view'
 import * as queryActionCreators from '../../data_explorer/actions/view'
+import {
+  everyAdded as everyAddedAction,
+  everyRemoved as everyRemovedAction,
+} from 'src/kapacitor/actions/view'
+
 import {bindActionCreators} from 'redux'
 import {getActiveKapacitor, getKapacitorConfig} from 'shared/apis/index'
 import {ALERTS, DEFAULT_RULE_ID} from 'src/kapacitor/constants'
@@ -29,6 +35,8 @@ export const KapacitorRulePage = React.createClass({
       updateRuleName: PropTypes.func.isRequired,
     }).isRequired,
     queryActions: PropTypes.shape({}).isRequired,
+    everyAdded: PropTypes.func.isRequired,
+    everyRemoved: PropTypes.func.isRequired,
     params: PropTypes.shape({
       ruleID: PropTypes.string,
     }).isRequired,
@@ -90,6 +98,8 @@ export const KapacitorRulePage = React.createClass({
       kapacitorActions,
       source,
       queryActions,
+      everyAdded,
+      everyRemoved,
       addFlashMessage,
       router,
     } = this.props
@@ -110,7 +120,7 @@ export const KapacitorRulePage = React.createClass({
         rule={rule}
         query={query}
         queryConfigs={queryConfigs}
-        queryActions={queryActions}
+        queryActions={{...queryActions, everyAdded, everyRemoved}}
         kapacitorActions={kapacitorActions}
         addFlashMessage={addFlashMessage}
         enabledAlerts={enabledAlerts}
@@ -138,6 +148,8 @@ function mapDispatchToProps(dispatch) {
   return {
     kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
     queryActions: bindActionCreators(queryActionCreators, dispatch),
+    everyAdded: bindActionCreators(everyAddedAction, dispatch),
+    everyRemoved: bindActionCreators(everyRemovedAction, dispatch),
   }
 }
 

--- a/ui/src/kapacitor/reducers/rules.js
+++ b/ui/src/kapacitor/reducers/rules.js
@@ -45,12 +45,12 @@ export default function rules(state = {}, action) {
       })
     }
 
-    case 'EVERY_ADDED': {
+    case 'ADD_EVERY': {
       const {ruleID, frequency} = action.payload
       return {...state, [ruleID]: {...state[ruleID], every: frequency}}
     }
 
-    case 'EVERY_REMOVED': {
+    case 'REMOVE_EVERY': {
       const {ruleID} = action.payload
       return {...state, [ruleID]: {...state[ruleID], every: null}}
     }

--- a/ui/src/kapacitor/reducers/rules.js
+++ b/ui/src/kapacitor/reducers/rules.js
@@ -15,7 +15,7 @@ export default function rules(state = {}, action) {
           message: '',
           alerts: [],
           alertNodes: [],
-          every: '30s',
+          every: null,
           name: 'Untitled Rule',
         },
       })
@@ -43,6 +43,16 @@ export default function rules(state = {}, action) {
           values: defaultRuleConfigs[trigger.toLowerCase()],
         }),
       })
+    }
+
+    case 'EVERY_ADDED': {
+      const {ruleID, frequency} = action.payload
+      return {...state, [ruleID]: {...state[ruleID], every: frequency}}
+    }
+
+    case 'EVERY_REMOVED': {
+      const {ruleID} = action.payload
+      return {...state, [ruleID]: {...state[ruleID], every: null}}
     }
 
     case 'UPDATE_RULE_VALUES': {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### WIP TODOZ
  - [x] Add tests for go reversing of kapa
  - [x] Add tests for new reducers
  - [x] Add validation for rules that have functions but no every
  - [x] Fix which state is updated on rule create
  - [x] Test if null doesn't break rule updating

Connect #1531

### The problem
- In the Chronograf client, a user could not update an existing Kapacitor rule's field to use a function, if a function had not been applied when that rule was created.
- The client was including a default `30s` value for `.every` without respect to whether a field had yet been applied to the query (or a function to a field).
- The server was returning the Kapacitor rule request object to the client as the response, rather than the rule as it was actually persisted to the database.
- Server wasn't performing request validation (unlike other data coming to server)

### The solution
- Explicitly set the `.every` property of a rule to `30s` or `null` when adding a function to a field, or removing that field from the alert query, via dedicated Redux action creators.
- Return the persisted Kapacitor rule to the client as the response object.
- Have server perform the following minimum validation on requests:
  - has queryConfig
  - has every when there are functions

### Note
- There should probably be further validation performed by the server (https://github.com/influxdata/chronograf/issues/1545)