### PR TITLE
BUGFIX: 'fields' property missing from queryConfig in DataExplorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1. [#1886](https://github.com/influxdata/chronograf/pull/1886): Fix limit of 100 alert rules on alert rules page
 1. [#1930](https://github.com/influxdata/chronograf/pull/1930): Fix graphs when y-values are constant
+1. [#1947](https://github.com/influxdata/chronograf/pull/1947): Fix DataExplorer crash if field property not present on queryConfig
 
 
 ### Features

--- a/ui/spec/data_explorer/reducers/queryConfigSpec.js
+++ b/ui/spec/data_explorer/reducers/queryConfigSpec.js
@@ -146,6 +146,20 @@ describe('Chronograf.Reducers.DataExplorer.queryConfigs', () => {
         expect(newState[queryId].fields[1].funcs.length).to.equal(1)
         expect(newState[queryId].fields[1].funcs[0]).to.equal('func1')
       })
+
+      it('adds the field property to query config if not found', () => {
+        delete state[queryId].fields
+        expect(state[queryId].fields).to.equal(undefined)
+
+        const field = 'fk1'
+        const newState = reducer(
+          state,
+          toggleField(queryId, {field: 'fk1', funcs: []})
+        )
+
+        expect(newState[queryId].fields.length).to.equal(1)
+        expect(newState[queryId].fields[0].field).to.equal(field)
+      })
     })
   })
 

--- a/ui/src/shared/components/FieldList.js
+++ b/ui/src/shared/components/FieldList.js
@@ -67,9 +67,7 @@ class FieldList extends Component {
       }
 
       this.setState({
-        fields: fieldSets[measurement].map(f => {
-          return {field: f, funcs: []}
-        }),
+        fields: fieldSets[measurement].map(f => ({field: f, funcs: []})),
       })
     })
   }

