### PR TITLE
Fix clipped scroll containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#1703](https://github.com/influxdata/chronograf/pull/1703): Fix cell name cancel not reverting to original name
 1. [#1751](https://github.com/influxdata/chronograf/pull/1751): Fix typo that may have affected PagerDuty node creation in Kapacitor
 1. [#1756](https://github.com/influxdata/chronograf/pull/1756): Prevent 'auto' GROUP BY as option in Kapacitor rule builder when applying a function to a field
+1. [#1773](https://github.com/influxdata/chronograf/pull/1773): Prevent clipped buttons in Rule Builder, Data Explorer, and Configuration pages
 
 ### Features
 1. [#1717](https://github.com/influxdata/chronograf/pull/1717): View server generated TICKscripts

--- a/ui/src/style/components/fancy-scrollbars.scss
+++ b/ui/src/style/components/fancy-scrollbars.scss
@@ -54,11 +54,6 @@ ul.dropdown-menu {
   .fancy-scroll--thumb-h { @include gradient-h($c-neutrino,$c-laser); }
   .fancy-scroll--thumb-v { @include gradient-v($c-neutrino,$c-laser); }
 }
-
-/* Hacky fix to hide strange white lines in chrome */
-.fancy-scroll--view {
-  margin-right: -16px !important
-}
 /* Hacky Fix to make fancy scrollbars work in Safari */
 .query-builder--list {
   position: relative;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1706 
Connect #1692 

### The Problem
- Occasionally scrollbars in the browser render in an unexpected way
  - Unclear whether this is a chrome issue or `react-custom-scrollbars`
- `margin-right: -16px !important` is set on the scroll containers but when the scrollbars don't render properly this becomes a UI bug affecting all instances of `react-custom-scrollbars`

### The Solution
- Remove the negative margin fix until the intermittent nature of `react-custom-scrollbars` can be diagnosed


