### PR TITLE
Fix missing cell type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.7.0 [unreleased]
 ### Bug Fixes
 1. [#1845](https://github.com/influxdata/chronograf/pull/1845): Fix no-scroll bar appearing in the Data Explorer table
+1. [#1866](https://github.com/influxdata/chronograf/pull/1866): Fix missing cell type (and consequently single-stat)
 
 ### Features
 

--- a/server/cells.go
+++ b/server/cells.go
@@ -45,6 +45,7 @@ func newCellResponses(dID chronograf.DashboardID, dcells []chronograf.DashboardC
 		newCell.H = cell.H
 		newCell.Name = cell.Name
 		newCell.ID = cell.ID
+		newCell.Type = cell.Type
 
 		for _, lbl := range labels {
 			if axis, found := cell.Axes[lbl]; !found {

--- a/server/cells_test.go
+++ b/server/cells_test.go
@@ -105,6 +105,7 @@ func Test_Service_DashboardCells(t *testing.T) {
 					W:       4,
 					H:       4,
 					Name:    "CPU",
+					Type:    "bar",
 					Queries: []chronograf.DashboardQuery{},
 					Axes:    map[string]chronograf.Axis{},
 				},
@@ -117,6 +118,7 @@ func Test_Service_DashboardCells(t *testing.T) {
 					W:       4,
 					H:       4,
 					Name:    "CPU",
+					Type:    "bar",
 					Queries: []chronograf.DashboardQuery{},
 					Axes: map[string]chronograf.Axis{
 						"x": chronograf.Axis{


### PR DESCRIPTION
Because we are now creating new instances of dashboards when we create a
response, it's critical to copy every element of Dashboards from the
previous to the new instance.

We were not previously copying the Type field of cells, so this was
defaulting to the empty string zero value. This patch adds "Type" to the
tests and ensures that it's properly copied


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [ ] Tests pass

Connect #1865


