### PR TITLE
Prevent 'auto' GROUP BY option in Kapacitor rule builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#1752](https://github.com/influxdata/chronograf/pull/1752): Clarify BoltPath server flag help text by making example the default path
 1. [#1703](https://github.com/influxdata/chronograf/pull/1703): Fix cell name cancel not reverting to original name
 1. [#1751](https://github.com/influxdata/chronograf/pull/1751): Fix typo that may have affected PagerDuty node creation in Kapacitor
+1. [#1756](https://github.com/influxdata/chronograf/pull/1756): Prevent 'auto' GROUP BY as option in Kapacitor rule builder when applying a function to a field
 
 ### Features
 1. [#1717](https://github.com/influxdata/chronograf/pull/1717): View server generated TICKscripts

--- a/ui/src/data_explorer/components/GroupByTimeDropdown.js
+++ b/ui/src/data_explorer/components/GroupByTimeDropdown.js
@@ -25,7 +25,7 @@ const GroupByTimeDropdown = React.createClass({
     } = this.props
 
     let validOptions = groupByTimeOptions
-    if (isInDataExplorer) {
+    if (isInDataExplorer || isInRuleBuilder) {
       validOptions = validOptions.filter(
         ({menuOption}) => menuOption !== DEFAULT_DASHBOARD_GROUP_BY_INTERVAL
       )

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -32,6 +32,7 @@ export const DataSection = React.createClass({
     onAddEvery: PropTypes.func.isRequired,
     onRemoveEvery: PropTypes.func.isRequired,
     timeRange: PropTypes.shape({}).isRequired,
+    isKapacitorRule: PropTypes.bool,
   },
 
   childContextTypes: {
@@ -69,7 +70,13 @@ export const DataSection = React.createClass({
   },
 
   handleApplyFuncsToField(fieldFunc) {
-    this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc)
+    this.props.actions.applyFuncsToField(
+      this.props.query.id,
+      fieldFunc,
+      // this 3rd arg (isKapacitorRule) makes sure 'auto' is not added as
+      // default group by in Kapacitor rule
+      this.props.isKapacitorRule
+    )
     this.props.onAddEvery(defaultEveryFrequency)
   },
 
@@ -109,7 +116,7 @@ export const DataSection = React.createClass({
   },
 
   renderQueryBuilder() {
-    const {query} = this.props
+    const {query, isKapacitorRule} = this.props
 
     return (
       <div className="query-builder">
@@ -129,7 +136,7 @@ export const DataSection = React.createClass({
           onToggleField={this.handleToggleField}
           onGroupByTime={this.handleGroupByTime}
           applyFuncsToField={this.handleApplyFuncsToField}
-          isKapacitorRule={true}
+          isKapacitorRule={isKapacitorRule}
         />
       </div>
     )

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -71,6 +71,7 @@ export const KapacitorRule = React.createClass({
                     actions={queryActions}
                     onAddEvery={this.handleAddEvery}
                     onRemoveEvery={this.handleRemoveEvery}
+                    isKapacitorRule={true}
                   />
                   <ValuesSection
                     rule={rule}

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -86,7 +86,7 @@ export function toggleTagAcceptance(query) {
 export function applyFuncsToField(
   query,
   {field, funcs},
-  isInDataExplorer = false
+  preventAutoGroupBy = false
 ) {
   const shouldRemoveFuncs = funcs.length === 0
   const nextFields = query.fields.map(f => {
@@ -103,7 +103,7 @@ export function applyFuncsToField(
     return f
   })
 
-  const defaultGroupBy = isInDataExplorer
+  const defaultGroupBy = preventAutoGroupBy
     ? DEFAULT_DATA_EXPLORER_GROUP_BY_INTERVAL
     : DEFAULT_DASHBOARD_GROUP_BY_INTERVAL
   // If there are no functions, then there should be no GROUP BY time


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1730 

### The problem
`auto` was appearing as an option (and the default option) in Kapacitor rule builder when a user would apply a function a field. This doesn't make sense and also would cause an unspecific error notification to the user (unless they looked at the console) when they tried to save their alert, if they had applied a function to a field and didn't change their GROUP BY away from the default option of 'auto', resulting in confusion and no insight into how to successfully save an alert.

### The Solution
Make `10s` the default option for Kapacitor rule builder function field GROUP BY dropdown, and prevent 'auto' from appearing.
