### PR TITLE
UI-IMPROVEMENT: Add custom findClosestPoint method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Improve usability of dashboard cell context menus
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Move dashboard cell renaming UI into Cell Editor Overlay
 1. [#2040](https://github.com/influxdata/chronograf/pull/2040): Prevent the legend from overlapping graphs at the bottom of the screen
+1. [#2052](https://github.com/influxdata/chronograf/pull/2052): Make hovering over series smoother
 
 ## v1.3.8.1 [unreleased]
 ### Bug Fixes

--- a/ui/src/external/dygraph.js
+++ b/ui/src/external/dygraph.js
@@ -248,6 +248,57 @@ function attachSelectionHandlers(gs, prevCallbacks) {
   }
 }
 
+function isValidPoint(p, opt_allowNaNY) {
+  if (!p) return false // null or undefined object
+  if (p.yval === null) return false // missing point
+  if (p.x === null || p.x === undefined) return false
+  if (p.y === null || p.y === undefined) return false
+  if (isNaN(p.x) || (!opt_allowNaNY && isNaN(p.y))) return false
+  return true
+}
+
+Dygraph.prototype.findClosestPoint = function(domX, domY) {
+  if (Dygraph.VERSION !== '2.0.0') {
+    console.error(
+      `Dygraph version changed to ${Dygraph.VERSION} - re-copy findClosestPoint`
+    )
+  }
+  var minXDist = Infinity
+  var minYDist = Infinity
+  var xdist, ydist, dx, dy, point, closestPoint, closestSeries, closestRow
+  for (var setIdx = this.layout_.points.length - 1; setIdx >= 0; --setIdx) {
+    var points = this.layout_.points[setIdx]
+    for (var i = 0; i < points.length; ++i) {
+      point = points[i]
+      if (!isValidPoint(point)) continue
+
+      dx = point.canvasx - domX
+      dy = point.canvasy - domY
+
+      xdist = dx * dx
+      ydist = dy * dy
+
+      if (xdist < minXDist) {
+        minXDist = xdist
+        minYDist = ydist
+        closestRow = point.idx
+        closestSeries = setIdx
+      } else if (xdist === minXDist && ydist < minYDist) {
+        minXDist = xdist
+        minYDist = ydist
+        closestRow = point.idx
+        closestSeries = setIdx
+      }
+    }
+  }
+  var name = this.layout_.setNames[closestSeries]
+  return {
+    row: closestRow,
+    seriesName: name,
+    point: closestPoint,
+  }
+}
+
 Dygraph.synchronize = synchronize
 
 Dygraph.Plugins.Crosshair = (function() {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2039 

### The problem
Dygraph's current `findClosestPoint` method technically finds the closest point to the cursor.  However, that's not really how human eyes expect hovering to work.  When hovering horizontally, users expect the hover line to highlight the nearest point that intersects with the hover line.  

### The Solution
Prioritize the closest x-value first. Then, if there is an x-value tie use the y-value as the tie breaker.  This results in a smoother and less 'jumpy' and 'jagged' hovering experience.  The smoothness is a bit difficult to display in a GIF, but take a look at the differences...


### Before. 

Notice how only the peaks get highlighted:

![](http://g.recordit.co/JrM4RKk8pD.gif)

### After

Notice how the troughs are now highlighted:

![kapture 2017-09-29 at 11 35 41](https://user-images.githubusercontent.com/7582765/31030502-6d89d9a0-a50a-11e7-8e10-e690457b2f9e.gif)

