### PR TITLE
Sidebar Polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 1. [#1933](https://github.com/influxdata/chronograf/pull/1933): Use line-stacked graph type for memory information - thank you, @Joxit!
 1. [#1940](https://github.com/influxdata/chronograf/pull/1940): Improve cell sizes in Admin Database tables
 1. [#1942](https://github.com/influxdata/chronograf/pull/1942): Polish appearance of optional alert parameters in Kapacitor rule builder
+1. [#1944](https://github.com/influxdata/chronograf/pull/1944): Add active state for Status page navbar icon
+1. [#1944](https://github.com/influxdata/chronograf/pull/1944): Improve UX of navigation to a sub-nav item in the navbar
 
 ## v1.3.7.0 [2017-08-23]
 ### Bug Fixes

--- a/ui/src/side_nav/components/NavItems.js
+++ b/ui/src/side_nav/components/NavItems.js
@@ -86,6 +86,7 @@ const NavBlock = React.createClass({
         {this.renderSquare()}
         <div className="sidebar-menu">
           {children}
+          <div className="sidebar-menu--triangle" />
         </div>
       </div>
     )

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -69,10 +69,14 @@ const SideNav = React.createClass({
     const dataExplorerLink = `${sourcePrefix}/chronograf/data-explorer`
     const isUsingAuth = !!logoutLink
 
+    const isDefaultPage = location.split('/').includes(DEFAULT_HOME_PAGE)
+
     return isHidden
       ? null
       : <NavBar location={location}>
-          <div className="sidebar--item">
+          <div
+            className={isDefaultPage ? 'sidebar--item active' : 'sidebar--item'}
+          >
             <Link
               to={`${sourcePrefix}/${DEFAULT_HOME_PAGE}`}
               className="sidebar--square sidebar--logo"

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -93,6 +93,7 @@ $sidebar-menu--gutter: 18px;
 */
 .sidebar--item:hover {
   cursor: pointer;
+  z-index: 5;
 
   .sidebar--square {background-color: $sidebar--item-bg-hover;}
   .sidebar--icon {color: $sidebar--icon-hover;}
@@ -186,4 +187,14 @@ $sidebar-menu--gutter: 18px;
   font-size: 19px;
   font-weight: 400;
   padding: 0px $sidebar-menu--gutter;
+}
+// Invisible triangle for easier mouse movement when navigating to sub items
+.sidebar-menu--item + .sidebar-menu--triangle {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  z-index: -1;
+  top: $sidebar--width;
+  left: 0px;
+  transform: translate(-50%,-50%) rotate(45deg);
 }

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -115,6 +115,16 @@ $sidebar-menu--gutter: 18px;
   background-color: $sidebar--logo-bg-hover;
   .sidebar--icon {color: $sidebar--logo-color-hover;}
 }
+.sidebar--item.active .sidebar--square.sidebar--logo {
+  background-color: $sidebar--logo-bg-hover;
+  .sidebar--icon {
+    color: $sidebar--logo-color-hover;
+    text-shadow:
+      0 0 9px $c-hydrogen,
+      0 0 15px $c-neutrino,
+      0 0 20px $c-yeti;
+  }
+}
 
 /*
     Sidebar Sub Menus


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1760 
Connect #1690 

### The Problem
- Logo tile for `Status` page has no `active` state
- Mousing from a hovered nav item to a sub-nav item can sometimes cause a hover on the item below (undesired)

### The Solution
- Make an active state for the logo tile
- Insert an invisible triangle between the nav item and nav menu when there are sub-nav items present

### Preview
![logo-tile-glow](https://user-images.githubusercontent.com/2433762/29851974-33d55ab2-8cec-11e7-902b-83f35e11dc04.gif)

![screen shot 2017-08-29 at 6 50 48 pm](https://user-images.githubusercontent.com/2433762/29851916-d048d154-8ceb-11e7-940f-9c7514caa795.png)
_NOTE: The red triangle is actually transparent, but for the sake of illustrating where the helper area is I have made it red_
![invisible-nav-triangle](https://user-images.githubusercontent.com/2433762/29851972-31489d72-8cec-11e7-8c14-1540531b35e1.gif)




