### PR TITLE
Fix hidden submenus when alert notification on screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#1535](https://github.com/influxdata/chronograf/pull/1535): Fix add field functions to existing Kapacitor rules
 1. [#1564](https://github.com/influxdata/chronograf/pull/1564): Fix regression of logout menu item functionality
 1. [#1562](https://github.com/influxdata/chronograf/pull/1562): Fix InfluxQL parsing with multiple tag values for a tag key
+1. [#1584](https://github.com/influxdata/chronograf/pull/1584): Fix submenus not appearing when alert notification was on screen
 
 ### Features
   1. [#1537](https://github.com/influxdata/chronograf/pull/1537): Add UI for writing data to influxdb.

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -24,8 +24,8 @@ const App = React.createClass({
   render() {
     return (
       <div className="chronograf-root">
-        <SideNav />
         <Notifications />
+        <SideNav />
         {this.props.children &&
           React.cloneElement(this.props.children, {
             addFlashMessage: this.handleAddFlashMessage,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1583 

### The problem
Submenus would not appear after stopping an InfluxDb source while connected to it. It turned out that this was due to a z-index issue stemming from the ordering of top-level components in the DOM, so that while an alert notification was on-screen, the submenus would be hidden. If you x-ed out of the notification, the submenus would appear.

### The Solution
Switch the order of the `<Notifications>` and `<SideNav>` components in `index.js` -- voilà!

