### PR TITLE
WIP BUGFIX: deadman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1. [#1942](https://github.com/influxdata/chronograf/pull/1942): Polish appearance of optional alert parameters in Kapacitor rule builder
 1. [#1944](https://github.com/influxdata/chronograf/pull/1944): Add active state for Status page navbar icon
 1. [#1944](https://github.com/influxdata/chronograf/pull/1944): Improve UX of navigation to a sub-nav item in the navbar
+1. [#1971](https://github.com/influxdata/chronograf/pull/1971): Resolve confusing deadman trigger alert rule UI
 
 ## v1.3.7.0 [2017-08-23]
 ## v1.3.7.0 [unreleased]

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -11,10 +11,6 @@ class DataSection extends Component {
     super(props)
   }
 
-  getChildContext() {
-    return {source: this.props.source}
-  }
-
   handleChooseNamespace = namespace => {
     this.props.actions.chooseNamespace(this.props.query.id, namespace)
   }
@@ -109,15 +105,6 @@ DataSection.propTypes = {
   onRemoveEvery: PropTypes.func.isRequired,
   timeRange: PropTypes.shape({}).isRequired,
   isKapacitorRule: PropTypes.bool,
-}
-
-DataSection.childContextTypes = {
-  source: PropTypes.shape({
-    links: PropTypes.shape({
-      proxy: PropTypes.string.isRequired,
-      self: PropTypes.string.isRequired,
-    }).isRequired,
-  }).isRequired,
 }
 
 export default DataSection

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 import buildInfluxQLQuery from 'utils/influxql'
 import classnames from 'classnames'
 
@@ -8,83 +8,52 @@ import FieldList from 'src/shared/components/FieldList'
 
 import {defaultEveryFrequency} from 'src/kapacitor/constants'
 
-export const DataSection = React.createClass({
-  propTypes: {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        kapacitors: PropTypes.string.isRequired,
-      }).isRequired,
-    }),
-    query: PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    }).isRequired,
-    addFlashMessage: PropTypes.func,
-    actions: PropTypes.shape({
-      chooseNamespace: PropTypes.func.isRequired,
-      chooseMeasurement: PropTypes.func.isRequired,
-      applyFuncsToField: PropTypes.func.isRequired,
-      chooseTag: PropTypes.func.isRequired,
-      groupByTag: PropTypes.func.isRequired,
-      toggleField: PropTypes.func.isRequired,
-      groupByTime: PropTypes.func.isRequired,
-      toggleTagAcceptance: PropTypes.func.isRequired,
-    }).isRequired,
-    onAddEvery: PropTypes.func.isRequired,
-    onRemoveEvery: PropTypes.func.isRequired,
-    timeRange: PropTypes.shape({}).isRequired,
-    isKapacitorRule: PropTypes.bool,
-  },
-
-  childContextTypes: {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        proxy: PropTypes.string.isRequired,
-        self: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
-  },
+class DataSection extends Component {
+  constructor(props) {
+    super(props)
+  }
 
   getChildContext() {
     return {source: this.props.source}
-  },
+  }
 
-  handleChooseNamespace(namespace) {
+  handleChooseNamespace = namespace => {
     this.props.actions.chooseNamespace(this.props.query.id, namespace)
-  },
+  }
 
-  handleChooseMeasurement(measurement) {
+  handleChooseMeasurement = measurement => {
     this.props.actions.chooseMeasurement(this.props.query.id, measurement)
-  },
+  }
 
-  handleToggleField(field) {
+  handleToggleField = field => {
     this.props.actions.toggleField(this.props.query.id, field)
     // Every is only added when a function has been added to a field.
     // Here, the field is selected without a function.
     this.props.onRemoveEvery()
     // Because there are no functions there is no group by time.
     this.props.actions.groupByTime(this.props.query.id, null)
-  },
+  }
 
-  handleGroupByTime(time) {
+  handleGroupByTime = time => {
     this.props.actions.groupByTime(this.props.query.id, time)
-  },
+  }
 
-  handleApplyFuncsToField(fieldFunc) {
+  handleApplyFuncsToField = fieldFunc => {
     this.props.actions.applyFuncsToField(this.props.query.id, fieldFunc)
     this.props.onAddEvery(defaultEveryFrequency)
-  },
+  }
 
-  handleChooseTag(tag) {
+  handleChooseTag = tag => {
     this.props.actions.chooseTag(this.props.query.id, tag)
-  },
+  }
 
-  handleToggleTagAcceptance() {
+  handleToggleTagAcceptance = () => {
     this.props.actions.toggleTagAcceptance(this.props.query.id)
-  },
+  }
 
