### PR TITLE
Display Custom Time Range on Cell

### DIFF
--- a/ui/src/shared/components/NameableGraph.js
+++ b/ui/src/shared/components/NameableGraph.js
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react'
 import classnames from 'classnames'
 import OnClickOutside from 'react-onclickoutside'
 
-const {bool, func, node, number, shape, string} = PropTypes
+const {array, bool, func, node, number, shape, string} = PropTypes
 
 const NameableGraph = React.createClass({
   propTypes: {
@@ -11,6 +11,7 @@ const NameableGraph = React.createClass({
       isEditing: bool,
       x: number.isRequired,
       y: number.isRequired,
+      queries: array.isRequired,
     }).isRequired,
     children: node.isRequired,
     onEditCell: func,
@@ -37,6 +38,21 @@ const NameableGraph = React.createClass({
     this.setState({
       isMenuOpen: false,
     })
+  },
+
+  renderCustomTimeIndicator() {
+    const {cell} = this.props
+    let customTimeRange = null
+
+    cell.queries.map(q => {
+      if (!q.query.includes(':dashboardTime:')) {
+        customTimeRange = q.queryConfig.range.lower.split(' ').reverse()[0]
+      }
+    })
+
+    return customTimeRange
+      ? <span className="dash-graph--custom-time">{customTimeRange}</span>
+      : null
   },
 
   render() {
@@ -75,7 +91,12 @@ const NameableGraph = React.createClass({
         />
       )
     } else {
-      nameOrField = <span className="dash-graph--name">{name}</span>
+      nameOrField = (
+        <span className="dash-graph--name">
+          {name}
+          {this.renderCustomTimeIndicator()}
+        </span>
+      )
     }
 
     let onStartRenaming

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -144,7 +144,7 @@ $dash-graph-options-arrow: 8px;
 .dash-graph--name {
   height: $dash-graph-heading;
   line-height: $dash-graph-heading;
-  width: calc(100% - 50px);
+  width: calc(100% - 30px);
   padding-left: 16px;
   transition:
     color 0.25s ease,
@@ -159,6 +159,19 @@ input.form-control.dash-graph--name-edit {
   line-height: (26px - 4px) !important;
   position: relative;
   top: -1px; // Fix for slight offset
+}
+.dash-graph--custom-time {
+  font-family: $code-font;
+  color: $c-pool;
+  background-color: $g2-kevlar;
+  height: 24px;
+  font-size: 10px;
+  line-height: 24px;
+  border-radius: 3px;
+  padding: 0 7px;
+  position: absolute;
+  top: 3px;
+  right: 30px;
 }
 .dash-graph--options {
   width: $dash-graph-heading;


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1604 

### The Problem
It is hard for users to discern which cells are not using `:dashboardTime:` at a glance. This can be problematic when changing the global time range

### The Solution
Cell headers show a little indicator with the custom time range in it
Currently this will only show 1 indicator. I tried building a graph with two queries, each with a different custom time range, and it breaks dygraph. I am operating under the assumption that users are not using multiple time ranges in a single cell.

![screen shot 2017-06-28 at 5 48 12 pm](https://user-images.githubusercontent.com/2433762/27666634-003dc344-5c2a-11e7-8dee-06caf5a4f5f3.png)


