### PR TITLE
Fix RP duration editing on admin page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Prevent users from being able to write to internal system databases
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
+1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
 
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider

--- a/ui/src/admin/components/DatabaseRow.js
+++ b/ui/src/admin/components/DatabaseRow.js
@@ -225,12 +225,18 @@ class DatabaseRow extends Component {
   }
 
   getInputValues() {
-    const {notify, retentionPolicy: {name: currentName}} = this.props
+    const {
+      notify,
+      retentionPolicy: {name: currentName},
+      isRFDisplayed,
+    } = this.props
+
     const name = (this.name && this.name.value.trim()) || currentName
     let duration = this.duration.value.trim()
-    const replication = +this.replication.value.trim()
+    // Replication > 1 is only valid for Influx Enterprise
+    const replication = isRFDisplayed ? +this.replication.value.trim() : 1
 
-    if (!duration || !replication) {
+    if (!duration || (isRFDisplayed && !replication)) {
       notify('error', 'Fields cannot be empty')
       return
     }


### PR DESCRIPTION
Connect #1678

Validation logic in the "DatabaseRow" component made some optimistic
assumptions about the presence of the "replication" in state.
Replication won't be present in OSS or Influx Relay sources, so when
users tried to update other properties of a retention policy, it failed
with an error that indicated "replication" was undefined.

Since this is expected and desired behavior, this patch uses the
existing "isRFVisible" property to determine whether or not we should
process the "replication" part of the component's state, or simply
replace it with a "1", which is the only allowed value for
non-Enterprise sources.