### PR TITLE
Display error if new db name matches an existing db name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.9.0 [unreleased]
 ### Bug Fixes
 1.[#2004](https://github.com/influxdata/chronograf/pull/2004): Fix DE query templates dropdown disappearance.
+1.[#2006](https://github.com/influxdata/chronograf/pull/2006): Fix no alert for duplicate db name
 ### Features
 1. [#1885](https://github.com/influxdata/chronograf/pull/1885): Add `fill` options to data explorer and dashboard queries
 1. [#1978](https://github.com/influxdata/chronograf/pull/1978): Support editing kapacitor TICKScript

--- a/ui/spec/admin/reducers/adminSpec.js
+++ b/ui/spec/admin/reducers/adminSpec.js
@@ -145,8 +145,12 @@ describe('Admin.Reducers', () => {
     it('can add a database', () => {
       const actual = reducer(state, addDatabase())
       const expected = [{...NEW_DEFAULT_DATABASE, isEditing: true}, db1, db2]
-
-      expect(actual.databases).to.deep.equal(expected)
+      expect(actual.databases.length).to.equal(expected.length)
+      expect(actual.databases[0].name).to.equal(expected[0].name)
+      expect(actual.databases[0].isNew).to.equal(expected[0].isNew)
+      expect(actual.databases[0].retentionPolicies).to.equal(
+        expected[0].retentionPolicies
+      )
     })
 
     it('can edit a database', () => {

--- a/ui/src/admin/components/DatabaseManager.js
+++ b/ui/src/admin/components/DatabaseManager.js
@@ -41,9 +41,9 @@ const DatabaseManager = ({
         </button>
       </div>
       <div className="panel-body">
-        {databases.map((db, dbInd) =>
+        {databases.map(db =>
           <DatabaseTable
-            key={dbInd}
+            key={db.links.self}
             database={db}
             notify={notify}
             isRFDisplayed={isRFDisplayed}

--- a/ui/src/admin/components/DatabaseManager.js
+++ b/ui/src/admin/components/DatabaseManager.js
@@ -41,9 +41,9 @@ const DatabaseManager = ({
         </button>
       </div>
       <div className="panel-body">
-        {databases.map(db =>
+        {databases.map((db, db_ind) =>
           <DatabaseTable
-            key={db.links.self}
+            key={db_ind}
             database={db}
             notify={notify}
             isRFDisplayed={isRFDisplayed}

--- a/ui/src/admin/components/DatabaseManager.js
+++ b/ui/src/admin/components/DatabaseManager.js
@@ -41,9 +41,9 @@ const DatabaseManager = ({
         </button>
       </div>
       <div className="panel-body">
-        {databases.map((db, db_ind) =>
+        {databases.map((db, dbInd) =>
           <DatabaseTable
-            key={db_ind}
+            key={dbInd}
             database={db}
             notify={notify}
             isRFDisplayed={isRFDisplayed}

--- a/ui/src/admin/constants/index.js
+++ b/ui/src/admin/constants/index.js
@@ -45,5 +45,4 @@ export const NEW_DEFAULT_DATABASE = {
   name: '',
   isNew: true,
   retentionPolicies: [NEW_DEFAULT_RP],
-  links: {self: ''},
 }

--- a/ui/src/admin/containers/DatabaseManagerPage.js
+++ b/ui/src/admin/containers/DatabaseManagerPage.js
@@ -59,12 +59,10 @@ class DatabaseManagerPage extends Component {
 
   handleCreateDatabase = database => {
     const {actions, notify, source, databases} = this.props
-
     if (!database.name) {
       return notify('error', 'Database name cannot be blank')
     }
-
-    if (_.findIndex(databases, {name: database.name}, 1)) {
+    if (_.findIndex(databases, {name: database.name}, 1) !== -1) {
       return notify('error', 'A database by this name already exists')
     }
 
@@ -78,7 +76,7 @@ class DatabaseManagerPage extends Component {
 
   handleKeyDownDatabase = database => e => {
     const {key} = e
-    const {actions, notify, source} = this.props
+    const {actions, notify, source, databases} = this.props
 
     if (key === 'Escape') {
       actions.removeDatabase(database)
@@ -87,6 +85,10 @@ class DatabaseManagerPage extends Component {
     if (key === 'Enter') {
       if (!database.name) {
         return notify('error', 'Database name cannot be blank')
+      }
+
+      if (_.findIndex(databases, {name: database.name}, 1) !== -1) {
+        return notify('error', 'A database by this name already exists')
       }
 
       actions.createDatabaseAsync(source.links.databases, database)

--- a/ui/src/admin/containers/DatabaseManagerPage.js
+++ b/ui/src/admin/containers/DatabaseManagerPage.js
@@ -1,6 +1,7 @@
 import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
+import _ from 'lodash'
 
 import DatabaseManager from 'src/admin/components/DatabaseManager'
 
@@ -57,10 +58,14 @@ class DatabaseManagerPage extends Component {
   }
 
   handleCreateDatabase = database => {
-    const {actions, notify, source} = this.props
+    const {actions, notify, source, databases} = this.props
 
     if (!database.name) {
       return notify('error', 'Database name cannot be blank')
+    }
+
+    if (_.findIndex(databases, {name: database.name}, 1)) {
+      return notify('error', 'A database by this name already exists')
     }
 
     actions.createDatabaseAsync(source.links.databases, database)

--- a/ui/src/admin/containers/DatabaseManagerPage.js
+++ b/ui/src/admin/containers/DatabaseManagerPage.js
@@ -62,6 +62,7 @@ class DatabaseManagerPage extends Component {
     if (!database.name) {
       return notify('error', 'Database name cannot be blank')
     }
+
     if (_.findIndex(databases, {name: database.name}, 1) !== -1) {
       return notify('error', 'A database by this name already exists')
     }

--- a/ui/src/admin/reducers/admin.js
+++ b/ui/src/admin/reducers/admin.js
@@ -5,6 +5,7 @@ import {
   NEW_DEFAULT_DATABASE,
   NEW_EMPTY_RP,
 } from 'src/admin/constants'
+import uuid from 'node-uuid'
 
 const initialState = {
   users: null,
@@ -50,7 +51,11 @@ export default function admin(state = initialState, action) {
     }
 
     case 'ADD_DATABASE': {
-      const newDatabase = {...NEW_DEFAULT_DATABASE, isEditing: true}
+      const newDatabase = {
+        ...NEW_DEFAULT_DATABASE,
+        links: {self: `temp-ID${uuid.v4()}`},
+        isEditing: true,
+      }
 
       return {
         ...state,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect [#1283](https://github.com/influxdata/chronograf/issues/1283)

### The problem
No visual feedback that db creation has failed when user tries to create a database with a name that already exists in databases

### The Solution
Show alert when new db has a name that matches an existing db name

![kapture 2017-09-18 at 20 11 26](https://user-images.githubusercontent.com/10937678/30574541-75cd0780-9caf-11e7-8fbf-1ce59cdebec7.gif)
