### PR TITLE
Better future-proofs docs links by using 'latest' in URL

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,1 +1,1 @@
-**We've moved our documentation!** Check out the latest [getting started guide](https://docs.influxdata.com/chronograf/v1.3/introduction/getting-started/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/v1.3/).
+**We've moved our documentation!** Check out the latest [getting started guide](https://docs.influxdata.com/chronograf/latest/introduction/getting-started/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/latest/).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,1 +1,1 @@
-**We've moved our documentation!** Check out the latest [installation guide](https://docs.influxdata.com/chronograf/v1.3/introduction/installation/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/v1.3/).
+**We've moved our documentation!** Check out the latest [installation guide](https://docs.influxdata.com/chronograf/latest/introduction/installation/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/latest/).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,1 +1,1 @@
-**We've moved our documentation!** Check out the latest [authentication content](https://docs.influxdata.com/chronograf/v1.3/administration/security-best-practices/#chronograf-with-oauth-2-0-authentication) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/v1.3/).
+**We've moved our documentation!** Check out the latest [authentication content](https://docs.influxdata.com/chronograf/latest/administration/security-best-practices/#chronograf-with-oauth-2-0-authentication) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/latest/).

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -1,1 +1,1 @@
-**We've moved our documentation!** Check out the latest [TLS content](https://docs.influxdata.com/chronograf/v1.3/administration/security-best-practices/#tls) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/v1.3/).
+**We've moved our documentation!** Check out the latest [TLS content](https://docs.influxdata.com/chronograf/latest/administration/security-best-practices/#tls) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/latest/).

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,1 +1,1 @@
-**We've moved our documentation!** Check our latest [guides](https://docs.influxdata.com/chronograf/v1.3/guides/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/v1.3/).
+**We've moved our documentation!** Check our latest [guides](https://docs.influxdata.com/chronograf/latest/guides/) on InfluxData's [main docs site](https://docs.influxdata.com/chronograf/latest/).

--- a/ui/src/data_explorer/components/WriteDataForm.js
+++ b/ui/src/data_explorer/components/WriteDataForm.js
@@ -88,7 +88,7 @@ class WriteDataForm extends Component {
             <span className="write-data-form--helper">
               Need help writing InfluxDB Line Protocol? -&nbsp;
               <a
-                href="https://docs.influxdata.com/influxdb/v1.2/write_protocols/line_protocol_tutorial/"
+                href="https://docs.influxdata.com/influxdb/latest/write_protocols/line_protocol_tutorial/"
                 target="_blank"
               >
                 See Documentation

--- a/ui/src/kapacitor/components/config/TelegramConfig.js
+++ b/ui/src/kapacitor/components/config/TelegramConfig.js
@@ -58,7 +58,7 @@ const TelegramConfig = React.createClass({
             You need a
             {' '}
             <a
-              href="https://docs.influxdata.com/kapacitor/v1.3/guides/event-handler-setup/#telegram-setup"
+              href="https://docs.influxdata.com/kapacitor/latest/guides/event-handler-setup/#telegram-setup"
               target="_blank"
             >
               Telegram Bot


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1615 #1613 

### The problem
Docs links were hard-coded to specific version numbers.

### The Solution
Better future-proof these links by updating to `/latest`.
