### PR TITLE
BUGFIX: Fix improper banner error for duplicate kapacitor name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## v1.3.9.0 [unreleased]
 ### Bug Fixes
-1.[#2004](https://github.com/influxdata/chronograf/pull/2004): Fix DE query templates dropdown disappearance.
+1.[#2004](https://github.com/influxdata/chronograf/pull/2004): Fix DE query templates dropdown disappearance
 1.[#2006](https://github.com/influxdata/chronograf/pull/2006): Fix no alert for duplicate db name
+1.[#2019](https://github.com/influxdata/chronograf/pull/2006): Fix false error warning for duplicate kapacitor name
+
 ### Features
 1. [#1885](https://github.com/influxdata/chronograf/pull/1885): Add `fill` options to data explorer and dashboard queries
 1. [#1978](https://github.com/influxdata/chronograf/pull/1978): Support editing kapacitor TICKScript

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -24,12 +24,6 @@ class KapacitorPage extends Component {
       },
       exists: false,
     }
-
-    this.handleInputChange = ::this.handleInputChange
-    this.handleSubmit = ::this.handleSubmit
-    this.handleResetToDefaults = ::this.handleResetToDefaults
-    this._parseKapacitorURL = ::this._parseKapacitorURL
-    this.checkKapacitorConnection = ::this.checkKapacitorConnection
   }
 
   componentDidMount() {
@@ -44,7 +38,7 @@ class KapacitorPage extends Component {
     })
   }
 
-  async checkKapacitorConnection(kapacitor) {
+  checkKapacitorConnection = async kapacitor => {
     try {
       await pingKapacitor(kapacitor)
       this.setState({exists: true})
@@ -57,7 +51,7 @@ class KapacitorPage extends Component {
     }
   }
 
-  handleInputChange(e) {
+  handleInputChange = e => {
     const {value, name} = e.target
 
     this.setState(prevState => {
@@ -66,7 +60,7 @@ class KapacitorPage extends Component {
     })
   }
 
-  handleSubmit(e) {
+  handleSubmit = e => {
     e.preventDefault()
     const {
       addFlashMessage,
@@ -122,7 +116,7 @@ class KapacitorPage extends Component {
     }
   }
 
-  handleResetToDefaults(e) {
+  handleResetToDefaults = e => {
     e.preventDefault()
     const defaultState = {
       url: this._parseKapacitorURL(),
@@ -134,7 +128,7 @@ class KapacitorPage extends Component {
     this.setState({kapacitor: {...defaultState}})
   }
 
-  _parseKapacitorURL() {
+  _parseKapacitorURL = () => {
     const parser = document.createElement('a')
     parser.href = this.props.source.url
 

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -78,8 +78,9 @@ class KapacitorPage extends Component {
     const {kapacitor} = this.state
 
     const isNameTaken = kapacitors.some(k => k.name === kapacitor.name)
+    const isNew = !params.id
 
-    if (isNameTaken) {
+    if (isNew && isNameTaken) {
       addFlashMessage({
         type: 'error',
         text: `There is already a Kapacitor configuration named "${kapacitor.name}"`,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1999 

### The problem
This error would flash when editing a kapacitor source:
![screen shot 2017-09-21 at 3 08 45 pm](https://user-images.githubusercontent.com/7582765/30721010-cfaa660e-9ede-11e7-92df-963494542daf.png)

### The Solution
Only fire that error when creating a new kapacitor source.


