### PR TITLE
Add auto group by functionality using :interval: template variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
   1. [#1567](https://github.com/influxdata/chronograf/pull/1567): Replace the user icon with a solid style
   1. [#1561](https://github.com/influxdata/chronograf/pull/1561): Disable query save in cell editor mode if the query does not have a database, measurement, and field
   1. [#1575](https://github.com/influxdata/chronograf/pull/1575): Improve UX of applying functions to fields in the query builder
+  1. [#1560](https://github.com/influxdata/chronograf/pull/1560): Apply mean to fields by default
 
 ## v1.3.1.0 [2017-05-22]
 

--- a/bolt/internal/internal.go
+++ b/bolt/internal/internal.go
@@ -265,9 +265,9 @@ func UnmarshalDashboard(data []byte, d *chronograf.Dashboard) error {
 
 	templates := make([]chronograf.Template, len(pb.Templates))
 	for i, t := range pb.Templates {
-		vals := make([]chronograf.TemplateValue, len(t.Values))
+		vals := make([]chronograf.BasicTemplateValue, len(t.Values))
 		for j, v := range t.Values {
-			vals[j] = chronograf.TemplateValue{
+			vals[j] = chronograf.BasicTemplateValue{
 				Selected: v.Selected,
 				Type:     v.Type,
 				Value:    v.Value,
@@ -276,7 +276,7 @@ func UnmarshalDashboard(data []byte, d *chronograf.Dashboard) error {
 
 		template := chronograf.Template{
 			ID: chronograf.TemplateID(t.ID),
-			TemplateVar: chronograf.TemplateVar{
+			BasicTemplateVar: chronograf.BasicTemplateVar{
 				Var:    t.TempVar,
 				Values: vals,
 			},

--- a/chronograf.go
+++ b/chronograf.go
@@ -231,7 +231,7 @@ func (g *GroupByVar) String() string {
 
 	//TODO(timraymond): ascertain group by resolution
 	duration := g.Duration.Nanoseconds() / g.ReportingInterval.Nanoseconds() * int64(g.Resolution)
-	return "group by time(" + strconv.Itoa(int(duration)/1000000) + "s)"
+	return "time(" + strconv.Itoa(int(duration)/1000000) + "s)"
 }
 
 func (g *GroupByVar) Name() string {

--- a/chronograf.go
+++ b/chronograf.go
@@ -134,7 +134,8 @@ type Range struct {
 
 type TemplateVariable interface {
 	fmt.Stringer
-	Name() string // returns the variable name
+	Name() string     // returns the variable name
+	Precedence() uint // ordinal indicating precedence level for replacement
 }
 
 type ExecutableVar interface {
@@ -176,6 +177,10 @@ func (t BasicTemplateVar) String() string {
 	default:
 		return ""
 	}
+}
+
+func (t BasicTemplateVar) Precedence() uint {
+	return 0
 }
 
 type GroupByVar struct {
@@ -229,6 +234,10 @@ func (g *GroupByVar) String() string {
 
 func (g *GroupByVar) Name() string {
 	return g.Var
+}
+
+func (g *GroupByVar) Precedence() uint {
+	return 1
 }
 
 // TemplateID is the unique ID used to identify a template

--- a/chronograf.go
+++ b/chronograf.go
@@ -254,18 +254,18 @@ type Template struct {
 
 // Query retrieves a Response from a TimeSeries.
 type Query struct {
-	Command      string       `json:"query"`              // Command is the query itself
-	DB           string       `json:"db,omitempty"`       // DB is optional and if empty will not be used.
-	RP           string       `json:"rp,omitempty"`       // RP is a retention policy and optional; if empty will not be used.
-	TemplateVars TemplateVars `json:"tempVars,omitempty"` // TemplateVars are template variables to replace within an InfluxQL query
-	Wheres       []string     `json:"wheres,omitempty"`   // Wheres restricts the query to certain attributes
-	GroupBys     []string     `json:"groupbys,omitempty"` // GroupBys collate the query by these tags
-	Resolution   uint         `json:"resolution,omitempty"`
-	Label        string       `json:"label,omitempty"` // Label is the Y-Axis label for the data
-	Range        *Range       `json:"range,omitempty"` // Range is the default Y-Axis range for the data
+	Command      string       `json:"query"`                // Command is the query itself
+	DB           string       `json:"db,omitempty"`         // DB is optional and if empty will not be used.
+	RP           string       `json:"rp,omitempty"`         // RP is a retention policy and optional; if empty will not be used.
+	TemplateVars TemplateVars `json:"tempVars,omitempty"`   // TemplateVars are template variables to replace within an InfluxQL query
+	Wheres       []string     `json:"wheres,omitempty"`     // Wheres restricts the query to certain attributes
+	GroupBys     []string     `json:"groupbys,omitempty"`   // GroupBys collate the query by these tags
+	Resolution   uint         `json:"resolution,omitempty"` // Resolution is the available screen resolution to render query results
+	Label        string       `json:"label,omitempty"`      // Label is the Y-Axis label for the data
+	Range        *Range       `json:"range,omitempty"`      // Range is the default Y-Axis range for the data
 }
 
-// TemplateVars are a hetergenous collection of different TemplateVariables
+// TemplateVars are a heterogeneous collection of different TemplateVariables
 // with the capability to decode arbitrary JSON into the appropriate template
 // variable type
 type TemplateVars []TemplateVariable

--- a/chronograf.go
+++ b/chronograf.go
@@ -221,15 +221,11 @@ func (g *GroupByVar) Exec(query string) {
 }
 
 func (g *GroupByVar) String() string {
-	intervalNS := g.ReportingInterval.Nanoseconds()
-	// prevent division by zero
-	if intervalNS == 0 || g.Resolution == 0 {
-		return " "
+	duration := g.Duration.Nanoseconds() / (g.ReportingInterval.Nanoseconds() * int64(g.Resolution))
+	if duration == 0 {
+		duration = 1
 	}
-
-	//TODO(timraymond): ascertain group by resolution
-	duration := g.Duration.Nanoseconds() / g.ReportingInterval.Nanoseconds() * int64(g.Resolution)
-	return "time(" + strconv.Itoa(int(duration)/1000000) + "s)"
+	return "time(" + strconv.Itoa(int(duration)) + "s)"
 }
 
 func (g *GroupByVar) Name() string {
@@ -271,6 +267,7 @@ type Query struct {
 type TemplateVars []TemplateVariable
 
 func (t *TemplateVars) UnmarshalJSON(text []byte) error {
+	// TODO: Need to test that server throws an error when :interval:'s Resolution or ReportingInterval or zero-value
 	rawVars := bytes.NewReader(text)
 	dec := json.NewDecoder(rawVars)
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -13,6 +13,8 @@ import (
 	"time"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/influxdata/influxdb/influxql"
 )
 
 // General errors.
@@ -212,7 +214,7 @@ func (g *GroupByVar) Exec(query string) {
 		pos++
 	}
 
-	dur, err := time.ParseDuration(durStr[:pos])
+	dur, err := influxql.ParseDuration(durStr[:pos])
 	if err != nil {
 		return
 	}

--- a/chronograf.go
+++ b/chronograf.go
@@ -302,7 +302,6 @@ func (t *TemplateVars) UnmarshalJSON(text []byte) error {
 
 		// ensure that we really have a GroupByVar
 		if agb.Resolution != 0 {
-			agb.ReportingInterval = 10 * time.Second
 			(*t) = append(*t, &agb)
 			continue
 		}

--- a/chronograf.go
+++ b/chronograf.go
@@ -174,8 +174,6 @@ func (t BasicTemplateVar) String() string {
 		return `'` + t.Values[0].Value + `'`
 	case "csv", "constant":
 		return t.Values[0].Value
-	case "autoGroupBy":
-		return "group by time(1555s)"
 	default:
 		return ""
 	}

--- a/chronograf.go
+++ b/chronograf.go
@@ -206,7 +206,7 @@ func (g *GroupByVar) Exec(query string) {
 
 	// advance to next space
 	pos := 0
-	for {
+	for pos < len(durStr) {
 		rn, _ := utf8.DecodeRuneInString(durStr[pos:])
 		if unicode.IsSpace(rn) {
 			break

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -69,6 +69,7 @@ func (c *Client) query(u *url.URL, q chronograf.Query) (chronograf.Response, err
 	}
 	req.Header.Set("Content-Type", "application/json")
 	command := q.Command
+	// TODO(timraymond): move this upper Query() function
 	if len(q.TemplateVars) > 0 {
 		command = TemplateReplace(q.Command, q.TemplateVars)
 	}
@@ -84,7 +85,7 @@ func (c *Client) query(u *url.URL, q chronograf.Query) (chronograf.Response, err
 	params.Set("q", command)
 	params.Set("db", q.DB)
 	params.Set("rp", q.RP)
-	params.Set("epoch", "ms")
+	params.Set("epoch", "ms") // TODO(timraymond): set this based on analysis
 	req.URL.RawQuery = params.Encode()
 
 	hc := &http.Client{}

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -125,10 +125,10 @@ func Test_Influx_HTTPS_InsecureSkipVerify(t *testing.T) {
 	q = ""
 	query = chronograf.Query{
 		Command: "select $field from cpu",
-		TemplateVars: []chronograf.TemplateVar{
-			{
+		TemplateVars: chronograf.TemplateVars{
+			chronograf.BasicTemplateVar{
 				Var: "$field",
-				Values: []chronograf.TemplateValue{
+				Values: []chronograf.BasicTemplateValue{
 					{
 						Value: "usage_user",
 						Type:  "fieldKey",

--- a/influx/templates.go
+++ b/influx/templates.go
@@ -8,19 +8,33 @@ import (
 
 // TemplateReplace replaces templates with values within the query string
 func TemplateReplace(query string, templates chronograf.TemplateVars) string {
-	replacements := []string{}
-
-	for _, v := range templates {
-		if evar, ok := v.(chronograf.ExecutableVar); ok {
-			evar.Exec(query)
+	tvarsByPrecedence := make(map[uint]chronograf.TemplateVars, len(templates))
+	maxPrecedence := uint(0)
+	for _, tmp := range templates {
+		precedence := tmp.Precedence()
+		if precedence > maxPrecedence {
+			maxPrecedence = precedence
 		}
-		newVal := v.String()
-		if newVal != "" {
-			replacements = append(replacements, v.Name(), newVal)
-		}
+		tvarsByPrecedence[precedence] = append(tvarsByPrecedence[precedence], tmp)
 	}
 
-	replacer := strings.NewReplacer(replacements...)
-	replaced := replacer.Replace(query)
+	replaced := query
+	for prc := uint(0); prc <= maxPrecedence; prc++ {
+		replacements := []string{}
+
+		for _, v := range tvarsByPrecedence[prc] {
+			if evar, ok := v.(chronograf.ExecutableVar); ok {
+				evar.Exec(replaced)
+			}
+			newVal := v.String()
+			if newVal != "" {
+				replacements = append(replacements, v.Name(), newVal)
+			}
+		}
+
+		replacer := strings.NewReplacer(replacements...)
+		replaced = replacer.Replace(replaced)
+	}
+
 	return replaced
 }

--- a/influx/templates.go
+++ b/influx/templates.go
@@ -9,7 +9,11 @@ import (
 // TemplateReplace replaces templates with values within the query string
 func TemplateReplace(query string, templates chronograf.TemplateVars) string {
 	replacements := []string{}
+
 	for _, v := range templates {
+		if evar, ok := v.(chronograf.ExecutableVar); ok {
+			evar.Exec(query)
+		}
 		newVal := v.String()
 		if newVal != "" {
 			replacements = append(replacements, v.Name(), newVal)

--- a/influx/templates.go
+++ b/influx/templates.go
@@ -7,12 +7,12 @@ import (
 )
 
 // TemplateReplace replaces templates with values within the query string
-func TemplateReplace(query string, templates []chronograf.TemplateVar) string {
+func TemplateReplace(query string, templates chronograf.TemplateVars) string {
 	replacements := []string{}
 	for _, v := range templates {
 		newVal := v.String()
 		if newVal != "" {
-			replacements = append(replacements, v.Var, newVal)
+			replacements = append(replacements, v.Name(), newVal)
 		}
 	}
 

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -147,7 +147,29 @@ func TestTemplateReplace(t *testing.T) {
 					ReportingInterval: 10 * time.Second,
 				},
 			},
-			want: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(1555s)`,
+			want: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h group by time(1555s)`,
+		},
+		{
+			name:  "auto group by with :dashboardTime:",
+			query: `SELECT mean(usage_idle) from "cpu" WHERE time > :dashboardTime: :autoGroupBy:`,
+			vars: chronograf.TemplateVars{
+				&chronograf.GroupByVar{
+					Var:               ":autoGroupBy:",
+					Duration:          0 * time.Minute,
+					Resolution:        1000,
+					ReportingInterval: 10 * time.Second,
+				},
+				&chronograf.BasicTemplateVar{
+					Var: ":dashboardTime:",
+					Values: []chronograf.BasicTemplateValue{
+						{
+							Type:  "constant",
+							Value: "now() - 4320h",
+						},
+					},
+				},
+			},
+			want: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h group by time(1555s)`,
 		},
 	}
 	for _, tt := range tests {

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -171,6 +172,28 @@ func TestTemplateReplace(t *testing.T) {
 			},
 			want: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h group by time(1555s)`,
 		},
+		{
+			name:  "auto group by failing condition",
+			query: `SELECT mean(usage_idle) FROM "cpu" WHERE time > :dashboardTime: GROUP BY :interval:`,
+			vars: []chronograf.TemplateVariable{
+				&chronograf.GroupByVar{
+					Var:               ":interval:",
+					Resolution:        115,
+					ReportingInterval: 10 * time.Second,
+				},
+				chronograf.BasicTemplateVar{
+					Var: ":dashboardTime:",
+					Values: []chronograf.BasicTemplateValue{
+						{
+							Value:    "now() - 1h",
+							Type:     "constant",
+							Selected: true,
+						},
+					},
+				},
+			},
+			want: `SELECT mean(usage_idle) FROM "cpu" WHERE time > now() - 1h GROUP BY time(3s)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -186,12 +209,11 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	req := `[
 	{
 		"tempVar": ":interval:",
-		"duration": 15552000,
 		"resolution": 1000,
 		"reportingInterval": 10
 	},
 	{
-		"tempVar": "cpu",
+		"tempVar": ":cpu:",
 		"values": [
 			{
 				"type": "tagValue",
@@ -202,9 +224,22 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	}
 	]`
 
-	expected := []string{
-		"time(1555s)",
-		"'cpu-total'",
+	expected := []chronograf.TemplateVariable{
+		&chronograf.GroupByVar{
+			Var:               ":interval:",
+			Resolution:        1000,
+			ReportingInterval: 10 * time.Nanosecond,
+		},
+		chronograf.BasicTemplateVar{
+			Var: ":cpu:",
+			Values: []chronograf.BasicTemplateValue{
+				{
+					Value:    "cpu-total",
+					Type:     "tagValue",
+					Selected: false,
+				},
+			},
+		},
 	}
 
 	var tvars chronograf.TemplateVars
@@ -217,9 +252,46 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 		t.Fatal("Expected", len(expected), "vars but found", len(tvars))
 	}
 
-	for idx, tvar := range tvars {
-		if actual := tvar.String(); expected[idx] != actual {
-			t.Error("Unexpected tvar. Want:", expected[idx], "Got:", actual)
-		}
+	if !reflect.DeepEqual(*(tvars[0].(*chronograf.GroupByVar)), *(expected[0].(*chronograf.GroupByVar))) {
+		t.Errorf("UnmarshalJSON() = \n%#v\n want \n%#v\n", *(tvars[0].(*chronograf.GroupByVar)), *(expected[0].(*chronograf.GroupByVar)))
+	}
+
+	if !reflect.DeepEqual(tvars[1].(chronograf.BasicTemplateVar), expected[1].(chronograf.BasicTemplateVar)) {
+		t.Errorf("UnmarshalJSON() = \n%#v\n want \n%#v\n", tvars[1].(chronograf.BasicTemplateVar), expected[1].(chronograf.BasicTemplateVar))
+	}
+}
+
+func TestGroupByVarString(t *testing.T) {
+	tests := []struct {
+		name string
+		tvar *chronograf.GroupByVar
+		want string
+	}{
+		{
+			name: "String() calculates the GROUP BY interval",
+			tvar: &chronograf.GroupByVar{
+				Resolution:        700,
+				ReportingInterval: 10 * time.Second,
+				Duration:          24 * time.Hour,
+			},
+			want: "time(12s)",
+		},
+		{
+			name: "String() outputs a minimum of 1s intervals",
+			tvar: &chronograf.GroupByVar{
+				Resolution:        100000,
+				ReportingInterval: 10 * time.Second,
+				Duration:          time.Hour,
+			},
+			want: "time(1s)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.tvar.String()
+			if got != tt.want {
+				t.Errorf("TestGroupByVarString %s =\n%s\nwant\n%s", tt.name, got, tt.want)
+			}
+		})
 	}
 }

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -138,7 +138,7 @@ func TestTemplateReplace(t *testing.T) {
 		},
 		{
 			name:  "auto group by without duration",
-			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h :autoGroupBy:`,
+			query: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h :autoGroupBy:`,
 			vars: chronograf.TemplateVars{
 				&chronograf.GroupByVar{
 					Var:               ":autoGroupBy:",
@@ -185,7 +185,7 @@ func TestTemplateReplace(t *testing.T) {
 func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	req := `[
 	{
-		"tempVar": "autoGroupBy",
+		"tempVar": ":autoGroupBy:",
 		"duration": 15552000,
 		"resolution": 1000,
 		"reportingInterval": 10

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -125,7 +125,7 @@ func TestTemplateReplace(t *testing.T) {
 		},
 		{
 			name:  "auto group by",
-			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 180d :autoGroupBy:`,
+			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h :autoGroupBy:`,
 			vars: chronograf.TemplateVars{
 				&chronograf.GroupByVar{
 					Var:               ":autoGroupBy:",
@@ -134,7 +134,20 @@ func TestTemplateReplace(t *testing.T) {
 					ReportingInterval: 10 * time.Second,
 				},
 			},
-			want: `SELECT mean(usage_idle) from "cpu" where time > now() - 180d group by time(1555s)`,
+			want: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(1555s)`,
+		},
+		{
+			name:  "auto group by without duration",
+			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h :autoGroupBy:`,
+			vars: chronograf.TemplateVars{
+				&chronograf.GroupByVar{
+					Var:               ":autoGroupBy:",
+					Duration:          0 * time.Minute,
+					Resolution:        1000,
+					ReportingInterval: 10 * time.Second,
+				},
+			},
+			want: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(1555s)`,
 		},
 	}
 	for _, tt := range tests {

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -160,7 +160,8 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 		"values": [
 			{
 				"type": "tagValue",
-				"value": "cpu-total"
+				"value": "cpu-total",
+				"selected": false
 			}
 		]
 	}
@@ -175,6 +176,10 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	err := json.Unmarshal([]byte(req), &tvars)
 	if err != nil {
 		t.Fatal("Err unmarshaling:", err)
+	}
+
+	if len(tvars) != len(expected) {
+		t.Fatal("Expected", len(expected), "vars but found", len(tvars))
 	}
 
 	for idx, tvar := range tvars {

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -125,10 +125,10 @@ func TestTemplateReplace(t *testing.T) {
 		},
 		{
 			name:  "auto group by",
-			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h :autoGroupBy:`,
+			query: `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by :interval:`,
 			vars: chronograf.TemplateVars{
 				&chronograf.GroupByVar{
-					Var:               ":autoGroupBy:",
+					Var:               ":interval:",
 					Duration:          180 * 24 * time.Hour,
 					Resolution:        1000,
 					ReportingInterval: 10 * time.Second,
@@ -138,10 +138,10 @@ func TestTemplateReplace(t *testing.T) {
 		},
 		{
 			name:  "auto group by without duration",
-			query: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h :autoGroupBy:`,
+			query: `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 4320h group by :interval:`,
 			vars: chronograf.TemplateVars{
 				&chronograf.GroupByVar{
-					Var:               ":autoGroupBy:",
+					Var:               ":interval:",
 					Duration:          0 * time.Minute,
 					Resolution:        1000,
 					ReportingInterval: 10 * time.Second,
@@ -151,10 +151,10 @@ func TestTemplateReplace(t *testing.T) {
 		},
 		{
 			name:  "auto group by with :dashboardTime:",
-			query: `SELECT mean(usage_idle) from "cpu" WHERE time > :dashboardTime: :autoGroupBy:`,
+			query: `SELECT mean(usage_idle) from "cpu" WHERE time > :dashboardTime: group by :interval:`,
 			vars: chronograf.TemplateVars{
 				&chronograf.GroupByVar{
-					Var:               ":autoGroupBy:",
+					Var:               ":interval:",
 					Duration:          0 * time.Minute,
 					Resolution:        1000,
 					ReportingInterval: 10 * time.Second,
@@ -185,7 +185,7 @@ func TestTemplateReplace(t *testing.T) {
 func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	req := `[
 	{
-		"tempVar": ":autoGroupBy:",
+		"tempVar": ":interval:",
 		"duration": 15552000,
 		"resolution": 1000,
 		"reportingInterval": 10
@@ -203,7 +203,7 @@ func Test_TemplateVarsUnmarshalling(t *testing.T) {
 	]`
 
 	expected := []string{
-		"group by time(1555s)",
+		"time(1555s)",
 		"'cpu-total'",
 	}
 

--- a/server/queries.go
+++ b/server/queries.go
@@ -28,7 +28,7 @@ type QueryResponse struct {
 	QueryConfig    chronograf.QueryConfig   `json:"queryConfig"`
 	QueryAST       *queries.SelectStatement `json:"queryAST,omitempty"`
 	QueryTemplated *string                  `json:"queryTemplated,omitempty"`
-	TemplateVars   []chronograf.TemplateVar `json:"tempVars,omitempty"`
+	TemplateVars   chronograf.TemplateVars  `json:"tempVars,omitempty"`
 }
 
 type QueriesResponse struct {

--- a/server/queries.go
+++ b/server/queries.go
@@ -13,9 +13,9 @@ import (
 )
 
 type QueryRequest struct {
-	ID           string                   `json:"id"`
-	Query        string                   `json:"query"`
-	TemplateVars []chronograf.TemplateVar `json:"tempVars,omitempty"`
+	ID           string                  `json:"id"`
+	Query        string                  `json:"query"`
+	TemplateVars chronograf.TemplateVars `json:"tempVars,omitempty"`
 }
 
 type QueriesRequest struct {

--- a/server/templates_test.go
+++ b/server/templates_test.go
@@ -16,8 +16,8 @@ func TestValidTemplateRequest(t *testing.T) {
 			name: "Valid Template",
 			template: &chronograf.Template{
 				Type: "fieldKeys",
-				TemplateVar: chronograf.TemplateVar{
-					Values: []chronograf.TemplateValue{
+				BasicTemplateVar: chronograf.BasicTemplateVar{
+					Values: []chronograf.BasicTemplateValue{
 						{
 							Type: "fieldKey",
 						},
@@ -30,8 +30,8 @@ func TestValidTemplateRequest(t *testing.T) {
 			wantErr: true,
 			template: &chronograf.Template{
 				Type: "Unknown Type",
-				TemplateVar: chronograf.TemplateVar{
-					Values: []chronograf.TemplateValue{
+				BasicTemplateVar: chronograf.BasicTemplateVar{
+					Values: []chronograf.BasicTemplateValue{
 						{
 							Type: "fieldKey",
 						},
@@ -44,8 +44,8 @@ func TestValidTemplateRequest(t *testing.T) {
 			wantErr: true,
 			template: &chronograf.Template{
 				Type: "csv",
-				TemplateVar: chronograf.TemplateVar{
-					Values: []chronograf.TemplateValue{
+				BasicTemplateVar: chronograf.BasicTemplateVar{
+					Values: []chronograf.BasicTemplateValue{
 						{
 							Type: "unknown value",
 						},

--- a/ui/spec/data_explorer/reducers/queryConfigSpec.js
+++ b/ui/spec/data_explorer/reducers/queryConfigSpec.js
@@ -149,23 +149,22 @@ describe('Chronograf.Reducers.queryConfig', () => {
         expect(newState[queryId].fields[1].field).to.equal('a different field')
       })
 
-      // TODO: uncomment when automatically applied funtions are added back to the code
-      // it('applies a funcs to newly selected fields', () => {
-      //   expect(state[queryId].fields.length).to.equal(1)
+      it('applies a funcs to newly selected fields', () => {
+        expect(state[queryId].fields.length).to.equal(1)
 
-      //   const oneFieldOneFunc = reducer(
-      //     state,
-      //     applyFuncsToField(queryId, {field: 'a great field', funcs: ['func1']})
-      //   )
+        const oneFieldOneFunc = reducer(
+          state,
+          applyFuncsToField(queryId, {field: 'a great field', funcs: ['func1']})
+        )
 
-      //   const newState = reducer(
-      //     oneFieldOneFunc,
-      //     toggleField(queryId, {field: 'a different field', funcs: []})
-      //   )
+        const newState = reducer(
+          oneFieldOneFunc,
+          toggleField(queryId, {field: 'a different field', funcs: []})
+        )
 
-      //   expect(newState[queryId].fields[1].funcs.length).to.equal(1)
-      //   expect(newState[queryId].fields[1].funcs[0]).to.equal('func1')
-      // })
+        expect(newState[queryId].fields[1].funcs.length).to.equal(1)
+        expect(newState[queryId].fields[1].funcs[0]).to.equal('func1')
+      })
     })
   })
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -259,8 +259,17 @@ class DashboardPage extends Component {
       ],
     }
 
-    const templatesIncludingDashTime =
-      (dashboard && dashboard.templates.concat(dashboardTime)) || []
+    const autoGroupBy = {
+      id: 'autoGroupBy',
+      type: 'constant',
+      tempVar: ':autoGroupBy:',
+      resolution: 1000,
+      values: [],
+    }
+
+    const templatesIncludingDashTime = (dashboard &&
+      dashboard.templates.concat(dashboardTime) &&
+      dashboard.templates.concat(autoGroupBy)) || []
 
     const {selectedCell, isEditMode, isTemplating} = this.state
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -259,17 +259,18 @@ class DashboardPage extends Component {
       ],
     }
 
-    const autoGroupBy = {
-      id: 'autoGroupBy',
+    // this controls the auto group by behavior
+    const interval = {
+      id: 'interval',
       type: 'constant',
-      tempVar: ':autoGroupBy:',
+      tempVar: ':interval:',
       resolution: 1000,
       reportingInterval: 10000000000,
       values: [],
     }
 
     const templatesIncludingDashTime = (dashboard &&
-      dashboard.templates.concat(dashboardTime).concat(autoGroupBy)) || []
+      dashboard.templates.concat(dashboardTime).concat(interval)) || []
 
     const {selectedCell, isEditMode, isTemplating} = this.state
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -264,6 +264,7 @@ class DashboardPage extends Component {
       type: 'constant',
       tempVar: ':autoGroupBy:',
       resolution: 1000,
+      reportingInterval: 10000000000,
       values: [],
     }
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -268,8 +268,7 @@ class DashboardPage extends Component {
     }
 
     const templatesIncludingDashTime = (dashboard &&
-      dashboard.templates.concat(dashboardTime) &&
-      dashboard.templates.concat(autoGroupBy)) || []
+      dashboard.templates.concat(dashboardTime).concat(autoGroupBy)) || []
 
     const {selectedCell, isEditMode, isTemplating} = this.state
 

--- a/ui/src/data_explorer/actions/view/index.js
+++ b/ui/src/data_explorer/actions/view/index.js
@@ -3,6 +3,7 @@ import uuid from 'node-uuid'
 import {getQueryConfig} from 'shared/apis'
 
 import {errorThrown} from 'shared/actions/errors'
+import {DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL} from 'src/data_explorer/constants'
 
 export function addQuery(options = {}) {
   return {
@@ -34,6 +35,13 @@ export function toggleField(queryId, fieldFunc, isKapacitorRule) {
       fieldFunc,
     },
   }
+}
+
+// all fields implicitly have a function applied to them, so consequently
+// we need to set the auto group by time
+export const toggleFieldWithGroupByInterval = (queryID, fieldFunc, isKapacitorRule) => (dispatch) => {
+  dispatch(toggleField(queryID, fieldFunc, isKapacitorRule))
+  dispatch(groupByTime(queryID, DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL))
 }
 
 export function groupByTime(queryId, time) {

--- a/ui/src/data_explorer/actions/view/index.js
+++ b/ui/src/data_explorer/actions/view/index.js
@@ -54,12 +54,13 @@ export function groupByTime(queryId, time) {
   }
 }
 
-export function applyFuncsToField(queryId, fieldFunc) {
+export function applyFuncsToField(queryId, fieldFunc, isInDataExplorer) {
   return {
     type: 'APPLY_FUNCS_TO_FIELD',
     payload: {
       queryId,
       fieldFunc,
+      isInDataExplorer,
     },
   }
 }

--- a/ui/src/data_explorer/components/FieldList.js
+++ b/ui/src/data_explorer/components/FieldList.js
@@ -7,7 +7,13 @@ import FancyScrollbar from 'shared/components/FancyScrollbar'
 import {showFieldKeys} from 'shared/apis/metaQuery'
 import showFieldKeysParser from 'shared/parsing/showFieldKeys'
 
-const {string, shape, func} = PropTypes
+const {
+  bool,
+  func,
+  shape,
+  string,
+} = PropTypes
+
 const FieldList = React.createClass({
   propTypes: {
     query: shape({
@@ -18,7 +24,8 @@ const FieldList = React.createClass({
     onToggleField: func.isRequired,
     onGroupByTime: func.isRequired,
     applyFuncsToField: func.isRequired,
-    isKapacitorRule: PropTypes.bool,
+    isKapacitorRule: bool,
+    isInDataExplorer: bool,
   },
 
   getDefaultProps() {
@@ -28,9 +35,9 @@ const FieldList = React.createClass({
   },
 
   contextTypes: {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        proxy: PropTypes.string.isRequired,
+    source: shape({
+      links: shape({
+        proxy: string.isRequired,
       }).isRequired,
     }).isRequired,
   },
@@ -77,7 +84,7 @@ const FieldList = React.createClass({
   },
 
   render() {
-    const {query, isKapacitorRule} = this.props
+    const {query, isKapacitorRule, isInDataExplorer} = this.props
     const hasAggregates = query.fields.some(f => f.funcs && f.funcs.length)
     const hasGroupByTime = query.groupBy.time
 
@@ -91,6 +98,7 @@ const FieldList = React.createClass({
                 selected={query.groupBy.time}
                 onChooseGroupByTime={this.handleGroupByTime}
                 isInRuleBuilder={isKapacitorRule}
+                isInDataExplorer={isInDataExplorer}
               />
             : null}
         </div>

--- a/ui/src/data_explorer/components/GroupByTimeDropdown.js
+++ b/ui/src/data_explorer/components/GroupByTimeDropdown.js
@@ -4,6 +4,8 @@ import groupByTimeOptions from 'hson!../data/groupByTimes.hson'
 
 import Dropdown from 'shared/components/Dropdown'
 
+import {DEFAULT_DASHBOARD_GROUP_BY_INTERVAL} from 'shared/constants'
+
 const {bool, func, string} = PropTypes
 
 const GroupByTimeDropdown = React.createClass({
@@ -11,17 +13,23 @@ const GroupByTimeDropdown = React.createClass({
     selected: string,
     onChooseGroupByTime: func.isRequired,
     isInRuleBuilder: bool,
+    isInDataExplorer: bool,
   },
 
   render() {
-    const {selected, onChooseGroupByTime, isInRuleBuilder} = this.props
+    const {selected, onChooseGroupByTime, isInRuleBuilder, isInDataExplorer} = this.props
+
+    let validOptions = groupByTimeOptions
+    if (isInDataExplorer) {
+      validOptions = validOptions.filter(({menuOption}) => menuOption !== DEFAULT_DASHBOARD_GROUP_BY_INTERVAL)
+    }
 
     return (
       <Dropdown
         className="dropdown-130"
         menuClass={isInRuleBuilder ? 'dropdown-malachite' : null}
         buttonColor={isInRuleBuilder ? 'btn-default' : 'btn-info'}
-        items={groupByTimeOptions.map(groupBy => ({
+        items={validOptions.map(groupBy => ({
           ...groupBy,
           text: groupBy.menuOption,
         }))}

--- a/ui/src/data_explorer/components/QueryBuilder.js
+++ b/ui/src/data_explorer/components/QueryBuilder.js
@@ -52,7 +52,7 @@ const QueryBuilder = React.createClass({
   },
 
   handleToggleField(field) {
-    this.props.actions.toggleField(this.props.query.id, field)
+    this.props.actions.toggleFieldWithGroupByInterval(this.props.query.id, field)
   },
 
   handleGroupByTime(time) {
@@ -109,7 +109,7 @@ const QueryBuilder = React.createClass({
   },
 
   renderLists() {
-    const {query, layout} = this.props
+    const {query, layout, isInDataExplorer} = this.props
 
     // Panel layout uses a dropdown instead of a list for database selection
     // Also groups measurements & fields into their own container so they
@@ -135,6 +135,7 @@ const QueryBuilder = React.createClass({
               onToggleField={this.handleToggleField}
               onGroupByTime={this.handleGroupByTime}
               applyFuncsToField={this.handleApplyFuncsToField}
+              isInDataExplorer={isInDataExplorer}
             />
           </div>
         </div>
@@ -159,6 +160,7 @@ const QueryBuilder = React.createClass({
           onToggleField={this.handleToggleField}
           onGroupByTime={this.handleGroupByTime}
           applyFuncsToField={this.handleApplyFuncsToField}
+          isInDataExplorer={isInDataExplorer}
         />
       </div>
     )

--- a/ui/src/data_explorer/components/QueryBuilder.js
+++ b/ui/src/data_explorer/components/QueryBuilder.js
@@ -60,7 +60,7 @@ const QueryBuilder = React.createClass({
   },
 
   handleApplyFuncsToField(fieldFunc) {
-    this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc)
+    this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc, this.props.isInDataExplorer)
   },
 
   handleChooseTag(tag) {

--- a/ui/src/data_explorer/constants/index.js
+++ b/ui/src/data_explorer/constants/index.js
@@ -81,3 +81,5 @@ export const QUERY_TEMPLATES = [
   {text: 'Show Stats', query: 'SHOW STATS'},
   {text: 'Show Diagnostics', query: 'SHOW DIAGNOSTICS'},
 ]
+
+export const DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL = '10s'

--- a/ui/src/data_explorer/data/groupByTimes.hson
+++ b/ui/src/data_explorer/data/groupByTimes.hson
@@ -1,4 +1,5 @@
 [
+  {defaultTimeBound: ':autoGroupBy:', seconds: 604800, menuOption: 'auto'},
   {defaultTimeBound: 'now() - 5m', seconds: 10, menuOption: '10s'},
   {defaultTimeBound: 'now() - 15m', seconds: 60, menuOption: '1m'},
   {defaultTimeBound: 'now() - 1h', seconds: 300, menuOption: '5m'},

--- a/ui/src/data_explorer/data/groupByTimes.hson
+++ b/ui/src/data_explorer/data/groupByTimes.hson
@@ -1,5 +1,5 @@
 [
-  {defaultTimeBound: ':autoGroupBy:', seconds: 604800, menuOption: 'auto'},
+  {defaultTimeBound: ':interval:', seconds: 604800, menuOption: 'auto'},
   {defaultTimeBound: 'now() - 5m', seconds: 10, menuOption: '10s'},
   {defaultTimeBound: 'now() - 15m', seconds: 60, menuOption: '1m'},
   {defaultTimeBound: 'now() - 1h', seconds: 300, menuOption: '5m'},

--- a/ui/src/data_explorer/reducers/queryConfigs.js
+++ b/ui/src/data_explorer/reducers/queryConfigs.js
@@ -129,8 +129,8 @@ export default function queryConfigs(state = {}, action) {
     }
 
     case 'APPLY_FUNCS_TO_FIELD': {
-      const {queryId, fieldFunc} = action.payload
-      const nextQueryConfig = applyFuncsToField(state[queryId], fieldFunc)
+      const {queryId, fieldFunc, isInDataExplorer} = action.payload
+      const nextQueryConfig = applyFuncsToField(state[queryId], fieldFunc, isInDataExplorer)
 
       return Object.assign({}, state, {
         [queryId]: nextQueryConfig,

--- a/ui/src/shared/actions/timeSeries.js
+++ b/ui/src/shared/actions/timeSeries.js
@@ -40,7 +40,7 @@ export const handleError = (error, query, editQueryStatus) => {
 }
 
 export const fetchTimeSeriesAsync = async (
-  {source, db, rp, query, tempVars},
+  {source, db, rp, query, tempVars, resolution},
   editQueryStatus = noop
 ) => {
   handleLoading(query, editQueryStatus)
@@ -51,6 +51,7 @@ export const fetchTimeSeriesAsync = async (
       rp,
       query: query.text,
       tempVars,
+      resolution,
     })
     return handleSuccess(data, query, editQueryStatus)
   } catch (error) {

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -117,7 +117,7 @@ const AutoRefresh = ComposedComponent => {
       const timeSeriesPromises = queries.map(query => {
         const {host, database, rp} = query
 
-        const templatesWithResolution = templates.map((temp) => {
+        const templatesWithResolution = templates.map(temp => {
           if (temp.tempVar === ':interval:') {
             if (resolution) {
               return {...temp, resolution}
@@ -175,7 +175,13 @@ const AutoRefresh = ComposedComponent => {
         return this.renderNoResults()
       }
 
-      return <ComposedComponent {...this.props} data={timeSeries} setResolution={this.setResolution} />
+      return (
+        <ComposedComponent
+          {...this.props}
+          data={timeSeries}
+          setResolution={this.setResolution}
+        />
+      )
     },
 
     /**
@@ -188,6 +194,7 @@ const AutoRefresh = ComposedComponent => {
         <ComposedComponent
           {...this.props}
           data={data}
+          setResolution={this.setResolution}
           isFetchingInitially={isFirstFetch}
           isRefreshing={!isFirstFetch}
         />

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -50,6 +50,7 @@ const AutoRefresh = ComposedComponent => {
       return {
         lastQuerySuccessful: false,
         timeSeries: [],
+        resolution: null,
       }
     },
 
@@ -104,6 +105,7 @@ const AutoRefresh = ComposedComponent => {
 
     executeQueries(queries, templates = []) {
       const {editQueryStatus} = this.props
+      const {resolution} = this.state
 
       if (!queries.length) {
         this.setState({timeSeries: []})
@@ -121,6 +123,7 @@ const AutoRefresh = ComposedComponent => {
             rp,
             query,
             tempVars: removeUnselectedTemplateValues(templates),
+            resolution,
           },
           editQueryStatus
         )
@@ -143,6 +146,10 @@ const AutoRefresh = ComposedComponent => {
       this.intervalID = false
     },
 
+    setResolution(resolution) {
+      this.setState({resolution})
+    },
+
     render() {
       const {timeSeries} = this.state
 
@@ -157,7 +164,7 @@ const AutoRefresh = ComposedComponent => {
         return this.renderNoResults()
       }
 
-      return <ComposedComponent {...this.props} data={timeSeries} />
+      return <ComposedComponent {...this.props} data={timeSeries} setResolution={this.setResolution} />
     },
 
     /**

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -118,7 +118,7 @@ const AutoRefresh = ComposedComponent => {
         const {host, database, rp} = query
 
         const templatesWithResolution = templates.map((temp) => {
-          if (temp.tempVar === ':autoGroupBy:') {
+          if (temp.tempVar === ':interval:') {
             if (resolution) {
               return {...temp, resolution}
             }

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -116,13 +116,24 @@ const AutoRefresh = ComposedComponent => {
 
       const timeSeriesPromises = queries.map(query => {
         const {host, database, rp} = query
+
+        const templatesWithResolution = templates.map((temp) => {
+          if (temp.tempVar === ':autoGroupBy:') {
+            if (resolution) {
+              return {...temp, resolution}
+            }
+            return {...temp, resolution: 1000}
+          }
+          return {...temp}
+        })
+
         return fetchTimeSeriesAsync(
           {
             source: host,
             db: database,
             rp,
             query,
-            tempVars: removeUnselectedTemplateValues(templates),
+            tempVars: removeUnselectedTemplateValues(templatesWithResolution),
             resolution,
           },
           editQueryStatus

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -7,6 +7,7 @@ import _ from 'lodash'
 import Dygraphs from 'src/external/dygraph'
 import getRange from 'shared/parsing/getRangeForDygraph'
 
+
 const LINE_COLORS = [
   '#00C9FF',
   '#9394FF',
@@ -233,6 +234,9 @@ export default class Dygraph extends Component {
       ...options,
     })
 
+    const {w} = this.dygraph.getArea()
+    this.props.setResolution(w)
+
     // Simple opt-out for now, if a graph should not be synced
     if (this.props.synchronizer) {
       this.sync()
@@ -358,4 +362,5 @@ Dygraph.propTypes = {
     lower: string.isRequired,
   }),
   synchronizer: func,
+  setResolution: func,
 }

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -7,7 +7,6 @@ import _ from 'lodash'
 import Dygraphs from 'src/external/dygraph'
 import getRange from 'shared/parsing/getRangeForDygraph'
 
-
 const LINE_COLORS = [
   '#00C9FF',
   '#9394FF',
@@ -309,6 +308,8 @@ export default class Dygraph extends Component {
     // }
 
     dygraph.resize()
+    const {w} = this.dygraph.getArea()
+    this.props.setResolution(w)
   }
 
   sync() {

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -37,6 +37,7 @@ export default React.createClass({
     }),
     isInDataExplorer: bool,
     synchronizer: func,
+    setResolution: func,
   },
 
   getDefaultProps() {
@@ -149,6 +150,7 @@ export default React.createClass({
           ruleValues={ruleValues}
           synchronizer={synchronizer}
           timeRange={timeRange}
+          setResolution={this.props.setResolution}
         />
         {showSingleStat
           ? <div className="graph-single-stat single-stat">

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -401,4 +401,4 @@ export const TABLE = 'table'
 export const VIS_VIEWS = [GRAPH, TABLE]
 
 // InfluxQL Macros
-export const AUTO_GROUP_BY = ':autoGroupBy:'
+export const AUTO_GROUP_BY = ':interval:'

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -401,4 +401,5 @@ export const TABLE = 'table'
 export const VIS_VIEWS = [GRAPH, TABLE]
 
 // InfluxQL Macros
-export const AUTO_GROUP_BY = ':interval:'
+export const TEMP_VAR_INTERVAL = ':interval:'
+export const DEFAULT_DASHBOARD_GROUP_BY_INTERVAL = 'auto'

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -399,3 +399,6 @@ export const AUTOREFRESH_DEFAULT = 15000 // in milliseconds
 export const GRAPH = 'graph'
 export const TABLE = 'table'
 export const VIS_VIEWS = [GRAPH, TABLE]
+
+// InfluxQL Macros
+export const AUTO_GROUP_BY = ':autoGroupBy:'

--- a/ui/src/utils/influxql.js
+++ b/ui/src/utils/influxql.js
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-import {AUTO_GROUP_BY} from 'shared/constants'
+import {TEMP_VAR_INTERVAL, DEFAULT_DASHBOARD_GROUP_BY_INTERVAL} from 'shared/constants'
 
 export default function buildInfluxQLQuery(timeBounds, config) {
   const {groupBy, tags, areTagsAccepted} = config
@@ -94,7 +94,7 @@ function _buildGroupByTime(groupBy) {
     return ''
   }
 
-  return ` GROUP BY ${groupBy.time === 'auto' ? AUTO_GROUP_BY : `time(${groupBy.time})`}`
+  return ` GROUP BY ${groupBy.time === DEFAULT_DASHBOARD_GROUP_BY_INTERVAL ? TEMP_VAR_INTERVAL : `time(${groupBy.time})`}`
 }
 
 function _buildGroupByTags(groupBy) {

--- a/ui/src/utils/influxql.js
+++ b/ui/src/utils/influxql.js
@@ -1,5 +1,7 @@
 import _ from 'lodash'
 
+import {AUTO_GROUP_BY} from 'shared/constants'
+
 export default function buildInfluxQLQuery(timeBounds, config) {
   const {groupBy, tags, areTagsAccepted} = config
   const {upper, lower} = timeBounds
@@ -92,7 +94,7 @@ function _buildGroupByTime(groupBy) {
     return ''
   }
 
-  return ` GROUP BY time(${groupBy.time})`
+  return ` GROUP BY ${groupBy.time === 'auto' ? AUTO_GROUP_BY : `time(${groupBy.time})`}`
 }
 
 function _buildGroupByTags(groupBy) {

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -79,7 +79,7 @@ export function toggleTagAcceptance(query) {
   })
 }
 
-export function applyFuncsToField(query, {field, funcs}) {
+export function applyFuncsToField(query, {field, funcs}, isInDataExplorer = false) {
   const shouldRemoveFuncs = funcs.length === 0
   const nextFields = query.fields.map(f => {
     // If one field has no funcs, all fields must have no funcs
@@ -95,8 +95,9 @@ export function applyFuncsToField(query, {field, funcs}) {
     return f
   })
 
+  const defaultGroupBy = isInDataExplorer ? DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL : DEFAULT_DASHBOARD_GROUP_BY_INTERVAL
   // If there are no functions, then there should be no GROUP BY time
-  const nextGroupBy = Object.assign({}, query.groupBy, {time: shouldRemoveFuncs ? null : DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL})
+  const nextGroupBy = Object.assign({}, query.groupBy, {time: shouldRemoveFuncs ? null : defaultGroupBy})
 
   return Object.assign({}, query, {
     fields: nextFields,

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -42,9 +42,17 @@ export const toggleField = (query, {field, funcs}, isKapacitorRule = false) => {
     }
   }
 
+  let newFuncs = ['mean']
+  if (query.fields.length) {
+    newFuncs = query.fields.find(f => f.funcs).funcs
+  }
+
   return {
     ...query,
-    fields: query.fields.concat({field, funcs}),
+    fields: query.fields.concat({
+      field,
+      funcs: newFuncs,
+    }),
   }
 }
 

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -1,5 +1,6 @@
 import defaultQueryConfig from './defaultQueryConfig'
 import {DEFAULT_DASHBOARD_GROUP_BY_INTERVAL} from 'shared/constants'
+import {DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL} from 'src/data_explorer/constants'
 
 export function editRawText(query, rawText) {
   return Object.assign({}, query, {rawText})
@@ -95,15 +96,12 @@ export function applyFuncsToField(query, {field, funcs}) {
   })
 
   // If there are no functions, then there should be no GROUP BY time
-  if (shouldRemoveFuncs) {
-    const nextGroupBy = Object.assign({}, query.groupBy, {time: null})
-    return Object.assign({}, query, {
-      fields: nextFields,
-      groupBy: nextGroupBy,
-    })
-  }
+  const nextGroupBy = Object.assign({}, query.groupBy, {time: shouldRemoveFuncs ? null : DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL})
 
-  return Object.assign({}, query, {fields: nextFields})
+  return Object.assign({}, query, {
+    fields: nextFields,
+    groupBy: nextGroupBy,
+  })
 }
 
 export function updateRawQuery(query, rawText) {

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -1,4 +1,5 @@
 import defaultQueryConfig from './defaultQueryConfig'
+import {DEFAULT_DASHBOARD_GROUP_BY_INTERVAL} from 'shared/constants'
 
 export function editRawText(query, rawText) {
   return Object.assign({}, query, {rawText})
@@ -54,6 +55,13 @@ export const toggleField = (query, {field, funcs}, isKapacitorRule = false) => {
       funcs: newFuncs,
     }),
   }
+}
+
+// all fields implicitly have a function applied to them, so consequently
+// we need to set the auto group by time
+export const toggleFieldWithGroupByInterval = (query, {field, funcs}, isKapacitorRule) => {
+  const queryWithField = toggleField(query, {field, funcs}, isKapacitorRule)
+  return groupByTime(queryWithField, DEFAULT_DASHBOARD_GROUP_BY_INTERVAL)
 }
 
 export function groupByTime(query, time) {

--- a/ui/src/utils/queryUrlGenerator.js
+++ b/ui/src/utils/queryUrlGenerator.js
@@ -1,6 +1,6 @@
 import AJAX from 'utils/ajax'
 
-export const proxy = async ({source, query, db, rp, tempVars}) => {
+export const proxy = async ({source, query, db, rp, tempVars, resolution}) => {
   try {
     return await AJAX({
       method: 'POST',
@@ -8,6 +8,7 @@ export const proxy = async ({source, query, db, rp, tempVars}) => {
       data: {
         tempVars,
         query,
+        resolution,
         db,
         rp,
       },


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1471 

### The problem

It's far too easy to select more data than your monitor can actually display.

### The Solution

This introduces a new template variable, `:autoGroupBy:`, which calculates a group by time based off of the available resolution for rendering a graph (per @goller 's math in #829). This is supplied by Dygraphs along with the query.

This introduces another "type" of template variable, a `GroupByVar`, which handles this calculation and is instantiated by a custom `UnmarshalJSON`, capable of determining Template Variable types. Also, Template Variables now have varying precedence, as `GroupByVar` must be applied after all template variables so that it can see the selected time range in the query.

### Caveats / Known Grossness
1. This currently works only with data reporting at the Telegraf default of 10s. There is some follow-on work to determine the underlying reporting interval, and @goller and I have discussed some strategies for doing this.
2. Template Variables that analyze and modify queries, like `:autoGroupBy:` need to parse the query before they can do their job. Unfortunately, the InfluxQL parsing functions need a legal query to parse, which InfluxQL + Template Variables is not. We ran into this circular dependency with `:dashboardTime:` as well. To break this dependency, I instead manually parsed out the duration, which limits the types of `where` expressions that can be understood by `:autoGroupBy:`. Ideally, template variables and template macros (which `:autoGroupBy:` and `:dashboardTime:` really are) would be supported directly by InfluxQL.