### PR TITLE
Display Query Templates dropdown even when status is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.9.0 [unreleased]
 ### Bug Fixes
+1.[#2004](https://github.com/influxdata/chronograf/pull/2004): Fix DE query templates dropdown disappearance.
 ### Features
 1. [#1885](https://github.com/influxdata/chronograf/pull/1885): Add `fill` options to data explorer and dashboard queries
 1. [#1978](https://github.com/influxdata/chronograf/pull/1978): Support editing kapacitor TICKScript

--- a/ui/src/shared/components/QueryStatus.js
+++ b/ui/src/shared/components/QueryStatus.js
@@ -4,7 +4,11 @@ import classnames from 'classnames'
 
 const QueryStatus = ({status, children}) => {
   if (!status) {
-    return <div className="query-editor--status" />
+    return (
+      <div className="query-editor--status">
+        {children}
+      </div>
+    )
   }
 
   if (status.loading) {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect [#1972](https://github.com/influxdata/chronograf/issues/1972)
### The problem
Query Templates dropdown is not visible for a newly created query editor window, until some data is selected- it also disappears after being used. 

### The Solution
Query Templates dropdown is now visible at query creation, and remains visible after it is used. 
![kapture 2017-09-18 at 14 23 42](https://user-images.githubusercontent.com/10937678/30565409-ff88134e-9c7c-11e7-8c55-34736828713c.gif)

