### PR TITLE
Fix PagerDuty kapacitor node typo bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#1708](https://github.com/influxdata/chronograf/pull/1708): Fix z-index issue in dashboard cell context menu
+1. [#1751](https://github.com/influxdata/chronograf/pull/1751): Fix typo that may have affected PagerDuty node creation in Kapacitor
 
 ### Features
 1. [#1717](https://github.com/influxdata/chronograf/pull/1717): View server generated TICKscripts

--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -559,7 +559,7 @@ func extractPagerduty(node *pipeline.AlertNode, rule *chronograf.AlertRule) {
 	rule.Alerts = append(rule.Alerts, "pagerduty")
 	p := node.PagerDutyHandlers[0]
 	alert := chronograf.KapacitorNode{
-		Name: "paperduty",
+		Name: "pagerduty",
 	}
 
 	if p.ServiceKey != "" {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1748 

### The problem
Adding a PagerDuty Kapacitor node may have been broken due to a typo.

### The Solution
Fix the typo.

