### PR TITLE
Fix inability to add kapacitor from source page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
 1. [#1930](https://github.com/influxdata/chronograf/pull/1930): Fix graphs when y-values are constant
+1. [#1943](https://github.com/influxdata/chronograf/pull/1943): Fix inability to add kapacitor from source page on fresh install
 
 
 ### Features

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -68,11 +68,18 @@ class KapacitorPage extends Component {
 
   handleSubmit(e) {
     e.preventDefault()
-    const {addFlashMessage, source, params, router} = this.props
+    const {
+      addFlashMessage,
+      source,
+      source: {kapacitors = []},
+      params,
+      router,
+    } = this.props
     const {kapacitor} = this.state
 
-    const kapNames = source.kapacitors.map(k => k.name)
-    if (kapNames.includes(kapacitor.name)) {
+    const isNameTaken = kapacitors.some(k => k.name === kapacitor.name)
+
+    if (isNameTaken) {
       addFlashMessage({
         type: 'error',
         text: `There is already a Kapacitor configuration named "${kapacitor.name}"`,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1919 

### The problem
Could not add a kapacitor from source page with a clean chonograf-v1.db

### The Solution
The `kapacitors` list on `source` was not yet defined.  So, I added
a default empty array to the `kapacitors` key.  


### Extra Credit
Cleaned up some logic regarding the prevention of dup of kapacitor names.




