### PR TITLE
Fix load localStorage and warning UX on fresh Chronograf install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#1535](https://github.com/influxdata/chronograf/pull/1535): Fix add field functions to existing Kapacitor rules
 1. [#1564](https://github.com/influxdata/chronograf/pull/1564): Fix regression of logout menu item functionality
 1. [#1562](https://github.com/influxdata/chronograf/pull/1562): Fix InfluxQL parsing with multiple tag values for a tag key
+1. [#1582](https://github.com/influxdata/chronograf/pull/1582): Fix load localStorage and warning UX on fresh Chronograf install
 
 ### Features
   1. [#1537](https://github.com/influxdata/chronograf/pull/1537): Add UI for writing data to influxdb.

--- a/ui/src/localStorage.js
+++ b/ui/src/localStorage.js
@@ -2,10 +2,10 @@ export const loadLocalStorage = errorsQueue => {
   try {
     const serializedState = localStorage.getItem('state')
 
-    const state = JSON.parse(serializedState)
+    const state = JSON.parse(serializedState) || {}
 
     // eslint-disable-next-line no-undef
-    if (state.VERSION !== VERSION) {
+    if (state.VERSION && state.VERSION !== VERSION) {
       const errorText =
         'New version of Chronograf detected. Local settings cleared.'
 
@@ -18,7 +18,7 @@ export const loadLocalStorage = errorsQueue => {
 
     delete state.VERSION
 
-    return state || {}
+    return state
   } catch (error) {
     const errorText = `Loading local settings failed: ${error}`
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1580 

### The problem
On fresh install of Chronograf, localStorage would be `null` and the user would receive a warning of failure to load local storage. This apparently led one user to not even use Chronograf: https://twitter.com/gkreimer/status/870388663573729280.

### The Solution
Update `null` localStorage state handling logic in `loadLocalStorage` to simply load a clean slate on fresh install.