--- a/ui/src/shared/components/FieldList.js
+++ b/ui/src/shared/components/FieldList.js
@@ -104,7 +104,7 @@ class FieldList extends Component {
   }
 
   renderList() {
-    const {database, measurement, fields} = this.props.query
+    const {database, measurement, fields = []} = this.props.query
     if (!database || !measurement) {
       return (
         <div className="query-builder--list-empty">

--- a/ui/src/shared/components/FieldList.js
+++ b/ui/src/shared/components/FieldList.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 
 import FieldListItem from 'src/data_explorer/components/FieldListItem'
 import GroupByTimeDropdown from 'src/data_explorer/components/GroupByTimeDropdown'
@@ -7,41 +7,13 @@ import FancyScrollbar from 'shared/components/FancyScrollbar'
 import {showFieldKeys} from 'shared/apis/metaQuery'
 import showFieldKeysParser from 'shared/parsing/showFieldKeys'
 
-const {bool, func, shape, string} = PropTypes
-
-const FieldList = React.createClass({
-  propTypes: {
-    query: shape({
-      database: string,
-      retentionPolicy: string,
-      measurement: string,
-    }).isRequired,
-    onToggleField: func.isRequired,
-    onGroupByTime: func.isRequired,
-    applyFuncsToField: func.isRequired,
-    isKapacitorRule: bool,
-    isInDataExplorer: bool,
-  },
-
-  getDefaultProps() {
-    return {
-      isKapacitorRule: false,
-    }
-  },
-
-  contextTypes: {
-    source: shape({
-      links: shape({
-        proxy: string.isRequired,
-      }).isRequired,
-    }).isRequired,
-  },
-
-  getInitialState() {
-    return {
+class FieldList extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
       fields: [],
     }
-  },
+  }
 
   componentDidMount() {
     const {database, measurement} = this.props.query
@@ -50,7 +22,7 @@ const FieldList = React.createClass({
     }
 
     this._getFields()
-  },
+  }
 
   componentDidUpdate(prevProps) {
     const {database, measurement, retentionPolicy} = this.props.query
@@ -72,11 +44,35 @@ const FieldList = React.createClass({
     }
 
     this._getFields()
-  },
+  }
 
-  handleGroupByTime(groupBy) {
+  handleGroupByTime = groupBy => {
     this.props.onGroupByTime(groupBy.menuOption)
-  },
+  }
+
+  _getFields = () => {
+    const {database, measurement, retentionPolicy} = this.props.query
+    const {source} = this.context
+    const proxySource = source.links.proxy
+
+    showFieldKeys(
+      proxySource,
+      database,
+      measurement,
+      retentionPolicy
+    ).then(resp => {
+      const {errors, fieldSets} = showFieldKeysParser(resp.data)
+      if (errors.length) {
+        console.error('Error parsing fields keys: ', errors)
+      }
+
+      this.setState({
+        fields: fieldSets[measurement].map(f => {
+          return {field: f, funcs: []}
+        }),
+      })
+    })
+  }
 
   render() {
     const {
@@ -105,10 +101,10 @@ const FieldList = React.createClass({
         {this.renderList()}
       </div>
     )
-  },
+  }
 
   renderList() {
-    const {database, measurement} = this.props.query
+    const {database, measurement, fields} = this.props.query
     if (!database || !measurement) {
       return (
         <div className="query-builder--list-empty">
@@ -123,9 +119,7 @@ const FieldList = React.createClass({
       <div className="query-builder--list">
         <FancyScrollbar>
           {this.state.fields.map(fieldFunc => {
-            const selectedField = this.props.query.fields.find(
-              f => f.field === fieldFunc.field
-            )
+            const selectedField = fields.find(f => f.field === fieldFunc.field)
             return (
               <FieldListItem
                 key={fieldFunc.field}
@@ -140,31 +134,34 @@ const FieldList = React.createClass({
         </FancyScrollbar>
       </div>
     )
-  },
+  }
+}
 
-  _getFields() {
-    const {database, measurement, retentionPolicy} = this.props.query
-    const {source} = this.context
-    const proxySource = source.links.proxy
+const {bool, func, shape, string} = PropTypes
 
-    showFieldKeys(
-      proxySource,
-      database,
-      measurement,
-      retentionPolicy
-    ).then(resp => {
-      const {errors, fieldSets} = showFieldKeysParser(resp.data)
-      if (errors.length) {
-        // TODO: do something
-      }
+FieldList.defaultProps = {
+  isKapacitorRule: false,
+}
 
-      this.setState({
-        fields: fieldSets[measurement].map(f => {
-          return {field: f, funcs: []}
-        }),
-      })
-    })
-  },
-})
+FieldList.contextTypes = {
+  source: shape({
+    links: shape({
+      proxy: string.isRequired,
+    }).isRequired,
+  }).isRequired,
+}
+
+FieldList.propTypes = {
+  query: shape({
+    database: string,
+    retentionPolicy: string,
+    measurement: string,
+  }).isRequired,
+  onToggleField: func.isRequired,
+  onGroupByTime: func.isRequired,
+  applyFuncsToField: func.isRequired,
+  isKapacitorRule: bool,
+  isInDataExplorer: bool,
+}
 
 export default FieldList

--- a/ui/src/shared/components/FieldList.js
+++ b/ui/src/shared/components/FieldList.js
@@ -79,9 +79,14 @@ const FieldList = React.createClass({
   },
 
   render() {
-    const {query, isKapacitorRule, isInDataExplorer} = this.props
-    const hasAggregates = query.fields.some(f => f.funcs && f.funcs.length)
-    const hasGroupByTime = query.groupBy.time
+    const {
+      query: {fields = [], groupBy},
+      isKapacitorRule,
+      isInDataExplorer,
+    } = this.props
+
+    const hasAggregates = fields.some(f => f.funcs && f.funcs.length)
+    const hasGroupByTime = groupBy.time
 
     return (
       <div className="query-builder--column">
@@ -90,7 +95,7 @@ const FieldList = React.createClass({
           {hasAggregates
             ? <GroupByTimeDropdown
                 isOpen={!hasGroupByTime}
-                selected={query.groupBy.time}
+                selected={groupBy.time}
                 onChooseGroupByTime={this.handleGroupByTime}
                 isInRuleBuilder={isKapacitorRule}
                 isInDataExplorer={isInDataExplorer}

--- a/ui/src/utils/queryTransitions.js
+++ b/ui/src/utils/queryTransitions.js
@@ -19,15 +19,23 @@ export function chooseMeasurement(query, measurement) {
 }
 
 export const toggleField = (query, {field, funcs}, isKapacitorRule = false) => {
-  const isSelected = query.fields.find(f => f.field === field)
+  const {fields, groupBy} = query
+
+  if (!fields) {
+    return {
+      ...query,
+      fields: [{field, funcs: ['mean']}],
+    }
+  }
+
+  const isSelected = fields.find(f => f.field === field)
   if (isSelected) {
-    const nextFields = query.fields.filter(f => f.field !== field)
+    const nextFields = fields.filter(f => f.field !== field)
     if (!nextFields.length) {
-      const nextGroupBy = {...query.groupBy, time: null}
       return {
         ...query,
         fields: nextFields,
-        groupBy: nextGroupBy,
+        groupBy: {...groupBy, time: null},
       }
     }
 


### PR DESCRIPTION
- [x] CHANGELOG.md updated with a link to the PR (not the Issue)
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1576

### The problem
It appears the queryConfig in the `DataExplorer` got into a state where the `fields` key was missing.  

### The Solution
Toughen up the happy path of query creation in the `FieldList` component and `toggleField` function in `/queryTransitions`

### Repro Steps (Assuming you are using Chrome)
1) Go to `DataExporer`
2) Build a query with a field
3) Go into console
4) Go to Application tab
5) Delete the `fields` key from localStorage
6) Navigate away from DE and back again try clicking on fields and watch everything break

### Notes
Really we should be validating every qC that gets saved to localStorage and preventing bogus state from getting saved in the first place.