### PR TITLE
Fixes #1077 by removing win_system and system from the select query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.3.11.0 [unreleased]
 ### Bug Fixes
 1. [#2167](https://github.com/influxdata/chronograf/pull/2167): Add fractions of seconds to time field in csv export
+2. [#1077](https://github.com/influxdata/chronograf/pull/2087):  Fix Chronograf requires users to run Telegraf's CPU and system plugins to ensure that all Apps appear on the HOST LIST page.
 ### Features
 ### UI Improvements
 

--- a/ui/src/hosts/apis/index.js
+++ b/ui/src/hosts/apis/index.js
@@ -11,7 +11,7 @@ export function getCpuAndLoadForHosts(proxyLink, telegrafDB) {
       SELECT mean("Percent_Processor_Time") FROM win_cpu WHERE time > now() - 10m GROUP BY host;
       SELECT mean("Processor_Queue_Length") FROM win_system WHERE time > now() - 10s GROUP BY host;
       SELECT non_negative_derivative(mean("System_Up_Time")) AS winDeltaUptime FROM win_system WHERE time > now() - 10m GROUP BY host, time(1m) fill(0);
-      SHOW TAG VALUES FROM /win_system|system/ WITH KEY = "host"`,
+      SHOW TAG VALUES WITH KEY = "host";`,
     db: telegrafDB,
   }).then(resp => {
     const hosts = {}
@@ -87,7 +87,7 @@ export async function getAllHosts(proxyLink, telegrafDB) {
   try {
     const resp = await proxy({
       source: proxyLink,
-      query: 'show tag values from /win_system|system/ with key = "host"',
+      query: 'show tag values with key = "host"',
       db: telegrafDB,
     })
     const hosts = {}


### PR DESCRIPTION
Added Avg Ping to hosts table

Added last packet loss capture

Updated status to check the ping statistics when the cpu statistics are not available. Before marking the host as down.


  - [x ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x ] Rebased/mergable
  - [x ] Tests pass
  - [x ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #

### The problem

### The Solution


