### PR TITLE
Add missing attributes for safari compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#1897](https://github.com/influxdata/chronograf/pull/1897): Fix regression from [#1864](https://github.com/influxdata/chronograf/pull/1864) and redesign drag & drop interaction
 1. [#1872](https://github.com/influxdata/chronograf/pull/1872): Prevent stats in the legend from wrapping line
 1. [#1899](https://github.com/influxdata/chronograf/pull/1899): Fix raw query editor in Data Explorer not using selected time
+1. [#1922](https://github.com/influxdata/chronograf/pull/1922): Fix Safari display issue in the Cell Editor Visualization Type options
 
 ### Features
 1. [#1863](https://github.com/influxdata/chronograf/pull/1863): Improve 'new-sources' server flag example by adding 'type' key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 1. [#1897](https://github.com/influxdata/chronograf/pull/1897): Fix regression from [#1864](https://github.com/influxdata/chronograf/pull/1864) and redesign drag & drop interaction
 1. [#1872](https://github.com/influxdata/chronograf/pull/1872): Prevent stats in the legend from wrapping line
 1. [#1899](https://github.com/influxdata/chronograf/pull/1899): Fix raw query editor in Data Explorer not using selected time
-1. [#1922](https://github.com/influxdata/chronograf/pull/1922): Fix Safari display issue in the Cell Editor Visualization Type options
+1. [#1922](https://github.com/influxdata/chronograf/pull/1922): Fix Safari display issues in the Cell Editor display options
 
 ### Features
 1. [#1863](https://github.com/influxdata/chronograf/pull/1863): Improve 'new-sources' server flag example by adding 'type' key

--- a/ui/src/dashboards/graphics/graph.js
+++ b/ui/src/dashboards/graphics/graph.js
@@ -7,6 +7,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="Line"
           x="0px"
@@ -48,6 +50,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="LineStacked"
           x="0px"
@@ -89,6 +93,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="StepPlot"
           x="0px"
@@ -122,6 +128,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="SingleStat"
           x="0px"
@@ -155,6 +163,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="LineAndSingleStat"
           x="0px"
@@ -204,6 +214,8 @@ export const graphTypes = [
     graphic: (
       <div className="viz-type-selector--graphic">
         <svg
+          width="100%"
+          height="100%"
           version="1.1"
           id="Bar"
           x="0px"

--- a/ui/src/style/components/ceo-display-options.scss
+++ b/ui/src/style/components/ceo-display-options.scss
@@ -11,6 +11,7 @@
   align-items: stretch;
 }
 .display-options--cell {
+  position: relative;
   border-radius: 3px;
   background-color: $g3-castle;
   padding: 30px;
@@ -33,8 +34,12 @@
 .viz-type-selector {
   display: flex;
   flex-wrap: wrap;
-  height: calc(100% - 22px);
-  margin: -4px;
+  position: absolute;
+  top: 60px;
+  left: 26px;
+  height: calc(100% - 85px);
+  width: calc(100% - 52px);
+  margin: 0;
 }
 .viz-type-selector--option {
   flex: 1 0 33.3333%;

--- a/ui/src/style/components/opt-in.scss
+++ b/ui/src/style/components/opt-in.scss
@@ -65,6 +65,7 @@
     content: '';
     display: block;
     position: absolute;
+    left: 0;
     width: 100%;
     height: 100%;
     transition: opacity 0.25s ease;

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -244,3 +244,16 @@ $tick-script-overlay-margin: 30px;
   padding: 20px;
   border: 2px solid $g4-onyx;
 }
+
+/*
+  Fix Display issue in Safari
+  -----------------------------------------------------------------------------
+  The pseudo elements offset items in the tablists
+*/
+.nav-tablist {
+  &:before,
+  &:after {
+    content: none;
+    display: none;
+  }
+}


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1918 
Connect #1873 
Connect #1923 

### The Problem
- Safari has weird flexbox quirks that work fine everywhere else
- `OptIn` component renders strangely in Safari

### The Solution
- Using a less elegant but more cross-browser compatible positioning approach
- Position `OptIn` gradient more explicitly
