### PR TITLE
Dont sync graphs if there is only one graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## v1.3.6.0 [unreleased]
 ### Bug Fixes
+1. [#1799](https://github.com/influxdata/chronograf/pull/1799): Fix console error spam from Dygraph.syncronize
+
 ### Features
 ### UI Improvements
 1. [#1796](https://github.com/influxdata/chronograf/pull/1796): Add spinner to indicate data is being written

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## v1.3.6.0 [unreleased]
 ### Bug Fixes
-1. [#1799](https://github.com/influxdata/chronograf/pull/1799): Fix console error spam from Dygraph.syncronize
+1. [#1799](https://github.com/influxdata/chronograf/pull/1799): Prevent console error spam from Dygraph.synchronize when a dashboard has only one graph
 
 ### Features
 ### UI Improvements

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -209,7 +209,11 @@ class DashboardPage extends Component {
     const dygraphs = [...this.state.dygraphs, dygraph]
     const {dashboards, params} = this.props
     const dashboard = dashboards.find(d => d.id === +params.dashboardID)
-    if (dashboard && dygraphs.length === dashboard.cells.length) {
+    if (
+      dashboard &&
+      dygraphs.length === dashboard.cells.length &&
+      dashboard.cells.length > 1
+    ) {
       Dygraph.synchronize(dygraphs, {
         selection: true,
         zoom: false,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1669 

### The problem
Console error spam from dygraph's synchronize function.  

### The Solution
Don't synchronize graphs if there's only one graph ya silly goose.


