### PR TITLE
View server generated TICKscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix z-index issue in dashboard cell context menu
 
 ### Features
+1. [#1717](https://github.com/influxdata/chronograf/pull/1717): View server generated TICKscripts
+
 ### UI Improvements
 1. [#1707](https://github.com/influxdata/chronograf/pull/1707): Polish alerts table in status page to wrap text less
 

--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -220,7 +220,7 @@
     'react/jsx-uses-react': 2,
     'react/jsx-uses-vars': 2,
     'react/no-danger': 2,
-    'react/no-did-mount-set-state': 'error',
+    'react/no-did-mount-set-state': 0,
     'react/no-did-update-set-state': 2,
     'react/no-direct-mutation-state': 2,
     'react/no-is-mounted': 2,

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -7,6 +7,7 @@ import {
   deleteRule as deleteRuleAPI,
   updateRuleStatus as updateRuleStatusAPI,
 } from 'src/kapacitor/apis'
+import {errorThrown} from 'shared/actions/errors'
 
 export function fetchRule(source, ruleID) {
   return dispatch => {
@@ -48,16 +49,12 @@ export function loadDefaultRule() {
   }
 }
 
-export function fetchRules(kapacitor) {
-  return dispatch => {
-    getRules(kapacitor).then(({data: {rules}}) => {
-      dispatch({
-        type: 'LOAD_RULES',
-        payload: {
-          rules,
-        },
-      })
-    })
+export const fetchRules = kapacitor => async dispatch => {
+  try {
+    const {data: {rules}} = await getRules(kapacitor)
+    dispatch({type: 'LOAD_RULES', payload: {rules}})
+  } catch (error) {
+    dispatch(errorThrown(error))
   }
 }
 

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -63,8 +63,8 @@ const KapacitorRules = ({
   )
 }
 
-const PageContents = ({children, source, tickscript, onCloseTickscript}) => (
-  <div>
+const PageContents = ({children, source, tickscript, onCloseTickscript}) =>
+  <div className="page">
     <div className="page-header">
       <div className="page-header__container">
         <div className="page-header__left">
@@ -93,7 +93,6 @@ const PageContents = ({children, source, tickscript, onCloseTickscript}) => (
         />
       : null}
   </div>
-)
 
 const {arrayOf, bool, func, node, shape, string} = PropTypes
 

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -18,6 +18,14 @@ const KapacitorRules = ({
   onReadTickscript,
   onCloseTickscript,
 }) => {
+  if (loading) {
+    return (
+      <PageContents>
+        <h2>Loading...</h2>
+      </PageContents>
+    )
+  }
+
   if (!hasKapacitor) {
     return (
       <PageContents>
@@ -26,13 +34,6 @@ const KapacitorRules = ({
     )
   }
 
-  if (loading) {
-    return (
-      <PageContents>
-        <h2>Loading...</h2>
-      </PageContents>
-    )
-  }
   const tableHeader = rules.length === 1
     ? '1 Alert Rule'
     : `${rules.length} Alert Rules`

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -74,7 +74,7 @@ const KapacitorRules = ({
   )
 }
 
-const PageContents = ({children, source, tickscript, onCloseTickscript}) =>
+const PageContents = ({children, source, tickscript, onCloseTickscript}) => (
   <div className="page">
     <div className="page-header">
       <div className="page-header__container">
@@ -104,6 +104,7 @@ const PageContents = ({children, source, tickscript, onCloseTickscript}) =>
         />
       : null}
   </div>
+)
 
 const {arrayOf, bool, func, node, shape, string} = PropTypes
 

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -5,6 +5,7 @@ import NoKapacitorError from 'shared/components/NoKapacitorError'
 import SourceIndicator from 'shared/components/SourceIndicator'
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
+import TICKscriptOverlay from 'src/kapacitor/components/TICKscriptOverlay'
 
 const KapacitorRules = ({
   source,
@@ -12,7 +13,10 @@ const KapacitorRules = ({
   hasKapacitor,
   loading,
   onDelete,
+  tickscript,
   onChangeRuleStatus,
+  onReadTickscript,
+  onCloseTickscript,
 }) => {
   if (!hasKapacitor) {
     return (
@@ -33,7 +37,12 @@ const KapacitorRules = ({
     ? '1 Alert Rule'
     : `${rules.length} Alert Rules`
   return (
-    <PageContents source={source}>
+    <PageContents
+      source={source}
+      tickscript={tickscript}
+      onReadTickscript={onReadTickscript}
+      onCloseTickscript={onCloseTickscript}
+    >
       <div className="panel-heading u-flex u-ai-center u-jc-space-between">
         <h2 className="panel-title">{tableHeader}</h2>
         <Link
@@ -47,14 +56,15 @@ const KapacitorRules = ({
         source={source}
         rules={rules}
         onDelete={onDelete}
+        onReadTickscript={onReadTickscript}
         onChangeRuleStatus={onChangeRuleStatus}
       />
     </PageContents>
   )
 }
 
-const PageContents = ({children, source}) =>
-  <div className="page">
+const PageContents = ({children, source, tickscript, onCloseTickscript}) => (
+  <div>
     <div className="page-header">
       <div className="page-header__container">
         <div className="page-header__left">
@@ -76,9 +86,16 @@ const PageContents = ({children, source}) =>
         </div>
       </div>
     </FancyScrollbar>
+    {tickscript
+      ? <TICKscriptOverlay
+          tickscript={tickscript}
+          onClose={onCloseTickscript}
+        />
+      : null}
   </div>
+)
 
-const {arrayOf, bool, func, shape, node} = PropTypes
+const {arrayOf, bool, func, node, shape, string} = PropTypes
 
 KapacitorRules.propTypes = {
   source: shape(),
@@ -87,11 +104,16 @@ KapacitorRules.propTypes = {
   loading: bool,
   onChangeRuleStatus: func,
   onDelete: func,
+  tickscript: string,
+  onReadTickscript: func,
+  onCloseTickscript: func,
 }
 
 PageContents.propTypes = {
   children: node,
   source: shape(),
+  tickscript: string,
+  onCloseTickscript: func,
 }
 
 export default KapacitorRules

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -21,7 +21,17 @@ const KapacitorRules = ({
   if (loading) {
     return (
       <PageContents>
-        <h2>Loading...</h2>
+        <div className="panel-heading u-flex u-ai-center u-jc-space-between">
+          <h2 className="panel-title">Alert Rules</h2>
+          <button className="btn btn-primary btn-sm disabled" disabled={true}>
+            Create Rule
+          </button>
+        </div>
+        <div className="panel-body">
+          <div className="generic-empty-state">
+            <p>Loading Rules...</p>
+          </div>
+        </div>
       </PageContents>
     )
   }

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -1,7 +1,13 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 
-const KapacitorRulesTable = ({rules, source, onDelete, onChangeRuleStatus}) =>
+const KapacitorRulesTable = ({
+  rules,
+  source,
+  onDelete,
+  onReadTickscript,
+  onChangeRuleStatus,
+}) => (
   <div className="panel-body">
     <table className="table v-center">
       <thead>
@@ -23,14 +29,16 @@ const KapacitorRulesTable = ({rules, source, onDelete, onChangeRuleStatus}) =>
               source={source}
               onDelete={onDelete}
               onChangeRuleStatus={onChangeRuleStatus}
+              onRead={onReadTickscript}
             />
           )
         })}
       </tbody>
     </table>
   </div>
+)
 
-const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
+const RuleRow = ({rule, source, onRead, onDelete, onChangeRuleStatus}) => (
   <tr key={rule.id}>
     <td className="monotype">
       <RuleTitle rule={rule} source={source} />
@@ -50,12 +58,16 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
         <label htmlFor={`kapacitor-enabled ${rule.id}`} />
       </div>
     </td>
-    <td className="text-right">
+    <td className="text-right" style={{display: 'flex'}}>
+      <button className="btn btn-info btn-xs" onClick={() => onRead(rule)}>
+        View TICKscript
+      </button>
       <button className="btn btn-danger btn-xs" onClick={() => onDelete(rule)}>
         Delete
       </button>
     </td>
   </tr>
+)
 
 const RuleTitle = ({rule: {id, name, query}, source}) => {
   // no queryConfig means the rule was manually created outside of Chronograf
@@ -75,6 +87,7 @@ KapacitorRulesTable.propTypes = {
   source: shape({
     id: string.isRequired,
   }).isRequired,
+  onReadTickscript: func,
 }
 
 RuleRow.propTypes = {
@@ -82,6 +95,7 @@ RuleRow.propTypes = {
   source: shape(),
   onChangeRuleStatus: func,
   onDelete: func,
+  onRead: func,
 }
 
 RuleTitle.propTypes = {
@@ -90,7 +104,7 @@ RuleTitle.propTypes = {
     query: shape(),
     links: shape({
       self: string.isRequired,
-    }).isRequired,
+    }),
   }),
   source: shape({
     id: string.isRequired,

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -1,23 +1,33 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 
+import {KAPACITOR_RULES_TABLE} from 'src/kapacitor/constants/tableSizing'
+const {
+  colName,
+  colType,
+  colMessage,
+  colAlerts,
+  colEnabled,
+  colActions,
+} = KAPACITOR_RULES_TABLE
+
 const KapacitorRulesTable = ({
   rules,
   source,
   onDelete,
   onReadTickscript,
   onChangeRuleStatus,
-}) => (
+}) =>
   <div className="panel-body">
     <table className="table v-center">
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Rule Type</th>
-          <th>Message</th>
-          <th>Alerts</th>
-          <th className="text-center">Enabled</th>
-          <th />
+          <th style={{width: colName}}>Name</th>
+          <th style={{width: colType}}>Rule Type</th>
+          <th style={{width: colMessage}}>Message</th>
+          <th style={{width: colAlerts}}>Alerts</th>
+          <th style={{width: colEnabled}} className="text-center">Enabled</th>
+          <th style={{width: colActions}} />
         </tr>
       </thead>
       <tbody>
@@ -36,17 +46,25 @@ const KapacitorRulesTable = ({
       </tbody>
     </table>
   </div>
-)
 
-const RuleRow = ({rule, source, onRead, onDelete, onChangeRuleStatus}) => (
+const RuleRow = ({rule, source, onRead, onDelete, onChangeRuleStatus}) =>
   <tr key={rule.id}>
-    <td className="monotype">
+    <td style={{width: colName}} className="monotype">
       <RuleTitle rule={rule} source={source} />
     </td>
-    <td className="monotype">{rule.trigger}</td>
-    <td className="monotype">{rule.message}</td>
-    <td className="monotype">{rule.alerts.join(', ')}</td>
-    <td className="monotype text-center">
+    <td style={{width: colType}} className="monotype">{rule.trigger}</td>
+    <td className="monotype">
+      <span
+        className="table-cell-nowrap"
+        style={{display: 'inline-block', maxWidth: colMessage}}
+      >
+        {rule.message}
+      </span>
+    </td>
+    <td style={{width: colAlerts}} className="monotype">
+      {rule.alerts.join(', ')}
+    </td>
+    <td style={{width: colEnabled}} className="monotype text-center">
       <div className="dark-checkbox">
         <input
           id={`kapacitor-enabled ${rule.id}`}
@@ -58,7 +76,7 @@ const RuleRow = ({rule, source, onRead, onDelete, onChangeRuleStatus}) => (
         <label htmlFor={`kapacitor-enabled ${rule.id}`} />
       </div>
     </td>
-    <td className="text-right" style={{display: 'flex'}}>
+    <td style={{width: colActions}} className="text-right table-cell-nowrap">
       <button className="btn btn-info btn-xs" onClick={() => onRead(rule)}>
         View TICKscript
       </button>
@@ -67,7 +85,6 @@ const RuleRow = ({rule, source, onRead, onDelete, onChangeRuleStatus}) => (
       </button>
     </td>
   </tr>
-)
 
 const RuleTitle = ({rule: {id, name, query}, source}) => {
   // no queryConfig means the rule was manually created outside of Chronograf

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
+import _ from 'lodash'
 
 import {KAPACITOR_RULES_TABLE} from 'src/kapacitor/constants/tableSizing'
 const {
@@ -31,7 +32,7 @@ const KapacitorRulesTable = ({
         </tr>
       </thead>
       <tbody>
-        {rules.map(rule => {
+        {_.sortBy(rules, r => r.name.toLowerCase()).map(rule => {
           return (
             <RuleRow
               key={rule.id}

--- a/ui/src/kapacitor/components/TICKscriptOverlay.js
+++ b/ui/src/kapacitor/components/TICKscriptOverlay.js
@@ -17,21 +17,21 @@ const style = {
 const TICKscriptOverlay = ({tickscript, onClose}) => (
   <OverlayTechnologies>
     <div style={style}>
-      <div style={{display: 'flex', justifyContent: 'space-around'}}>
-        <h2>Generated TICKscript</h2>
+      <div style={{width: '100%', display: 'flex', justifyContent: 'flex-end'}}>
         <span
           style={{cursor: 'pointer'}}
           className="icon remove"
           onClick={onClose}
         />
       </div>
+      <h2>Generated TICKscript</h2>
       <pre
         style={{
           border: '1px solid white',
           borderRadius: '4px',
           overflow: 'auto',
           whiteSpace: 'pre',
-          color: '#4ed8a0',
+          color: '#FFB94A',
           fontSize: '14px',
           width: '95%',
         }}

--- a/ui/src/kapacitor/components/TICKscriptOverlay.js
+++ b/ui/src/kapacitor/components/TICKscriptOverlay.js
@@ -1,0 +1,52 @@
+import React, {PropTypes} from 'react'
+import OverlayTechnologies from 'shared/components/OverlayTechnologies'
+
+const style = {
+  padding: '8px',
+  borderRadius: '4px',
+  backgroundColor: '#202028',
+  margin: '0 15%',
+  top: '16px',
+  position: 'relative',
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  height: 'calc(100% - 76px)',
+}
+
+const TICKscriptOverlay = ({tickscript, onClose}) => (
+  <OverlayTechnologies>
+    <div style={style}>
+      <div style={{display: 'flex', justifyContent: 'space-around'}}>
+        <h2>Generated TICKscript</h2>
+        <span
+          style={{cursor: 'pointer'}}
+          className="icon remove"
+          onClick={onClose}
+        />
+      </div>
+      <pre
+        style={{
+          border: '1px solid white',
+          borderRadius: '4px',
+          overflow: 'auto',
+          whiteSpace: 'pre',
+          color: '#4ed8a0',
+          fontSize: '14px',
+          width: '95%',
+        }}
+      >
+        {tickscript}
+      </pre>
+    </div>
+  </OverlayTechnologies>
+)
+
+const {string, func} = PropTypes
+
+TICKscriptOverlay.propTypes = {
+  tickscript: string,
+  onClose: func.isRequired,
+}
+
+export default TICKscriptOverlay

--- a/ui/src/kapacitor/components/TICKscriptOverlay.js
+++ b/ui/src/kapacitor/components/TICKscriptOverlay.js
@@ -1,46 +1,24 @@
 import React, {PropTypes} from 'react'
 import OverlayTechnologies from 'shared/components/OverlayTechnologies'
 
-const style = {
-  padding: '8px',
-  borderRadius: '4px',
-  backgroundColor: '#202028',
-  margin: '0 15%',
-  top: '16px',
-  position: 'relative',
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  height: 'calc(100% - 76px)',
-}
-
-const TICKscriptOverlay = ({tickscript, onClose}) => (
+const TICKscriptOverlay = ({tickscript, onClose}) =>
   <OverlayTechnologies>
-    <div style={style}>
-      <div style={{width: '100%', display: 'flex', justifyContent: 'flex-end'}}>
-        <span
-          style={{cursor: 'pointer'}}
-          className="icon remove"
-          onClick={onClose}
-        />
+    <div className="tick-script-overlay">
+      <div className="write-data-form--header">
+        <div className="page-header__left">
+          <h1 className="page-header__title">Generated TICKscript</h1>
+        </div>
+        <div className="page-header__right">
+          <span className="page-header__dismiss" onClick={onClose} />
+        </div>
       </div>
-      <h2>Generated TICKscript</h2>
-      <pre
-        style={{
-          border: '1px solid white',
-          borderRadius: '4px',
-          overflow: 'auto',
-          whiteSpace: 'pre',
-          color: '#FFB94A',
-          fontSize: '14px',
-          width: '95%',
-        }}
-      >
-        {tickscript}
-      </pre>
+      <div className="write-data-form--body">
+        <pre className="tick-script-overlay--sample">
+          {tickscript}
+        </pre>
+      </div>
     </div>
   </OverlayTechnologies>
-)
 
 const {string, func} = PropTypes
 

--- a/ui/src/kapacitor/constants/tableSizing.js
+++ b/ui/src/kapacitor/constants/tableSizing.js
@@ -1,0 +1,8 @@
+export const KAPACITOR_RULES_TABLE = {
+  colName: '200px',
+  colType: '90px',
+  colMessage: '460px',
+  colAlerts: '120px',
+  colEnabled: '64px',
+  colActions: '176px',
+}

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
 
@@ -10,43 +10,17 @@ import {getActiveKapacitor, getKapacitorConfig} from 'shared/apis/index'
 import {ALERTS, DEFAULT_RULE_ID} from 'src/kapacitor/constants'
 import KapacitorRule from 'src/kapacitor/components/KapacitorRule'
 
-export const KapacitorRulePage = React.createClass({
-  propTypes: {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        proxy: PropTypes.string.isRequired,
-        self: PropTypes.string.isRequired,
-      }),
-    }),
-    addFlashMessage: PropTypes.func,
-    rules: PropTypes.shape({}).isRequired,
-    queryConfigs: PropTypes.shape({}).isRequired,
-    kapacitorActions: PropTypes.shape({
-      loadDefaultRule: PropTypes.func.isRequired,
-      fetchRule: PropTypes.func.isRequired,
-      chooseTrigger: PropTypes.func.isRequired,
-      addEvery: PropTypes.func.isRequired,
-      removeEvery: PropTypes.func.isRequired,
-      updateRuleValues: PropTypes.func.isRequired,
-      updateMessage: PropTypes.func.isRequired,
-      updateAlerts: PropTypes.func.isRequired,
-      updateRuleName: PropTypes.func.isRequired,
-    }).isRequired,
-    queryActions: PropTypes.shape({}).isRequired,
-    params: PropTypes.shape({
-      ruleID: PropTypes.string,
-    }).isRequired,
-    router: PropTypes.shape({
-      push: PropTypes.func.isRequired,
-    }).isRequired,
-  },
+class KapacitorRulePage extends Component {
+  constructor(props) {
+    super(props)
 
-  getInitialState() {
-    return {
+    this.state = {
       enabledAlerts: [],
       kapacitor: {},
     }
-  },
+
+    this.isEditing = ::this.isEditing
+  }
 
   async componentDidMount() {
     const {params, source, kapacitorActions, addFlashMessage} = this.props
@@ -83,7 +57,7 @@ export const KapacitorRulePage = React.createClass({
           text: 'There was a problem communicating with Kapacitor',
         })
       })
-  },
+  }
 
   render() {
     const {
@@ -122,13 +96,13 @@ export const KapacitorRulePage = React.createClass({
         kapacitor={kapacitor}
       />
     )
-  },
+  }
 
   isEditing() {
     const {params} = this.props
     return params.ruleID && params.ruleID !== 'new'
-  },
-})
+  }
+}
 
 function mapStateToProps(state) {
   return {
@@ -142,6 +116,36 @@ function mapDispatchToProps(dispatch) {
     kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
     queryActions: bindActionCreators(queryActionCreators, dispatch),
   }
+}
+
+KapacitorRulePage.propTypes = {
+  source: PropTypes.shape({
+    links: PropTypes.shape({
+      proxy: PropTypes.string.isRequired,
+      self: PropTypes.string.isRequired,
+    }),
+  }),
+  addFlashMessage: PropTypes.func,
+  rules: PropTypes.shape({}).isRequired,
+  queryConfigs: PropTypes.shape({}).isRequired,
+  kapacitorActions: PropTypes.shape({
+    loadDefaultRule: PropTypes.func.isRequired,
+    fetchRule: PropTypes.func.isRequired,
+    chooseTrigger: PropTypes.func.isRequired,
+    addEvery: PropTypes.func.isRequired,
+    removeEvery: PropTypes.func.isRequired,
+    updateRuleValues: PropTypes.func.isRequired,
+    updateMessage: PropTypes.func.isRequired,
+    updateAlerts: PropTypes.func.isRequired,
+    updateRuleName: PropTypes.func.isRequired,
+  }).isRequired,
+  queryActions: PropTypes.shape({}).isRequired,
+  params: PropTypes.shape({
+    ruleID: PropTypes.string,
+  }).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulePage)

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -38,25 +38,27 @@ class KapacitorRulePage extends Component {
       })
     }
 
-    getKapacitorConfig(kapacitor)
-      .then(({data: {sections}}) => {
-        const enabledAlerts = Object.keys(sections).filter(section => {
-          return (
-            _.get(
-              sections,
-              [section, 'elements', '0', 'options', 'enabled'],
-              false
-            ) && ALERTS.includes(section)
-          )
-        })
-        this.setState({kapacitor, enabledAlerts})
+    try {
+      const {data: {sections}} = await getKapacitorConfig(kapacitor)
+      const enabledAlerts = Object.keys(sections).filter(section => {
+        return (
+          _.get(
+            sections,
+            [section, 'elements', '0', 'options', 'enabled'],
+            false
+          ) && ALERTS.includes(section)
+        )
       })
-      .catch(() => {
-        addFlashMessage({
-          type: 'error',
-          text: 'There was a problem communicating with Kapacitor',
-        })
+
+      this.setState({kapacitor, enabledAlerts})
+    } catch (error) {
+      addFlashMessage({
+        type: 'error',
+        text: 'There was a problem communicating with Kapacitor',
       })
+      console.error(error)
+      throw error
+    }
   }
 
   render() {

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -136,14 +136,14 @@ KapacitorRulePage.propTypes = {
   }).isRequired,
 }
 
-function mapStateToProps(state) {
+const mapStateToProps = state => {
   return {
     rules: state.rules,
     queryConfigs: state.queryConfigs,
   }
 }
 
-function mapDispatchToProps(dispatch) {
+const mapDispatchToProps = dispatch => {
   return {
     kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
     queryActions: bindActionCreators(queryActionCreators, dispatch),

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -138,18 +138,14 @@ KapacitorRulePage.propTypes = {
   }).isRequired,
 }
 
-const mapStateToProps = state => {
-  return {
-    rules: state.rules,
-    queryConfigs: state.queryConfigs,
-  }
-}
+const mapStateToProps = ({rules, queryConfigs}) => ({
+  rules,
+  queryConfigs,
+})
 
-const mapDispatchToProps = dispatch => {
-  return {
-    kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
-    queryActions: bindActionCreators(queryActionCreators, dispatch),
-  }
-}
+const mapDispatchToProps = dispatch => ({
+  kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
+  queryActions: bindActionCreators(queryActionCreators, dispatch),
+})
 
 export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulePage)

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -104,6 +104,38 @@ class KapacitorRulePage extends Component {
   }
 }
 
+const {func, shape, string} = PropTypes
+
+KapacitorRulePage.propTypes = {
+  source: shape({
+    links: shape({
+      proxy: string.isRequired,
+      self: string.isRequired,
+    }),
+  }),
+  addFlashMessage: func,
+  rules: shape({}).isRequired,
+  queryConfigs: shape({}).isRequired,
+  kapacitorActions: shape({
+    loadDefaultRule: func.isRequired,
+    fetchRule: func.isRequired,
+    chooseTrigger: func.isRequired,
+    addEvery: func.isRequired,
+    removeEvery: func.isRequired,
+    updateRuleValues: func.isRequired,
+    updateMessage: func.isRequired,
+    updateAlerts: func.isRequired,
+    updateRuleName: func.isRequired,
+  }).isRequired,
+  queryActions: shape({}).isRequired,
+  params: shape({
+    ruleID: string,
+  }).isRequired,
+  router: shape({
+    push: func.isRequired,
+  }).isRequired,
+}
+
 function mapStateToProps(state) {
   return {
     rules: state.rules,
@@ -116,36 +148,6 @@ function mapDispatchToProps(dispatch) {
     kapacitorActions: bindActionCreators(kapacitorActionCreators, dispatch),
     queryActions: bindActionCreators(queryActionCreators, dispatch),
   }
-}
-
-KapacitorRulePage.propTypes = {
-  source: PropTypes.shape({
-    links: PropTypes.shape({
-      proxy: PropTypes.string.isRequired,
-      self: PropTypes.string.isRequired,
-    }),
-  }),
-  addFlashMessage: PropTypes.func,
-  rules: PropTypes.shape({}).isRequired,
-  queryConfigs: PropTypes.shape({}).isRequired,
-  kapacitorActions: PropTypes.shape({
-    loadDefaultRule: PropTypes.func.isRequired,
-    fetchRule: PropTypes.func.isRequired,
-    chooseTrigger: PropTypes.func.isRequired,
-    addEvery: PropTypes.func.isRequired,
-    removeEvery: PropTypes.func.isRequired,
-    updateRuleValues: PropTypes.func.isRequired,
-    updateMessage: PropTypes.func.isRequired,
-    updateAlerts: PropTypes.func.isRequired,
-    updateRuleName: PropTypes.func.isRequired,
-  }).isRequired,
-  queryActions: PropTypes.shape({}).isRequired,
-  params: PropTypes.shape({
-    ruleID: PropTypes.string,
-  }).isRequired,
-  router: PropTypes.shape({
-    push: PropTypes.func.isRequired,
-  }).isRequired,
 }
 
 export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulePage)

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -55,19 +55,17 @@ class KapacitorRulesPage extends Component {
     const {hasKapacitor, loading, tickscript} = this.state
 
     return (
-      <div>
-        <KapacitorRules
-          source={source}
-          rules={rules}
-          hasKapacitor={hasKapacitor}
-          loading={loading}
-          onDelete={this.handleDeleteRule}
-          onChangeRuleStatus={this.handleRuleStatus}
-          onReadTickscript={this.handleReadTickscript}
-          tickscript={tickscript}
-          onCloseTickscript={this.handleCloseTickscript}
-        />
-      </div>
+      <KapacitorRules
+        source={source}
+        rules={rules}
+        hasKapacitor={hasKapacitor}
+        loading={loading}
+        onDelete={this.handleDeleteRule}
+        onChangeRuleStatus={this.handleRuleStatus}
+        onReadTickscript={this.handleReadTickscript}
+        tickscript={tickscript}
+        onCloseTickscript={this.handleCloseTickscript}
+      />
     )
   }
 }

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -11,10 +11,13 @@ class KapacitorRulesPage extends Component {
     this.state = {
       hasKapacitor: false,
       loading: true,
+      tickscript: null,
     }
 
     this.handleDeleteRule = ::this.handleDeleteRule
     this.handleRuleStatus = ::this.handleRuleStatus
+    this.handleReadTickscript = ::this.handleReadTickscript
+    this.handleCloseTickscript = ::this.handleCloseTickscript
   }
 
   componentDidMount() {
@@ -39,19 +42,32 @@ class KapacitorRulesPage extends Component {
     actions.updateRuleStatusSuccess(rule.id, status)
   }
 
+  handleReadTickscript({tickscript}) {
+    this.setState({tickscript})
+  }
+
+  handleCloseTickscript() {
+    this.setState({tickscript: null})
+  }
+
   render() {
     const {source, rules} = this.props
-    const {hasKapacitor, loading} = this.state
+    const {hasKapacitor, loading, tickscript} = this.state
 
     return (
-      <KapacitorRules
-        source={source}
-        rules={rules}
-        hasKapacitor={hasKapacitor}
-        loading={loading}
-        onDelete={this.handleDeleteRule}
-        onChangeRuleStatus={this.handleRuleStatus}
-      />
+      <div>
+        <KapacitorRules
+          source={source}
+          rules={rules}
+          hasKapacitor={hasKapacitor}
+          loading={loading}
+          onDelete={this.handleDeleteRule}
+          onChangeRuleStatus={this.handleRuleStatus}
+          onReadTickscript={this.handleReadTickscript}
+          tickscript={tickscript}
+          onCloseTickscript={this.handleCloseTickscript}
+        />
+      </div>
     )
   }
 }

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.js
@@ -20,13 +20,14 @@ class KapacitorRulesPage extends Component {
     this.handleCloseTickscript = ::this.handleCloseTickscript
   }
 
-  componentDidMount() {
-    getActiveKapacitor(this.props.source).then(kapacitor => {
-      if (kapacitor) {
-        this.props.actions.fetchRules(kapacitor)
-      }
-      this.setState({loading: false, hasKapacitor: !!kapacitor})
-    })
+  async componentDidMount() {
+    const kapacitor = await getActiveKapacitor(this.props.source)
+    if (!kapacitor) {
+      return
+    }
+
+    await this.props.actions.fetchRules(kapacitor)
+    this.setState({loading: false, hasKapacitor: !!kapacitor})
   }
 
   handleDeleteRule(rule) {

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -67,14 +67,19 @@ export function getKapacitor(source, kapacitorID) {
   })
 }
 
-export function getActiveKapacitor(source) {
-  return AJAX({
-    url: source.links.kapacitors,
-    method: 'GET',
-  }).then(({data}) => {
+export const getActiveKapacitor = async source => {
+  try {
+    const {data} = await AJAX({
+      url: source.links.kapacitors,
+      method: 'GET',
+    })
+
     const activeKapacitor = data.kapacitors.find(k => k.active)
     return activeKapacitor || data.kapacitors[0]
-  })
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
 }
 
 export const getKapacitors = async source => {
@@ -163,11 +168,9 @@ export function updateKapacitorConfigSection(kapacitor, section, properties) {
 }
 
 export function testAlertOutput(kapacitor, outputName, properties) {
-  return kapacitorProxy(
-    kapacitor,
-    'GET',
-    '/kapacitor/v1/service-tests'
-  ).then(({data: {services}}) => {
+  return kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/service-tests').then(({
+    data: {services},
+  }) => {
     const service = services.find(s => s.name === outputName)
     return kapacitorProxy(
       kapacitor,

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -143,11 +143,11 @@ export function updateKapacitor({
   })
 }
 
-export function getKapacitorConfig(kapacitor) {
-  return kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/config', '')
+export const getKapacitorConfig = async kapacitor => {
+  return await kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/config', '')
 }
 
-export function getKapacitorConfigSection(kapacitor, section) {
+export const getKapacitorConfigSection = (kapacitor, section) => {
   return kapacitorProxy(kapacitor, 'GET', `/kapacitor/v1/config/${section}`, '')
 }
 

--- a/ui/src/style/components/tables.scss
+++ b/ui/src/style/components/tables.scss
@@ -261,3 +261,14 @@ $table-tab-scrollbar-height: 6px;
     text-overflow: ellipsis;
   }
 }
+
+/*
+    No Wrap Cells
+    ----------------------------------------------
+*/
+
+table .table-cell-nowrap {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -217,3 +217,30 @@ br {
   color: $g11-sidewalk;
   font-size: 13px;
 }
+
+
+
+/*
+  View TICKscript Overlay
+  -----------------------------------------------------------------------------
+*/
+$tick-script-overlay-margin: 30px;
+.tick-script-overlay {
+  max-width: 960px;
+  margin: 0 auto $tick-script-overlay-margin auto;
+  height: calc(100% - #{$tick-script-overlay-margin});
+  position: relative;
+
+  .write-data-form--body {
+    height: calc(100% - 60px);
+    display: flex;
+    flex-direction: column;
+  }
+}
+.tick-script-overlay--sample {
+  margin: 0;
+  white-space: pre-wrap;
+  font-size: 14px;
+  padding: 20px;
+  border: 2px solid $g4-onyx;
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1663 

### The problem
Users can build TICKscripts with our Kapacitor Rule generator but there's no way to see the sweet scripts in the UI!

### The Solution
Add some UI!

### Notes
Removed a silly eslint rule for no setState in componentDidMount.  We do this everywhere but they weren't triggered when in a `then` block.  Even airbnb thinks its [silly as a standard](https://github.com/airbnb/javascript/issues/684#issuecomment-284392220).

![](http://g.recordit.co/mKxBj1IGRC.gif)


