### PR TITLE
Fix Legend Positioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Sort database list in Schema Explorer alphabetically
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Improve usability of dashboard cell context menus
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Move dashboard cell renaming UI into Cell Editor Overlay
+1. [#2040](https://github.com/influxdata/chronograf/pull/2040): Prevent the legend from overlapping graphs at the bottom of the screen
 
 ## v1.3.8.1 [unreleased]
 ### Bug Fixes

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -367,9 +367,7 @@ export default class Dygraph extends Component {
     // Disallow screen overflow of legend
     const isLegendBottomClipped = graphBottom + legendHeight > screenHeight
 
-    const legendTop = isLegendBottomClipped
-      ? -(legendHeight + 8)
-      : graphHeight + 8
+    const legendTop = isLegendBottomClipped ? -legendHeight : graphHeight + 8
 
     if (isLegendBottomClipped) {
       this.legendRef.classList.add('dygraph-legend--above')

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -368,7 +368,7 @@ export default class Dygraph extends Component {
     const isLegendBottomClipped = graphBottom + legendHeight > screenHeight
 
     const legendTop = isLegendBottomClipped
-      ? graphHeight + 8 - legendHeight
+      ? -(legendHeight + 8)
       : graphHeight + 8
 
     this.legendRef.style.left = `${legendLeft}px`

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -371,6 +371,12 @@ export default class Dygraph extends Component {
       ? -(legendHeight + 8)
       : graphHeight + 8
 
+    if (isLegendBottomClipped) {
+      this.legendRef.classList.add('dygraph-legend--above')
+    } else {
+      this.legendRef.classList.remove('dygraph-legend--above')
+    }
+
     this.legendRef.style.left = `${legendLeft}px`
     this.legendRef.style.top = `${legendTop}px`
 

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -147,6 +147,25 @@
   &.hidden {
     display: none !important;
   }
+
+  // Arrow
+  &:after {
+    content: '';
+    position: absolute;
+    border-width: 8px;
+    border-style: solid;
+    border-color: transparent;
+    border-bottom-color: $g0-obsidian;
+    left: 50%;
+    top: -16px;
+    transform: translateX(-50%);
+  }
+  &.dygraph-legend--above:after {
+    top: initial;
+    border-color: transparent;
+    border-top-color: $g0-obsidian;
+    bottom: -16px;
+  }
 }
 .dygraph-legend--header {
   display: flex;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2024 

### The Problem
- When hovering over a cell at the bottom of the screen the legend appears on top of the graph, making it hard to actually see what you are doing

### The Solution
- Position the legend above the graph instead of on top of the graph
- Add indicator arrows to make it more clear which cell the legend is pointing to

### Preview
![screen shot 2017-09-27 at 10 52 37 am](https://user-images.githubusercontent.com/2433762/30929310-f1416dce-a372-11e7-8f78-867cce5456a2.png)
Normal legend below a graph (has arrow on top)

![screen shot 2017-09-27 at 10 52 23 am](https://user-images.githubusercontent.com/2433762/30929325-facb783a-a372-11e7-8ee4-775ba5ab9f0f.png)
Legend above a graph (has arrow on bottom)

Only potential issue here is that the crosshair does not line up with the arrows, which I find slightly distracting


