### PR TITLE
BUGFIX: Stacked graph bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#1951](https://github.com/influxdata/chronograf/pull/1951): Fix crosshair not being removed when user leaves graph
 1. [#1943](https://github.com/influxdata/chronograf/pull/1943): Fix inability to add kapacitor from source page on fresh install
 1. [#1947](https://github.com/influxdata/chronograf/pull/1947): Fix DataExplorer crash if field property not present on queryConfig
+1. [#1957](https://github.com/influxdata/chronograf/pull/1957): Fix stacked graphs not being fully displayed
 
 ### Features
 1. [#1928](https://github.com/influxdata/chronograf/pull/1928): Add prefix, suffix, scale, and other y-axis formatting

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -6,7 +6,7 @@ import _ from 'lodash'
 import moment from 'moment'
 
 import Dygraphs from 'src/external/dygraph'
-import getRange from 'shared/parsing/getRangeForDygraph'
+import getRange, {getStackedRange} from 'shared/parsing/getRangeForDygraph'
 import DygraphLegend from 'src/shared/components/DygraphLegend'
 import {DISPLAY_OPTIONS} from 'src/dashboards/constants'
 import {buildDefaultYLabel} from 'shared/presenters'
@@ -63,7 +63,9 @@ export default class Dygraph extends Component {
       plugins: [new Dygraphs.Plugins.Crosshair({direction: 'vertical'})],
       axes: {
         y: {
-          valueRange: getRange(timeSeries, y.bounds, ruleValues),
+          valueRange: options.stackedGraph
+            ? getStackedRange(y.bounds)
+            : getRange(timeSeries, y.bounds, ruleValues),
           axisLabelFormatter: (yval, __, opts) =>
             numberValueFormatter(yval, opts, y.prefix, y.suffix),
           axisLabelWidth: this.getLabelWidth(),
@@ -142,12 +144,14 @@ export default class Dygraph extends Component {
     const updateOptions = {
       ...options,
       labels,
-      ylabel: this.getLabel('y'),
       file: timeSeries,
       logscale: y.scale === LOG,
+      ylabel: this.getLabel('y'),
       axes: {
         y: {
-          valueRange: getRange(timeSeries, y.bounds, ruleValues),
+          valueRange: options.stackedGraph
+            ? getStackedRange(y.bounds)
+            : getRange(timeSeries, y.bounds, ruleValues),
           axisLabelFormatter: (yval, __, opts) =>
             numberValueFormatter(yval, opts, y.prefix, y.suffix),
           axisLabelWidth: this.getLabelWidth(),

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -79,4 +79,18 @@ const getRange = (
   return [min, max]
 }
 
+const parseNumber = bound => {
+  if (bound) {
+    return +bound
+  }
+
+  return null
+}
+
+export const getStackedRange = (bounds = [null, null]) => {
+  const min = bounds[0]
+  const max = bounds[1]
+
+  return [parseNumber(min), parseNumber(max)]
+}
 export default getRange

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -79,18 +79,10 @@ const getRange = (
   return [min, max]
 }
 
-const parseNumber = bound => {
-  if (bound) {
-    return +bound
-  }
+const coerceToNum = str => (str ? +str : null)
+export const getStackedRange = (bounds = [null, null]) => [
+  coerceToNum(bounds[0]),
+  coerceToNum(bounds[1]),
+]
 
-  return null
-}
-
-export const getStackedRange = (bounds = [null, null]) => {
-  const min = bounds[0]
-  const max = bounds[1]
-
-  return [parseNumber(min), parseNumber(max)]
-}
 export default getRange


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1766 
Connect #1460  

### The problem
Stacked graphs ranges were incorrect and resulted in entire visualization not being displayed.

### The Solution
Allow Dygraphs to do the proper range calculation while respecting user defined ranges.

### Before
![screen shot 2017-09-01 at 10 15 41 am](https://user-images.githubusercontent.com/7582765/29980404-9c3deede-8efe-11e7-87df-136adb831911.png)

### After
![screen shot 2017-09-01 at 10 15 22 am](https://user-images.githubusercontent.com/7582765/29980397-8f2dd876-8efe-11e7-9cb7-ff649ef719aa.png)


