### PR TITLE
Do not prefix basepath to external link for news feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
-## v1.3.4.0 [unreleased]
-
+## v1.3.3.1 [2017-06-20]
 ### Bug Fixes
-### Features
-### UI Improvements
+1. [#1642](https://github.com/influxdata/chronograf/pull/1642): Do not prefix basepath to external link for news feed
 
 ## v1.3.3.0 [2017-06-19]
 

--- a/ui/src/status/apis/index.js
+++ b/ui/src/status/apis/index.js
@@ -1,10 +1,13 @@
 import AJAX from 'utils/ajax'
 
 export const fetchJSONFeed = url =>
-  AJAX({
-    method: 'GET',
-    url,
-    // For explanation of why this header makes this work:
-    // https://stackoverflow.com/questions/22968406/how-to-skip-the-options-preflight-request-in-angularjs
-    headers: {'Content-Type': 'text/plain; charset=UTF-8'},
-  })
+  AJAX(
+    {
+      method: 'GET',
+      url,
+      // For explanation of why this header makes this work:
+      // https://stackoverflow.com/questions/22968406/how-to-skip-the-options-preflight-request-in-angularjs
+      headers: {'Content-Type': 'text/plain; charset=UTF-8'},
+    },
+    true // don't prefix route of external link with basepath
+  )

--- a/ui/src/utils/ajax.js
+++ b/ui/src/utils/ajax.js
@@ -2,6 +2,13 @@ import axios from 'axios'
 
 let links
 
+// do not prefix route with basepath, ex. for external links
+const addBasepath = (url, excludeBasepath) => {
+  const basepath = window.basepath || ''
+
+  return excludeBasepath ? url : `${basepath}${url}`
+}
+
 const generateResponseWithLinks = (response, {auth, logout, external}) => ({
   ...response,
   auth: {links: auth},
@@ -9,24 +16,18 @@ const generateResponseWithLinks = (response, {auth, logout, external}) => ({
   external,
 })
 
-const AJAX = async ({
-  url,
-  resource,
-  id,
-  method = 'GET',
-  data = {},
-  params = {},
-  headers = {},
-}) => {
+const AJAX = async (
+  {url, resource, id, method = 'GET', data = {}, params = {}, headers = {}},
+  excludeBasepath
+) => {
   try {
-    const basepath = window.basepath || ''
     let response
 
-    url = `${basepath}${url}`
+    url = addBasepath(url, excludeBasepath)
 
     if (!links) {
       const linksRes = (response = await axios({
-        url: `${basepath}/chronograf/v1`,
+        url: addBasepath('/chronograf/v1', excludeBasepath),
         method: 'GET',
       }))
       links = linksRes.data
@@ -34,8 +35,8 @@ const AJAX = async ({
 
     if (resource) {
       url = id
-        ? `${basepath}${links[resource]}/${id}`
-        : `${basepath}${links[resource]}`
+        ? addBasepath(`${links[resource]}/${id}`, excludeBasepath)
+        : addBasepath(`${links[resource]}`, excludeBasepath)
     }
 
     response = await axios({


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1640 

### The problem
If a user was using the server options to prefix their routes with a basepath, a prefixed basepath was being added to the new external news feed link, resulting in an incorrect URL and failure to load the news feed.

### The Solution
- Implement an option to exclude basepath from urls in `ajax.js`.
- Have `fetchJSONFeed` in `/status/apis` utilize this exclusion.

### How to Test
- get your `<provider-client-id>` and `<provider-client-secret>` from your OAuth provider settings and use them below
- run Chronograf via `./chronograf -d -i <provider-client-id> -s <provider-client-secret> -t supersecret2 --auth-duration=15m --prefix-routes -p <your-basepath>`
- make sure your OAuth provider settings (such as on GitHub/settings) use the same basepath that you used in `<your-basepath>` above (i.e. `/chronograf`) in the homepage and callback URL