### PR TITLE
Prevent CEO toggle from de-centering when no queries present

### DIFF
--- a/ui/src/dashboards/components/OverlayControls.js
+++ b/ui/src/dashboards/components/OverlayControls.js
@@ -16,13 +16,12 @@ const OverlayControls = ({
   onClickDisplayOptions,
 }) =>
   <div className="overlay-controls">
-    {queries.length
-      ? <SourceSelector
-          sources={sources}
-          selected={selected}
-          onSetQuerySource={onSetQuerySource}
-        />
-      : null}
+    <SourceSelector
+      sources={sources}
+      selected={selected}
+      onSetQuerySource={onSetQuerySource}
+      queries={queries}
+    />
     <ul className="nav nav-tablist nav-tablist-sm">
       <li
         key="queries"

--- a/ui/src/dashboards/components/SourceSelector.js
+++ b/ui/src/dashboards/components/SourceSelector.js
@@ -1,8 +1,8 @@
 import React, {PropTypes} from 'react'
 import Dropdown from 'shared/components/Dropdown'
 
-const SourceSelector = ({sources = [], selected, onSetQuerySource}) =>
-  sources.length > 1
+const SourceSelector = ({sources = [], selected, onSetQuerySource, queries}) =>
+  sources.length > 1 && queries.length
     ? <div className="source-selector">
         <h3>Source:</h3>
         <Dropdown
@@ -15,14 +15,15 @@ const SourceSelector = ({sources = [], selected, onSetQuerySource}) =>
           className="dropdown-240"
         />
       </div>
-    : null
+    : <div className="source-selector" />
 
-const {arrayOf, func, shape, string} = PropTypes
+const {array, arrayOf, func, shape, string} = PropTypes
 
 SourceSelector.propTypes = {
   sources: arrayOf(shape()).isRequired,
   onSetQuerySource: func.isRequired,
   selected: string,
+  queries: array,
 }
 
 export default SourceSelector


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The Problem
- CEO options toggle becomes uncentered when no queries present

### The Solution
- CEO options toggle always centered

![ceo-toggle-center](https://user-images.githubusercontent.com/2433762/31206245-6ac4a824-a92b-11e7-97c1-3d30fb96b996.gif)


