### PR TITLE
Improve error message on JSON Feed GET fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### UI Improvements
 1. [#1796](https://github.com/influxdata/chronograf/pull/1796): Add spinner to indicate data is being written
 1. [#1800](https://github.com/influxdata/chronograf/pull/1796): Embiggen text area for line protocol manual entry in Data Explorer's Write Data overlay
+1. [#1812](https://github.com/influxdata/chronograf/pull/1812): Improve error message when request for Status Page News Feed fails
 
 ## v1.3.5.0 [2017-07-27]
 ### Bug Fixes

--- a/ui/src/status/actions/index.js
+++ b/ui/src/status/actions/index.js
@@ -7,8 +7,6 @@ import {errorThrown} from 'shared/actions/errors'
 
 import * as actionTypes from 'src/status/constants/actionTypes'
 
-import {HTTP_NOT_FOUND} from 'shared/constants'
-
 const fetchJSONFeedRequested = () => ({
   type: actionTypes.FETCH_JSON_FEED_REQUESTED,
 })
@@ -45,15 +43,11 @@ export const fetchJSONFeedAsync = url => async dispatch => {
   } catch (error) {
     console.error(error)
     dispatch(fetchJSONFeedFailed())
-    if (error.status === HTTP_NOT_FOUND) {
-      dispatch(
-        errorThrown(
-          error,
-          `Failed to fetch News Feed. JSON Feed at '${url}' returned 404 (Not Found)`
-        )
+    dispatch(
+      errorThrown(
+        error,
+        `Failed to fetch JSON Feed for News Feed from '${url}'`
       )
-    } else {
-      dispatch(errorThrown(error, 'Failed to fetch NewsFeed'))
-    }
+    )
   }
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1628 

### The problem
If a JSON Feed failed to be retrieved, the error message was generic.

### The Solution
Improve the error message by providing the URL and a slightly more specific message when a failure occurs.

### Note
It turns out that, given that we are attempting to access the JSON Feed resource directly from the Chronograf client, we are not provided with a status code for failure, even though the browser knows why the XHR failed. So it's not possible to use the status code for a greater variation of error messages. It may be that there is some tweaking that can be done to the XHR, including handling possible pre-flights performed, in order to gain access to this error code. I drilled into Axios pretty deeply, and it doesn't appear that updating to https://github.com/mzabriskie/axios/releases/tag/v0.16.2 (which does include better error handling) would give us this insight. We are currently constructing an XHR with a special Header for the JSON Feed, so this may be part of the culprit. Another option to get better insight could be to handle this external URL request via the Chronograf server (proxy).