### PR TITLE
Add env override to chronograf.service

### DIFF
--- a/etc/scripts/chronograf.service
+++ b/etc/scripts/chronograf.service
@@ -8,6 +8,7 @@ After=network-online.target
 [Service]
 User=chronograf
 Group=chronograf
+EnvironmentFile=-/etc/default/chronograf
 ExecStart=/usr/bin/chronograf --host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned
 KillMode=control-group
 Restart=on-failure


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem
Chronograf does not have a default env override to the chronograf.service systemd service config

### The Solution
Add a default that matches other TICK products

