### PR TITLE
Add 'present' url param detection to presentation mode middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Features
 1. [#1928](https://github.com/influxdata/chronograf/pull/1928): Add prefix, suffix, scale, and other y-axis formatting
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
+1. [#1945](https://github.com/influxdata/chronograf/pull/1945): Add Presentation Mode to `present` on URL detection
 
 ### UI Improvements
 1. [#1933](https://github.com/influxdata/chronograf/pull/1933): Use line-stacked graph type for memory information - thank you, @Joxit!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Features
 1. [#1928](https://github.com/influxdata/chronograf/pull/1928): Add prefix, suffix, scale, and other y-axis formatting
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
-1. [#1945](https://github.com/influxdata/chronograf/pull/1945): Add Presentation Mode to `present` on URL detection
+1. [#1945](https://github.com/influxdata/chronograf/pull/1945):Add `present` query param to URL to enable presentation mode
 
 ### UI Improvements
 1. [#1933](https://github.com/influxdata/chronograf/pull/1933): Use line-stacked graph type for memory information - thank you, @Joxit!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Features
 1. [#1928](https://github.com/influxdata/chronograf/pull/1928): Add prefix, suffix, scale, and other y-axis formatting
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
-1. [#1945](https://github.com/influxdata/chronograf/pull/1945): Add `present` query param to URL to enable presentation mode
+1. [#1945](https://github.com/influxdata/chronograf/pull/1945): Add `present` boolean query param to URL to enable presentation mode
 
 ### UI Improvements
 1. [#1933](https://github.com/influxdata/chronograf/pull/1933): Use line-stacked graph type for memory information - thank you, @Joxit!

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Features
 1. [#1928](https://github.com/influxdata/chronograf/pull/1928): Add prefix, suffix, scale, and other y-axis formatting
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
-1. [#1945](https://github.com/influxdata/chronograf/pull/1945):Add `present` query param to URL to enable presentation mode
+1. [#1945](https://github.com/influxdata/chronograf/pull/1945): Add `present` query param to URL to enable presentation mode
 
 ### UI Improvements
 1. [#1933](https://github.com/influxdata/chronograf/pull/1933): Use line-stacked graph type for memory information - thank you, @Joxit!

--- a/ui/package.json
+++ b/ui/package.json
@@ -109,6 +109,7 @@
     "lodash": "^4.3.0",
     "moment": "^2.13.0",
     "node-uuid": "^1.4.7",
+    "query-string": "^5.0.0",
     "react": "^15.0.2",
     "react-addons-shallow-compare": "^15.0.2",
     "react-custom-scrollbars": "^4.1.1",

--- a/ui/src/shared/middleware/resizeLayout.js
+++ b/ui/src/shared/middleware/resizeLayout.js
@@ -1,4 +1,5 @@
 // Trigger resize event to relayout the React Layout plugin
+import {enablePresentationMode} from '../actions/app'
 
 export default function resizeLayout() {
   return next => action => {
@@ -11,6 +12,10 @@ export default function resizeLayout() {
       const evt = document.createEvent('HTMLEvents')
       evt.initEvent('resize', false, true)
       window.dispatchEvent(evt)
+    }
+    if (window.location.search.includes('present')) {
+      next(enablePresentationMode())
+      next(action)
     }
   }
 }

--- a/ui/src/shared/middleware/resizeLayout.js
+++ b/ui/src/shared/middleware/resizeLayout.js
@@ -1,5 +1,6 @@
 // Trigger resize event to relayout the React Layout plugin
-import {enablePresentationMode} from '../actions/app'
+import queryString from 'query-string'
+import {enablePresentationMode} from 'src/shared/actions/app'
 
 export default function resizeLayout() {
   return next => action => {
@@ -13,7 +14,10 @@ export default function resizeLayout() {
       evt.initEvent('resize', false, true)
       window.dispatchEvent(evt)
     }
-    if (window.location.search.includes('present')) {
+
+    const qs = queryString.parse(window.location.search)
+
+    if (typeof qs.present !== 'undefined') {
       next(enablePresentationMode())
       next(action)
     }

--- a/ui/src/shared/middleware/resizeLayout.js
+++ b/ui/src/shared/middleware/resizeLayout.js
@@ -17,7 +17,7 @@ export default function resizeLayout() {
 
     const qs = queryString.parse(window.location.search)
 
-    if (typeof qs.present !== 'undefined') {
+    if (qs.present === 'true') {
       next(enablePresentationMode())
       next(action)
     }

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2329,6 +2329,10 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
+decode-uri-component@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
+
 deep-eql@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-0.1.3.tgz#ef558acab8de25206cd713906d74e56930eb69f2"
@@ -5859,6 +5863,14 @@ query-string@^4.1.0, query-string@^4.2.2:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/query-string/-/query-string-4.2.3.tgz#9f27273d207a25a8ee4c7b8c74dcd45d556db822"
   dependencies:
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
+query-string@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.0.0.tgz#fbdf7004b4d2aff792f9871981b7a2794f555947"
+  dependencies:
+    decode-uri-component "^0.2.0"
     object-assign "^4.1.0"
     strict-uri-encode "^1.0.0"
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1208 

### The problem
One of our users is linking to Chronograf in iframes. If one could enter presentation mode automatically from simply adding a param to the URL, that'd be really useful.

### The Solution
If `present` is present on the URL search property, the application will automatically enter presentation mode on just about any page it's used on. This was done by adding that detection to the middleware, which I think is the most appropriate solution.