### PR TITLE
UI IMPROVEMENT: More complete fix of legend positioning

### DIFF
--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -37,6 +37,7 @@ export default class Dygraph extends Component {
       isAscending: true,
       isSnipped: false,
       isFilterVisible: false,
+      arrowPosition: 'top',
     }
   }
 
@@ -373,19 +374,11 @@ export default class Dygraph extends Component {
     const willLegendFitLeft = e.pageX - chronografChromeSize > legendWidth
 
     let legendTop = graphHeight + 8
-    if (!isLegendBottomClipped && !isLegendTopClipped) {
-      this.legendRef.classList.add('dygraph-legend--top')
-      this.legendRef.classList.remove('dygraph-legend--bottom')
-      this.legendRef.classList.remove('dygraph-legend--left')
-      this.legendRef.classList.remove('dygraph-legend--right')
-    }
+    this.setState({arrowPosition: 'top'})
 
     // If legend is only clipped on the bottom, position above graph
     if (isLegendBottomClipped && !isLegendTopClipped) {
-      this.legendRef.classList.add('dygraph-legend--bottom')
-      this.legendRef.classList.remove('dygraph-legend--top')
-      this.legendRef.classList.remove('dygraph-legend--left')
-      this.legendRef.classList.remove('dygraph-legend--right')
+      this.setState({arrowPosition: 'bottom'})
       legendTop = -legendHeight
     }
     // If legend is clipped on top and bottom, posiition on either side of crosshair
@@ -393,19 +386,13 @@ export default class Dygraph extends Component {
       legendTop = 0
 
       if (willLegendFitLeft) {
+        this.setState({arrowPosition: 'right'})
         legendLeft = trueGraphX - legendWidth / 2
         legendLeft -= 8
-        this.legendRef.classList.add('dygraph-legend--right')
-        this.legendRef.classList.remove('dygraph-legend--top')
-        this.legendRef.classList.remove('dygraph-legend--bottom')
-        this.legendRef.classList.remove('dygraph-legend--left')
       } else {
+        this.setState({arrowPosition: 'left'})
         legendLeft = trueGraphX + legendWidth / 2
         legendLeft += 32
-        this.legendRef.classList.add('dygraph-legend--left')
-        this.legendRef.classList.remove('dygraph-legend--top')
-        this.legendRef.classList.remove('dygraph-legend--right')
-        this.legendRef.classList.remove('dygraph-legend--bottom')
       }
     }
 
@@ -438,11 +425,12 @@ export default class Dygraph extends Component {
   render() {
     const {
       legend,
-      filterText,
-      isAscending,
       sortType,
       isHidden,
       isSnipped,
+      filterText,
+      isAscending,
+      arrowPosition,
       isFilterVisible,
     } = this.state
 
@@ -462,6 +450,7 @@ export default class Dygraph extends Component {
           legendRef={this.handleLegendRef}
           onToggleFilter={this.handleToggleFilter}
           onInputChange={this.handleLegendInputChange}
+          arrowPosition={arrowPosition}
         />
         <div
           ref={r => {

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -342,6 +342,8 @@ export default class Dygraph extends Component {
   }
 
   highlightCallback = e => {
+    const chronografChromeSize = 60 // Width & Height of navigation page elements
+
     // Move the Legend on hover
     const graphRect = this.graphRef.getBoundingClientRect()
     const legendRect = this.legendRef.getBoundingClientRect()
@@ -366,13 +368,45 @@ export default class Dygraph extends Component {
 
     // Disallow screen overflow of legend
     const isLegendBottomClipped = graphBottom + legendHeight > screenHeight
+    const isLegendTopClipped =
+      legendHeight > graphRect.top - chronografChromeSize
+    const willLegendFitLeft = e.pageX - chronografChromeSize > legendWidth
 
-    const legendTop = isLegendBottomClipped ? -legendHeight : graphHeight + 8
+    let legendTop = graphHeight + 8
+    if (!isLegendBottomClipped && !isLegendTopClipped) {
+      this.legendRef.classList.add('dygraph-legend--top')
+      this.legendRef.classList.remove('dygraph-legend--bottom')
+      this.legendRef.classList.remove('dygraph-legend--left')
+      this.legendRef.classList.remove('dygraph-legend--right')
+    }
 
-    if (isLegendBottomClipped) {
-      this.legendRef.classList.add('dygraph-legend--above')
-    } else {
-      this.legendRef.classList.remove('dygraph-legend--above')
+    // If legend is only clipped on the bottom, position above graph
+    if (isLegendBottomClipped && !isLegendTopClipped) {
+      this.legendRef.classList.add('dygraph-legend--bottom')
+      this.legendRef.classList.remove('dygraph-legend--top')
+      this.legendRef.classList.remove('dygraph-legend--left')
+      this.legendRef.classList.remove('dygraph-legend--right')
+      legendTop = -legendHeight
+    }
+    // If legend is clipped on top and bottom, posiition on either side of crosshair
+    if (isLegendBottomClipped && isLegendTopClipped) {
+      legendTop = 0
+
+      if (willLegendFitLeft) {
+        legendLeft = trueGraphX - legendWidth / 2
+        legendLeft -= 8
+        this.legendRef.classList.add('dygraph-legend--right')
+        this.legendRef.classList.remove('dygraph-legend--top')
+        this.legendRef.classList.remove('dygraph-legend--bottom')
+        this.legendRef.classList.remove('dygraph-legend--left')
+      } else {
+        legendLeft = trueGraphX + legendWidth / 2
+        legendLeft += 32
+        this.legendRef.classList.add('dygraph-legend--left')
+        this.legendRef.classList.remove('dygraph-legend--top')
+        this.legendRef.classList.remove('dygraph-legend--right')
+        this.legendRef.classList.remove('dygraph-legend--bottom')
+      }
     }
 
     this.legendRef.style.left = `${legendLeft}px`

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -37,7 +37,7 @@ export default class Dygraph extends Component {
       isAscending: true,
       isSnipped: false,
       isFilterVisible: false,
-      arrowPosition: 'top',
+      legendArrowPosition: 'top',
     }
   }
 
@@ -374,11 +374,11 @@ export default class Dygraph extends Component {
     const willLegendFitLeft = e.pageX - chronografChromeSize > legendWidth
 
     let legendTop = graphHeight + 8
-    this.setState({arrowPosition: 'top'})
+    this.setState({legendArrowPosition: 'top'})
 
     // If legend is only clipped on the bottom, position above graph
     if (isLegendBottomClipped && !isLegendTopClipped) {
-      this.setState({arrowPosition: 'bottom'})
+      this.setState({legendArrowPosition: 'bottom'})
       legendTop = -legendHeight
     }
     // If legend is clipped on top and bottom, posiition on either side of crosshair
@@ -386,11 +386,11 @@ export default class Dygraph extends Component {
       legendTop = 0
 
       if (willLegendFitLeft) {
-        this.setState({arrowPosition: 'right'})
+        this.setState({legendArrowPosition: 'right'})
         legendLeft = trueGraphX - legendWidth / 2
         legendLeft -= 8
       } else {
-        this.setState({arrowPosition: 'left'})
+        this.setState({legendArrowPosition: 'left'})
         legendLeft = trueGraphX + legendWidth / 2
         legendLeft += 32
       }
@@ -430,7 +430,7 @@ export default class Dygraph extends Component {
       isSnipped,
       filterText,
       isAscending,
-      arrowPosition,
+      legendArrowPosition,
       isFilterVisible,
     } = this.state
 
@@ -450,7 +450,7 @@ export default class Dygraph extends Component {
           legendRef={this.handleLegendRef}
           onToggleFilter={this.handleToggleFilter}
           onInputChange={this.handleLegendInputChange}
-          arrowPosition={arrowPosition}
+          arrowPosition={legendArrowPosition}
         />
         <div
           ref={r => {

--- a/ui/src/shared/components/DygraphLegend.js
+++ b/ui/src/shared/components/DygraphLegend.js
@@ -8,20 +8,21 @@ const removeMeasurement = (label = '') => {
 }
 
 const DygraphLegend = ({
+  xHTML,
   series,
   onSort,
   onSnip,
   onHide,
   isHidden,
-  isFilterVisible,
   isSnipped,
   sortType,
   legendRef,
   filterText,
   isAscending,
   onInputChange,
+  arrowPosition,
+  isFilterVisible,
   onToggleFilter,
-  xHTML,
 }) => {
   const sorted = _.sortBy(
     series,
@@ -64,7 +65,7 @@ const DygraphLegend = ({
 
   return (
     <div
-      className={`dygraph-legend ${hidden}`}
+      className={`dygraph-legend dygraph-legend--${arrowPosition} ${hidden}`}
       ref={legendRef}
       onMouseLeave={onHide}
     >
@@ -153,6 +154,7 @@ DygraphLegend.propTypes = {
   legendRef: func.isRequired,
   isSnipped: bool.isRequired,
   isFilterVisible: bool.isRequired,
+  arrowPosition: string.isRequired,
 }
 
 export default DygraphLegend

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -148,23 +148,37 @@
     display: none !important;
   }
 
-  // Arrow
+  // Arrow (default is on top of legend aka below graph)
   &:after {
     content: '';
     position: absolute;
     border-width: 8px;
     border-style: solid;
     border-color: transparent;
+  }
+  &.dygraph-legend--top:after {
+    top: -16px;
     border-bottom-color: $g0-obsidian;
     left: 50%;
-    top: -16px;
     transform: translateX(-50%);
   }
-  &.dygraph-legend--above:after {
-    top: initial;
-    border-color: transparent;
-    border-top-color: $g0-obsidian;
+  &.dygraph-legend--bottom:after {
     bottom: -16px;
+    border-top-color: $g0-obsidian;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  &.dygraph-legend--left:after {
+    left: -16px;
+    border-right-color: $g0-obsidian;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  &.dygraph-legend--right:after {
+    right: -16px;
+    border-left-color: $g0-obsidian;
+    top: 50%;
+    transform: translateY(-50%);
   }
 }
 .dygraph-legend--header {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2024 

### The Problem
- When a cell is the height of the entire dashboard, the legend gets clipped above the cell

### The Solution
- When the legend cannot fit above or below a cell, it will either appear to the right or left of the crosshair based on available space
- Didn't update changelog as my previous entry for the same issue still encapsulates this fix

### Preview
![screen shot 2017-09-27 at 6 38 55 pm](https://user-images.githubusercontent.com/2433762/30945661-5997434e-a3b4-11e7-8440-d1b8b8cde1fa.png)
Legend positioned to left of crosshair on full height cell

![screen shot 2017-09-27 at 6 38 45 pm](https://user-images.githubusercontent.com/2433762/30945670-67a32110-a3b4-11e7-98e0-467fd2ecb276.png)
Legend positioned to right of crosshair on full height cell


