### PR TITLE
FEATURE: Toggle now() in date picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 1. [#1992](https://github.com/influxdata/chronograf/pull/1992): Add .csv download button to data explorer
 1. [#2082](https://github.com/influxdata/chronograf/pull/2082): Add Data Explorer InfluxQL query and location query synchronization, so queries can be shared via a a URL
 1. [#1996](https://github.com/influxdata/chronograf/pull/1996): Able to switch InfluxDB sources on a per graph basis
+1. [#2041](https://github.com/influxdata/chronograf/pull/2041): Add now() as an option in the Dashboard date picker
 
 ### UI Improvements
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Require a second click when deleting a dashboard cell

--- a/chronograf_test.go
+++ b/chronograf_test.go
@@ -2,54 +2,61 @@ package chronograf_test
 
 import (
 	"testing"
-	"time"
 
 	"github.com/influxdata/chronograf"
 )
 
 func Test_GroupByVar(t *testing.T) {
 	gbvTests := []struct {
-		name              string
-		query             string
-		expected          time.Duration
-		resolution        uint // the screen resolution to render queries into
-		reportingInterval time.Duration
+		name       string
+		query      string
+		want       string
+		resolution uint // the screen resolution to render queries into
 	}{
 		{
-			"relative time",
-			"SELECT mean(usage_idle) FROM cpu WHERE time > now() - 180d GROUP BY :interval:",
-			4320 * time.Hour,
-			1000,
-			10 * time.Second,
+			name:       "relative time only lower bound with one day of duration",
+			query:      "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1d GROUP BY :interval:",
+			resolution: 1000,
+			want:       "time(259s)",
 		},
 		{
-			"absolute time",
-			"SELECT mean(usage_idle) FROM cpu WHERE time > '1985-10-25T00:01:00Z' and time < '1985-10-25T00:02:00Z' GROUP BY :interval:",
-			1 * time.Minute,
-			1000,
-			10 * time.Second,
+			name:       "relative time with relative upper bound with one minute of duration",
+			query:      "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 3m  AND time < now() - 2m GROUP BY :interval:",
+			resolution: 1000,
+			want:       "time(180ms)",
 		},
 		{
-			"absolute time with nano",
-			"SELECT mean(usage_idle) FROM cpu WHERE time > '2017-07-24T15:33:42.994Z' and time < '2017-08-24T15:33:42.994Z' GROUP BY :interval:",
-			744 * time.Hour,
-			1000,
-			10 * time.Second,
+			name:       "relative time with relative lower bound and now upper with one day of duration",
+			query:      "SELECT mean(usage_idle) FROM cpu WHERE time > now() - 1d  AND time < now() GROUP BY :interval:",
+			resolution: 1000,
+			want:       "time(259s)",
+		},
+		{
+			name:       "absolute time with one minute of duration",
+			query:      "SELECT mean(usage_idle) FROM cpu WHERE time > '1985-10-25T00:01:00Z' and time < '1985-10-25T00:02:00Z' GROUP BY :interval:",
+			resolution: 1000,
+			want:       "time(180ms)",
+		},
+		{
+			name:       "absolute time with nano seconds and zero duraiton",
+			query:      "SELECT mean(usage_idle) FROM cpu WHERE time > '2017-07-24T15:33:42.994Z' and time < '2017-07-24T15:33:42.994Z' GROUP BY :interval:",
+			resolution: 1000,
+			want:       "time(1ms)",
 		},
 	}
 
 	for _, test := range gbvTests {
 		t.Run(test.name, func(t *testing.T) {
 			gbv := chronograf.GroupByVar{
-				Var:               ":interval:",
-				Resolution:        test.resolution,
-				ReportingInterval: test.reportingInterval,
+				Var:        ":interval:",
+				Resolution: test.resolution,
 			}
 
 			gbv.Exec(test.query)
+			got := gbv.String()
 
-			if gbv.Duration != test.expected {
-				t.Fatalf("%q - durations not equal! Want: %s, Got: %s", test.name, test.expected, gbv.Duration)
+			if got != test.want {
+				t.Fatalf("%q - durations not equal! Want: %s, Got: %s", test.name, test.want, got)
 			}
 		})
 	}

--- a/ui/src/data_explorer/containers/Header.js
+++ b/ui/src/data_explorer/containers/Header.js
@@ -59,6 +59,7 @@ const Header = React.createClass({
             <TimeRangeDropdown
               onChooseTimeRange={this.handleChooseTimeRange}
               selected={timeRange}
+              page="DataExplorer"
             />
           </div>
         </div>

--- a/ui/src/shared/components/CustomTimeRange.js
+++ b/ui/src/shared/components/CustomTimeRange.js
@@ -9,7 +9,7 @@ class CustomTimeRange extends Component {
   constructor(props) {
     super(props)
     this.state = {
-      isNow: this.props.timeRange.upper.match(/^now/),
+      isNow: this.props.timeRange.upper === 'now()',
     }
   }
 

--- a/ui/src/shared/components/CustomTimeRange.js
+++ b/ui/src/shared/components/CustomTimeRange.js
@@ -203,7 +203,7 @@ class CustomTimeRange extends Component {
                   : 'btn-default'}`}
                 onClick={this.handleToggleNow}
               >
-                now()
+                Now
               </div>
               <input
                 className="custom-time--upper form-control input-sm"

--- a/ui/src/shared/components/CustomTimeRange.js
+++ b/ui/src/shared/components/CustomTimeRange.js
@@ -164,6 +164,8 @@ class CustomTimeRange extends Component {
 
   render() {
     const {isNow} = this.state
+    const {page} = this.props
+    const isNowDisplayed = page !== 'DataExplorer'
 
     return (
       <div className="custom-time--container">
@@ -197,14 +199,16 @@ class CustomTimeRange extends Component {
               ref={r => (this.upperContainer = r)}
               disabled={isNow}
             >
-              <div
-                className={`btn btn-xs custom-time--now ${isNow
-                  ? 'btn-primary'
-                  : 'btn-default'}`}
-                onClick={this.handleToggleNow}
-              >
-                Now
-              </div>
+              {isNowDisplayed
+                ? <div
+                    className={`btn btn-xs custom-time--now ${isNow
+                      ? 'btn-primary'
+                      : 'btn-default'}`}
+                    onClick={this.handleToggleNow}
+                  >
+                    Now
+                  </div>
+                : null}
               <input
                 className="custom-time--upper form-control input-sm"
                 ref={r => (this.upper = r)}
@@ -212,7 +216,7 @@ class CustomTimeRange extends Component {
                 onKeyUp={this.handleRefreshCals}
                 disabled={isNow}
               />
-              {isNow
+              {isNow && page !== 'DataExplorer'
                 ? <div
                     className="custom-time--mask"
                     onClick={this.handleNowOff}
@@ -241,6 +245,7 @@ CustomTimeRange.propTypes = {
     upper: string,
   }).isRequired,
   onClose: func,
+  page: string,
 }
 
 export default CustomTimeRange

--- a/ui/src/shared/components/CustomTimeRange.js
+++ b/ui/src/shared/components/CustomTimeRange.js
@@ -8,6 +8,9 @@ const dateFormat = 'YYYY-MM-DD HH:mm'
 class CustomTimeRange extends Component {
   constructor(props) {
     super(props)
+    this.state = {
+      isNow: this.props.timeRange.upper.match(/^now/),
+    }
   }
 
   componentDidMount() {
@@ -68,6 +71,14 @@ class CustomTimeRange extends Component {
     this.upperCal.refresh()
   }
 
+  handleToggleNow = () => {
+    this.setState({isNow: !this.state.isNow})
+  }
+
+  handleNowOff = () => {
+    this.setState({isNow: false})
+  }
+
   /*
    * Upper and lower time ranges are passed in with single quotes as part of
    * the string literal, i.e. "'2015-09-23T18:00:00.000Z'".  Remove them
@@ -76,6 +87,10 @@ class CustomTimeRange extends Component {
   _formatTimeRange = timeRange => {
     if (!timeRange) {
       return ''
+    }
+
+    if (timeRange === 'now()') {
+      return moment(new Date()).format(dateFormat)
     }
 
     // If the given time range is relative, create a fixed timestamp based on its value
@@ -89,10 +104,16 @@ class CustomTimeRange extends Component {
 
   handleClick = () => {
     const {onApplyTimeRange, onClose} = this.props
+    const {isNow} = this.state
+
     const lower = this.lowerCal.getDate().toISOString()
     const upper = this.upperCal.getDate().toISOString()
 
-    onApplyTimeRange({lower, upper})
+    if (isNow) {
+      onApplyTimeRange({lower, upper: 'now()'})
+    } else {
+      onApplyTimeRange({lower, upper})
+    }
 
     if (onClose) {
       onClose()
@@ -142,6 +163,8 @@ class CustomTimeRange extends Component {
   }
 
   render() {
+    const {isNow} = this.state
+
     return (
       <div className="custom-time--container">
         <div className="custom-time--shortcuts">
@@ -159,7 +182,7 @@ class CustomTimeRange extends Component {
         <div className="custom-time--wrap">
           <div className="custom-time--dates" onClick={this.handleRefreshCals}>
             <div
-              className="lower-container"
+              className="custom-time--lower-container"
               ref={r => (this.lowerContainer = r)}
             >
               <input
@@ -170,15 +193,31 @@ class CustomTimeRange extends Component {
               />
             </div>
             <div
-              className="upper-container"
+              className="custom-time--upper-container"
               ref={r => (this.upperContainer = r)}
+              disabled={isNow}
             >
+              <div
+                className={`btn btn-xs custom-time--now ${isNow
+                  ? 'btn-primary'
+                  : 'btn-default'}`}
+                onClick={this.handleToggleNow}
+              >
+                now()
+              </div>
               <input
                 className="custom-time--upper form-control input-sm"
                 ref={r => (this.upper = r)}
                 placeholder="to"
                 onKeyUp={this.handleRefreshCals}
+                disabled={isNow}
               />
+              {isNow
+                ? <div
+                    className="custom-time--mask"
+                    onClick={this.handleNowOff}
+                  />
+                : null}
             </div>
           </div>
           <div

--- a/ui/src/shared/components/CustomTimeRangeOverlay.js
+++ b/ui/src/shared/components/CustomTimeRangeOverlay.js
@@ -13,7 +13,7 @@ class CustomTimeRangeOverlay extends Component {
   }
 
   render() {
-    const {onClose, timeRange, onApplyTimeRange} = this.props
+    const {onClose, timeRange, onApplyTimeRange, page} = this.props
 
     return (
       <div className="custom-time--overlay">
@@ -21,6 +21,7 @@ class CustomTimeRangeOverlay extends Component {
           onApplyTimeRange={onApplyTimeRange}
           timeRange={timeRange}
           onClose={onClose}
+          page={page}
         />
       </div>
     )
@@ -36,6 +37,7 @@ CustomTimeRangeOverlay.propTypes = {
     upper: string,
   }).isRequired,
   onClose: func,
+  page: string,
 }
 
 export default OnClickOutside(CustomTimeRangeOverlay)

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -9,7 +9,9 @@ import CustomTimeRangeOverlay from 'shared/components/CustomTimeRangeOverlay'
 import timeRanges from 'hson!shared/data/timeRanges.hson'
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'shared/constants/index'
 
+const dateFormat = 'YYYY-MM-DD HH:mm'
 const emptyTime = {lower: '', upper: ''}
+const format = t => moment(t.replace(/\'/g, '')).format(dateFormat)
 
 class TimeRangeDropdown extends Component {
   constructor(props) {
@@ -29,8 +31,10 @@ class TimeRangeDropdown extends Component {
 
   findTimeRangeInputValue = ({upper, lower}) => {
     if (upper && lower) {
-      const format = t =>
-        moment(t.replace(/\'/g, '')).format('YYYY-MM-DD HH:mm')
+      if (upper === 'now()') {
+        return `${format(lower)} - ${upper}`
+      }
+
       return `${format(lower)} - ${format(upper)}`
     }
 

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -48,7 +48,7 @@ class TimeRangeDropdown extends Component {
 
   handleSelection = timeRange => () => {
     this.props.onChooseTimeRange(timeRange)
-    this.setState({isOpen: false})
+    this.setState({customTimeRange: emptyTime, isOpen: false})
   }
 
   toggleMenu = () => {

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -73,7 +73,7 @@ class TimeRangeDropdown extends Component {
   }
 
   render() {
-    const {selected, preventCustomTimeRange} = this.props
+    const {selected, preventCustomTimeRange, page} = this.props
     const {isOpen, customTimeRange, isCustomTimeRangeOpen} = this.state
     const isRelativeTimeRange = selected.upper === null
     const isNow = selected.upper === 'now()'
@@ -142,6 +142,7 @@ class TimeRangeDropdown extends Component {
               isVisible={isCustomTimeRangeOpen}
               onToggle={this.handleToggleCustomTimeRange}
               onClose={this.handleCloseCustomTimeRange}
+              page={page}
             />
           : null}
       </div>
@@ -151,6 +152,10 @@ class TimeRangeDropdown extends Component {
 
 const {bool, func, shape, string} = PropTypes
 
+TimeRangeDropdown.defaultProps = {
+  page: 'default',
+}
+
 TimeRangeDropdown.propTypes = {
   selected: shape({
     lower: string,
@@ -158,6 +163,7 @@ TimeRangeDropdown.propTypes = {
   }).isRequired,
   onChooseTimeRange: func.isRequired,
   preventCustomTimeRange: bool,
+  page: string,
 }
 
 export default OnClickOutside(TimeRangeDropdown)

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -32,7 +32,7 @@ class TimeRangeDropdown extends Component {
   findTimeRangeInputValue = ({upper, lower}) => {
     if (upper && lower) {
       if (upper === 'now()') {
-        return `${format(lower)} - ${upper}`
+        return `${format(lower)} - Now`
       }
 
       return `${format(lower)} - ${format(upper)}`
@@ -76,13 +76,15 @@ class TimeRangeDropdown extends Component {
     const {selected, preventCustomTimeRange} = this.props
     const {isOpen, customTimeRange, isCustomTimeRangeOpen} = this.state
     const isRelativeTimeRange = selected.upper === null
+    const isNow = selected.upper === 'now()'
 
     return (
       <div className="time-range-dropdown">
         <div
           className={classnames('dropdown', {
             'dropdown-160': isRelativeTimeRange,
-            'dropdown-290': !isRelativeTimeRange,
+            'dropdown-210': isNow,
+            'dropdown-290': !isRelativeTimeRange && !isNow,
             open: isOpen,
           })}
         >

--- a/ui/src/style/components/custom-time-range.scss
+++ b/ui/src/style/components/custom-time-range.scss
@@ -33,6 +33,10 @@
   align-items: flex-start;
   justify-content: space-between;
 }
+.custom-time--upper-container,
+.custom-time--lower-container {
+  position: relative;
+}
 .custom-time--lower {
   margin-right: 4px;
   text-align: center;
@@ -40,6 +44,21 @@
 .custom-time--upper {
   margin-left: 4px;
   text-align: center;
+}
+.custom-time--mask {
+  position: absolute;
+  width: 100%;
+  height: calc(100% - 30px);
+  top: 30px;
+  left: 0;
+  opacity: 0.5;
+  background-color: $g5-pepper;
+  z-index: 2;
+}
+.custom-time--now {
+  position: absolute !important;
+  right: 0;
+  top: 4px;
 }
 .custom-time--shortcuts {
   @include no-user-select();


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1825 

### The problem
Users would like to specify a lower time besides the ones we provide them. now() - 5m etc just isn't enough.

### The Solution
Allow users to specify an absolute lower bound with a specific date and time and an upper time relative to `now()`.

### Notes
The chronograf server needs to actually use template variables types rather than what is used now

### Look at its beauty
![](http://g.recordit.co/S14hZgrfnt.gif)