### PR TITLE
Save CEO only with fully qualified queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,10 @@
 ### Features
 
 ### UI Improvements
-  1. [#1508](https://github.com/influxdata/chronograf/pull/1508): The enter and escape keys now perform as expected when renaming dashboard headers.
+  1. [#1508](https://github.com/influxdata/chronograf/pull/1508): The enter and escape keys now perform as expected when renaming dashboard headers
   1. [#1524](https://github.com/influxdata/chronograf/pull/1524): Rewrite UI copy in Kapacitor Node configuration to be more clear
   1. [#1544](https://github.com/influxdata/chronograf/pull/1544): Upgrade to new version of Influx Theme, remove excess stylesheets
+  1. [#1561](https://github.com/influxdata/chronograf/pull/1561): Disable query save in dashboard editing if the query does not have a database, measurement, and field
 
 ## v1.3.1.0 [2017-05-22]
 

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -153,7 +153,7 @@ class CellEditorOverlay extends Component {
       ..._.mapValues(queryModifiers, qm => this.queryStateReducer(qm)),
     }
 
-    const querySavable = query =>
+    const isQuerySavable = query =>
       (!!query.measurement && !!query.database && !!query.fields.length) ||
       !!query.rawText
 
@@ -183,7 +183,7 @@ class CellEditorOverlay extends Component {
               onSelectGraphType={this.handleSelectGraphType}
               onCancel={onCancel}
               onSave={this.handleSaveCell}
-              isSavable={queriesWorkingDraft.every(querySavable)}
+              isSavable={queriesWorkingDraft.every(isQuerySavable)}
             />
             <QueryMaker
               source={source}

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -153,6 +153,10 @@ class CellEditorOverlay extends Component {
       ..._.mapValues(queryModifiers, qm => this.queryStateReducer(qm)),
     }
 
+    const querySavable = query =>
+      (!!query.measurement && !!query.database && !!query.fields.length) ||
+      !!query.rawText
+
     return (
       <div className="overlay-technology">
         <ResizeContainer
@@ -179,6 +183,7 @@ class CellEditorOverlay extends Component {
               onSelectGraphType={this.handleSelectGraphType}
               onCancel={onCancel}
               onSave={this.handleSaveCell}
+              isSavable={queriesWorkingDraft.every(querySavable)}
             />
             <QueryMaker
               source={source}

--- a/ui/src/dashboards/components/OverlayControls.js
+++ b/ui/src/dashboards/components/OverlayControls.js
@@ -6,7 +6,13 @@ import ConfirmButtons from 'shared/components/ConfirmButtons'
 import graphTypes from 'hson!shared/data/graphTypes.hson'
 
 const OverlayControls = props => {
-  const {onCancel, onSave, selectedGraphType, onSelectGraphType} = props
+  const {
+    onCancel,
+    onSave,
+    selectedGraphType,
+    onSelectGraphType,
+    isSavable,
+  } = props
   return (
     <div className="overlay-controls">
       <h3 className="overlay--graph-name">Cell Editor</h3>
@@ -25,19 +31,24 @@ const OverlayControls = props => {
             </li>
           ))}
         </ul>
-        <ConfirmButtons onCancel={onCancel} onConfirm={onSave} />
+        <ConfirmButtons
+          onCancel={onCancel}
+          onConfirm={onSave}
+          isSavable={isSavable}
+        />
       </div>
     </div>
   )
 }
 
-const {func, string} = PropTypes
+const {func, string, bool} = PropTypes
 
 OverlayControls.propTypes = {
   onCancel: func.isRequired,
   onSave: func.isRequired,
   selectedGraphType: string.isRequired,
   onSelectGraphType: func.isRequired,
+  isSavable: bool,
 }
 
 export default OverlayControls

--- a/ui/src/dashboards/components/OverlayControls.js
+++ b/ui/src/dashboards/components/OverlayControls.js
@@ -34,7 +34,7 @@ const OverlayControls = props => {
         <ConfirmButtons
           onCancel={onCancel}
           onConfirm={onSave}
-          isSavable={isSavable}
+          isDisabled={!isSavable}
         />
       </div>
     </div>

--- a/ui/src/shared/components/ConfirmButtons.js
+++ b/ui/src/shared/components/ConfirmButtons.js
@@ -1,7 +1,7 @@
 import React, {PropTypes} from 'react'
 import classnames from 'classnames'
 
-const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize}) => (
+const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize, isSavable}) => (
   <div className="confirm-buttons">
     <button
       className={classnames('btn btn-info btn-square', {
@@ -15,6 +15,8 @@ const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize}) => (
       className={classnames('btn btn-success btn-square', {
         [buttonSize]: buttonSize,
       })}
+      disabled={!isSavable}
+      title={isSavable ? 'Save' : 'Cannot save'}
       onClick={() => onConfirm(item)}
     >
       <span className="icon checkmark" />
@@ -22,13 +24,14 @@ const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize}) => (
   </div>
 )
 
-const {func, oneOfType, shape, string} = PropTypes
+const {func, oneOfType, shape, string, bool} = PropTypes
 
 ConfirmButtons.propTypes = {
   onConfirm: func.isRequired,
   item: oneOfType([shape(), string]),
   onCancel: func.isRequired,
   buttonSize: string,
+  isSavable: bool,
 }
 
 ConfirmButtons.defaultProps = {

--- a/ui/src/shared/components/ConfirmButtons.js
+++ b/ui/src/shared/components/ConfirmButtons.js
@@ -1,7 +1,13 @@
 import React, {PropTypes} from 'react'
 import classnames from 'classnames'
 
-const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize, isSavable}) => (
+const ConfirmButtons = ({
+  onConfirm,
+  item,
+  onCancel,
+  buttonSize,
+  isDisabled,
+}) => (
   <div className="confirm-buttons">
     <button
       className={classnames('btn btn-info btn-square', {
@@ -15,8 +21,8 @@ const ConfirmButtons = ({onConfirm, item, onCancel, buttonSize, isSavable}) => (
       className={classnames('btn btn-success btn-square', {
         [buttonSize]: buttonSize,
       })}
-      disabled={!isSavable}
-      title={isSavable ? 'Save' : 'Cannot save'}
+      disabled={isDisabled}
+      title={isDisabled ? 'Cannot Save' : 'Save'}
       onClick={() => onConfirm(item)}
     >
       <span className="icon checkmark" />
@@ -31,7 +37,7 @@ ConfirmButtons.propTypes = {
   item: oneOfType([shape(), string]),
   onCancel: func.isRequired,
   buttonSize: string,
-  isSavable: bool,
+  isDisabled: bool,
 }
 
 ConfirmButtons.defaultProps = {

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -39,7 +39,7 @@ export const LayoutRenderer = React.createClass({
         type: string.isRequired,
       }).isRequired
     ),
-    templates: arrayOf(shape()).isRequired,
+    templates: arrayOf(shape()),
     host: string,
     source: string,
     onPositionChange: func,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1429 

### The problem
When using the CEO, if a user selected a db and measurement and then saved the app got into a funky state.

### The Solution
Only allow the user to save if a queryConfig is 'fully qualified' or contains `rawText`.  A fully qualified query is one which contains a db, measurement, and field.  These are the minimum data required for InfluxDB to retrieve time series. 

### Suggestions for Improvement
Better feedback as to why a user cannot save. Would like to add a tooltip or more descriptive title message. 
