### PR TITLE
Prevent TempVar Dropdown Size Jitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ### Bug Fixes
 1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Prevent users from being able to write to internal system databases
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
+1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
+1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Fix size jitter bug in Template Variable dropdown menus
 
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider

--- a/ui/package.json
+++ b/ui/package.json
@@ -90,6 +90,7 @@
   "dependencies": {
     "axios": "^0.13.1",
     "bootstrap": "^3.3.7",
+    "calculate-size": "^1.1.1",
     "classnames": "^2.2.3",
     "dygraphs": "^2.0.0",
     "fast.js": "^0.1.1",

--- a/ui/src/dashboards/components/TemplateControlBar.js
+++ b/ui/src/dashboards/components/TemplateControlBar.js
@@ -5,26 +5,48 @@ import Dropdown from 'shared/components/Dropdown'
 
 import omit from 'lodash/omit'
 
+const pixelsPerCharacter = 9
+const minTempVarDropdownWidth = 146
+
 const TemplateControlBar = ({
   templates,
   onSelectTemplate,
   onOpenTemplateManager,
   isOpen,
-}) => (
+}) =>
   <div className={classnames('template-control-bar', {show: isOpen})}>
     <div className="template-control--container">
       <div className="template-control--controls">
         {templates.length
           ? templates.map(({id, values, tempVar}) => {
               const items = values.map(value => ({...value, text: value.value}))
+              const itemValues = values.map(value => value.value)
               const selectedItem = items.find(item => item.selected) || items[0]
               const selectedText = selectedItem && selectedItem.text
+              let customDropdownWidth = 0
+              if (itemValues.length > 1) {
+                const longest = itemValues.reduce(function(a, b) {
+                  return a.length > b.length ? a : b
+                })
+                const longestLengthPixels = longest.length * pixelsPerCharacter
+                if (longestLengthPixels > minTempVarDropdownWidth) {
+                  customDropdownWidth = longestLengthPixels
+                }
+              }
 
               // TODO: change Dropdown to a MultiSelectDropdown, `selected` to
               // the full array, and [item] to all `selected` values when we update
               // this component to support multiple values
               return (
-                <div key={id} className="template-control--dropdown">
+                <div
+                  key={id}
+                  className="template-control--dropdown"
+                  style={
+                    customDropdownWidth > 0
+                      ? {minWidth: customDropdownWidth}
+                      : null
+                  }
+                >
                   <Dropdown
                     items={items}
                     buttonSize="btn-xs"
@@ -53,7 +75,6 @@ const TemplateControlBar = ({
       </button>
     </div>
   </div>
-)
 
 const {arrayOf, bool, func, shape, string} = PropTypes
 

--- a/ui/src/dashboards/components/TemplateControlBar.js
+++ b/ui/src/dashboards/components/TemplateControlBar.js
@@ -1,12 +1,14 @@
 import React, {PropTypes} from 'react'
 import classnames from 'classnames'
+import calculateSize from 'calculate-size'
 
 import Dropdown from 'shared/components/Dropdown'
 
 import omit from 'lodash/omit'
 
-const pixelsPerCharacter = 9
 const minTempVarDropdownWidth = 146
+const maxTempVarDropdownWidth = 300
+const tempVarDropdownPadding = 30
 
 const TemplateControlBar = ({
   templates,
@@ -25,12 +27,22 @@ const TemplateControlBar = ({
               const selectedText = selectedItem && selectedItem.text
               let customDropdownWidth = 0
               if (itemValues.length > 1) {
-                const longest = itemValues.reduce(function(a, b) {
-                  return a.length > b.length ? a : b
-                })
-                const longestLengthPixels = longest.length * pixelsPerCharacter
-                if (longestLengthPixels > minTempVarDropdownWidth) {
+                const longest = itemValues.reduce(
+                  (a, b) => (a.length > b.length ? a : b)
+                )
+                const longestLengthPixels =
+                  calculateSize(longest, {
+                    font: 'Monospace',
+                    fontSize: '12px',
+                  }).width + tempVarDropdownPadding
+
+                if (
+                  longestLengthPixels > minTempVarDropdownWidth &&
+                  longestLengthPixels < maxTempVarDropdownWidth
+                ) {
                   customDropdownWidth = longestLengthPixels
+                } else if (longestLengthPixels > maxTempVarDropdownWidth) {
+                  customDropdownWidth = maxTempVarDropdownWidth
                 }
               }
 

--- a/ui/src/style/components/template-control-bar.scss
+++ b/ui/src/style/components/template-control-bar.scss
@@ -8,6 +8,7 @@
 $template-control--margin: 2px;
 $template-control--min-height: 52px;
 $template-control-dropdown-min-width: 146px;
+$template-control-dropdown-max-width: 300px;
 
 .template-control-bar {
   display: none;
@@ -54,6 +55,7 @@ button.btn.template-control--manage {
 .template-control--dropdown {
   flex: 0 1 auto;
   min-width: $template-control-dropdown-min-width;
+  max-width: $template-control-dropdown-max-width;
   display: flex;
   flex-direction: column;
   align-items: stretch;
@@ -69,6 +71,11 @@ button.btn.template-control--manage {
     width: 100%;
     font-size: 12px;
     font-family: $code-font;
+  }
+  .dropdown .dropdown-menu .fancy-scroll--view li.dropdown-item a {
+    white-space: pre-wrap;
+    word-break: break-all;
+    overflow: hidden;
   }
 }
 .template-control--label {

--- a/ui/src/style/components/template-control-bar.scss
+++ b/ui/src/style/components/template-control-bar.scss
@@ -76,6 +76,8 @@ button.btn.template-control--manage {
     white-space: pre-wrap;
     word-break: break-all;
     overflow: hidden;
+    font-family: $code-font;
+    font-size: 12px;
   }
 }
 .template-control--label {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1564,6 +1564,10 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
+calculate-size@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/calculate-size/-/calculate-size-1.1.1.tgz#ae7caa1c7795f82c4f035dc7be270e3581dae3ee"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"


### PR DESCRIPTION
@timhallinflux pointed out this UI issue with the Template Variable dropdowns


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

### The Problem
Depending on the variety of string lengths in a Template Variable dropdown menu, it resizes in unexpected ways

![tempvar-jitter](https://user-images.githubusercontent.com/2433762/27881544-eb5d0fda-617d-11e7-8e62-e066f63c7304.gif)


### The Solution
Determines the required length in pixels based on the length of the
longest item in the menu and only sets it if it is greater than the
minimum dropdown width. Using [this package](https://github.com/schickling/calculate-size) as per @cryptoquick's recommendation. 

![prevent-tempvar-jitter](https://user-images.githubusercontent.com/2433762/27881510-c1a79e9e-617d-11e7-857e-cbafefdc88f6.gif)

There is a maximum width of `300px` for the dropdowns. This number is somewhat arbitrary as I have no idea how it relates to common string lengths in the menu during actual use. if it makes sense later to increase the max width it will easy to adjust. If an item exceeds max width it just wraps text:

![screen shot 2017-07-05 at 2 05 40 pm](https://user-images.githubusercontent.com/2433762/27885054-71eea02e-618b-11e7-90cc-11da3dd8666f.png)




