### PR TITLE
Fix z-index for options context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
 1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
 1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Fix size jitter bug in Template Variable dropdown menus
-1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Z-index for options context menu fixed
+1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix Z-index for options context menu
 
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
 1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
 1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Fix size jitter bug in Template Variable dropdown menus
+1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Z-index for options context menu fixed
 
 ### Features
 1. [#1645](https://github.com/influxdata/chronograf/pull/1645): Add Auth0 as a supported OAuth2 provider

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,6 @@
 ### Bug Fixes
 1. [#1612](https://github.com/influxdata/chronograf/pull/1612): Disallow writing to \_internal in the Data Explorer
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
-1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
-1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Fix size jitter bug in Template Variable dropdown menus
 1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating Retention Policies in single-node InfluxDB instances
 1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Lock the width of Template Variable dropdown menus to the size of their longest option
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v1.3.5.0 [unreleased]
 
 ### Bug Fixes
-1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix Z-index for options context menu
+1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix z-index issue in dashboard cell context menu
 
 ### Features
 ### UI Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## v1.3.5.0 [unreleased]
 
 ### Bug Fixes
+1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix Z-index for options context menu
+
 ### Features
 ### UI Improvements
 
@@ -10,7 +12,6 @@
 1. [#1655](https://github.com/influxdata/chronograf/pull/1655): Add more than one color to Line+Stat graphs
 1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating retention policies on single-node instances.
 1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Fix size jitter bug in Template Variable dropdown menus
-1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix Z-index for options context menu
 1. [#1688](https://github.com/influxdata/chronograf/pull/1688): Fix updating Retention Policies in single-node InfluxDB instances
 1. [#1689](https://github.com/influxdata/chronograf/pull/1689): Lock the width of Template Variable dropdown menus to the size of their longest option
 

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -176,7 +176,6 @@ input.form-control.dash-graph--name-edit {
 .dash-graph--options {
   width: $dash-graph-heading;
   position: absolute;
-  z-index: 11;
   right: 0px;
   top: 0px;
   text-align: center;
@@ -209,6 +208,7 @@ input.form-control.dash-graph--name-edit {
   left: 50%;
   transform: translateX(-50%);
   display: block;
+  z-index: 11;
   list-style: none;
   padding: 0;
   margin: 0;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1643

### The problem
Due to the z-index being set for the entire .dash-graph--options div, when the context menu is shown and overlaps another caret, the caret will display above the context menu.

### The Solution
Move the z-index declaration to the .dash-graph--options-menu ul (removing it from .dash-graph--options div). The z-index is unnecessary for the entire div, it is only needed for the ul so that it displays above the other elements.

### Preview
![zindex_chronograf](https://user-images.githubusercontent.com/12586676/28030971-c2971f38-6573-11e7-9fca-a62e0d0a33c6.gif)

P.S. This is my first open source contribution. Pretty excited! Please let me know if I did anything incorrectly

