### PR TITLE
Use UUID for AlertsTable element keys to prevent overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1. [#1798](https://github.com/influxdata/chronograf/pull/1798): Fix domain not updating in visualizations when changing time range manually
 1. [#1799](https://github.com/influxdata/chronograf/pull/1799): Prevent console error spam from Dygraph.synchronize when a dashboard has only one graph
+1. [#1813](https://github.com/influxdata/chronograf/pull/1813): Guarantee UUID for each Alert Table key to prevent dropping items when keys overlap
 
 ### Features
 ### UI Improvements

--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -1,7 +1,9 @@
 import React, {Component, PropTypes} from 'react'
+
 import _ from 'lodash'
 import classnames from 'classnames'
 import {Link} from 'react-router'
+import uuid from 'node-uuid'
 
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 
@@ -130,10 +132,7 @@ class AlertsTable extends Component {
           >
             {alerts.map(({name, level, time, host, value}) => {
               return (
-                <div
-                  className="alert-history-table--tr"
-                  key={`${name}-${level}-${time}-${host}-${value}`}
-                >
+                <div className="alert-history-table--tr" key={uuid.v4()}>
                   <div
                     className="alert-history-table--td"
                     style={{width: colName}}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1813 

### The problem
Console error and dropped items would occur in AlertsTable due to assigning the same `key` to multiple items.

### The Solution
Generate and assign a UUID for each AlertsTable key.

