### PR TITLE
Specify that version is for Chronograf on Sources page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### UI Improvements
 1. [#1707](https://github.com/influxdata/chronograf/pull/1707): Polish alerts table in status page to wrap text less
+1. [#1770](https://github.com/influxdata/chronograf/pull/1770): Specify that version is for Chronograf on Configuration page
 
 ## v1.3.4.0 [2017-07-10]
 ### Bug Fixes

--- a/ui/src/sources/containers/ManageSources.js
+++ b/ui/src/sources/containers/ManageSources.js
@@ -74,7 +74,7 @@ class ManageSources extends Component {
               handleDeleteKapacitor={deleteKapacitor}
             />
             <p className="version-number">
-              Version: {V_NUMBER}
+              Chronograf Version: {V_NUMBER}
             </p>
           </div>
         </FancyScrollbar>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1671 

### The problem
It wasn't fully clear what product `Version x.x.x.x` referred to on the Sources page, for the Chronograf version, since it was in the context of configuring InfluxDB and Kapacitor as well.

### The Solution
Explicitly state `Chronograf Version x.x.x.x`.

