### PR TITLE
Fix Single Stat Displaying Null Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#1897](https://github.com/influxdata/chronograf/pull/1897): Fix regression from [#1864](https://github.com/influxdata/chronograf/pull/1864) and redesign drag & drop interaction
 1. [#1872](https://github.com/influxdata/chronograf/pull/1872): Prevent stats in the legend from wrapping line
 1. [#1899](https://github.com/influxdata/chronograf/pull/1899): Fix raw query editor in Data Explorer not using selected time
+1. [#1921](https://github.com/influxdata/chronograf/pull/1921): Fix Single Stat value display to skip null values and calculate mean value from series returned from query
 
 ### Features
 1. [#1863](https://github.com/influxdata/chronograf/pull/1863): Improve 'new-sources' server flag example by adding 'type' key

--- a/ui/src/shared/components/SingleStat.js
+++ b/ui/src/shared/components/SingleStat.js
@@ -30,10 +30,10 @@ export default React.createClass({
       )
     }
 
-    const lastValue = lastValues(data)[1]
+    const meanValue = lastValues(data)
 
     const precision = 100.0
-    const roundedValue = Math.round(+lastValue * precision) / precision
+    const roundedValue = Math.round(meanValue * precision) / precision
 
     return (
       <div className="single-stat">

--- a/ui/src/shared/parsing/lastValues.js
+++ b/ui/src/shared/parsing/lastValues.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import {reduce} from 'fast.js'
 
 export default function(timeSeriesResponse) {
   const values = _.get(
@@ -6,7 +7,7 @@ export default function(timeSeriesResponse) {
     ['0', 'response', 'results', '0', 'series', '0', 'values'],
     [['', '']]
   )
-  const sum = values.reduce((acc, val) => acc + (val[1] || 0), 0)
+  const sum = reduce(values, (acc, val) => acc + (val[1] || 0), 0)
   const mean = sum / values.length
 
   return mean

--- a/ui/src/shared/parsing/lastValues.js
+++ b/ui/src/shared/parsing/lastValues.js
@@ -6,7 +6,8 @@ export default function(timeSeriesResponse) {
     ['0', 'response', 'results', '0', 'series', '0', 'values'],
     [['', '']]
   )
-  const lastValues = values[values.length - 1]
+  const sum = values.reduce((acc, val) => acc + (val[1] || 0), 0)
+  const mean = sum / values.length
 
-  return lastValues
+  return mean
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1920 #1493 

### The problem
Single Stat display would display inconsistent and often null values.

### The Solution
Get mean values for single stat instead of just plucking the last values.

