### PR TITLE
add email to auth0 required scopes

### DIFF
--- a/oauth2/auth0.go
+++ b/oauth2/auth0.go
@@ -34,7 +34,7 @@ func NewAuth0(auth0Domain, clientID, clientSecret, redirectURL string, logger ch
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 
-			RequiredScopes: []string{"openid"},
+			RequiredScopes: []string{"openid", "email"},
 
 			RedirectURL: redirectURL,
 			AuthURL:     authURL,


### PR DESCRIPTION
Connect #1667 

We need the email address from OIDC when using auth0 for authentication.