### PR TITLE
Success / error messages for queries not displaying

### DIFF
--- a/ui/src/data_explorer/components/VisView.js
+++ b/ui/src/data_explorer/components/VisView.js
@@ -44,6 +44,7 @@ const VisView = ({
       templates={templates}
       cellHeight={heightPixels}
       autoRefresh={autoRefresh}
+      editQueryStatus={editQueryStatus}
     />
   )
 }

--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -8,14 +8,15 @@ const RefreshingLineGraph = AutoRefresh(LineGraph)
 const RefreshingSingleStat = AutoRefresh(SingleStat)
 
 const RefreshingGraph = ({
-  timeRange,
-  autoRefresh,
-  templates,
-  synchronizer,
+  axes,
   type,
   queries,
+  templates,
+  timeRange,
   cellHeight,
-  axes,
+  autoRefresh,
+  synchronizer,
+  editQueryStatus,
 }) => {
   if (type === 'single-stat') {
     return (
@@ -43,6 +44,7 @@ const RefreshingGraph = ({
       isBarGraph={type === 'bar'}
       displayOptions={displayOptions}
       synchronizer={synchronizer}
+      editQueryStatus={editQueryStatus}
       axes={axes}
     />
   )
@@ -58,9 +60,10 @@ RefreshingGraph.propTypes = {
   templates: arrayOf(shape()),
   synchronizer: func,
   type: string.isRequired,
-  queries: arrayOf(shape()).isRequired,
   cellHeight: number,
   axes: shape(),
+  queries: arrayOf(shape()).isRequired,
+  editQueryStatus: func,
 }
 
 export default RefreshingGraph


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1850 

### The problem
No more sweet error / success messages in the DataExplorer or Chart Creator (what do you think of that instead of CellEditorOverlay?)

### The Solution
Looks like somewhere down the line of refactor the `editQueryStatus` action wasn't being passed along. 

