### PR TITLE
Revert removal of x and y axes and some style changes on Line + Single Stat graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
 ### Bug Fixes
 1. [1651](https://github.com/influxdata/chronograf/pull/1651): Add back in x and y axes on Line + Single Stat graphs
 
-## v1.3.3.2 [2017-06-20]
+## v1.3.3.2 [2017-06-21]
+### Bug Fixes
 1. [1650](https://github.com/influxdata/chronograf/pull/1650): Fix broken cpu reporting on hosts page and normalize InfluxQL
 
-## v1.3.3.1 [2017-06-20]
+## v1.3.3.1 [2017-06-21]
 ### Bug Fixes
 1. [#1642](https://github.com/influxdata/chronograf/pull/1642): Do not prefix basepath to external link for news feed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ### Features
 ### UI Improvements
 
+## v1.3.3.3 [2017-06-21]
+### Bug Fixes
+1. [1651](https://github.com/influxdata/chronograf/pull/1651): Add back in x and y axes on Line + Single Stat graphs
+
 ## v1.3.3.2 [2017-06-20]
 1. [1650](https://github.com/influxdata/chronograf/pull/1650): Fix broken cpu reporting on hosts page and normalize InfluxQL
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ## v1.3.3.3 [2017-06-21]
 ### Bug Fixes
-1. [1651](https://github.com/influxdata/chronograf/pull/1651): Add back in x and y axes on Line + Single Stat graphs
+1. [1651](https://github.com/influxdata/chronograf/pull/1651): Add back in x and y axes and revert some style changes on Line + Single Stat graphs
 
 ## v1.3.3.2 [2017-06-21]
 ### Bug Fixes

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -129,21 +129,13 @@ export default React.createClass({
       labels,
       connectSeparatedPoints: true,
       labelsKMB: true,
-      axes: {
-        x: {
-          drawGrid: false,
-          drawAxis: false,
-        },
-        y: {
-          drawGrid: false,
-          drawAxis: false,
-        },
-      },
       title,
       rightGap: 0,
       strokeWidth: 1.5,
       drawAxesAtZero: true,
       underlayCallback,
+      ylabel: _.get(queries, ['0', 'label'], ''),
+      y2label: _.get(queries, ['1', 'label'], ''),
       ...displayOptions,
       highlightSeriesOpts: {
         strokeWidth: 1.5,

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -126,17 +126,7 @@ export default React.createClass({
     }
 
     const singleStatOptions = {
-      labels,
-      connectSeparatedPoints: true,
-      labelsKMB: true,
-      title,
-      rightGap: 0,
-      strokeWidth: 1.5,
-      drawAxesAtZero: true,
-      underlayCallback,
-      ylabel: _.get(queries, ['0', 'label'], ''),
-      y2label: _.get(queries, ['1', 'label'], ''),
-      ...displayOptions,
+      ...options,
       highlightSeriesOpts: {
         strokeWidth: 1.5,
       },


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1651 

### The problem
A regression was introduced where the x and y axes were removed and other stylistic changes were modified for Line + Single Stat graphs.

### The Solution
Add both axes and grid back in.

