### PR TITLE
Fix equal min max bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.8.0 [unreleased]
 ### Bug Fixes
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
+1. [#1930](https://github.com/influxdata/chronograf/pull/1930): Fix graphs when values are of constant values
 
 ### Features
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -96,6 +96,7 @@
   },
   "dependencies": {
     "axios": "^0.13.1",
+    "bignumber.js": "^4.0.2",
     "bootstrap": "^3.3.7",
     "calculate-size": "^1.1.1",
     "classnames": "^2.2.3",

--- a/ui/spec/shared/parsing/getRangeForDygraphSpec.js
+++ b/ui/spec/shared/parsing/getRangeForDygraphSpec.js
@@ -4,6 +4,7 @@ const date = new Date()
 const max = 20
 const mid = 10
 const min = 5
+const negMax = -20
 const kapacitor = {value: null, rangeValue: null, operator: null}
 
 describe('getRangeForDygraphSpec', () => {
@@ -23,14 +24,6 @@ describe('getRangeForDygraphSpec', () => {
     expect(actual).to.deep.equal([0, 4])
   })
 
-  it('does not use the user submitted range if they are equal', () => {
-    const timeSeries = [[date, min], [date, max], [date, mid]]
-    const providedRange = ['0', '0']
-    const actual = getRange(timeSeries, providedRange)
-
-    expect(actual).to.deep.equal([min, max])
-  })
-
   it('gets the range for multiple timeSeries', () => {
     const timeSeries = [[date, null, min], [date, max, mid], [date, null, mid]]
     const actual = getRange(timeSeries)
@@ -39,12 +32,22 @@ describe('getRangeForDygraphSpec', () => {
     expect(actual).to.deep.equal(expected)
   })
 
-  it('returns a null array of two elements when min and max are equal', () => {
-    const timeSeries = [[date, max], [date, max], [date, max]]
-    const actual = getRange(timeSeries)
-    const expected = [null, null]
+  describe('if min and max are equal', () => {
+    it('it sets min to 0 if they are positive', () => {
+      const timeSeries = [[date, max], [date, max], [date, max]]
+      const actual = getRange(timeSeries)
+      const expected = [0, max]
 
-    expect(actual).to.deep.equal(expected)
+      expect(actual).to.deep.equal(expected)
+    })
+
+    it('it sets max to 0 if they are negative', () => {
+      const timeSeries = [[date, negMax], [date, negMax], [date, negMax]]
+      const actual = getRange(timeSeries)
+      const expected = [negMax, 0]
+
+      expect(actual).to.deep.equal(expected)
+    })
   })
 
   describe('when user provides a Kapacitor rule value', () => {

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -1,4 +1,7 @@
-const PADDING_FACTOR = 0.1
+import BigNumber from 'bignumber.js'
+
+const ADD_FACTOR = 1.1
+const SUB_FACTOR = 0.9
 
 const considerEmpty = (userNumber, number) => {
   if (userNumber) {
@@ -16,19 +19,21 @@ const getRange = (
   const {value, rangeValue, operator} = ruleValues
   const [userMin, userMax] = userSelectedRange
 
-  const subtractPadding = val => +val - Math.abs(val * PADDING_FACTOR)
-  const addPadding = val => +val + Math.abs(val * PADDING_FACTOR)
+  const addPad = bigNum => bigNum.times(ADD_FACTOR).toNumber()
+  const subPad = bigNum => bigNum.times(SUB_FACTOR).toNumber()
 
-  const pad = val => {
-    if (val === null || val === '') {
+  const pad = v => {
+    if (v === null || v === '') {
       return null
     }
 
+    const val = new BigNumber(v)
+
     if (operator === 'less than') {
-      return val < 0 ? addPadding(val) : subtractPadding(val)
+      return val.lessThan(0) ? addPad(val) : subPad(val)
     }
 
-    return val < 0 ? subtractPadding(val) : addPadding(val)
+    return val.lessThan(0) ? subPad(val) : addPad(val)
   }
 
   const points = [...timeSeries, [null, pad(value)], [null, pad(rangeValue)]]
@@ -58,11 +63,8 @@ const getRange = (
   )
 
   const [calcMin, calcMax] = range
-
-  const [min, max] = [
-    considerEmpty(userMin, calcMin),
-    considerEmpty(userMax, calcMax),
-  ]
+  const min = considerEmpty(userMin, calcMin)
+  const max = considerEmpty(userMax, calcMax)
 
   if (min === max) {
     if (min > 0) {

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -1,10 +1,6 @@
 const PADDING_FACTOR = 0.1
 
 const considerEmpty = (userNumber, number) => {
-  if (userNumber === '') {
-    return null
-  }
-
   if (userNumber) {
     return +userNumber
   }
@@ -61,22 +57,24 @@ const getRange = (
     [null, null]
   )
 
-  const [min, max] = range
+  const [calcMin, calcMax] = range
 
-  // If time series is such that min and max are equal use Dygraph defaults
+  const [min, max] = [
+    considerEmpty(userMin, calcMin),
+    considerEmpty(userMax, calcMax),
+  ]
+
   if (min === max) {
-    return [null, null]
+    if (min > 0) {
+      return [0, max]
+    }
+
+    if (min < 0) {
+      return [min, 0]
+    }
   }
 
-  if (userMin === userMax) {
-    return [min, max]
-  }
-
-  if (userMin && userMax) {
-    return [considerEmpty(userMin), considerEmpty(userMax)]
-  }
-
-  return [considerEmpty(userMin, min), considerEmpty(userMax, max)]
+  return [min, max]
 }
 
 export default getRange

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1446,6 +1446,10 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
+bignumber.js@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1857 
Connect #1900 

### The problem
When y-values were the same throughout all time ranges the graph got into a very ugly state.  

### The Solution
Respect selected range when calculated ranges are equal, and be a bit smarter about what to do by default if min and max are equal.

### Repro steps
Run the shell script in #1857 and follow the instructions locally.