### PR TITLE
UI IMPROVEMENT: Add Plus Icon to all Add/Create buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Improve usability of dashboard cell context menus
 1. [#2002](https://github.com/influxdata/chronograf/pull/2002): Move dashboard cell renaming UI into Cell Editor Overlay
 1. [#2040](https://github.com/influxdata/chronograf/pull/2040): Prevent the legend from overlapping graphs at the bottom of the screen
+1. [#2054](https://github.com/influxdata/chronograf/pull/2054): Add a "Plus" icon to every button with an Add or Create action for clarity and consistency
 
 ## v1.3.8.1 [unreleased]
 ### Bug Fixes

--- a/ui/src/admin/components/DatabaseManager.js
+++ b/ui/src/admin/components/DatabaseManager.js
@@ -37,7 +37,7 @@ const DatabaseManager = ({
           disabled={isAddDBDisabled}
           onClick={addDatabase}
         >
-          Create Database
+          <span className="icon plus" /> Create Database
         </button>
       </div>
       <div className="panel-body">

--- a/ui/src/admin/components/DatabaseTableHeader.js
+++ b/ui/src/admin/components/DatabaseTableHeader.js
@@ -59,7 +59,7 @@ const Header = ({
         disabled={isAddRPDisabled}
         onClick={onAddRetentionPolicy(database)}
       >
-        Add Retention Policy
+        <span className="icon plus" /> Add Retention Policy
       </button>
       {database.name === '_internal'
         ? null

--- a/ui/src/admin/components/FilterBar.js
+++ b/ui/src/admin/components/FilterBar.js
@@ -44,7 +44,8 @@ class FilterBar extends Component {
           disabled={isEditing}
           onClick={onClickCreate(type)}
         >
-          Create {placeholderText.substring(0, placeholderText.length - 1)}
+          <span className="icon plus" /> Create{' '}
+          {placeholderText.substring(0, placeholderText.length - 1)}
         </button>
       </div>
     )

--- a/ui/src/dashboards/components/DashboardsPageContents.js
+++ b/ui/src/dashboards/components/DashboardsPageContents.js
@@ -32,7 +32,7 @@ const DashboardsPageContents = ({
                   className="btn btn-sm btn-primary"
                   onClick={onCreateDashboard}
                 >
-                  Create Dashboard
+                  <span className="icon plus" /> Create Dashboard
                 </button>
               </div>
               <div className="panel-body">

--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -54,7 +54,7 @@ const DashboardsTable = ({
           onClick={onCreateDashboard}
           style={{marginBottom: '90px'}}
         >
-          Create Dashboard
+          <span className="icon plus" /> Create Dashboard
         </button>
       </div>
 }

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -59,7 +59,7 @@ const KapacitorRules = ({
             className="btn btn-sm btn-primary"
             style={{marginRight: '4px'}}
           >
-            Build Rule
+            <span className="icon plus" /> Build Rule
           </Link>
         </div>
       </div>

--- a/ui/src/shared/components/EmptyQuery.js
+++ b/ui/src/shared/components/EmptyQuery.js
@@ -5,7 +5,7 @@ const EmptyQueryState = ({onAddQuery}) =>
     <h5>This Graph has no Queries</h5>
     <br />
     <div className="btn btn-primary" onClick={onAddQuery}>
-      Add a Query
+      <span className="icon plus" /> Add a Query
     </div>
   </div>
 

--- a/ui/src/shared/components/LayoutCell.js
+++ b/ui/src/shared/components/LayoutCell.js
@@ -60,7 +60,7 @@ class LayoutCell extends Component {
                   className="no-query--button btn btn-md btn-primary"
                   onClick={this.handleSummonOverlay(cell)}
                 >
-                  Add Graph
+                  <span className="icon plus" /> Add Graph
                 </button>
               </div>}
         </div>

--- a/ui/src/sources/components/InfluxTable.js
+++ b/ui/src/sources/components/InfluxTable.js
@@ -17,7 +17,7 @@ const kapacitorDropdown = (
         to={`/sources/${source.id}/kapacitors/new`}
         className="btn btn-xs btn-default"
       >
-        Add Config
+        <span className="icon plus" /> Add Config
       </Link>
     )
   }
@@ -89,7 +89,7 @@ const InfluxTable = ({
             to={`/sources/${source.id}/manage-sources/new`}
             className="btn btn-sm btn-primary"
           >
-            Add Source
+            <span className="icon plus" /> Add Source
           </Link>
         </div>
         <div className="panel-body">


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2026 

### The Problem
- Most buttons with an add or create action do not have matching icons

### The Solution
- All add/create buttons have a plus icon

### Preview
![screen shot 2017-09-29 at 2 12 19 pm](https://user-images.githubusercontent.com/2433762/31036276-48876d46-a520-11e7-804a-8eba7aed43e5.png)
![screen shot 2017-09-29 at 2 12 13 pm](https://user-images.githubusercontent.com/2433762/31036283-4b74efc4-a520-11e7-85e0-13dffaf1413a.png)
![screen shot 2017-09-29 at 2 12 07 pm](https://user-images.githubusercontent.com/2433762/31036286-4c94dbbc-a520-11e7-8322-e5efa18f9a67.png)
![screen shot 2017-09-29 at 2 11 58 pm](https://user-images.githubusercontent.com/2433762/31036287-4e519cc4-a520-11e7-8d81-41e9b38c7d5c.png)
![screen shot 2017-09-29 at 2 11 53 pm](https://user-images.githubusercontent.com/2433762/31036288-501b7ca0-a520-11e7-824a-f68f8410647e.png)
![screen shot 2017-09-29 at 2 11 46 pm](https://user-images.githubusercontent.com/2433762/31036291-5246ad92-a520-11e7-9e4d-d255cc9547b3.png)
![screen shot 2017-09-29 at 2 11 26 pm](https://user-images.githubusercontent.com/2433762/31036293-5490a512-a520-11e7-93bb-65c65ed19e45.png)

