### PR TITLE
BUGFIX: Add double quotes by default to tempvar csv unless strings are already

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1.[#2015](https://github.com/influxdata/chronograf/pull/2015): Chronograf shows real status for windows hosts when metrics are saved in non-default db - thank you, @ar7z1!
 1.[#2019](https://github.com/influxdata/chronograf/pull/2006): Fix false error warning for duplicate kapacitor name
 1.[#2018](https://github.com/influxdata/chronograf/pull/2018): Fix unresponsive display options and query builder in dashboards
+1.[#2043](https://github.com/influxdata/chronograf/pull/2043): Add double quotes by default to CSV template variables
 
 ### Features
 1. [#1885](https://github.com/influxdata/chronograf/pull/1885): Add `fill` options to data explorer and dashboard queries

--- a/ui/src/dashboards/components/template_variables/RowValues.js
+++ b/ui/src/dashboards/components/template_variables/RowValues.js
@@ -10,7 +10,7 @@ const RowValues = ({
 }) => {
   const quoteRegex = /^['"].+?['"]$/
   const _values = values
-    .map(({value}) => (quoteRegex.test(value) ? value : `'${value}'`))
+    .map(({value}) => (quoteRegex.test(value) ? value : `"${value}"`))
     .join(', ')
 
   if (selectedType === 'csv') {

--- a/ui/src/dashboards/components/template_variables/RowValues.js
+++ b/ui/src/dashboards/components/template_variables/RowValues.js
@@ -8,7 +8,10 @@ const RowValues = ({
   onStartEdit,
   autoFocusTarget,
 }) => {
-  const _values = values.map(v => v.value).join(', ')
+  const quoteRegex = /^['"].+?['"]$/
+  const _values = values
+    .map(({value}) => (quoteRegex.test(value) ? value : `'${value}'`))
+    .join(', ')
 
   if (selectedType === 'csv') {
     return (


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1975 

### The problem
No quotes on CSV temp vars by default can lead to unexpected invalid queries

### The Solution
Apply double quotes to the list of CSV tempvars by default.


