### PR TITLE
Add server flag to add new InfluxDb source and Kapacitor server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider
 1. [#1660](https://github.com/influxdata/chronograf/pull/1660): Add ability to add custom links to User menu via server CLI or ENV vars
+1. [#1695](https://github.com/influxdata/chronograf/pull/1695): Add server flag for adding new InfluxDb sources with Kapacitor servers
 
 ### UI Improvements
 1. [#1644](https://github.com/influxdata/chronograf/pull/1644): Redesign Alerts History table to have sticky headers

--- a/chronograf.go
+++ b/chronograf.go
@@ -641,7 +641,7 @@ func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore Ser
 		if err := json.Unmarshal([]byte(newSources), &srcsKaps); err != nil {
 			logger.
 				WithField("component", "server").
-				WithField("NewSource", "invalid").
+				WithField("NewSources", "invalid").
 				Error(err)
 		} else {
 			srcs, err := sourcesStore.All(ctx)
@@ -660,7 +660,7 @@ func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore Ser
 						isNewSource = false
 						logger.
 							WithField("component", "server").
-							WithField("NewSource", src.Name).
+							WithField("NewSources", src.Name).
 							Info("Source already exists")
 						break
 					}

--- a/chronograf.go
+++ b/chronograf.go
@@ -658,6 +658,10 @@ func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore Ser
 				for _, src := range srcs {
 					if src.Name == srcKap.Source.Name {
 						isNewSource = false
+						logger.
+							WithField("component", "server").
+							WithField("NewSource", src.Name).
+							Info("Source already exists")
 						break
 					}
 				}

--- a/chronograf.go
+++ b/chronograf.go
@@ -626,7 +626,7 @@ type LayoutStore interface {
 	Update(context.Context, Layout) error
 }
 
-// NewSources adds sources and respective kapacitors to BoltDb idempotently by name
+// NewSources adds sources to BoltDb idempotently by name, as well as respective kapacitors
 func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore ServersStore, newSources string, logger Logger) error {
 	if newSources == "" {
 		return nil

--- a/chronograf.go
+++ b/chronograf.go
@@ -626,22 +626,14 @@ type LayoutStore interface {
 	Update(context.Context, Layout) error
 }
 
+// SourceAndKapacitor is used to parse any NewSources server flag arguments
+type SourceAndKapacitor struct {
+	Source    Source `json:"influxdb"`
+	Kapacitor Server `json:"kapacitor"`
+}
+
 // NewSources adds sources to BoltDb idempotently by name, as well as respective kapacitors
-func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore ServersStore, newSources string, logger Logger) error {
-	if newSources == "" {
-		return nil
-	}
-
-	type SourceAndKapacitor struct {
-		Source    Source `json:"influxdb"`
-		Kapacitor Server `json:"kapacitor"`
-	}
-	var srcsKaps []SourceAndKapacitor
-	// On JSON unmarshal error, continue server process without new source and write error to log
-	if err := json.Unmarshal([]byte(newSources), &srcsKaps); err != nil {
-		return err
-	}
-
+func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore ServersStore, srcsKaps []SourceAndKapacitor, logger Logger) error {
 	srcs, err := sourcesStore.All(ctx)
 	if err != nil {
 		return err

--- a/chronograf.go
+++ b/chronograf.go
@@ -626,17 +626,16 @@ type LayoutStore interface {
 	Update(context.Context, Layout) error
 }
 
-// SourceAndKapacitor allows a --new-source to be parsed into a source and a kapacitor
-type SourceAndKapacitor struct {
-	Source    Source `json:"influxdb"`
-	Kapacitor Server `json:"kapacitor"`
-}
-
 // NewSources adds sources and respective kapacitors to BoltDb idempotently by name
 func NewSources(ctx context.Context, sourcesStore SourcesStore, serversStore ServersStore, newSources string, logger Logger) error {
 	// Once a bolt connection is created, try to add any new sources with respective kapacitor servers
 	if newSources != "" {
+		type SourceAndKapacitor struct {
+			Source    Source `json:"influxdb"`
+			Kapacitor Server `json:"kapacitor"`
+		}
 		var srcsKaps []SourceAndKapacitor
+
 		// On JSON unmarshal error, continue server process without new source and write error to log
 		if err := json.Unmarshal([]byte(newSources), &srcsKaps); err != nil {
 			logger.

--- a/chronograf_test.go
+++ b/chronograf_test.go
@@ -1,0 +1,88 @@
+package chronograf_test
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/mocks"
+)
+
+func Test_NewSources(t *testing.T) {
+	t.Parallel()
+
+	srcsKaps := []chronograf.SourceAndKapacitor{
+		{
+			Source: chronograf.Source{
+				Default:            true,
+				InsecureSkipVerify: false,
+				MetaURL:            "http://metaurl.com",
+				Name:               "Influx 1",
+				Password:           "pass1",
+				Telegraf:           "telegraf",
+				URL:                "http://localhost:8086",
+				Username:           "user1",
+			},
+			Kapacitor: chronograf.Server{
+				Active: true,
+				Name:   "Kapa 1",
+				URL:    "http://localhost:9092",
+			},
+		},
+	}
+	saboteurSrcsKaps := []chronograf.SourceAndKapacitor{
+		{
+			Source: chronograf.Source{
+				Name: "Influx 1",
+			},
+			Kapacitor: chronograf.Server{
+				Name: "Kapa Aspiring Saboteur",
+			},
+		},
+	}
+
+	ctx := context.Background()
+	srcs := []chronograf.Source{}
+	srcsStore := mocks.SourcesStore{
+		AllF: func(ctx context.Context) ([]chronograf.Source, error) {
+			return srcs, nil
+		},
+		AddF: func(ctx context.Context, src chronograf.Source) (chronograf.Source, error) {
+			srcs = append(srcs, src)
+			return src, nil
+		},
+	}
+	srvs := []chronograf.Server{}
+	srvsStore := mocks.ServersStore{
+		AddF: func(ctx context.Context, srv chronograf.Server) (chronograf.Server, error) {
+			srvs = append(srvs, srv)
+			return srv, nil
+		},
+	}
+
+	err := chronograf.NewSources(ctx, &srcsStore, &srvsStore, srcsKaps, &mocks.TestLogger{})
+	if err != nil {
+		t.Fatal("Expected no error when creating New Sources. Error:", err)
+	}
+	if len(srcs) != 1 {
+		t.Error("Expected one source in sourcesStore")
+	}
+	if len(srvs) != 1 {
+		t.Error("Expected one source in serversStore")
+	}
+
+	err = chronograf.NewSources(ctx, &srcsStore, &srvsStore, saboteurSrcsKaps, &mocks.TestLogger{})
+	if err != nil {
+		t.Fatal("Expected no error when creating New Sources. Error:", err)
+	}
+	if len(srcs) != 1 {
+		t.Error("Expected one source in sourcesStore")
+	}
+	if len(srvs) != 1 {
+		t.Error("Expected one source in serversStore")
+	}
+	if !reflect.DeepEqual(srcs[0], srcsKaps[0].Source) {
+		t.Error("Expected source in sourceStore to remain unchanged")
+	}
+}

--- a/cmd/chronograf/main.go
+++ b/cmd/chronograf/main.go
@@ -42,6 +42,25 @@ func main() {
 		os.Exit(0)
 	}
 
+	if srv.NewSource != "" {
+		/*
+			// parse influxdb key from newsource into chronograf.Source struct from chronograf.go
+			// parse kapacitor key from newsource into chronograf.Server struct from chronograf.go
+			// open connection to boltDB
+			// use sources.All to get all sources
+			// if that influxdb does not exist (how to compare?)
+			// use sourcesStore to add this new source
+				// if successful
+					// hold onto this new source id
+					// if that kapacitor does not exist (how to compare?)
+					// use serverStore to add new kapacitor, including new source id
+				// else
+					// throw error
+			// else
+			// do nothing
+		*/
+	}
+
 	ctx := context.Background()
 	if err := srv.Serve(ctx); err != nil {
 		log.Fatalln(err)

--- a/cmd/chronograf/main.go
+++ b/cmd/chronograf/main.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"log"
 	"os"
 
+	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/server"
 	flags "github.com/jessevdk/go-flags"
 )
@@ -43,6 +46,16 @@ func main() {
 	}
 
 	if srv.NewSource != "" {
+		type SourceServer struct {
+			Source    chronograf.Source `json:"influxdb"`
+			Kapacitor chronograf.Server `json:"kapacitor"`
+		}
+		var sourceServers []SourceServer
+		err := json.Unmarshal([]byte(srv.NewSource), &sourceServers)
+		if err != nil {
+			fmt.Print(err)
+		}
+
 		/*
 			// parse influxdb key from newsource into chronograf.Source struct from chronograf.go
 			// parse kapacitor key from newsource into chronograf.Server struct from chronograf.go

--- a/cmd/chronograf/main.go
+++ b/cmd/chronograf/main.go
@@ -2,12 +2,9 @@ package main
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log"
 	"os"
 
-	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/server"
 	flags "github.com/jessevdk/go-flags"
 )
@@ -43,35 +40,6 @@ func main() {
 	if srv.ShowVersion {
 		log.Printf("Chronograf %s (git: %s)\n", version, commit)
 		os.Exit(0)
-	}
-
-	if srv.NewSource != "" {
-		type SourceServer struct {
-			Source    chronograf.Source `json:"influxdb"`
-			Kapacitor chronograf.Server `json:"kapacitor"`
-		}
-		var sourceServers []SourceServer
-		err := json.Unmarshal([]byte(srv.NewSource), &sourceServers)
-		if err != nil {
-			fmt.Print(err)
-		}
-
-		/*
-			// parse influxdb key from newsource into chronograf.Source struct from chronograf.go
-			// parse kapacitor key from newsource into chronograf.Server struct from chronograf.go
-			// open connection to boltDB
-			// use sources.All to get all sources
-			// if that influxdb does not exist (how to compare?)
-			// use sourcesStore to add this new source
-				// if successful
-					// hold onto this new source id
-					// if that kapacitor does not exist (how to compare?)
-					// use serverStore to add new kapacitor, including new source id
-				// else
-					// throw error
-			// else
-			// do nothing
-		*/
 	}
 
 	ctx := context.Background()

--- a/mocks/logger.go
+++ b/mocks/logger.go
@@ -1,4 +1,4 @@
-package server_test
+package mocks
 
 import (
 	"fmt"

--- a/mocks/servers.go
+++ b/mocks/servers.go
@@ -1,0 +1,38 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/influxdata/chronograf"
+)
+
+var _ chronograf.ServersStore = &ServersStore{}
+
+// ServersStore mock allows all functions to be set for testing
+type ServersStore struct {
+	AllF    func(context.Context) ([]chronograf.Server, error)
+	AddF    func(context.Context, chronograf.Server) (chronograf.Server, error)
+	DeleteF func(context.Context, chronograf.Server) error
+	GetF    func(ctx context.Context, ID int) (chronograf.Server, error)
+	UpdateF func(context.Context, chronograf.Server) error
+}
+
+func (s *ServersStore) All(ctx context.Context) ([]chronograf.Server, error) {
+	return s.AllF(ctx)
+}
+
+func (s *ServersStore) Add(ctx context.Context, srv chronograf.Server) (chronograf.Server, error) {
+	return s.AddF(ctx, srv)
+}
+
+func (s *ServersStore) Delete(ctx context.Context, srv chronograf.Server) error {
+	return s.DeleteF(ctx, srv)
+}
+
+func (s *ServersStore) Get(ctx context.Context, id int) (chronograf.Server, error) {
+	return s.GetF(ctx, id)
+}
+
+func (s *ServersStore) Update(ctx context.Context, srv chronograf.Server) error {
+	return s.UpdateF(ctx, srv)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -50,7 +50,7 @@ type Server struct {
 	KapacitorUsername string `long:"kapacitor-username" description:"Username of your Kapacitor instance" env:"KAPACITOR_USERNAME"`
 	KapacitorPassword string `long:"kapacitor-password" description:"Password of your Kapacitor instance" env:"KAPACITOR_PASSWORD"`
 
-	NewSources string `long:"new-source" description:"Config for adding a new InfluxDb source and Kapacitor server, in JSON and surrounded by single quotes" env:"NEW_SOURCES"`
+	NewSources string `long:"new-sources" description:"Config for adding a new InfluxDb source and Kapacitor server, in JSON as an array of objects, and surrounded by single quotes. E.g. --new-sources='[{\"influxdb\":{\"name\":\"Influx 1\",\"username\":\"user1\",\"password\":\"pass1\",\"url\":\"http://localhost:8086\",\"metaUrl\":\"http://metaurl.com\",\"insecureSkipVerify\":false,\"default\":true,\"telegraf\":\"telegraf\"},\"kapacitor\":{\"name\":\"Kapa 1\",\"url\":\"http://localhost:9092\",\"active\":true}}]'" env:"NEW_SOURCES"`
 
 	Develop      bool          `short:"d" long:"develop" description:"Run server in develop mode."`
 	BoltPath     string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (/var/lib/chronograf/chronograf-v1.db)" env:"BOLT_PATH" default:"chronograf-v1.db"`

--- a/server/server.go
+++ b/server/server.go
@@ -436,8 +436,7 @@ func openService(ctx context.Context, boltPath string, lBuilder LayoutBuilder, s
 	}
 }
 
-// processNewSources parses and persists new sources passed in via server flag.
-// It's used within a goroutine so its return is negligible.
+// processNewSources parses and persists new sources passed in via server flag
 func processNewSources(ctx context.Context, service Service, newSources string, logger chronograf.Logger) error {
 	if newSources == "" {
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -304,7 +304,7 @@ func (s *Server) Serve(ctx context.Context) error {
 	if err := chronograf.NewSources(ctx, service.SourcesStore, service.ServersStore, s.NewSources, logger); err != nil {
 		logger.
 			WithField("component", "server").
-			WithField("NewSource", "invalid").
+			WithField("NewSources", "invalid").
 			Error(err)
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -301,12 +301,12 @@ func (s *Server) Serve(ctx context.Context) error {
 	service := openService(ctx, s.BoltPath, layoutBuilder, sourcesBuilder, kapacitorBuilder, logger, s.useAuth())
 
 	// Add any new sources and kapacitors as specified via server flag
-	if err := chronograf.NewSources(ctx, service.SourcesStore, service.ServersStore, s.NewSources, logger); err != nil {
+	if err = chronograf.NewSources(ctx, service.SourcesStore, service.ServersStore, s.NewSources, logger); err != nil {
+		// Continue with server run even if adding NewSources fails
 		logger.
 			WithField("component", "server").
 			WithField("NewSources", "invalid").
 			Error(err)
-		return err
 	}
 
 	basepath = s.Basepath

--- a/server/server.go
+++ b/server/server.go
@@ -50,6 +50,8 @@ type Server struct {
 	KapacitorUsername string `long:"kapacitor-username" description:"Username of your Kapacitor instance" env:"KAPACITOR_USERNAME"`
 	KapacitorPassword string `long:"kapacitor-password" description:"Password of your Kapacitor instance" env:"KAPACITOR_PASSWORD"`
 
+	NewSource map[string]string `long:"new-source" description:"Config for adding a new InfluxDb source and Kapacitor server" env:"NEW_SOURCE"`
+
 	Develop      bool          `short:"d" long:"develop" description:"Run server in develop mode."`
 	BoltPath     string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (/var/lib/chronograf/chronograf-v1.db)" env:"BOLT_PATH" default:"chronograf-v1.db"`
 	CannedPath   string        `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`

--- a/server/server.go
+++ b/server/server.go
@@ -50,7 +50,7 @@ type Server struct {
 	KapacitorUsername string `long:"kapacitor-username" description:"Username of your Kapacitor instance" env:"KAPACITOR_USERNAME"`
 	KapacitorPassword string `long:"kapacitor-password" description:"Password of your Kapacitor instance" env:"KAPACITOR_PASSWORD"`
 
-	NewSource map[string]string `long:"new-source" description:"Config for adding a new InfluxDb source and Kapacitor server" env:"NEW_SOURCE"`
+	NewSource string `long:"new-source" description:"Config for adding a new InfluxDb source and Kapacitor server, in JSON and surrounded by single quotes" env:"NEW_SOURCE"`
 
 	Develop      bool          `short:"d" long:"develop" description:"Run server in develop mode."`
 	BoltPath     string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (/var/lib/chronograf/chronograf-v1.db)" env:"BOLT_PATH" default:"chronograf-v1.db"`

--- a/server/server.go
+++ b/server/server.go
@@ -78,13 +78,12 @@ type Server struct {
 	GenericTokenURL     string   `long:"generic-token-url" description:"OAuth 2.0 provider's token endpoint URL" env:"GENERIC_TOKEN_URL"`
 	GenericAPIURL       string   `long:"generic-api-url" description:"URL that returns OpenID UserInfo compatible information." env:"GENERIC_API_URL"`
 
-	StatusFeedURL string `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
-
-	CustomLinks map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`
-
 	Auth0Domain       string `long:"auth0-domain" description:"Subdomain of auth0.com used for Auth0 OAuth2 authentication" env:"AUTH0_DOMAIN"`
 	Auth0ClientID     string `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
 	Auth0ClientSecret string `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
+
+	StatusFeedURL string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
+	CustomLinks   map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`
 
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
 	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`

--- a/server/url_prefixer_test.go
+++ b/server/url_prefixer_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/influxdata/chronograf/mocks"
 	"github.com/influxdata/chronograf/server"
 )
 
@@ -138,7 +139,7 @@ func Test_Server_Prefixer_NoPrefixingWithoutFlusther(t *testing.T) {
 		})
 	}
 
-	tl := &TestLogger{}
+	tl := &mocks.TestLogger{}
 	pfx := &server.URLPrefixer{
 		Prefix: "/hill",
 		Next:   backend,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1555 

### The problem
Upon spinning up new installation of Chronograf, a user had to manually configure a new InfluxDb source and respective Kapacitor server as their first task. This was a jarring experience, as it would be much nicer to be dropped directly into a functional application, assuming default source and kapacitor settings.

### The Solution
Add a server flag to allow new sources to be added automatically (and idempotently) when server runs, which can be set via CLI (`--new-sources`) or ENV var (`NEW_SOURCES`). This way default sources and kapacitors can be added to a fresh installation of Chronograf. (This could also be seen as allowing a kind of safety for source persistence, in case a user were to delete a Chronograf source that would automatically be re-persisted upon re-running the server.)

### How to try it out
```
./chronograf --new-sources='[{"influxdb":{"name":"Influx 1","username":"user1","password":"pass1","url":"http://localhost:8086","metaUrl":"http://metaurl.com","insecureSkipVerify":false,"default":true,"telegraf":"telegraf"},"kapacitor":{"name":"Kapa 1","url":"http://localhost:9092","active":true}},{"influxdb":{"name":"Influx 2","username":"user2","password":"pass2","url":"http://localhost:8086","metaUrl":"http://metaurl.com","insecureSkipVerify":false,"default":false,"telegraf":"telegraf"},"kapacitor":{"name":"Kapa 2","url":"http://localhost:9092","active":true}}]'
```