### PR TITLE
Fix Status Page timerange to be 30d again

### DIFF
--- a/ui/src/shared/data/timeRanges.hson
+++ b/ui/src/shared/data/timeRanges.hson
@@ -8,5 +8,4 @@
   {defaultGroupBy: '30m', seconds: 172800, inputValue: 'Past 2 days', lower: 'now() - 2d', upper: null, menuOption: 'Past 2 days'},
   {defaultGroupBy: '1h', seconds: 604800, inputValue: 'Past 7 days', lower: 'now() - 7d', upper: null, menuOption: 'Past 7 days'},
   {defaultGroupBy: '6h', seconds: 2592000, inputValue: 'Past 30 days', lower: 'now() - 30d', upper: null, menuOption: 'Past 30 days'},
-  {defaultGroupBy: '12h', seconds: 7776000, inputValue: 'Past 90 days', lower: 'now() - 90d', upper: null, menuOption: 'Past 90 days'},
 ]

--- a/ui/src/status/reducers/ui.js
+++ b/ui/src/status/reducers/ui.js
@@ -3,7 +3,7 @@ import timeRanges from 'hson!shared/data/timeRanges.hson'
 
 import * as actionTypes from 'src/status/constants/actionTypes'
 
-const {lower, upper} = timeRanges.find(tr => tr.lower === 'now() - 90d')
+const {lower, upper} = timeRanges.find(tr => tr.lower === 'now() - 30d')
 
 const initialState = {
   autoRefresh: AUTOREFRESH_DEFAULT,


### PR DESCRIPTION
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1608 

### The problem
Somewhere along the line, a 90d timeRange was being used for testing purposes and accidentally got committed and included in the PR, so the Status Page bar graph and Alerts are based on a 90d time window, despite saying "30 days".

### The Solution
- Fix the status reducer to use `30d` instead of `90d`
- Remove the 90d option from timeRanges.hson

