### PR TITLE
Sticky Alert Table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 ### Features
 ### UI Improvements
+1. [#1644](https://github.com/influxdata/chronograf/pull/1644): Redesign Alerts History table to have sticky headers
 
 ## v1.3.3.0 [2017-06-19]
 

--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -4,6 +4,8 @@ import {Link} from 'react-router'
 
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 
+import {ALERTS_TABLE} from 'src/alerts/constants/tableSizing'
+
 class AlertsTable extends Component {
   constructor(props) {
     super(props)
@@ -82,41 +84,42 @@ class AlertsTable extends Component {
       this.state.sortKey,
       this.state.sortDirection
     )
+    const {colName, colLevel, colTime, colHost, colValue} = ALERTS_TABLE
     return this.props.alerts.length
       ? <div className="alert-history-table">
           <div className="alert-history-table--thead">
             <div
               onClick={() => this.changeSort('name')}
               className={this.sortableClasses('name')}
-              style={{width: '15%'}}
+              style={{width: colName}}
             >
               Name
             </div>
             <div
               onClick={() => this.changeSort('level')}
               className={this.sortableClasses('level')}
-              style={{width: '10%'}}
+              style={{width: colLevel}}
             >
               Level
             </div>
             <div
               onClick={() => this.changeSort('time')}
               className={this.sortableClasses('time')}
-              style={{width: '25%'}}
+              style={{width: colTime}}
             >
               Time
             </div>
             <div
               onClick={() => this.changeSort('host')}
               className={this.sortableClasses('host')}
-              style={{width: '25%'}}
+              style={{width: colHost}}
             >
               Host
             </div>
             <div
               onClick={() => this.changeSort('value')}
               className={this.sortableClasses('value')}
-              style={{width: '25%'}}
+              style={{width: colValue}}
             >
               Value
             </div>
@@ -133,25 +136,25 @@ class AlertsTable extends Component {
                 >
                   <div
                     className="alert-history-table--td"
-                    style={{width: '15%'}}
+                    style={{width: colName}}
                   >
                     {name}
                   </div>
                   <div
                     className={`alert-history-table--td alert-level-${level.toLowerCase()}`}
-                    style={{width: '10%'}}
+                    style={{width: colLevel}}
                   >
                     {level}
                   </div>
                   <div
                     className="alert-history-table--td"
-                    style={{width: '25%'}}
+                    style={{width: colTime}}
                   >
                     {new Date(Number(time)).toISOString()}
                   </div>
                   <div
                     className="alert-history-table--td"
-                    style={{width: '25%'}}
+                    style={{width: colHost}}
                   >
                     <Link to={`/sources/${id}/hosts/${host}`}>
                       {host}
@@ -159,7 +162,7 @@ class AlertsTable extends Component {
                   </div>
                   <div
                     className="alert-history-table--td"
-                    style={{width: '25%'}}
+                    style={{width: colValue}}
                   >
                     {value}
                   </div>

--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -269,7 +269,7 @@ class SearchBar extends Component {
         <input
           type="text"
           className="form-control"
-          placeholder="Filter Alerts by Name..."
+          placeholder="Filter Alerts..."
           onChange={this.handleChange}
           value={this.state.searchTerm}
         />

--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react'
 import _ from 'lodash'
 import {Link} from 'react-router'
 
+import FancyScrollbar from 'shared/components/FancyScrollbar'
+
 class AlertsTable extends Component {
   constructor(props) {
     super(props)
@@ -55,11 +57,11 @@ class AlertsTable extends Component {
   sortableClasses(key) {
     if (this.state.sortKey === key) {
       if (this.state.sortDirection === 'asc') {
-        return 'sortable-header sorting-ascending'
+        return 'alert-history-table--th sortable-header sorting-ascending'
       }
-      return 'sortable-header sorting-descending'
+      return 'alert-history-table--th sortable-header sorting-descending'
     }
-    return 'sortable-header'
+    return 'alert-history-table--th sortable-header'
   }
 
   sort(alerts, key, direction) {
@@ -81,63 +83,91 @@ class AlertsTable extends Component {
       this.state.sortDirection
     )
     return this.props.alerts.length
-      ? <table className="table v-center table-highlight">
-          <thead>
-            <tr>
-              <th
-                onClick={() => this.changeSort('name')}
-                className={this.sortableClasses('name')}
-              >
-                Name
-              </th>
-              <th
-                onClick={() => this.changeSort('level')}
-                className={this.sortableClasses('level')}
-              >
-                Level
-              </th>
-              <th
-                onClick={() => this.changeSort('time')}
-                className={this.sortableClasses('time')}
-              >
-                Time
-              </th>
-              <th
-                onClick={() => this.changeSort('host')}
-                className={this.sortableClasses('host')}
-              >
-                Host
-              </th>
-              <th
-                onClick={() => this.changeSort('value')}
-                className={this.sortableClasses('value')}
-              >
-                Value
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+      ? <div className="alert-history-table">
+          <div className="alert-history-table--thead">
+            <div
+              onClick={() => this.changeSort('name')}
+              className={this.sortableClasses('name')}
+              style={{width: '15%'}}
+            >
+              Name
+            </div>
+            <div
+              onClick={() => this.changeSort('level')}
+              className={this.sortableClasses('level')}
+              style={{width: '10%'}}
+            >
+              Level
+            </div>
+            <div
+              onClick={() => this.changeSort('time')}
+              className={this.sortableClasses('time')}
+              style={{width: '25%'}}
+            >
+              Time
+            </div>
+            <div
+              onClick={() => this.changeSort('host')}
+              className={this.sortableClasses('host')}
+              style={{width: '25%'}}
+            >
+              Host
+            </div>
+            <div
+              onClick={() => this.changeSort('value')}
+              className={this.sortableClasses('value')}
+              style={{width: '25%'}}
+            >
+              Value
+            </div>
+          </div>
+          <FancyScrollbar
+            className="alert-history-table--tbody"
+            autoHide={false}
+          >
             {alerts.map(({name, level, time, host, value}) => {
               return (
-                <tr key={`${name}-${level}-${time}-${host}-${value}`}>
-                  <td className="monotype">{name}</td>
-                  <td className={`monotype alert-level-${level.toLowerCase()}`}>
+                <div
+                  className="alert-history-table--tr"
+                  key={`${name}-${level}-${time}-${host}-${value}`}
+                >
+                  <div
+                    className="alert-history-table--td"
+                    style={{width: '15%'}}
+                  >
+                    {name}
+                  </div>
+                  <div
+                    className={`alert-history-table--td alert-level-${level.toLowerCase()}`}
+                    style={{width: '10%'}}
+                  >
                     {level}
-                  </td>
-                  <td className="monotype">
+                  </div>
+                  <div
+                    className="alert-history-table--td"
+                    style={{width: '25%'}}
+                  >
                     {new Date(Number(time)).toISOString()}
-                  </td>
-                  <td className="monotype">
+                  </div>
+                  <div
+                    className="alert-history-table--td"
+                    style={{width: '25%'}}
+                  >
                     <Link to={`/sources/${id}/hosts/${host}`}>
                       {host}
                     </Link>
-                  </td>
-                  <td className="monotype">{value}</td>
-                </tr>
+                  </div>
+                  <div
+                    className="alert-history-table--td"
+                    style={{width: '25%'}}
+                  >
+                    {value}
+                  </div>
+                </div>
               )
             })}
-          </tbody>
-        </table>
+          </FancyScrollbar>
+        </div>
       : this.renderTableEmpty()
   }
 

--- a/ui/src/alerts/constants/tableSizing.js
+++ b/ui/src/alerts/constants/tableSizing.js
@@ -1,0 +1,7 @@
+export const ALERTS_TABLE = {
+  colName: '15%',
+  colLevel: '10%',
+  colTime: '25%',
+  colHost: '25%',
+  colValue: '25%',
+}

--- a/ui/src/alerts/containers/AlertsApp.js
+++ b/ui/src/alerts/containers/AlertsApp.js
@@ -4,7 +4,6 @@ import SourceIndicator from 'shared/components/SourceIndicator'
 import AlertsTable from 'src/alerts/components/AlertsTable'
 import NoKapacitorError from 'shared/components/NoKapacitorError'
 import CustomTimeRangeDropdown from 'shared/components/CustomTimeRangeDropdown'
-import FancyScrollbar from 'shared/components/FancyScrollbar'
 
 import {getAlerts} from 'src/alerts/apis'
 import AJAX from 'utils/ajax'
@@ -160,10 +159,8 @@ class AlertsApp extends Component {
     }
 
     return isWidget
-      ? <FancyScrollbar autoHide={false}>
-          {this.renderSubComponents()}
-        </FancyScrollbar>
-      : <div className="page">
+      ? this.renderSubComponents()
+      : <div className="page alert-history-page">
           <div className="page-header">
             <div className="page-header__container">
               <div className="page-header__left">
@@ -183,7 +180,7 @@ class AlertsApp extends Component {
               </div>
             </div>
           </div>
-          <FancyScrollbar className="page-contents">
+          <div className="page-contents">
             <div className="container-fluid">
               <div className="row">
                 <div className="col-md-12">
@@ -191,7 +188,7 @@ class AlertsApp extends Component {
                 </div>
               </div>
             </div>
-          </FancyScrollbar>
+          </div>
         </div>
   }
 }

--- a/ui/src/style/components/tables.scss
+++ b/ui/src/style/components/tables.scss
@@ -50,7 +50,8 @@
     Sortable Tables
     ----------------------------------------------
 */
-table.table thead th.sortable-header {
+table.table thead th.sortable-header,
+.alert-history-table--th.sortable-header {
   transition:
     color 0.25s ease,
     background-color 0.25s ease;
@@ -216,15 +217,6 @@ $table-tab-scrollbar-height: 6px;
   font-size: 13px;
   font-weight: 500;
   color: $g17-whisper;
-  transition:
-    color 0.25s ease,
-    background-color 0.25s ease;
-
-  &:hover {
-    background-color: $g5-pepper;
-    color: $g19-ghost;
-    cursor: pointer;
-  }
 }
 .alert-history-table--tbody {
   flex: 1 0 0;

--- a/ui/src/style/components/tables.scss
+++ b/ui/src/style/components/tables.scss
@@ -172,15 +172,60 @@ $table-tab-scrollbar-height: 6px;
 .table.table-highlight > tbody > tr.highlight {
   background-color: $g4-onyx;
 }
+
 /*
-    Responsive Tables
+    Alert History "Table"
     ----------------------------------------------
 */
 
-@media screen and (max-width: 767px) {
-  .table-responsive {
-    border-radius: 3px;
-    border-color: $g5-pepper;
-    @include custom-scrollbar($g5-pepper, $c-pool);
+.alert-history-table {
+
+}
+.alert-history-table--thead {
+  display: flex;
+  width: 100%;
+  border-bottom: 2px solid $g5-pepper;
+}
+.alert-history-table--th {
+  @include no-user-select();
+  padding: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  color: $g17-whisper;
+  transition:
+    color 0.25s ease,
+    background-color 0.25s ease;
+
+  &:hover {
+    background-color: $g5-pepper;
+    color: $g19-ghost;
+    cursor: pointer;
   }
+
+  &.col-name {width: 20%;}
+  &.col-level {width: 20%;}
+  &.col-time {width: 20%;}
+  &.col-host {width: 20%;}
+  &.col-value {width: 20%;}
+}
+.alert-history-table--tbody {
+  width: 100%;
+  height: 500px !important;
+}
+.alert-history-table--tr {
+  display: flex;
+  width: 100%;
+  &:hover {
+    background-color: $g4-onyx;
+  }
+}
+.alert-history-table--td {
+  font-size: 12px;
+  font-family: $code-font;
+  font-weight: 500;
+  padding: 4px 8px;
+  line-height: 1.42857143em;
+  color: $g13-mist;
+  white-space: pre-wrap;
+  word-break: break-all;
 }

--- a/ui/src/style/components/tables.scss
+++ b/ui/src/style/components/tables.scss
@@ -174,12 +174,36 @@ $table-tab-scrollbar-height: 6px;
 }
 
 /*
+    Alert History "Page"
+    ----------------------------------------------
+*/
+.alert-history-page {
+  .page-contents > .container-fluid,
+  .page-contents > .container-fluid > .row,
+  .page-contents > .container-fluid > .row > .col-md-12,
+  .page-contents > .container-fluid > .row > .col-md-12 > .panel {
+    height: 100%;
+  }
+
+  .col-md-12 > .panel {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+
+    > .panel-body {flex: 1 0 0;}
+    .generic-empty-state {height: 100%;}
+  }
+}
+/*
     Alert History "Table"
     ----------------------------------------------
 */
 
 .alert-history-table {
-
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
 }
 .alert-history-table--thead {
   display: flex;
@@ -201,16 +225,10 @@ $table-tab-scrollbar-height: 6px;
     color: $g19-ghost;
     cursor: pointer;
   }
-
-  &.col-name {width: 20%;}
-  &.col-level {width: 20%;}
-  &.col-time {width: 20%;}
-  &.col-host {width: 20%;}
-  &.col-value {width: 20%;}
 }
 .alert-history-table--tbody {
+  flex: 1 0 0;
   width: 100%;
-  height: 500px !important;
 }
 .alert-history-table--tr {
   display: flex;

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -192,3 +192,15 @@ br {
 
   p {font-size: 13px;}
 }
+.alerts-widget {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+
+  > .btn {margin: 20px 0;}
+
+  .alert-history-table {
+    flex: 1 0 0;
+  }
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1630 

### The Problem
- Once a user has accrued a large volume of alert events, the table headers become unusable
- Similarly, when the table appears in the Status Page it is even smaller and the headers disappear sooner

### The Solution
- Make the table stretch to fill height of its parent
- Make the table body scrollable instead of the table's container
- Make sure the table looks and feels great in both instances

### Note
- Initially tried setting `<tbody>` to `overflow: scroll` and in order to achieve that `<table>`,`<thead>`, and `<tbody>` all need their `display` CSS property changed away from the table standards
  - This breaks the only major benefit of using HTML tables: columns stayed the same width between the header and body
- Used `<div>` with fixed % widths to imitate a table
- Set the cell text wrap style to `white-space: pre-wrap` and `word-break: break-all` so that when the screen becomes less wide the contents are still visible. This looks ugly on small screens but is not unusable

### Preview
![alerts-sticky-header](https://user-images.githubusercontent.com/2433762/27355055-770c684e-55be-11e7-8894-73236282ad34.gif)
![screen shot 2017-06-20 at 1 43 57 pm](https://user-images.githubusercontent.com/2433762/27355089-934f7ed8-55be-11e7-997e-12e1dbea87a3.png)
![screen shot 2017-06-20 at 1 44 03 pm](https://user-images.githubusercontent.com/2433762/27355094-96c9f58e-55be-11e7-909f-58578211b10d.png)
![screen shot 2017-06-20 at 1 44 13 pm](https://user-images.githubusercontent.com/2433762/27355100-9acd2ba6-55be-11e7-9612-20e58ec22dd8.png)


