### PR TITLE
Fix Data Explorer Raw Query time range not getting updated through dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#1864](https://github.com/influxdata/chronograf/pull/1864): Fix Write Data form upload button and add `onDragExit` handler
 1. [#1891](https://github.com/influxdata/chronograf/pull/1891): Fix Kapacitor config for PagerDuty via the UI
 1. [#1872](https://github.com/influxdata/chronograf/pull/1872): Prevent stats in the legend from wrapping line
+1. [#1899](https://github.com/influxdata/chronograf/pull/1899): Fix raw query editor in Data Explorer not using selected time
 
 ### Features
 1. [#1863](https://github.com/influxdata/chronograf/pull/1863): Improve 'new-sources' server flag example by adding 'type' key

--- a/ui/src/data_explorer/components/QueryMaker.js
+++ b/ui/src/data_explorer/components/QueryMaker.js
@@ -10,7 +10,7 @@ const rawTextBinder = (links, id, action) => text =>
   action(links.queries, id, text)
 
 const buildText = (q, timeRange) =>
-  q.rawText || buildInfluxQLQuery(q.range || timeRange, q) || ''
+  q.rawText || buildInfluxQLQuery(timeRange, q) || ''
 
 const QueryMaker = ({
   source,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #

### The problem
Fixes QueryMaker not updating query time range when a the time range was changed through the time range dropdown.

### The Solution
Prevent the queryConfig range from superseding the supplied range argument.

