### PR TITLE
Add support for Auth0 organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider
 1. [#1660](https://github.com/influxdata/chronograf/pull/1660): Add ability to add custom links to User menu via server CLI or ENV vars
+1. [#1674](https://github.com/influxdata/chronograf/pull/1674): Add support for organizations in Auth0
 
 ### UI Improvements
 1. [#1644](https://github.com/influxdata/chronograf/pull/1644): Redesign Alerts History table to have sticky headers

--- a/oauth2/auth0_test.go
+++ b/oauth2/auth0_test.go
@@ -1,0 +1,139 @@
+package oauth2_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	clog "github.com/influxdata/chronograf/log"
+	"github.com/influxdata/chronograf/oauth2"
+)
+
+var auth0Tests = []struct {
+	name         string
+	email        string
+	organization string // empty string is "no organization"
+
+	allowedUsers []string
+	allowedOrgs  []string // empty disables organization checking
+	shouldErr    bool
+}{
+	{
+		"Simple, no orgs",
+		"marty.mcfly@example.com",
+		"",
+
+		[]string{"marty.mcfly@example.com"},
+		[]string{},
+		false,
+	},
+	{
+		"Unauthorized",
+		"marty.mcfly@example.com",
+		"",
+
+		[]string{"doc.brown@example.com"},
+		[]string{},
+		true,
+	},
+	{
+		"Success - member of an org",
+		"marty.mcfly@example.com",
+		"time-travelers",
+
+		[]string{"marty.mcfly@example.com"},
+		[]string{"time-travelers"},
+		false,
+	},
+	{
+		"Failure - not a member of an org",
+		"marty.mcfly@example.com",
+		"time-travelers",
+
+		[]string{"marty.mcfly@example.com"},
+		[]string{"biffs-gang"},
+		true,
+	},
+}
+
+func Test_Auth0_PrincipalID_RestrictsByOrganization(t *testing.T) {
+	for _, test := range auth0Tests {
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			expected := struct {
+				Email        string `json:"email"`
+				Organization string `json:"organization"`
+			}{
+				test.email,
+				test.organization,
+			}
+
+			mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/userinfo" {
+					rw.WriteHeader(http.StatusNotFound)
+					return
+				}
+
+				allowed := false
+				for _, user := range test.allowedUsers {
+					if test.email == user {
+						allowed = true
+					}
+				}
+
+				if !allowed {
+					rw.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+
+				enc := json.NewEncoder(rw)
+
+				rw.WriteHeader(http.StatusOK)
+				_ = enc.Encode(expected)
+			}))
+			defer mockAPI.Close()
+
+			logger := clog.New(clog.ParseLevel("debug"))
+			prov, err := oauth2.NewAuth0(mockAPI.URL, "id", "secret", mockAPI.URL+"/callback", test.allowedOrgs, logger)
+			if err != nil {
+				tt.Fatal("Unexpected error instantiating Auth0 provider: err:", err)
+			}
+
+			tripper, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
+			if err != nil {
+				tt.Fatal("Error initializing TestTripper: err:", err)
+			}
+
+			tc := &http.Client{
+				Transport: tripper,
+			}
+
+			var email string
+			email, err = prov.PrincipalID(tc)
+			if !test.shouldErr {
+				if err != nil {
+					tt.Fatal(test.name, ": Unexpected error while attempting to authenticate: err:", err)
+				}
+
+				if email != test.email {
+					tt.Fatal(test.name, ": email mismatch. Got", email, "want:", test.email)
+				}
+			}
+
+			if err == nil && test.shouldErr {
+				tt.Fatal(test.name, ": Expected error while attempting to authenticate but received none")
+			}
+		})
+	}
+}
+
+func Test_Auth0_ErrsWithBadDomain(t *testing.T) {
+	t.Parallel()
+
+	logger := clog.New(clog.ParseLevel("debug"))
+	_, err := oauth2.NewAuth0("!!@#$!@$%@#$%", "id", "secret", "http://example.com", []string{}, logger)
+	if err == nil {
+		t.Fatal("Expected err with bad domain but received none")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -83,10 +83,6 @@ type Server struct {
 	Auth0ClientSecret  string   `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
 	Auth0Organizations []string `long:"auth0-organizations" description:"Auth0 organizations permitted to access Chronograf (comma separated)" env:"AUTH0_ORGS" env-delim:","`
 
-	StatusFeedURL string `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
-
-	CustomLinks map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu" env:"CUSTOM_LINKS" env-delim:","`
-
 	StatusFeedURL string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
 	CustomLinks   map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`
 

--- a/server/server.go
+++ b/server/server.go
@@ -82,9 +82,10 @@ type Server struct {
 
 	CustomLinks map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu" env:"CUSTOM_LINKS" env-delim:","`
 
-	Auth0Domain       string `long:"auth0-domain" description:"Subdomain of auth0.com used for Auth0 OAuth2 authentication" env:"AUTH0_DOMAIN"`
-	Auth0ClientID     string `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
-	Auth0ClientSecret string `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
+	Auth0Domain        string   `long:"auth0-domain" description:"Subdomain of auth0.com used for Auth0 OAuth2 authentication" env:"AUTH0_DOMAIN"`
+	Auth0ClientID      string   `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
+	Auth0ClientSecret  string   `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
+	Auth0Organizations []string `long:"auth0-organizations" description:"Auth0 organizations permitted to access Chronograf (comma separated)" env:"AUTH0_ORGS" env-delim:","`
 
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
 	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
@@ -195,7 +196,7 @@ func (s *Server) auth0OAuth(logger chronograf.Logger, auth oauth2.Authenticator)
 	}
 	redirectURL.Path = redirectPath
 
-	auth0, err := oauth2.NewAuth0(s.Auth0Domain, s.Auth0ClientID, s.Auth0ClientSecret, redirectURL.String(), logger)
+	auth0, err := oauth2.NewAuth0(s.Auth0Domain, s.Auth0ClientID, s.Auth0ClientSecret, redirectURL.String(), s.Auth0Organizations, logger)
 
 	jwt := oauth2.NewJWT(s.TokenSecret)
 	genMux := oauth2.NewAuthMux(&auth0, auth, jwt, s.Basepath, logger)


### PR DESCRIPTION
Users were previously unable to categorize Auth0 users into organizations like
they have been able to with other OAuth2 providers, like Github, Google, and
Heroku. This limits the usefulness of the Auth0 integration.

Unlike other providers, Auth0 allows greater flexibility in what is returned to
applications. Many plugins exist which modify Auth0's responses. Knowing this,
it was important to adopt something light-weight which could be supported both
by human administrators as well as automation.

This requires operators to configure Auth0 to apply an "organization" key to
each user in the "app_metadata" section of each of their users ("app_metadata"
is read-only by users). The value of this key should be a string identifying
the organization that the user belongs to. This can either be done manually, or
automatically through the use of Auth0 Rules. The organization that is allowed
to access Chronograf should then be supplied as either the command line flag
`--auth0-organizations="biffs-gang"` or the ENV:
`AUTH0_ORGANIZATIONS=biffs-gang`. Multiple organizations can be supplied to the
ENV option only by separating organizations with a comma. For example,
`AUTH0_ORGANIZATIONS=biffs-gang,time-travelers`

Additional test coverage was added because the PrincipalID method had to be
overridden to support organizations.

Connect #1554 