### PR TITLE
Change some remaining npm mentions to yarn

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We really like to receive feature requests, as it helps us prioritize our work. 
 
 Contributing to the source code
 -------------------------------
-Chronograf is built using Go for its API backend and serving the front-end assets. The front-end visualization is built with React and uses NPM for package management. The assumption is that all your Go development are done in `$GOPATH/src`. `GOPATH` can be any directory under which Chronograf and all its dependencies will be cloned. For full details on the project structure, follow along below.
+Chronograf is built using Go for its API backend and serving the front-end assets. The front-end visualization is built with React and uses Yarn for package management. The assumption is that all your Go development are done in `$GOPATH/src`. `GOPATH` can be any directory under which Chronograf and all its dependencies will be cloned. For full details on the project structure, follow along below.
 
 Submitting a pull request
 -------------------------
@@ -43,9 +43,9 @@ Signing the CLA
 If you are going to be contributing back to Chronograf please take a second to sign our CLA, which can be found
 [on our website](https://influxdata.com/community/cla/).
 
-Installing NPM
+Installing Yarn
 --------------
-You'll need to install NPM to manage the JavaScript modules that the front-end uses. This varies depending on what platform you're developing on, but you should be able to find an installer on [the NPM downloads page](https://nodejs.org/en/download/).
+You'll need to install Yarn to manage the JavaScript modules that the front-end uses. This varies depending on what platform you're developing on, but you should be able to find an installer on [the Yarn installation page](https://yarnpkg.com/en/docs/install).
 
 Installing Go
 -------------
@@ -105,7 +105,7 @@ Retaining the directory structure `$GOPATH/src/github.com/influxdata` is necessa
 
 Build and Test
 --------------
-Make sure you have `go` and `npm` installed and the project structure as shown above. We provide a `Makefile` to get up and running quickly, so all you'll need to do is run the following:
+Make sure you have `go` and `yarn` installed and the project structure as shown above. We provide a `Makefile` to get up and running quickly, so all you'll need to do is run the following:
 
 ```bash
   cd $GOPATH/src/github.com/influxdata/chronograf

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ canned/bin_gen.go: canned/*.json
 	go generate -x ./canned
 
 .jssrc: $(UISOURCES)
-	cd ui && npm run build
+	cd ui && yarn run build
 	@touch .jssrc
 
 .dev-jssrc: $(UISOURCES)
-	cd ui && npm run build:dev
+	cd ui && yarn run build:dev
 	@touch .dev-jssrc
 
 dep: .jsdep .godep
@@ -98,7 +98,7 @@ gotestrace:
 	go test -race `go list ./... | grep -v /vendor/`
 
 jstest:
-	cd ui && npm test
+	cd ui && yarn test
 
 run: ${BINARY}
 	./chronograf
@@ -108,7 +108,7 @@ run-dev: chronogiraffe
 
 clean:
 	if [ -f ${BINARY} ] ; then rm ${BINARY} ; fi
-	cd ui && npm run clean
+	cd ui && yarn run clean
 	cd ui && rm -rf node_modules
 	rm -f dist/dist_gen.go canned/bin_gen.go server/swagger_gen.go
 	@rm -f .godep .jsdep .jssrc .dev-jssrc .bindata

--- a/ui/README.md
+++ b/ui/README.md
@@ -33,4 +33,4 @@ yarn upgrade packageName
 ```
 
 ## Testing
-Tests can be run via command line with `npm test`, from within the `/ui` directory. For more detailed reporting, use `npm test -- --reporters=verbose`.
+Tests can be run via command line with `yarn test`, from within the `/ui` directory. For more detailed reporting, use `yarn test -- --reporters=verbose`.

--- a/ui/karma.conf.js
+++ b/ui/karma.conf.js
@@ -16,7 +16,7 @@ module.exports = function(config) {
       'spec/index.js': ['webpack', 'sourcemap'],
     },
     // For more detailed reporting on tests, you can add 'verbose' and/or 'progress'.
-    // This can also be done via the command line with `npm test -- --reporters=verbose`.
+    // This can also be done via the command line with `yarn test -- --reporters=verbose`.
     reporters: ['dots'],
     webpack: {
       devtool: 'inline-source-map',

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,13 +9,13 @@
     "url": "github:influxdata/chronograf"
   },
   "scripts": {
-    "build": "npm run clean && env NODE_ENV=production node_modules/webpack/bin/webpack.js -p --config ./webpack/prodConfig.js",
+    "build": "yarn run clean && env NODE_ENV=production node_modules/webpack/bin/webpack.js -p --config ./webpack/prodConfig.js",
     "build:dev": "node_modules/webpack/bin/webpack.js --config ./webpack/devConfig.js",
     "start": "node_modules/webpack/bin/webpack.js -w --config ./webpack/devConfig.js",
     "lint": "node_modules/eslint/bin/eslint.js src/",
     "test": "karma start",
-    "test:lint": "npm run lint; npm run test",
-    "test:dev": "nodemon --exec npm run test:lint",
+    "test:lint": "yarn run lint; yarn run test",
+    "test:dev": "nodemon --exec yarn run test:lint",
     "clean": "rm -rf build",
     "storybook": "node ./storybook",
     "prettier": "prettier --single-quote --trailing-comma es5 --bracket-spacing false --semi false --write \"{src,spec}/**/*.js\"; eslint src --fix"


### PR DESCRIPTION
While `npm` is still installed as part of the build process, most of the
scripts and documentation should be using yarn.

Change `npm` to `yarn` where appropriate.

Signed-off-by: Nathan L Smith <smith@nlsmith.com>


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem

Some places in docs and scripts still use `npm` where `yarn` is more appropriate.

### The Solution

Change these occurrences.

