### PR TITLE
Add option for verbose reporting in client unit tests

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -33,5 +33,4 @@ yarn upgrade packageName
 ```
 
 ## Testing
-Tests can be run via command line with `npm run test`, from within the `/ui` directory. For more detailed reporting, use `npm test -- --reporters=verbose
-`.
+Tests can be run via command line with `npm test`, from within the `/ui` directory. For more detailed reporting, use `npm test -- --reporters=verbose`.

--- a/ui/README.md
+++ b/ui/README.md
@@ -15,7 +15,7 @@ yarn add --dev packageName
 ```
 
 ### Updating a package
-First, run 
+First, run
 
 ```sh
 yarn outdated
@@ -31,3 +31,7 @@ To upgrade a single package named `packageName`:
 ```sh
 yarn upgrade packageName
 ```
+
+## Testing
+Tests can be run via command line with `npm run test`, from within the `/ui` directory. For more detailed reporting, use `npm test -- --reporters=verbose
+`.

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -1,5 +1,5 @@
-var webpack = require('webpack');
-var path = require('path');
+var webpack = require('webpack')
+var path = require('path')
 
 module.exports = function(config) {
   config.set({
@@ -15,7 +15,7 @@ module.exports = function(config) {
       'spec/spec-helper.js': ['webpack', 'sourcemap'],
       'spec/index.js': ['webpack', 'sourcemap'],
     },
-    reporters: ['dots'],
+    reporters: ['dots'], // can also use 'verbose' and/or 'progress' for more detailed reporting
     webpack: {
       devtool: 'inline-source-map',
       module: {
@@ -35,7 +35,8 @@ module.exports = function(config) {
             exclude: /node_modules/,
             loader: 'style-loader!css-loader!sass-loader',
           },
-          { // Sinon behaves weirdly with webpack, see https://github.com/webpack/webpack/issues/304
+          {
+            // Sinon behaves weirdly with webpack, see https://github.com/webpack/webpack/issues/304
             test: /sinon\/pkg\/sinon\.js/,
             loader: 'imports?define=>false,require=>false',
           },
@@ -48,7 +49,7 @@ module.exports = function(config) {
       externals: {
         'react/addons': true,
         'react/lib/ExecutionEnvironment': true,
-        'react/lib/ReactContext': true
+        'react/lib/ReactContext': true,
       },
       resolve: {
         alias: {
@@ -65,5 +66,5 @@ module.exports = function(config) {
     webpackServer: {
       noInfo: true, // please don't spam the console when running in karma!
     },
-  });
-};
+  })
+}

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -15,7 +15,9 @@ module.exports = function(config) {
       'spec/spec-helper.js': ['webpack', 'sourcemap'],
       'spec/index.js': ['webpack', 'sourcemap'],
     },
-    reporters: ['dots'], // can also use 'verbose' and/or 'progress' for more detailed reporting
+    // For more detailed reporting on tests, you can add 'verbose' and/or 'progress'.
+    // This can also be done via the command line with `npm test -- --reporters=verbose`.
+    reporters: ['dots'],
     webpack: {
       devtool: 'inline-source-map',
       module: {

--- a/ui/package.json
+++ b/ui/package.json
@@ -68,6 +68,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-sinon-chai": "^1.2.4",
     "karma-sourcemap-loader": "^0.3.7",
+    "karma-verbose-reporter": "^0.0.6",
     "karma-webpack": "^1.8.0",
     "mocha": "^2.4.5",
     "mocha-loader": "^0.7.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1808,7 +1808,7 @@ colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
-colors@^1.1.0, colors@~1.1.2:
+colors@>=1.0, colors@^1.1.0, colors@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.1.2.tgz#168a4701756b6a7f51a12ce0c97bfa28c084ed63"
 
@@ -4091,6 +4091,12 @@ karma-sourcemap-loader@^0.3.7:
   resolved "https://registry.yarnpkg.com/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz#91322c77f8f13d46fed062b042e1009d4c4505d8"
   dependencies:
     graceful-fs "^4.1.2"
+
+karma-verbose-reporter@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/karma-verbose-reporter/-/karma-verbose-reporter-0.0.6.tgz#5909052451c607f02ac77c763791a2fe1251260c"
+  dependencies:
+    colors ">=1.0"
 
 karma-webpack@^1.8.0:
   version "1.8.1"


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass

### The problem
Fine-grained insight into tests that have been run is missing – we only see `dots`.

### The Solution
Add a dev dependency for karma verbose reporting, and comment two options for more detailed reporting in karma config.

