### PR TITLE
Fix for single value custom time ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.3.8.2 [2017-09-25]
+### Bug Fixes
+1. [#2020](https://github.com/influxdata/chronograf/pull/2020): Fix duration for single value custom time ranges
+
 ## v1.3.8.1 [2017-09-08]
 ### Bug Fixes
 1. [#1982](https://github.com/influxdata/chronograf/pull/1982): Fix return code on meta nodes when raft redirects to leader

--- a/chronograf.go
+++ b/chronograf.go
@@ -283,6 +283,10 @@ func (g *GroupByVar) parseAbsolute(fragment string) (time.Duration, error) {
 		}
 	}
 
+	if len(durs) == 1 {
+		durs = append(durs, time.Now())
+	}
+
 	// reject more than 2 times found
 	if len(durs) != 2 {
 		return time.Duration(0), errors.New("must provide exactly two absolute times")


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
Single value custom ranges do not return a duration

### The Solution
Fix that


