### PR TITLE
Fix node-sass version for Node 8 support.

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -70,7 +70,7 @@
     "mocha": "^2.4.5",
     "mocha-loader": "^0.7.1",
     "mustache": "^2.2.1",
-    "node-sass": "^4.5.2",
+    "node-sass": "^4.5.3",
     "postcss-browser-reporter": "^0.4.0",
     "postcss-calc": "^5.2.0",
     "postcss-loader": "^0.8.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -4804,9 +4804,9 @@ node-pre-gyp@^0.6.29:
     tar "~2.2.1"
     tar-pack "~3.3.0"
 
-node-sass@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.2.tgz#4012fa2bd129b1d6365117e88d9da0500d99da64"
+node-sass@^4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.5.3.tgz#d09c9d1179641239d1b97ffc6231fdcec53e1568"
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect: No issue

### The problem
node-sass breaks the build / install process with Node 8.

### The Solution
node-sass needed to be upgraded in order for chronograf to build on Node 8.
