### PR TITLE
BUGFIX: Unresponsive query builder, display options, and cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1.[#2004](https://github.com/influxdata/chronograf/pull/2004): Fix DE query templates dropdown disappearance.
 1.[#2006](https://github.com/influxdata/chronograf/pull/2006): Fix no alert for duplicate db name
+1.[#2018](https://github.com/influxdata/chronograf/pull/2018): Fix unresponsive display options and query builder in dashboards
 ### Features
 1. [#1885](https://github.com/influxdata/chronograf/pull/1885): Add `fill` options to data explorer and dashboard queries
 1. [#1978](https://github.com/influxdata/chronograf/pull/1978): Support editing kapacitor TICKScript

--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -1,5 +1,7 @@
 import React, {PropTypes} from 'react'
 
+import {emptyGraphCopy} from 'src/shared/copy/cell'
+
 import AutoRefresh from 'shared/components/AutoRefresh'
 import LineGraph from 'shared/components/LineGraph'
 import SingleStat from 'shared/components/SingleStat'
@@ -19,6 +21,16 @@ const RefreshingGraph = ({
   synchronizer,
   editQueryStatus,
 }) => {
+  if (!queries.length) {
+    return (
+      <div className="graph-empty">
+        <p data-test="data-explorer-no-results">
+          {emptyGraphCopy}
+        </p>
+      </div>
+    )
+  }
+
   if (type === 'single-stat') {
     return (
       <RefreshingSingleStat

--- a/ui/src/shared/copy/cell.js
+++ b/ui/src/shared/copy/cell.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 const emptyFunny = [
   'Looks like you dont have any queries.  Be a lot cooler if you did.',
   'Create a query below. Go on, I dare ya!',
@@ -5,7 +7,4 @@ const emptyFunny = [
   '1) Create a query below \n2) Profit',
 ]
 
-const getRandomInt = (min, max) =>
-  Math.floor(Math.random() * (max - min + 1)) + min
-
-export const emptyGraphCopy = emptyFunny[getRandomInt(0, 3)]
+export const emptyGraphCopy = _.sample(emptyFunny)

--- a/ui/src/shared/copy/cell.js
+++ b/ui/src/shared/copy/cell.js
@@ -1,0 +1,11 @@
+const emptyFunny = [
+  'Looks like you dont have any queries.  Be a lot cooler if you did.',
+  'Create a query below. Go on, I dare ya!',
+  'Create a query below.  Have fun!',
+  '1) Create a query below \n2) Profit',
+]
+
+const getRandomInt = (min, max) =>
+  Math.floor(Math.random() * (max - min + 1)) + min
+
+export const emptyGraphCopy = emptyFunny[getRandomInt(0, 3)]

--- a/ui/src/style/components/graph.scss
+++ b/ui/src/style/components/graph.scss
@@ -95,8 +95,9 @@ $graph-gutter: 16px;
     font-size: 20px;
     font-weight: 400;
     margin: 0;
-    text-align: center;
+    text-align: left;
     color: $g8-storm;
+    white-space: pre-wrap;
   }
 }
 .graph-fetching {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1986 
### Repro Steps
See #1986 

### The problem
In `Dashboard` => `DisplayOptions`.  If a user selected a visualization type before creating a query, the `CellEditorOverlay` component and corresponding `Cell` in that dashboard would become unresponsive.

### The Solution
I'm really happy that this bug was discovered as it provided the perfect opportunity to fix some UX.  You see, when a user goes to edit a cell for the first time, the first thing they see is:

![screen shot 2017-09-21 at 2 37 23 pm](https://user-images.githubusercontent.com/7582765/30719929-6de5608a-9eda-11e7-88c9-a8c49dee2da2.png)

'No results'?!?  From what?!? I didn't do anything.  Or did I?  I don't understand.  I am sad.

So now, when a user doesn't have any queries.  Instead of making calls to a 'host' with a non-existent query we now return more fun and useful guidance like: 
![screen shot 2017-09-21 at 2 36 38 pm](https://user-images.githubusercontent.com/7582765/30720043-d96e6bf8-9eda-11e7-8e93-7090f52f9675.png)

Which, as a lovely side-effect stops the overlay and cell from freezing up.
