### PR TITLE
Remove system databases from "Write Data" dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## v1.3.4.0 [unreleased]
 ### Bug Fixes
+1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Prevent users from being able to write to internal system databases via the write data modal
+
 ### Features
 ### UI Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.3.4.0 [unreleased]
 ### Bug Fixes
-1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Prevent users from being able to write to internal system databases via the write data modal
+1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Prevent users from being able to write to internal system databases
 
 ### Features
 ### UI Improvements

--- a/ui/src/shared/components/DatabaseDropdown.js
+++ b/ui/src/shared/components/DatabaseDropdown.js
@@ -49,7 +49,7 @@ class DatabaseDropdown extends Component {
       }
 
       // system databases are those preceded with an '_'
-      const nonSystemDatabases = databases.filter((name) => !name.startsWith('_'))
+      const nonSystemDatabases = databases.filter((name) => name !== '_internal')
 
       this.setState({databases: nonSystemDatabases})
       const selectedDatabaseText = nonSystemDatabases.includes(database)

--- a/ui/src/shared/components/DatabaseDropdown.js
+++ b/ui/src/shared/components/DatabaseDropdown.js
@@ -49,7 +49,7 @@ class DatabaseDropdown extends Component {
       }
 
       // system databases are those preceded with an '_'
-      const nonSystemDatabases = databases.filter((name) => name[0] !== '_')
+      const nonSystemDatabases = databases.filter((name) => !name.startsWith('_'))
 
       this.setState({databases: nonSystemDatabases})
       const selectedDatabaseText = nonSystemDatabases.includes(database)

--- a/ui/src/shared/components/DatabaseDropdown.js
+++ b/ui/src/shared/components/DatabaseDropdown.js
@@ -43,12 +43,18 @@ class DatabaseDropdown extends Component {
     const proxy = source.links.proxy
     try {
       const {data} = await showDatabases(proxy)
-      const {databases} = showDatabasesParser(data)
+      const {databases, errors} = showDatabasesParser(data)
+      if (errors.length > 0) {
+        throw errors[0] // only one error can come back from this, but it's returned as an array
+      }
 
-      this.setState({databases})
-      const selectedDatabaseText = databases.includes(database)
+      // system databases are those preceded with an '_'
+      const nonSystemDatabases = databases.filter((name) => name[0] !== '_')
+
+      this.setState({databases: nonSystemDatabases})
+      const selectedDatabaseText = nonSystemDatabases.includes(database)
         ? database
-        : databases[0] || 'No databases'
+        : nonSystemDatabases[0] || 'No databases'
       onSelectDatabase({text: selectedDatabaseText})
     } catch (error) {
       console.error(error)

--- a/ui/src/shared/components/DatabaseDropdown.js
+++ b/ui/src/shared/components/DatabaseDropdown.js
@@ -48,8 +48,7 @@ class DatabaseDropdown extends Component {
         throw errors[0] // only one error can come back from this, but it's returned as an array
       }
 
-      // system databases are those preceded with an '_'
-      const nonSystemDatabases = databases.filter((name) => name !== '_internal')
+      const nonSystemDatabases = databases.filter(name => name !== '_internal')
 
       this.setState({databases: nonSystemDatabases})
       const selectedDatabaseText = nonSystemDatabases.includes(database)


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1570 

Users should not write to \_internal, or generally any other database preceeded with an '\_', as we take that to mean a system-internal database of some kind. This filters the list of databases to remove those with names preceeded by a '\_' character.

Also 'SHOW DATABASES' can return an error if users are not authorized to do that, so it's important to throw that so it can be properly handled / displayed to the user.

EDIT: It was decided that the only system database is the `_internal` database, so a patch was added to explicitly remove just that database name instead of all database names prefixed with an underscore.

