### PR TITLE
Give preference to queryConfig range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.6.0 [unreleased]
 ### Bug Fixes
+1. [#1798](https://github.com/influxdata/chronograf/pull/1798): Fix domain on CEO not updating when new time is entered into InfluxQL in the builder
 ### Features
 ### UI Improvements
 

--- a/ui/src/data_explorer/components/Visualization.js
+++ b/ui/src/data_explorer/components/Visualization.js
@@ -93,7 +93,8 @@ const Visualization = React.createClass({
     const {view} = this.state
 
     const statements = queryConfigs.map(query => {
-      const text = query.rawText || buildInfluxQLQuery(timeRange, query)
+      const text =
+        query.rawText || buildInfluxQLQuery(query.range || timeRange, query)
       return {text, id: query.id}
     })
     const queries = statements.filter(s => s.text !== null).map(s => {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect ##1611

### The problem
In the CEO, the domain for the visualization did not update when a user updated the timeRange in InfluxQL.  

### The Solution
Give preference to a `queriesConfig`s `range`.  