-  handleGroupByTag(tagKey) {
+  handleGroupByTag = tagKey => {
     this.props.actions.groupByTag(this.props.query.id, tagKey)
-  },
+  }
 
   render() {
     const {query, timeRange: {lower}} = this.props
@@ -107,7 +76,7 @@ export const DataSection = React.createClass({
         </div>
       </div>
     )
-  },
+  }
 
   renderQueryBuilder() {
     const {query, isKapacitorRule} = this.props
@@ -134,7 +103,42 @@ export const DataSection = React.createClass({
         />
       </div>
     )
-  },
-})
+  }
+}
+
+DataSection.propTypes = {
+  source: PropTypes.shape({
+    links: PropTypes.shape({
+      kapacitors: PropTypes.string.isRequired,
+    }).isRequired,
+  }),
+  query: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+  }).isRequired,
+  addFlashMessage: PropTypes.func,
+  actions: PropTypes.shape({
+    chooseNamespace: PropTypes.func.isRequired,
+    chooseMeasurement: PropTypes.func.isRequired,
+    applyFuncsToField: PropTypes.func.isRequired,
+    chooseTag: PropTypes.func.isRequired,
+    groupByTag: PropTypes.func.isRequired,
+    toggleField: PropTypes.func.isRequired,
+    groupByTime: PropTypes.func.isRequired,
+    toggleTagAcceptance: PropTypes.func.isRequired,
+  }).isRequired,
+  onAddEvery: PropTypes.func.isRequired,
+  onRemoveEvery: PropTypes.func.isRequired,
+  timeRange: PropTypes.shape({}).isRequired,
+  isKapacitorRule: PropTypes.bool,
+}
+
+DataSection.childContextTypes = {
+  source: PropTypes.shape({
+    links: PropTypes.shape({
+      proxy: PropTypes.string.isRequired,
+      self: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+}
 
 export default DataSection

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -1,6 +1,4 @@
 import React, {PropTypes, Component} from 'react'
-import buildInfluxQLQuery from 'utils/influxql'
-import classnames from 'classnames'
 
 import DatabaseList from 'src/shared/components/DatabaseList'
 import MeasurementList from 'src/shared/components/MeasurementList'
@@ -56,51 +54,32 @@ class DataSection extends Component {
   }
 
   render() {
-    const {query, timeRange: {lower}} = this.props
-    const statement = query.rawText || buildInfluxQLQuery({lower}, query)
-
+    const {query, isKapacitorRule} = this.props
     return (
       <div className="rule-section">
         <h3 className="rule-section--heading">Select a Time Series</h3>
         <div className="rule-section--body">
-          <pre className="rule-section--border-bottom">
-            <code
-              className={classnames({
-                'metric-placeholder': !statement,
-              })}
-            >
-              {statement || 'Build a query below'}
-            </code>
-          </pre>
-          {this.renderQueryBuilder()}
+          <div className="query-builder rule-section--border-bottom">
+            <DatabaseList
+              query={query}
+              onChooseNamespace={this.handleChooseNamespace}
+            />
+            <MeasurementList
+              query={query}
+              onChooseMeasurement={this.handleChooseMeasurement}
+              onChooseTag={this.handleChooseTag}
+              onGroupByTag={this.handleGroupByTag}
+              onToggleTagAcceptance={this.handleToggleTagAcceptance}
+            />
+            <FieldList
+              query={query}
+              onToggleField={this.handleToggleField}
+              onGroupByTime={this.handleGroupByTime}
+              applyFuncsToField={this.handleApplyFuncsToField}
+              isKapacitorRule={isKapacitorRule}
+            />
+          </div>
         </div>
-      </div>
-    )
-  }
-
-  renderQueryBuilder() {
-    const {query, isKapacitorRule} = this.props
-
-    return (
-      <div className="query-builder">
-        <DatabaseList
-          query={query}
-          onChooseNamespace={this.handleChooseNamespace}
-        />
-        <MeasurementList
-          query={query}
-          onChooseMeasurement={this.handleChooseMeasurement}
-          onChooseTag={this.handleChooseTag}
-          onGroupByTag={this.handleGroupByTag}
-          onToggleTagAcceptance={this.handleToggleTagAcceptance}
-        />
-        <FieldList
-          query={query}
-          onToggleField={this.handleToggleField}
-          onGroupByTime={this.handleGroupByTime}
-          applyFuncsToField={this.handleApplyFuncsToField}
-          isKapacitorRule={isKapacitorRule}
-        />
       </div>
     )
   }

--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -50,61 +50,61 @@ class DataSection extends Component {
   }
 
   render() {
-    const {query, isKapacitorRule} = this.props
+    const {query, isKapacitorRule, isDeadman} = this.props
     return (
-      <div className="rule-section">
-        <h3 className="rule-section--heading">Select a Time Series</h3>
-        <div className="rule-section--body">
-          <div className="query-builder rule-section--border-bottom">
-            <DatabaseList
-              query={query}
-              onChooseNamespace={this.handleChooseNamespace}
-            />
-            <MeasurementList
-              query={query}
-              onChooseMeasurement={this.handleChooseMeasurement}
-              onChooseTag={this.handleChooseTag}
-              onGroupByTag={this.handleGroupByTag}
-              onToggleTagAcceptance={this.handleToggleTagAcceptance}
-            />
-            <FieldList
+      <div className="query-builder rule-section--border-bottom">
+        <DatabaseList
+          query={query}
+          onChooseNamespace={this.handleChooseNamespace}
+        />
+        <MeasurementList
+          query={query}
+          onChooseMeasurement={this.handleChooseMeasurement}
+          onChooseTag={this.handleChooseTag}
+          onGroupByTag={this.handleGroupByTag}
+          onToggleTagAcceptance={this.handleToggleTagAcceptance}
+        />
+        {isDeadman
+          ? null
+          : <FieldList
               query={query}
               onToggleField={this.handleToggleField}
               onGroupByTime={this.handleGroupByTime}
               applyFuncsToField={this.handleApplyFuncsToField}
               isKapacitorRule={isKapacitorRule}
-            />
-          </div>
-        </div>
+            />}
       </div>
     )
   }
 }
 
+const {string, func, shape, bool} = PropTypes
+
 DataSection.propTypes = {
-  source: PropTypes.shape({
-    links: PropTypes.shape({
-      kapacitors: PropTypes.string.isRequired,
+  source: shape({
+    links: shape({
+      kapacitors: string.isRequired,
     }).isRequired,
   }),
-  query: PropTypes.shape({
-    id: PropTypes.string.isRequired,
+  query: shape({
+    id: string.isRequired,
   }).isRequired,
-  addFlashMessage: PropTypes.func,
-  actions: PropTypes.shape({
-    chooseNamespace: PropTypes.func.isRequired,
-    chooseMeasurement: PropTypes.func.isRequired,
-    applyFuncsToField: PropTypes.func.isRequired,
-    chooseTag: PropTypes.func.isRequired,
-    groupByTag: PropTypes.func.isRequired,
-    toggleField: PropTypes.func.isRequired,
-    groupByTime: PropTypes.func.isRequired,
-    toggleTagAcceptance: PropTypes.func.isRequired,
+  addFlashMessage: func,
+  actions: shape({
+    chooseNamespace: func.isRequired,
+    chooseMeasurement: func.isRequired,
+    applyFuncsToField: func.isRequired,
+    chooseTag: func.isRequired,
+    groupByTag: func.isRequired,
+    toggleField: func.isRequired,
+    groupByTime: func.isRequired,
+    toggleTagAcceptance: func.isRequired,
   }).isRequired,
-  onAddEvery: PropTypes.func.isRequired,
-  onRemoveEvery: PropTypes.func.isRequired,
-  timeRange: PropTypes.shape({}).isRequired,
-  isKapacitorRule: PropTypes.bool,
+  onAddEvery: func.isRequired,
+  onRemoveEvery: func.isRequired,
+  timeRange: shape({}).isRequired,
+  isKapacitorRule: bool,
+  isDeadman: bool,
 }
 
 export default DataSection

--- a/ui/src/kapacitor/components/Deadman.js
+++ b/ui/src/kapacitor/components/Deadman.js
@@ -1,0 +1,32 @@
+import React, {PropTypes} from 'react'
+import {PERIODS} from 'src/kapacitor/constants'
+import Dropdown from 'shared/components/Dropdown'
+
+const periods = PERIODS.map(text => {
+  return {text}
+})
+
+const Deadman = ({rule, onChange}) =>
+  <div className="rule-section--row">
+    <p>Send Alert if Data is missing for</p>
+    <Dropdown
+      className="dropdown-80"
+      menuClass="dropdown-malachite"
+      items={periods}
+      selected={rule.values.period}
+      onChoose={onChange}
+    />
+  </div>
+
+const {shape, string, func} = PropTypes
+
+Deadman.propTypes = {
+  rule: shape({
+    values: shape({
+      period: string,
+    }),
+  }),
+  onChange: func.isRequired,
+}
+
+export default Deadman

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -136,6 +136,12 @@ class KapacitorRule extends Component {
             <div className="row">
               <div className="col-xs-12">
                 <div className="rule-builder">
+                  <ValuesSection
+                    rule={rule}
+                    query={queryConfigs[rule.queryID]}
+                    onChooseTrigger={chooseTrigger}
+                    onUpdateValues={updateRuleValues}
+                  />
                   <DataSection
                     timeRange={timeRange}
                     source={source}
@@ -144,12 +150,6 @@ class KapacitorRule extends Component {
                     onAddEvery={this.handleAddEvery}
                     onRemoveEvery={this.handleRemoveEvery}
                     isKapacitorRule={true}
-                  />
-                  <ValuesSection
-                    rule={rule}
-                    query={queryConfigs[rule.queryID]}
-                    onChooseTrigger={chooseTrigger}
-                    onUpdateValues={updateRuleValues}
                   />
                   <RuleGraph
                     timeRange={timeRange}

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -111,10 +111,16 @@ class KapacitorRule extends Component {
     ruleActions.updateRuleValues(rule.id, rule.trigger, {[type]: text})
   }
 
-  // handleThresholdInputChange = () => {
-  //   const {ruleActions, rule} = this.props
-  //   // ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
-  // }
+  handleThresholdInputChange = e => {
+    const {ruleActions, rule} = this.props
+    const {lower, upper} = e.target.form
+
+    ruleActions.updateRuleValues(rule.id, rule.trigger, {
+      ...this.props.rule.values,
+      value: lower.value,
+      rangeValue: upper ? upper.value : '',
+    })
+  }
   //
   // handleRelativeInputChange = () => {
   //   const {ruleActions, rule} = this.props
@@ -198,7 +204,9 @@ class KapacitorRule extends Component {
 
 KapacitorRule.propTypes = {
   source: PropTypes.shape({}).isRequired,
-  rule: PropTypes.shape({}).isRequired,
+  rule: PropTypes.shape({
+    values: PropTypes.shape({}),
+  }).isRequired,
   query: PropTypes.shape({}).isRequired,
   queryConfigs: PropTypes.shape({}).isRequired,
   queryConfigActions: PropTypes.shape({}).isRequired,

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -106,6 +106,11 @@ class KapacitorRule extends Component {
     return ''
   }
 
+  handleDeadmanChange = ({text}) => {
+    const {ruleActions, rule} = this.props
+    ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
+  }
+
   render() {
     const {
       queryConfigActions,
@@ -141,6 +146,7 @@ class KapacitorRule extends Component {
                     query={queryConfigs[rule.queryID]}
                     onChooseTrigger={chooseTrigger}
                     onUpdateValues={updateRuleValues}
+                    onDeadmanChange={this.handleDeadmanChange}
                   />
                   <DataSection
                     timeRange={timeRange}

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -106,6 +106,21 @@ class KapacitorRule extends Component {
     return ''
   }
 
+  handleRuleTypeDropdownChange = ({type, text}) => {
+    const {ruleActions, rule} = this.props
+    ruleActions.updateRuleValues(rule.id, rule.trigger, {[type]: text})
+  }
+
+  // handleThresholdInputChange = () => {
+  //   const {ruleActions, rule} = this.props
+  //   // ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
+  // }
+  //
+  // handleRelativeInputChange = () => {
+  //   const {ruleActions, rule} = this.props
+  //   // ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
+  // }
+
   handleDeadmanChange = ({text}) => {
     const {ruleActions, rule} = this.props
     ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
@@ -147,6 +162,9 @@ class KapacitorRule extends Component {
                     onChooseTrigger={chooseTrigger}
                     onUpdateValues={updateRuleValues}
                     onDeadmanChange={this.handleDeadmanChange}
+                    onRuleTypeDropdownChange={this.handleRuleTypeDropdownChange}
+                    onThresholdInputChange={this.handleThresholdInputChange}
+                    onRelativeInputChange={this.handleRelativeInputChange}
                   />
                   <DataSection
                     timeRange={timeRange}

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -2,7 +2,6 @@ import React, {PropTypes, Component} from 'react'
 
 import ValuesSection from 'src/kapacitor/components/ValuesSection'
 import RuleHeader from 'src/kapacitor/components/RuleHeader'
-import RuleGraph from 'src/kapacitor/components/RuleGraph'
 import RuleMessage from 'src/kapacitor/components/RuleMessage'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 
@@ -132,7 +131,6 @@ class KapacitorRule extends Component {
   render() {
     const {
       rule,
-      query,
       source,
       isEditing,
       ruleActions,

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -108,10 +108,13 @@ class KapacitorRule extends Component {
 
   handleRuleTypeDropdownChange = ({type, text}) => {
     const {ruleActions, rule} = this.props
-    ruleActions.updateRuleValues(rule.id, rule.trigger, {[type]: text})
+    ruleActions.updateRuleValues(rule.id, rule.trigger, {
+      ...this.props.rule.values,
+      [type]: text,
+    })
   }
 
-  handleThresholdInputChange = e => {
+  handleRuleTypeInputChange = e => {
     const {ruleActions, rule} = this.props
     const {lower, upper} = e.target.form
 
@@ -121,11 +124,6 @@ class KapacitorRule extends Component {
       rangeValue: upper ? upper.value : '',
     })
   }
-  //
-  // handleRelativeInputChange = () => {
-  //   const {ruleActions, rule} = this.props
-  //   // ruleActions.updateRuleValues(rule.id, rule.trigger, {period: text})
-  // }
 
   handleDeadmanChange = ({text}) => {
     const {ruleActions, rule} = this.props
@@ -169,8 +167,7 @@ class KapacitorRule extends Component {
                     onUpdateValues={updateRuleValues}
                     onDeadmanChange={this.handleDeadmanChange}
                     onRuleTypeDropdownChange={this.handleRuleTypeDropdownChange}
-                    onThresholdInputChange={this.handleThresholdInputChange}
-                    onRelativeInputChange={this.handleRelativeInputChange}
+                    onRuleTypeInputChange={this.handleRuleTypeInputChange}
                   />
                   <DataSection
                     timeRange={timeRange}

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -1,4 +1,4 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 
 import DataSection from 'src/kapacitor/components/DataSection'
 import ValuesSection from 'src/kapacitor/components/ValuesSection'
@@ -11,28 +11,100 @@ import {createRule, editRule} from 'src/kapacitor/apis'
 import buildInfluxQLQuery from 'utils/influxql'
 import timeRanges from 'hson!shared/data/timeRanges.hson'
 
-export const KapacitorRule = React.createClass({
-  propTypes: {
-    source: PropTypes.shape({}).isRequired,
-    rule: PropTypes.shape({}).isRequired,
-    query: PropTypes.shape({}).isRequired,
-    queryConfigs: PropTypes.shape({}).isRequired,
-    queryConfigActions: PropTypes.shape({}).isRequired,
-    ruleActions: PropTypes.shape({}).isRequired,
-    addFlashMessage: PropTypes.func.isRequired,
-    isEditing: PropTypes.bool.isRequired,
-    enabledAlerts: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
-    router: PropTypes.shape({
-      push: PropTypes.func.isRequired,
-    }).isRequired,
-    kapacitor: PropTypes.shape({}).isRequired,
-  },
-
-  getInitialState() {
-    return {
+class KapacitorRule extends Component {
+  constructor(props) {
+    super(props)
+    this.state = {
       timeRange: timeRanges.find(tr => tr.lower === 'now() - 15m'),
     }
-  },
+  }
+
+  handleChooseTimeRange = ({lower}) => {
+    const timeRange = timeRanges.find(range => range.lower === lower)
+    this.setState({timeRange})
+  }
+
+  handleCreate = () => {
+    const {
+      addFlashMessage,
+      queryConfigs,
+      rule,
+      source,
+      router,
+      kapacitor,
+    } = this.props
+
+    const newRule = Object.assign({}, rule, {
+      query: queryConfigs[rule.queryID],
+    })
+    delete newRule.queryID
+
+    createRule(kapacitor, newRule)
+      .then(() => {
+        router.push(`/sources/${source.id}/alert-rules`)
+        addFlashMessage({type: 'success', text: 'Rule successfully created'})
+      })
+      .catch(() => {
+        addFlashMessage({
+          type: 'error',
+          text: 'There was a problem creating the rule',
+        })
+      })
+  }
+
+  handleEdit = () => {
+    const {addFlashMessage, queryConfigs, rule} = this.props
+    const updatedRule = Object.assign({}, rule, {
+      query: queryConfigs[rule.queryID],
+    })
+
+    editRule(updatedRule)
+      .then(() => {
+        addFlashMessage({type: 'success', text: 'Rule successfully updated!'})
+      })
+      .catch(() => {
+        addFlashMessage({
+          type: 'error',
+          text: 'There was a problem updating the rule',
+        })
+      })
+  }
+
+  handleAddEvery = frequency => {
+    const {rule: {id: ruleID}, ruleActions: {addEvery}} = this.props
+    addEvery(ruleID, frequency)
+  }
+
+  handleRemoveEvery = () => {
+    const {rule: {id: ruleID}, ruleActions: {removeEvery}} = this.props
+    removeEvery(ruleID)
+  }
+
+  validationError = () => {
+    const {rule, query} = this.props
+    if (rule.trigger === 'deadman') {
+      return this.deadmanValidation()
+    }
+
+    if (!buildInfluxQLQuery({}, query)) {
+      return 'Please select a database, measurement, and field'
+    }
+
+    if (!rule.values.value) {
+      return 'Please enter a value in the Rule Conditions section'
+    }
+
+    return ''
+  }
+
+  deadmanValidation = () => {
+    const {query} = this.props
+    if (query && (!query.database || !query.measurement)) {
+      return 'Deadman requires a database and measurement'
+    }
+
+    return ''
+  }
 
   render() {
     const {
@@ -97,94 +169,23 @@ export const KapacitorRule = React.createClass({
         </FancyScrollbar>
       </div>
     )
-  },
+  }
+}
 
-  handleChooseTimeRange({lower}) {
-    const timeRange = timeRanges.find(range => range.lower === lower)
-    this.setState({timeRange})
-  },
-
-  handleCreate() {
-    const {
-      addFlashMessage,
-      queryConfigs,
-      rule,
-      source,
-      router,
-      kapacitor,
-    } = this.props
-
-    const newRule = Object.assign({}, rule, {
-      query: queryConfigs[rule.queryID],
-    })
-    delete newRule.queryID
-
-    createRule(kapacitor, newRule)
-      .then(() => {
-        router.push(`/sources/${source.id}/alert-rules`)
-        addFlashMessage({type: 'success', text: 'Rule successfully created'})
-      })
-      .catch(() => {
-        addFlashMessage({
-          type: 'error',
-          text: 'There was a problem creating the rule',
-        })
-      })
-  },
-
-  handleEdit() {
-    const {addFlashMessage, queryConfigs, rule} = this.props
-    const updatedRule = Object.assign({}, rule, {
-      query: queryConfigs[rule.queryID],
-    })
-
-    editRule(updatedRule)
-      .then(() => {
-        addFlashMessage({type: 'success', text: 'Rule successfully updated!'})
-      })
-      .catch(() => {
-        addFlashMessage({
-          type: 'error',
-          text: 'There was a problem updating the rule',
-        })
-      })
-  },
-
-  handleAddEvery(frequency) {
-    const {rule: {id: ruleID}, ruleActions: {addEvery}} = this.props
-    addEvery(ruleID, frequency)
-  },
-
-  handleRemoveEvery() {
-    const {rule: {id: ruleID}, ruleActions: {removeEvery}} = this.props
-    removeEvery(ruleID)
-  },
-
-  validationError() {
-    const {rule, query} = this.props
-    if (rule.trigger === 'deadman') {
-      return this.deadmanValidation()
-    }
-
-    if (!buildInfluxQLQuery({}, query)) {
-      return 'Please select a database, measurement, and field'
-    }
-
-    if (!rule.values.value) {
-      return 'Please enter a value in the Rule Conditions section'
-    }
-
-    return ''
-  },
-
-  deadmanValidation() {
-    const {query} = this.props
-    if (query && (!query.database || !query.measurement)) {
-      return 'Deadman requires a database and measurement'
-    }
-
-    return ''
-  },
-})
+KapacitorRule.propTypes = {
+  source: PropTypes.shape({}).isRequired,
+  rule: PropTypes.shape({}).isRequired,
+  query: PropTypes.shape({}).isRequired,
+  queryConfigs: PropTypes.shape({}).isRequired,
+  queryConfigActions: PropTypes.shape({}).isRequired,
+  ruleActions: PropTypes.shape({}).isRequired,
+  addFlashMessage: PropTypes.func.isRequired,
+  isEditing: PropTypes.bool.isRequired,
+  enabledAlerts: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
+  router: PropTypes.shape({
+    push: PropTypes.func.isRequired,
+  }).isRequired,
+  kapacitor: PropTypes.shape({}).isRequired,
+}
 
 export default KapacitorRule

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -1,6 +1,5 @@
 import React, {PropTypes, Component} from 'react'
 
-import DataSection from 'src/kapacitor/components/DataSection'
 import ValuesSection from 'src/kapacitor/components/ValuesSection'
 import RuleHeader from 'src/kapacitor/components/RuleHeader'
 import RuleGraph from 'src/kapacitor/components/RuleGraph'
@@ -132,14 +131,14 @@ class KapacitorRule extends Component {
 
   render() {
     const {
-      queryConfigActions,
-      source,
-      enabledAlerts,
-      queryConfigs,
-      query,
       rule,
-      ruleActions,
+      query,
+      source,
       isEditing,
+      ruleActions,
+      queryConfigs,
+      enabledAlerts,
+      queryConfigActions,
     } = this.props
     const {chooseTrigger, updateRuleValues} = ruleActions
     const {timeRange} = this.state
@@ -162,27 +161,17 @@ class KapacitorRule extends Component {
                 <div className="rule-builder">
                   <ValuesSection
                     rule={rule}
-                    query={queryConfigs[rule.queryID]}
+                    source={source}
+                    timeRange={timeRange}
                     onChooseTrigger={chooseTrigger}
-                    onUpdateValues={updateRuleValues}
-                    onDeadmanChange={this.handleDeadmanChange}
-                    onRuleTypeDropdownChange={this.handleRuleTypeDropdownChange}
-                    onRuleTypeInputChange={this.handleRuleTypeInputChange}
-                  />
-                  <DataSection
-                    timeRange={timeRange}
-                    source={source}
-                    query={query}
-                    actions={queryConfigActions}
                     onAddEvery={this.handleAddEvery}
+                    onUpdateValues={updateRuleValues}
+                    query={queryConfigs[rule.queryID]}
                     onRemoveEvery={this.handleRemoveEvery}
-                    isKapacitorRule={true}
-                  />
-                  <RuleGraph
-                    timeRange={timeRange}
-                    source={source}
-                    query={query}
-                    rule={rule}
+                    queryConfigActions={queryConfigActions}
+                    onDeadmanChange={this.handleDeadmanChange}
+                    onRuleTypeInputChange={this.handleRuleTypeInputChange}
+                    onRuleTypeDropdownChange={this.handleRuleTypeDropdownChange}
                   />
                   <RuleMessage
                     rule={rule}

--- a/ui/src/kapacitor/components/Relative.js
+++ b/ui/src/kapacitor/components/Relative.js
@@ -1,0 +1,77 @@
+import React, {PropTypes} from 'react'
+import {CHANGES, OPERATORS, SHIFTS} from 'src/kapacitor/constants'
+import Dropdown from 'shared/components/Dropdown'
+
+const mapToItems = (arr, type) => arr.map(text => ({text, type}))
+
+const Relative = React.createClass({
+  propTypes: {
+    rule: PropTypes.shape({
+      values: PropTypes.shape({
+        change: PropTypes.string,
+        shift: PropTypes.string,
+        operator: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    }),
+    onChange: PropTypes.func.isRequired,
+  },
+
+  handleDropdownChange(item) {
+    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
+  },
+
+  handleInputChange() {
+    this.props.onChange({...this.props.rule.values, value: this.input.value})
+  },
+
+  render() {
+    const {change, shift, operator, value} = this.props.rule.values
+
+    const changes = mapToItems(CHANGES, 'change')
+    const shifts = mapToItems(SHIFTS, 'shift')
+    const operators = mapToItems(OPERATORS, 'operator')
+
+    return (
+      <div className="rule-section--row rule-section--border-bottom">
+        <p>Send Alert when</p>
+        <Dropdown
+          className="dropdown-110"
+          menuClass="dropdown-malachite"
+          items={changes}
+          selected={change}
+          onChoose={this.handleDropdownChange}
+        />
+        <p>compared to previous</p>
+        <Dropdown
+          className="dropdown-80"
+          menuClass="dropdown-malachite"
+          items={shifts}
+          selected={shift}
+          onChoose={this.handleDropdownChange}
+        />
+        <p>is</p>
+        <Dropdown
+          className="dropdown-160"
+          menuClass="dropdown-malachite"
+          items={operators}
+          selected={operator}
+          onChoose={this.handleDropdownChange}
+        />
+        <input
+          className="form-control input-sm form-malachite monotype"
+          style={{width: '160px'}}
+          ref={r => (this.input = r)}
+          defaultValue={value}
+          onKeyUp={this.handleInputChange}
+          required={true}
+          type="text"
+          spellCheck="false"
+        />
+        {change === CHANGES[1] ? <p>%</p> : null}
+      </div>
+    )
+  },
+})
+
+export default Relative

--- a/ui/src/kapacitor/components/Relative.js
+++ b/ui/src/kapacitor/components/Relative.js
@@ -3,75 +3,68 @@ import {CHANGES, OPERATORS, SHIFTS} from 'src/kapacitor/constants'
 import Dropdown from 'shared/components/Dropdown'
 
 const mapToItems = (arr, type) => arr.map(text => ({text, type}))
+const changes = mapToItems(CHANGES, 'change')
+const shifts = mapToItems(SHIFTS, 'shift')
+const operators = mapToItems(OPERATORS, 'operator')
 
-const Relative = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      values: PropTypes.shape({
-        change: PropTypes.string,
-        shift: PropTypes.string,
-        operator: PropTypes.string,
-        value: PropTypes.string,
-      }),
+const Relative = ({
+  onRuleTypeInputChange,
+  onDropdownChange,
+  rule: {values: {change, shift, operator, value}},
+}) =>
+  <div className="rule-section--row rule-section--border-bottom">
+    <p>Send Alert when</p>
+    <Dropdown
+      className="dropdown-110"
+      menuClass="dropdown-malachite"
+      items={changes}
+      selected={change}
+      onChoose={onDropdownChange}
+    />
+    <p>compared to previous</p>
+    <Dropdown
+      className="dropdown-80"
+      menuClass="dropdown-malachite"
+      items={shifts}
+      selected={shift}
+      onChoose={onDropdownChange}
+    />
+    <p>is</p>
+    <Dropdown
+      className="dropdown-160"
+      menuClass="dropdown-malachite"
+      items={operators}
+      selected={operator}
+      onChoose={onDropdownChange}
+    />
+    <form style={{display: 'flex'}}>
+      <input
+        className="form-control input-sm form-malachite monotype"
+        style={{width: '160px', marginLeft: '6px'}}
+        type="text"
+        name="lower"
+        spellCheck="false"
+        value={value}
+        onChange={onRuleTypeInputChange}
+        required={true}
+      />
+    </form>
+    {change === CHANGES[1] ? <p>%</p> : null}
+  </div>
+
+const {shape, string, func} = PropTypes
+
+Relative.propTypes = {
+  onRuleTypeInputChange: func.isRequired,
+  onDropdownChange: func.isRequired,
+  rule: shape({
+    values: shape({
+      change: string,
+      shift: string,
+      operator: string,
+      value: string,
     }),
-    onChange: PropTypes.func.isRequired,
-  },
-
-  handleDropdownChange(item) {
-    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
-  },
-
-  handleInputChange() {
-    this.props.onChange({...this.props.rule.values, value: this.input.value})
-  },
-
-  render() {
-    const {change, shift, operator, value} = this.props.rule.values
-
-    const changes = mapToItems(CHANGES, 'change')
-    const shifts = mapToItems(SHIFTS, 'shift')
-    const operators = mapToItems(OPERATORS, 'operator')
-
-    return (
-      <div className="rule-section--row rule-section--border-bottom">
-        <p>Send Alert when</p>
-        <Dropdown
-          className="dropdown-110"
-          menuClass="dropdown-malachite"
-          items={changes}
-          selected={change}
-          onChoose={this.handleDropdownChange}
-        />
-        <p>compared to previous</p>
-        <Dropdown
-          className="dropdown-80"
-          menuClass="dropdown-malachite"
-          items={shifts}
-          selected={shift}
-          onChoose={this.handleDropdownChange}
-        />
-        <p>is</p>
-        <Dropdown
-          className="dropdown-160"
-          menuClass="dropdown-malachite"
-          items={operators}
-          selected={operator}
-          onChoose={this.handleDropdownChange}
-        />
-        <input
-          className="form-control input-sm form-malachite monotype"
-          style={{width: '160px'}}
-          ref={r => (this.input = r)}
-          defaultValue={value}
-          onKeyUp={this.handleInputChange}
-          required={true}
-          type="text"
-          spellCheck="false"
-        />
-        {change === CHANGES[1] ? <p>%</p> : null}
-      </div>
-    )
-  },
-})
+  }),
+}
 
 export default Relative

--- a/ui/src/kapacitor/components/Threshold.js
+++ b/ui/src/kapacitor/components/Threshold.js
@@ -9,7 +9,7 @@ const Threshold = ({
   rule: {values: {operator, value, rangeValue}},
   query,
   onDropdownChange,
-  onThresholdInputChange,
+  onRuleTypeInputChange,
 }) =>
   <div className="rule-section--row rule-section--border-bottom">
     <p>Send Alert where</p>
@@ -32,7 +32,7 @@ const Threshold = ({
         name="lower"
         spellCheck="false"
         value={value}
-        onChange={onThresholdInputChange}
+        onChange={onRuleTypeInputChange}
         placeholder={
           operator === 'inside range' || operator === 'outside range'
             ? 'Lower'
@@ -48,7 +48,7 @@ const Threshold = ({
           type="text"
           spellCheck="false"
           value={rangeValue}
-          onChange={onThresholdInputChange}
+          onChange={onRuleTypeInputChange}
         />}
     </form>
   </div>
@@ -65,7 +65,7 @@ Threshold.propTypes = {
     }),
   }),
   onDropdownChange: func.isRequired,
-  onThresholdInputChange: func.isRequired,
+  onRuleTypeInputChange: func.isRequired,
   query: shape({}).isRequired,
 }
 

--- a/ui/src/kapacitor/components/Threshold.js
+++ b/ui/src/kapacitor/components/Threshold.js
@@ -1,0 +1,83 @@
+import React, {PropTypes} from 'react'
+import {OPERATORS} from 'src/kapacitor/constants'
+import Dropdown from 'shared/components/Dropdown'
+
+const mapToItems = (arr, type) => arr.map(text => ({text, type}))
+
+const Threshold = React.createClass({
+  propTypes: {
+    rule: PropTypes.shape({
+      values: PropTypes.shape({
+        operator: PropTypes.string,
+        rangeOperator: PropTypes.string,
+        value: PropTypes.string,
+        rangeValue: PropTypes.string,
+      }),
+    }),
+    onChange: PropTypes.func.isRequired,
+    query: PropTypes.shape({}).isRequired,
+  },
+
+  handleDropdownChange(item) {
+    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
+  },
+
+  handleInputChange() {
+    this.props.onChange({
+      ...this.props.rule.values,
+      value: this.valueInput.value,
+      rangeValue: this.valueRangeInput ? this.valueRangeInput.value : '',
+    })
+  },
+
+  render() {
+    const {operator, value, rangeValue} = this.props.rule.values
+    const {query} = this.props
+
+    const operators = mapToItems(OPERATORS, 'operator')
+
+    return (
+      <div className="rule-section--row rule-section--border-bottom">
+        <p>Send Alert where</p>
+        <span className="rule-builder--metric">
+          {query.fields.length ? query.fields[0].field : 'Select a Time-Series'}
+        </span>
+        <p>is</p>
+        <Dropdown
+          className="dropdown-180"
+          menuClass="dropdown-malachite"
+          items={operators}
+          selected={operator}
+          onChoose={this.handleDropdownChange}
+        />
+        <input
+          className="form-control input-sm form-malachite monotype"
+          style={{width: '160px'}}
+          type="text"
+          spellCheck="false"
+          ref={r => (this.valueInput = r)}
+          defaultValue={value}
+          onKeyUp={this.handleInputChange}
+          placeholder={
+            operator === 'inside range' || operator === 'outside range'
+              ? 'Lower'
+              : null
+          }
+        />
+        {(operator === 'inside range' || operator === 'outside range') &&
+          <input
+            className="form-control input-sm form-malachite monotype"
+            style={{width: '160px'}}
+            placeholder="Upper"
+            type="text"
+            spellCheck="false"
+            ref={r => (this.valueRangeInput = r)}
+            defaultValue={rangeValue}
+            onKeyUp={this.handleInputChange}
+          />}
+      </div>
+    )
+  },
+})
+
+export default Threshold

--- a/ui/src/kapacitor/components/Threshold.js
+++ b/ui/src/kapacitor/components/Threshold.js
@@ -3,81 +3,70 @@ import {OPERATORS} from 'src/kapacitor/constants'
 import Dropdown from 'shared/components/Dropdown'
 
 const mapToItems = (arr, type) => arr.map(text => ({text, type}))
+const operators = mapToItems(OPERATORS, 'operator')
 
-const Threshold = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      values: PropTypes.shape({
-        operator: PropTypes.string,
-        rangeOperator: PropTypes.string,
-        value: PropTypes.string,
-        rangeValue: PropTypes.string,
-      }),
-    }),
-    onChange: PropTypes.func.isRequired,
-    query: PropTypes.shape({}).isRequired,
-  },
-
-  handleDropdownChange(item) {
-    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
-  },
-
-  handleInputChange() {
-    this.props.onChange({
-      ...this.props.rule.values,
-      value: this.valueInput.value,
-      rangeValue: this.valueRangeInput ? this.valueRangeInput.value : '',
-    })
-  },
-
-  render() {
-    const {operator, value, rangeValue} = this.props.rule.values
-    const {query} = this.props
-
-    const operators = mapToItems(OPERATORS, 'operator')
-
-    return (
-      <div className="rule-section--row rule-section--border-bottom">
-        <p>Send Alert where</p>
-        <span className="rule-builder--metric">
-          {query.fields.length ? query.fields[0].field : 'Select a Time-Series'}
-        </span>
-        <p>is</p>
-        <Dropdown
-          className="dropdown-180"
-          menuClass="dropdown-malachite"
-          items={operators}
-          selected={operator}
-          onChoose={this.handleDropdownChange}
-        />
+const Threshold = ({
+  rule: {values: {operator, value, rangeValue}},
+  query,
+  onDropdownChange,
+  onThresholdInputChange,
+}) =>
+  <div className="rule-section--row rule-section--border-bottom">
+    <p>Send Alert where</p>
+    <span className="rule-builder--metric">
+      {query.fields.length ? query.fields[0].field : 'Select a Time-Series'}
+    </span>
+    <p>is</p>
+    <Dropdown
+      className="dropdown-180"
+      menuClass="dropdown-malachite"
+      items={operators}
+      selected={operator}
+      onChoose={onDropdownChange}
+    />
+    <form style={{display: 'flex'}}>
+      <input
+        className="form-control input-sm form-malachite monotype"
+        style={{width: '160px', marginLeft: '6px'}}
+        type="text"
+        name="lower"
+        spellCheck="false"
+        value={value}
+        onChange={onThresholdInputChange}
+        placeholder={
+          operator === 'inside range' || operator === 'outside range'
+            ? 'Lower'
+            : null
+        }
+      />
+      {(operator === 'inside range' || operator === 'outside range') &&
         <input
           className="form-control input-sm form-malachite monotype"
+          name="upper"
           style={{width: '160px'}}
+          placeholder="Upper"
           type="text"
           spellCheck="false"
-          ref={r => (this.valueInput = r)}
-          defaultValue={value}
-          onKeyUp={this.handleInputChange}
-          placeholder={
-            operator === 'inside range' || operator === 'outside range'
-              ? 'Lower'
-              : null
-          }
-        />
-        {(operator === 'inside range' || operator === 'outside range') &&
-          <input
-            className="form-control input-sm form-malachite monotype"
-            style={{width: '160px'}}
-            placeholder="Upper"
-            type="text"
-            spellCheck="false"
-            ref={r => (this.valueRangeInput = r)}
-            defaultValue={rangeValue}
-            onKeyUp={this.handleInputChange}
-          />}
-      </div>
-    )
-  },
-})
+          value={rangeValue}
+          onChange={onThresholdInputChange}
+        />}
+    </form>
+  </div>
+
+const {shape, string, func} = PropTypes
+
+Threshold.propTypes = {
+  rule: shape({
+    values: shape({
+      operator: string,
+      rangeOperator: string,
+      value: string,
+      rangeValue: string,
+    }),
+  }),
+  onDropdownChange: func.isRequired,
+  onThresholdInputChange: func.isRequired,
+  query: shape({}).isRequired,
+}
 
 export default Threshold

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -23,6 +23,11 @@ export const ValuesSection = React.createClass({
     onDeadmanChange: PropTypes.func.isRequired,
     onRuleTypeDropdownChange: PropTypes.func.isRequired,
     onRuleTypeInputChange: PropTypes.func.isRequired,
+    onAddEvery: PropTypes.func.isRequired,
+    onRemoveEvery: PropTypes.func.isRequired,
+    timeRange: PropTypes.shape({}).isRequired,
+    queryConfigActions: PropTypes.shape({}).isRequired,
+    source: PropTypes.shape({}).isRequired,
   },
 
   render() {

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -20,7 +20,7 @@ export const ValuesSection = React.createClass({
     query: PropTypes.shape({}).isRequired,
     onDeadmanChange: PropTypes.func.isRequired,
     onRuleTypeDropdownChange: PropTypes.func.isRequired,
-    onThresholdInputChange: PropTypes.func.isRequired,
+    onRuleTypeInputChange: PropTypes.func.isRequired,
   },
 
   render() {
@@ -29,7 +29,7 @@ export const ValuesSection = React.createClass({
       query,
       onDeadmanChange,
       onRuleTypeDropdownChange,
-      onThresholdInputChange,
+      onRuleTypeInputChange,
     } = this.props
     const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
 
@@ -52,11 +52,15 @@ export const ValuesSection = React.createClass({
                   rule={rule}
                   query={query}
                   onDropdownChange={onRuleTypeDropdownChange}
-                  onThresholdInputChange={onThresholdInputChange}
+                  onRuleTypeInputChange={onRuleTypeInputChange}
                 />
               </TabPanel>
               <TabPanel>
-                <Relative rule={rule} onChange={this.handleValuesChange} />
+                <Relative
+                  rule={rule}
+                  onDropdownChange={onRuleTypeDropdownChange}
+                  onRuleTypeInputChange={onRuleTypeInputChange}
+                />
               </TabPanel>
               <TabPanel>
                 <Deadman rule={rule} onChange={onDeadmanChange} />

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -44,10 +44,11 @@ export const ValuesSection = React.createClass({
       onRuleTypeDropdownChange,
     } = this.props
     const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
+    const isDeadman = rule.trigger === 'deadman'
 
     return (
       <div className="rule-section">
-        <h3 className="rule-section--heading">Rule Conditions</h3>
+        <h3 className="rule-section--heading">Alert Type</h3>
         <div className="rule-section--body">
           <Tabs initialIndex={initialIndex} onSelect={this.handleChooseTrigger}>
             <TabList isKapacitorTabs="true">
@@ -57,15 +58,20 @@ export const ValuesSection = React.createClass({
                 </Tab>
               )}
             </TabList>
-            <DataSection
-              query={query}
-              timeRange={timeRange}
-              isKapacitorRule={true}
-              actions={queryConfigActions}
-              onAddEvery={onAddEvery}
-              onRemoveEvery={onRemoveEvery}
-            />
+            <div>
+              <h3 className="rule-builder--sub-header">Time Series</h3>
+              <DataSection
+                query={query}
+                timeRange={timeRange}
+                isKapacitorRule={true}
+                actions={queryConfigActions}
+                onAddEvery={onAddEvery}
+                onRemoveEvery={onRemoveEvery}
+                isDeadman={isDeadman}
+              />
+            </div>
 
+            <h3 className="rule-builder--sub-header">Rule Conditions</h3>
             <TabPanels>
               <TabPanel>
                 <Threshold
@@ -86,12 +92,14 @@ export const ValuesSection = React.createClass({
                 <Deadman rule={rule} onChange={onDeadmanChange} />
               </TabPanel>
             </TabPanels>
-            <RuleGraph
-              rule={rule}
-              query={query}
-              source={source}
-              timeRange={timeRange}
-            />
+            {isDeadman
+              ? null
+              : <RuleGraph
+                  rule={rule}
+                  query={query}
+                  source={source}
+                  timeRange={timeRange}
+                />}
           </Tabs>
         </div>
       </div>

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -5,6 +5,8 @@ import _ from 'lodash'
 import Deadman from 'src/kapacitor/components/Deadman'
 import Threshold from 'src/kapacitor/components/Threshold'
 import Relative from 'src/kapacitor/components/Relative'
+import DataSection from 'src/kapacitor/components/DataSection'
+import RuleGraph from 'src/kapacitor/components/RuleGraph'
 
 import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
 
@@ -27,9 +29,14 @@ export const ValuesSection = React.createClass({
     const {
       rule,
       query,
+      source,
+      timeRange,
+      onAddEvery,
+      onRemoveEvery,
       onDeadmanChange,
-      onRuleTypeDropdownChange,
+      queryConfigActions,
       onRuleTypeInputChange,
+      onRuleTypeDropdownChange,
     } = this.props
     const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
 
@@ -45,6 +52,14 @@ export const ValuesSection = React.createClass({
                 </Tab>
               )}
             </TabList>
+            <DataSection
+              query={query}
+              timeRange={timeRange}
+              isKapacitorRule={true}
+              actions={queryConfigActions}
+              onAddEvery={onAddEvery}
+              onRemoveEvery={onRemoveEvery}
+            />
 
             <TabPanels>
               <TabPanel>
@@ -66,6 +81,12 @@ export const ValuesSection = React.createClass({
                 <Deadman rule={rule} onChange={onDeadmanChange} />
               </TabPanel>
             </TabPanels>
+            <RuleGraph
+              rule={rule}
+              query={query}
+              source={source}
+              timeRange={timeRange}
+            />
           </Tabs>
         </div>
       </div>

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -1,8 +1,12 @@
 import React, {PropTypes} from 'react'
-import Dropdown from 'shared/components/Dropdown'
-import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
-import {OPERATORS, PERIODS, CHANGES, SHIFTS} from 'src/kapacitor/constants'
+
 import _ from 'lodash'
+
+import Dropdown from 'shared/components/Dropdown'
+import Deadman from 'src/kapacitor/components/Deadman'
+
+import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
+import {OPERATORS, CHANGES, SHIFTS} from 'src/kapacitor/constants'
 
 const TABS = ['Threshold', 'Relative', 'Deadman']
 const mapToItems = (arr, type) => arr.map(text => ({text, type}))
@@ -15,10 +19,11 @@ export const ValuesSection = React.createClass({
     onChooseTrigger: PropTypes.func.isRequired,
     onUpdateValues: PropTypes.func.isRequired,
     query: PropTypes.shape({}).isRequired,
+    onDeadmanChange: PropTypes.func.isRequired,
   },
 
   render() {
-    const {rule, query} = this.props
+    const {rule, query, onDeadmanChange} = this.props
     const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
 
     return (
@@ -46,7 +51,7 @@ export const ValuesSection = React.createClass({
                 <Relative rule={rule} onChange={this.handleValuesChange} />
               </TabPanel>
               <TabPanel>
-                <Deadman rule={rule} onChange={this.handleValuesChange} />
+                <Deadman rule={rule} onChange={onDeadmanChange} />
               </TabPanel>
             </TabPanels>
           </Tabs>
@@ -211,40 +216,6 @@ const Relative = React.createClass({
           spellCheck="false"
         />
         {change === CHANGES[1] ? <p>%</p> : null}
-      </div>
-    )
-  },
-})
-
-const Deadman = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      values: PropTypes.shape({
-        period: PropTypes.string,
-      }),
-    }),
-    onChange: PropTypes.func.isRequired,
-  },
-
-  handleChange(item) {
-    this.props.onChange({period: item.text})
-  },
-
-  render() {
-    const periods = PERIODS.map(text => {
-      return {text}
-    })
-
-    return (
-      <div className="rule-section--row">
-        <p>Send Alert if Data is missing for</p>
-        <Dropdown
-          className="dropdown-80"
-          menuClass="dropdown-malachite"
-          items={periods}
-          selected={this.props.rule.values.period}
-          onChoose={this.handleChange}
-        />
       </div>
     )
   },

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -19,10 +19,18 @@ export const ValuesSection = React.createClass({
     onUpdateValues: PropTypes.func.isRequired,
     query: PropTypes.shape({}).isRequired,
     onDeadmanChange: PropTypes.func.isRequired,
+    onRuleTypeDropdownChange: PropTypes.func.isRequired,
+    onThresholdInputChange: PropTypes.func.isRequired,
   },
 
   render() {
-    const {rule, query, onDeadmanChange} = this.props
+    const {
+      rule,
+      query,
+      onDeadmanChange,
+      onRuleTypeDropdownChange,
+      onThresholdInputChange,
+    } = this.props
     const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
 
     return (
@@ -43,7 +51,8 @@ export const ValuesSection = React.createClass({
                 <Threshold
                   rule={rule}
                   query={query}
-                  onChange={this.handleValuesChange}
+                  onDropdownChange={onRuleTypeDropdownChange}
+                  onThresholdInputChange={onThresholdInputChange}
                 />
               </TabPanel>
               <TabPanel>

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -12,7 +12,7 @@ import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
 
 const TABS = ['Threshold', 'Relative', 'Deadman']
 
-const handleChooseTrigger = (rule, onChooseTrigger) => {
+const handleChooseTrigger = (rule, onChooseTrigger) => triggerIndex => {
   if (TABS[triggerIndex] === rule.trigger) {
     return
   }

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -2,14 +2,13 @@ import React, {PropTypes} from 'react'
 
 import _ from 'lodash'
 
-import Dropdown from 'shared/components/Dropdown'
 import Deadman from 'src/kapacitor/components/Deadman'
+import Threshold from 'src/kapacitor/components/Threshold'
+import Relative from 'src/kapacitor/components/Relative'
 
 import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
-import {OPERATORS, CHANGES, SHIFTS} from 'src/kapacitor/constants'
 
 const TABS = ['Threshold', 'Relative', 'Deadman']
-const mapToItems = (arr, type) => arr.map(text => ({text, type}))
 
 export const ValuesSection = React.createClass({
   propTypes: {
@@ -72,152 +71,6 @@ export const ValuesSection = React.createClass({
   handleValuesChange(values) {
     const {onUpdateValues, rule} = this.props
     onUpdateValues(rule.id, rule.trigger, values)
-  },
-})
-
-const Threshold = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      values: PropTypes.shape({
-        operator: PropTypes.string,
-        rangeOperator: PropTypes.string,
-        value: PropTypes.string,
-        rangeValue: PropTypes.string,
-      }),
-    }),
-    onChange: PropTypes.func.isRequired,
-    query: PropTypes.shape({}).isRequired,
-  },
-
-  handleDropdownChange(item) {
-    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
-  },
-
-  handleInputChange() {
-    this.props.onChange({
-      ...this.props.rule.values,
-      value: this.valueInput.value,
-      rangeValue: this.valueRangeInput ? this.valueRangeInput.value : '',
-    })
-  },
-
-  render() {
-    const {operator, value, rangeValue} = this.props.rule.values
-    const {query} = this.props
-
-    const operators = mapToItems(OPERATORS, 'operator')
-
-    return (
-      <div className="rule-section--row rule-section--border-bottom">
-        <p>Send Alert where</p>
-        <span className="rule-builder--metric">
-          {query.fields.length ? query.fields[0].field : 'Select a Time-Series'}
-        </span>
-        <p>is</p>
-        <Dropdown
-          className="dropdown-180"
-          menuClass="dropdown-malachite"
-          items={operators}
-          selected={operator}
-          onChoose={this.handleDropdownChange}
-        />
-        <input
-          className="form-control input-sm form-malachite monotype"
-          style={{width: '160px'}}
-          type="text"
-          spellCheck="false"
-          ref={r => (this.valueInput = r)}
-          defaultValue={value}
-          onKeyUp={this.handleInputChange}
-          placeholder={
-            operator === 'inside range' || operator === 'outside range'
-              ? 'Lower'
-              : null
-          }
-        />
-        {(operator === 'inside range' || operator === 'outside range') &&
-          <input
-            className="form-control input-sm form-malachite monotype"
-            style={{width: '160px'}}
-            placeholder="Upper"
-            type="text"
-            spellCheck="false"
-            ref={r => (this.valueRangeInput = r)}
-            defaultValue={rangeValue}
-            onKeyUp={this.handleInputChange}
-          />}
-      </div>
-    )
-  },
-})
-
-const Relative = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      values: PropTypes.shape({
-        change: PropTypes.string,
-        shift: PropTypes.string,
-        operator: PropTypes.string,
-        value: PropTypes.string,
-      }),
-    }),
-    onChange: PropTypes.func.isRequired,
-  },
-
-  handleDropdownChange(item) {
-    this.props.onChange({...this.props.rule.values, [item.type]: item.text})
-  },
-
-  handleInputChange() {
-    this.props.onChange({...this.props.rule.values, value: this.input.value})
-  },
-
-  render() {
-    const {change, shift, operator, value} = this.props.rule.values
-
-    const changes = mapToItems(CHANGES, 'change')
-    const shifts = mapToItems(SHIFTS, 'shift')
-    const operators = mapToItems(OPERATORS, 'operator')
-
-    return (
-      <div className="rule-section--row rule-section--border-bottom">
-        <p>Send Alert when</p>
-        <Dropdown
-          className="dropdown-110"
-          menuClass="dropdown-malachite"
-          items={changes}
-          selected={change}
-          onChoose={this.handleDropdownChange}
-        />
-        <p>compared to previous</p>
-        <Dropdown
-          className="dropdown-80"
-          menuClass="dropdown-malachite"
-          items={shifts}
-          selected={shift}
-          onChoose={this.handleDropdownChange}
-        />
-        <p>is</p>
-        <Dropdown
-          className="dropdown-160"
-          menuClass="dropdown-malachite"
-          items={operators}
-          selected={operator}
-          onChoose={this.handleDropdownChange}
-        />
-        <input
-          className="form-control input-sm form-malachite monotype"
-          style={{width: '160px'}}
-          ref={r => (this.input = r)}
-          defaultValue={value}
-          onKeyUp={this.handleInputChange}
-          required={true}
-          type="text"
-          spellCheck="false"
-        />
-        {change === CHANGES[1] ? <p>%</p> : null}
-      </div>
-    )
   },
 })
 

--- a/ui/src/kapacitor/components/ValuesSection.js
+++ b/ui/src/kapacitor/components/ValuesSection.js
@@ -12,113 +12,104 @@ import {Tab, TabList, TabPanels, TabPanel, Tabs} from 'shared/components/Tabs'
 
 const TABS = ['Threshold', 'Relative', 'Deadman']
 
-export const ValuesSection = React.createClass({
-  propTypes: {
-    rule: PropTypes.shape({
-      id: PropTypes.string,
-    }).isRequired,
-    onChooseTrigger: PropTypes.func.isRequired,
-    onUpdateValues: PropTypes.func.isRequired,
-    query: PropTypes.shape({}).isRequired,
-    onDeadmanChange: PropTypes.func.isRequired,
-    onRuleTypeDropdownChange: PropTypes.func.isRequired,
-    onRuleTypeInputChange: PropTypes.func.isRequired,
-    onAddEvery: PropTypes.func.isRequired,
-    onRemoveEvery: PropTypes.func.isRequired,
-    timeRange: PropTypes.shape({}).isRequired,
-    queryConfigActions: PropTypes.shape({}).isRequired,
-    source: PropTypes.shape({}).isRequired,
-  },
+const handleChooseTrigger = (rule, onChooseTrigger) => {
+  if (TABS[triggerIndex] === rule.trigger) {
+    return
+  }
+  return onChooseTrigger(rule.id, TABS[triggerIndex])
+}
+const initialIndex = rule => TABS.indexOf(_.startCase(rule.trigger))
+const isDeadman = rule => rule.trigger === 'deadman'
 
-  render() {
-    const {
-      rule,
-      query,
-      source,
-      timeRange,
-      onAddEvery,
-      onRemoveEvery,
-      onDeadmanChange,
-      queryConfigActions,
-      onRuleTypeInputChange,
-      onRuleTypeDropdownChange,
-    } = this.props
-    const initialIndex = TABS.indexOf(_.startCase(rule.trigger))
-    const isDeadman = rule.trigger === 'deadman'
-
-    return (
-      <div className="rule-section">
-        <h3 className="rule-section--heading">Alert Type</h3>
-        <div className="rule-section--body">
-          <Tabs initialIndex={initialIndex} onSelect={this.handleChooseTrigger}>
-            <TabList isKapacitorTabs="true">
-              {TABS.map(tab =>
-                <Tab key={tab} isKapacitorTab={true}>
-                  {tab}
-                </Tab>
-              )}
-            </TabList>
-            <div>
-              <h3 className="rule-builder--sub-header">Time Series</h3>
-              <DataSection
-                query={query}
-                timeRange={timeRange}
-                isKapacitorRule={true}
-                actions={queryConfigActions}
-                onAddEvery={onAddEvery}
-                onRemoveEvery={onRemoveEvery}
-                isDeadman={isDeadman}
-              />
-            </div>
-
-            <h3 className="rule-builder--sub-header">Rule Conditions</h3>
-            <TabPanels>
-              <TabPanel>
-                <Threshold
-                  rule={rule}
-                  query={query}
-                  onDropdownChange={onRuleTypeDropdownChange}
-                  onRuleTypeInputChange={onRuleTypeInputChange}
-                />
-              </TabPanel>
-              <TabPanel>
-                <Relative
-                  rule={rule}
-                  onDropdownChange={onRuleTypeDropdownChange}
-                  onRuleTypeInputChange={onRuleTypeInputChange}
-                />
-              </TabPanel>
-              <TabPanel>
-                <Deadman rule={rule} onChange={onDeadmanChange} />
-              </TabPanel>
-            </TabPanels>
-            {isDeadman
-              ? null
-              : <RuleGraph
-                  rule={rule}
-                  query={query}
-                  source={source}
-                  timeRange={timeRange}
-                />}
-          </Tabs>
+const ValuesSection = ({
+  rule,
+  query,
+  source,
+  timeRange,
+  onAddEvery,
+  onRemoveEvery,
+  onDeadmanChange,
+  queryConfigActions,
+  onRuleTypeInputChange,
+  onRuleTypeDropdownChange,
+  onChooseTrigger,
+}) =>
+  <div className="rule-section">
+    <h3 className="rule-section--heading">Alert Type</h3>
+    <div className="rule-section--body">
+      <Tabs
+        initialIndex={initialIndex(rule)}
+        onSelect={handleChooseTrigger(rule, onChooseTrigger)}
+      >
+        <TabList isKapacitorTabs="true">
+          {TABS.map(tab =>
+            <Tab key={tab} isKapacitorTab={true}>
+              {tab}
+            </Tab>
+          )}
+        </TabList>
+        <div>
+          <h3 className="rule-builder--sub-header">Time Series</h3>
+          <DataSection
+            query={query}
+            timeRange={timeRange}
+            isKapacitorRule={true}
+            actions={queryConfigActions}
+            onAddEvery={onAddEvery}
+            onRemoveEvery={onRemoveEvery}
+            isDeadman={isDeadman(rule)}
+          />
         </div>
-      </div>
-    )
-  },
+        <h3 className="rule-builder--sub-header">Rule Conditions</h3>
+        <TabPanels>
+          <TabPanel>
+            <Threshold
+              rule={rule}
+              query={query}
+              onDropdownChange={onRuleTypeDropdownChange}
+              onRuleTypeInputChange={onRuleTypeInputChange}
+            />
+          </TabPanel>
+          <TabPanel>
+            <Relative
+              rule={rule}
+              onDropdownChange={onRuleTypeDropdownChange}
+              onRuleTypeInputChange={onRuleTypeInputChange}
+            />
+          </TabPanel>
+          <TabPanel>
+            <Deadman rule={rule} onChange={onDeadmanChange} />
+          </TabPanel>
+        </TabPanels>
+        {isDeadman(rule)
+          ? null
+          : <RuleGraph
+              rule={rule}
+              query={query}
+              source={source}
+              timeRange={timeRange}
+            />}
+      </Tabs>
+    </div>
+  </div>
 
-  handleChooseTrigger(triggerIndex) {
-    const {rule, onChooseTrigger} = this.props
-    if (TABS[triggerIndex] === rule.trigger) {
-      return
-    }
+const {shape, string, func} = PropTypes
 
-    onChooseTrigger(rule.id, TABS[triggerIndex])
-  },
-
-  handleValuesChange(values) {
-    const {onUpdateValues, rule} = this.props
-    onUpdateValues(rule.id, rule.trigger, values)
-  },
-})
+ValuesSection.propTypes = {
+  rule: shape({
+    id: string,
+  }).isRequired,
+  onChooseTrigger: func.isRequired,
+  onUpdateValues: func.isRequired,
+  query: shape({}).isRequired,
+  onDeadmanChange: func.isRequired,
+  onRuleTypeDropdownChange: func.isRequired,
+  onRuleTypeInputChange: func.isRequired,
+  onAddEvery: func.isRequired,
+  onRemoveEvery: func.isRequired,
+  timeRange: shape({}).isRequired,
+  queryConfigActions: shape({}).isRequired,
+  source: shape({}).isRequired,
+}
 
 export default ValuesSection

--- a/ui/src/kapacitor/containers/KapacitorRulePage.js
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.js
@@ -18,8 +18,6 @@ class KapacitorRulePage extends Component {
       enabledAlerts: [],
       kapacitor: {},
     }
-
-    this.isEditing = ::this.isEditing
   }
 
   async componentDidMount() {
@@ -97,7 +95,7 @@ class KapacitorRulePage extends Component {
     )
   }
 
-  isEditing() {
+  isEditing = () => {
     const {params} = this.props
     return params.ruleID && params.ruleID !== 'new'
   }

--- a/ui/src/shared/components/Tabs.js
+++ b/ui/src/shared/components/Tabs.js
@@ -59,7 +59,7 @@ export const TabList = React.createClass({
     if (this.props.isKapacitorTabs === 'true') {
       return (
         <div className="rule-section--row rule-section--row-first rule-section--border-bottom">
-          <p>Alert Type</p>
+          <p>Choose One:</p>
           <div className="nav nav-tablist nav-tablist-sm nav-tablist-malachite">
             {children}
           </div>
@@ -147,11 +147,13 @@ export const Tabs = React.createClass({
 
   render() {
     const children = React.Children.map(this.props.children, child => {
-      if (child.type === TabPanels) {
+      if (child && child.type === TabPanels) {
         return React.cloneElement(child, {
           activeIndex: this.state.activeIndex,
         })
-      } else if (child.type === TabList) {
+      }
+
+      if (child && child.type === TabList) {
         return React.cloneElement(child, {
           activeIndex: this.state.activeIndex,
           onActivate: this.handleActivateTab,

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -23,7 +23,7 @@ const getRange = (
   const subPad = bigNum => bigNum.times(SUB_FACTOR).toNumber()
 
   const pad = v => {
-    if (v === null || v === '') {
+    if (v === null || v === '' || v === undefined) {
       return null
     }
 

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -202,6 +202,13 @@ $rule-builder--radius-lg: 5px;
   Sectiom 2 - Rule Conditions
   -----------------------------------------------------------------------------
 */
+.rule-builder--sub-header {
+  margin: 0;
+  padding: 30px 0 13px 0;
+  font-size: 19px;
+  font-weight: 400 !important;
+  color: #a4a8b6;
+}
 .rule-builder--metric {
   height: 30px;
   line-height: 30px;
@@ -214,8 +221,6 @@ $rule-builder--radius-lg: 5px;
   @include no-user-select();
 }
 .rule-builder--graph {
-  margin-left: $rule-builder--left-gutter;
-  width: calc(100% - #{$rule-builder--left-gutter});
   background-color: $rule-builder--section-bg;
   border-radius: 0 0 $rule-builder--radius-lg $rule-builder--radius-lg;
   padding: 0 $rule-builder--padding-sm;
@@ -237,17 +242,6 @@ $rule-builder--radius-lg: 5px;
     }
   }
 
-  &:before {
-    content: '';
-    display: block;
-    position: absolute;
-    transform: translateX(-50%);
-    width: $rule-builder--accent-line-width;
-    height: 100%;
-    background-color: $rule-builder--accent-line-color;
-    top: 0;
-    left: (($rule-builder--dot / 2) - $rule-builder--left-gutter);
-  }
   .container--dygraph-legend {
     transform: translateX(-50%);
     background-color: $g5-pepper;

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -29,7 +29,9 @@ $rule-builder--radius-lg: 5px;
   color: $g15-platinum;
   @include no-user-select();
 
-  &:first-child {margin-left: 0;}
+  &:first-child {
+    margin-left: 0;
+  }
 }
 
 /*
@@ -59,7 +61,8 @@ $rule-builder--radius-lg: 5px;
 }
 .rule-section--heading {
   margin: 0;
-  padding: $rule-builder--section-gap 0 $rule-builder--padding-md $rule-builder--left-gutter;
+  padding: $rule-builder--section-gap 0 $rule-builder--padding-md
+    $rule-builder--left-gutter;
   font-size: $page-header-size;
   font-weight: $page-header-weight;
   color: $g12-forge;
@@ -127,7 +130,6 @@ $rule-builder--radius-lg: 5px;
   margin-left: $rule-builder--padding-sm - 2px;
 }
 
-
 /*
   Section 1 - Select a Time Series
   -----------------------------------------------------------------------------
@@ -174,7 +176,9 @@ $rule-builder--radius-lg: 5px;
   }
   .group-by-tag.active {
     background-color: $c-rainforest !important;
-    &:hover {background-color: $c-honeydew !important;}
+    &:hover {
+      background-color: $c-honeydew !important;
+    }
   }
   .query-builder--list-item .query-builder--checkbox:after {
     background-color: $c-rainforest;
@@ -293,8 +297,12 @@ textarea.rule-builder--message {
   border-radius: 0;
   @include custom-scrollbar($rule-builder--section-bg,$rule-builder--accent-color);
 
-  &:hover {border-color: $g4-onyx;}
-  &:focus {background-color: $rule-builder--section-bg;}
+  &:hover {
+    border-color: $g4-onyx;
+  }
+  &:focus {
+    background-color: $rule-builder--section-bg;
+  }
 }
 .rule-builder--message-template {
   height: 30px;
@@ -347,9 +355,7 @@ textarea.rule-builder--message {
     margin: 0;
     height: 18px;
     line-height: 20px;
-    transition:
-      background-color 0.4s ease,
-      color 0.4s ease,
+    transition: background-color 0.4s ease, color 0.4s ease,
       box-shadow 0.4s ease;
   }
   .form-group > input.form-control:hover + label {
@@ -363,18 +369,25 @@ textarea.rule-builder--message {
   }
 }
 
-
-
 /*
   Color coding for alerts in Alert History table
   -----------------------------------------------------------------------------
 */
 .alert-level-ok {
-  &, &:hover {color: $c-rainforest !important;}
+  &,
+  &:hover {
+    color: $c-rainforest !important;
+  }
 }
 .alert-level-warning {
-  &, &:hover {color: $c-pineapple !important;}
+  &,
+  &:hover {
+    color: $c-pineapple !important;
+  }
 }
 .alert-level-critical {
-  &, &:hover {color: $c-dreamsicle !important;}
+  &,
+  &:hover {
+    color: $c-dreamsicle !important;
+  }
 }

--- a/ui/src/style/pages/kapacitor.scss
+++ b/ui/src/style/pages/kapacitor.scss
@@ -157,10 +157,9 @@ $rule-builder--radius-lg: 5px;
   }
   .query-builder--column {
     margin-right: 2px;
-    &:last-child {margin-right: 0;}
-  }
-  .query-builder--column:nth-child(1) .query-builder--list {
-    border-bottom-left-radius: $rule-builder--radius-lg;
+    &:last-child {
+      margin-right: 0;
+    }
   }
   .query-builder--column:nth-child(4) .query-builder--list,
   .query-builder--column:nth-child(4) .query-builder--list-empty {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1890 

### The problem
The UI is lying to our users.

Chronograf makes it appear that you can set a deadman rule for a specific field. However, in Kapacitor this is not the case. Kapacitor considers something dead if a database, retentionPolicy, measurement and set of optional tags have not reported over a specified time interval. Put another way, for a deadman trigger Kapacitor doesn’t care about which fields exist, only that one exists.

### The Solution
Do not reveal fields or a graph to the user if the deadman trigger is selected.

### A GIF For You
![](http://g.recordit.co/duEGZUQMPE.gif)

