### PR TITLE
Fix alerts table to display if alerts are missing a host, name, or level

### DIFF
--- a/ui/src/alerts/components/AlertsTable.js
+++ b/ui/src/alerts/components/AlertsTable.js
@@ -28,15 +28,11 @@ class AlertsTable extends Component {
   filterAlerts = (searchTerm, newAlerts) => {
     const alerts = newAlerts || this.props.alerts
     const filterText = searchTerm.toLowerCase()
-    const filteredAlerts = alerts.filter(h => {
-      if (h.host === null || h.name === null || h.level === null) {
-        return false
-      }
-
+    const filteredAlerts = alerts.filter(({name, host, level}) => {
       return (
-        h.name.toLowerCase().includes(filterText) ||
-        h.host.toLowerCase().includes(filterText) ||
-        h.level.toLowerCase().includes(filterText)
+        (name && name.toLowerCase().includes(filterText)) ||
+        (host && host.toLowerCase().includes(filterText)) ||
+        (level && level.toLowerCase().includes(filterText))
       )
     })
     this.setState({searchTerm, filteredAlerts})


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1953 

### The problem
If no host was provided in an alert, the alert would disappear when the component updated

### The Solution
Fix the filtering function

