### PR TITLE
Redesign Dashboard Naming Interaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@
 1. [#2111](https://github.com/influxdata/chronograf/pull/2111): Increase size of Cell Editor query tabs to reveal more of their query strings
 1. [#2120](https://github.com/influxdata/chronograf/pull/2120): Improve appearance of Admin Page tabs on smaller screens
 1. [#2119](https://github.com/influxdata/chronograf/pull/2119): Add cancel button to Tickscript editor
+1.[#2104](https://github.com/influxdata/chronograf/pull/2104): Redesign dashboard naming & renaming interaction
+1.[#2104](https://github.com/influxdata/chronograf/pull/2104): Redesign dashboard switching dropdown
 
 ## v1.3.9.0 [2017-10-06]
 ### Bug Fixes

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -40,11 +40,13 @@ const DashboardHeader = ({
                 : 'page-header__left'
             }
           >
-            <DashboardSwitcher
-              dashboards={dashboards}
-              currentDashboard={dashboardName}
-              sourceID={sourceID}
-            />
+            {dashboards.length > 1
+              ? <DashboardSwitcher
+                  dashboards={dashboards}
+                  currentDashboard={dashboardName}
+                  sourceID={sourceID}
+                />
+              : null}
             {dashboard
               ? <DashboardHeaderEdit
                   onSave={onSave}

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -9,6 +9,7 @@ import DashboardHeaderEdit from 'src/dashboards/components/DashboardHeaderEdit'
 import DashboardSwitcher from 'src/dashboards/components/DashboardSwitcher'
 
 const DashboardHeader = ({
+  hosts,
   onSave,
   sourceID,
   onCancel,
@@ -40,9 +41,16 @@ const DashboardHeader = ({
                 : 'page-header__left'
             }
           >
-            {dashboards.length > 1
+            {dashboards && dashboards.length > 1
               ? <DashboardSwitcher
                   dashboards={dashboards}
+                  currentDashboard={dashboardName}
+                  sourceID={sourceID}
+                />
+              : null}
+            {hosts && hosts.length > 1
+              ? <DashboardSwitcher
+                  hosts={hosts}
                   currentDashboard={dashboardName}
                   sourceID={sourceID}
                 />
@@ -95,7 +103,7 @@ const DashboardHeader = ({
               className="btn btn-default btn-sm btn-square"
               onClick={handleClickPresentationButton}
             >
-              <span className="icon expand-a" style={{margin: 0}} />
+              <span className="icon expand-a" />
             </div>
           </div>
         </div>
@@ -112,7 +120,7 @@ DashboardHeader.defaultProps = {
 
 DashboardHeader.propTypes = {
   dashboardName: string.isRequired,
-  onEditDashboard: func.isRequired,
+  onEditDashboard: func,
   dashboard: shape({}),
   timeRange: shape({
     lower: string,
@@ -129,10 +137,11 @@ DashboardHeader.propTypes = {
   onToggleTempVarControls: func,
   showTemplateControlBar: bool,
   zoomedTimeRange: shape({}),
-  onCancel: func.isRequired,
-  onSave: func.isRequired,
-  dashboards: arrayOf(shape({})).isRequired,
-  sourceID: string.isRequired,
+  onCancel: func,
+  onSave: func,
+  dashboards: arrayOf(shape({})),
+  sourceID: string,
+  hosts: arrayOf(shape({})),
 }
 
 export default DashboardHeader

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -9,17 +9,15 @@ import DashboardHeaderEdit from 'src/dashboards/components/DashboardHeaderEdit'
 import DashboardSwitcher from 'src/dashboards/components/DashboardSwitcher'
 
 const DashboardHeader = ({
-  hosts,
+  names,
   onSave,
-  sourceID,
   onCancel,
   isEditMode,
   isHidden,
   dashboard,
   onAddCell,
-  dashboards,
   autoRefresh,
-  dashboardName,
+  activeDashboard,
   onEditDashboard,
   onManualRefresh,
   handleChooseTimeRange,
@@ -41,30 +39,22 @@ const DashboardHeader = ({
                 : 'page-header__left'
             }
           >
-            {dashboards && dashboards.length > 1
+            {names && names.length > 1
               ? <DashboardSwitcher
-                  dashboards={dashboards}
-                  currentDashboard={dashboardName}
-                  sourceID={sourceID}
-                />
-              : null}
-            {hosts && hosts.length > 1
-              ? <DashboardSwitcher
-                  hosts={hosts}
-                  currentDashboard={dashboardName}
-                  sourceID={sourceID}
+                  names={names}
+                  activeDashboard={activeDashboard}
                 />
               : null}
             {dashboard
               ? <DashboardHeaderEdit
                   onSave={onSave}
                   onCancel={onCancel}
-                  dashboardName={dashboardName}
+                  activeDashboard={activeDashboard}
                   onEditDashboard={onEditDashboard}
                   isEditMode={isEditMode}
                 />
               : <h1 className="page-header__title">
-                  {dashboardName}
+                  {activeDashboard}
                 </h1>}
           </div>
           <div className="page-header__right">
@@ -119,7 +109,7 @@ DashboardHeader.defaultProps = {
 }
 
 DashboardHeader.propTypes = {
-  dashboardName: string.isRequired,
+  activeDashboard: string.isRequired,
   onEditDashboard: func,
   dashboard: shape({}),
   timeRange: shape({
@@ -139,9 +129,7 @@ DashboardHeader.propTypes = {
   zoomedTimeRange: shape({}),
   onCancel: func,
   onSave: func,
-  dashboards: arrayOf(shape({})),
-  sourceID: string,
-  hosts: arrayOf(shape({})),
+  names: arrayOf(shape({})).isRequired,
 }
 
 export default DashboardHeader

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -10,7 +10,6 @@ const DashboardHeader = ({
   children,
   buttonText,
   dashboard,
-  headerText,
   timeRange: {upper, lower},
   zoomedTimeRange: {zoomedLower, zoomedUpper},
   autoRefresh,
@@ -45,7 +44,6 @@ const DashboardHeader = ({
                   {children}
                 </ul>
               </div>}
-            {headerText}
           </div>
           <div className="page-header__right">
             <GraphTips />
@@ -111,7 +109,6 @@ DashboardHeader.propTypes = {
   children: array,
   buttonText: string,
   dashboard: shape({}),
-  headerText: string,
   timeRange: shape({
     lower: string,
     upper: string,

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -1,49 +1,44 @@
 import React, {PropTypes} from 'react'
 import classnames from 'classnames'
+import _ from 'lodash'
 
 import AutoRefreshDropdown from 'shared/components/AutoRefreshDropdown'
 import TimeRangeDropdown from 'shared/components/TimeRangeDropdown'
 import SourceIndicator from 'shared/components/SourceIndicator'
 import GraphTips from 'shared/components/GraphTips'
+import DashboardHeaderEdit from 'src/dashboards/components/DashboardHeaderEdit'
 
 const DashboardHeader = ({
+  onSave,
   children,
-  buttonText,
-  dashboard,
-  timeRange: {upper, lower},
-  zoomedTimeRange: {zoomedLower, zoomedUpper},
-  autoRefresh,
+  onCancel,
+  isEditMode,
   isHidden,
+  dashboard,
+  onAddCell,
+  autoRefresh,
+  dashboardName,
+  onEditDashboard,
+  onManualRefresh,
   handleChooseTimeRange,
   handleChooseAutoRefresh,
-  onManualRefresh,
-  handleClickPresentationButton,
-  onAddCell,
-  onEditDashboard,
   onToggleTempVarControls,
   showTemplateControlBar,
+  timeRange: {upper, lower},
+  handleClickPresentationButton,
+  zoomedTimeRange: {zoomedLower, zoomedUpper},
 }) =>
   isHidden
     ? null
     : <div className="page-header full-width">
         <div className="page-header__container">
-          <div className="page-header__left">
-            {buttonText &&
-              <div className="dropdown page-header-dropdown">
-                <button
-                  className="dropdown-toggle"
-                  type="button"
-                  data-toggle="dropdown"
-                >
-                  <span>
-                    {buttonText}
-                  </span>
-                  <span className="caret" />
-                </button>
-                <ul className="dropdown-menu">
-                  {children}
-                </ul>
-              </div>}
+          <div
+            className={
+              dashboard
+                ? 'page-header__left page-header__dash-editable'
+                : 'page-header__left'
+            }
+          >
             {children.length > 1
               ? <div className="dropdown dashboard-switcher">
                   <button
@@ -60,6 +55,17 @@ const DashboardHeader = ({
                   </ul>
                 </div>
               : null}
+            {dashboard
+              ? <DashboardHeaderEdit
+                  onSave={onSave}
+                  onCancel={onCancel}
+                  dashboardName={dashboardName}
+                  onEditDashboard={onEditDashboard}
+                  isEditMode={isEditMode}
+                />
+              : <h1 className="page-header__title">
+                  {dashboardName}
+                </h1>}
           </div>
           <div className="page-header__right">
             <GraphTips />
@@ -68,15 +74,6 @@ const DashboardHeader = ({
               ? <button className="btn btn-primary btn-sm" onClick={onAddCell}>
                   <span className="icon plus" />
                   Add Cell
-                </button>
-              : null}
-            {dashboard
-              ? <button
-                  className="btn btn-default btn-sm"
-                  onClick={onEditDashboard}
-                >
-                  <span className="icon pencil" />
-                  Rename
                 </button>
               : null}
             {dashboard
@@ -123,7 +120,8 @@ DashboardHeader.defaultProps = {
 
 DashboardHeader.propTypes = {
   children: array,
-  buttonText: string,
+  dashboardName: string.isRequired,
+  onEditDashboard: func.isRequired,
   dashboard: shape({}),
   timeRange: shape({
     lower: string,
@@ -131,15 +129,17 @@ DashboardHeader.propTypes = {
   }).isRequired,
   autoRefresh: number.isRequired,
   isHidden: bool.isRequired,
+  isEditMode: bool,
   handleChooseTimeRange: func.isRequired,
   handleChooseAutoRefresh: func.isRequired,
   onManualRefresh: func.isRequired,
   handleClickPresentationButton: func.isRequired,
   onAddCell: func,
-  onEditDashboard: func,
   onToggleTempVarControls: func,
   showTemplateControlBar: bool,
   zoomedTimeRange: shape({}),
+  onCancel: func.isRequired,
+  onSave: func.isRequired,
 }
 
 export default DashboardHeader

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -44,6 +44,22 @@ const DashboardHeader = ({
                   {children}
                 </ul>
               </div>}
+            {children.length > 1
+              ? <div className="dropdown dashboard-switcher">
+                  <button
+                    className="btn btn-square btn-default btn-sm dropdown-toggle"
+                    type="button"
+                    data-toggle="dropdown"
+                  >
+                    <span className="icon dash-f" />
+                  </button>
+                  <ul className="dropdown-menu">
+                    {_.sortBy(children, c =>
+                      c.props.children.props.children.toLowerCase()
+                    )}
+                  </ul>
+                </div>
+              : null}
           </div>
           <div className="page-header__right">
             <GraphTips />

--- a/ui/src/dashboards/components/DashboardHeader.js
+++ b/ui/src/dashboards/components/DashboardHeader.js
@@ -1,21 +1,22 @@
 import React, {PropTypes} from 'react'
 import classnames from 'classnames'
-import _ from 'lodash'
 
 import AutoRefreshDropdown from 'shared/components/AutoRefreshDropdown'
 import TimeRangeDropdown from 'shared/components/TimeRangeDropdown'
 import SourceIndicator from 'shared/components/SourceIndicator'
 import GraphTips from 'shared/components/GraphTips'
 import DashboardHeaderEdit from 'src/dashboards/components/DashboardHeaderEdit'
+import DashboardSwitcher from 'src/dashboards/components/DashboardSwitcher'
 
 const DashboardHeader = ({
   onSave,
-  children,
+  sourceID,
   onCancel,
   isEditMode,
   isHidden,
   dashboard,
   onAddCell,
+  dashboards,
   autoRefresh,
   dashboardName,
   onEditDashboard,
@@ -39,22 +40,11 @@ const DashboardHeader = ({
                 : 'page-header__left'
             }
           >
-            {children.length > 1
-              ? <div className="dropdown dashboard-switcher">
-                  <button
-                    className="btn btn-square btn-default btn-sm dropdown-toggle"
-                    type="button"
-                    data-toggle="dropdown"
-                  >
-                    <span className="icon dash-f" />
-                  </button>
-                  <ul className="dropdown-menu">
-                    {_.sortBy(children, c =>
-                      c.props.children.props.children.toLowerCase()
-                    )}
-                  </ul>
-                </div>
-              : null}
+            <DashboardSwitcher
+              dashboards={dashboards}
+              currentDashboard={dashboardName}
+              sourceID={sourceID}
+            />
             {dashboard
               ? <DashboardHeaderEdit
                   onSave={onSave}
@@ -109,7 +99,7 @@ const DashboardHeader = ({
         </div>
       </div>
 
-const {array, bool, func, number, shape, string} = PropTypes
+const {arrayOf, bool, func, number, shape, string} = PropTypes
 
 DashboardHeader.defaultProps = {
   zoomedTimeRange: {
@@ -119,7 +109,6 @@ DashboardHeader.defaultProps = {
 }
 
 DashboardHeader.propTypes = {
-  children: array,
   dashboardName: string.isRequired,
   onEditDashboard: func.isRequired,
   dashboard: shape({}),
@@ -140,6 +129,8 @@ DashboardHeader.propTypes = {
   zoomedTimeRange: shape({}),
   onCancel: func.isRequired,
   onSave: func.isRequired,
+  dashboards: arrayOf(shape({})).isRequired,
+  sourceID: string.isRequired,
 }
 
 export default DashboardHeader

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -36,6 +36,10 @@ class DashboardEditHeader extends Component {
     }
   }
 
+  handleFocus = e => {
+    e.target.select()
+  }
+
   render() {
     const {onEditDashboard, isEditMode, dashboardName} = this.props
 
@@ -52,6 +56,7 @@ class DashboardEditHeader extends Component {
               spellCheck={false}
               onBlur={this.handleInputBlur}
               onKeyDown={this.handleKeyDown}
+              onFocus={this.handleFocus}
               placeholder="Name this Dashboard"
               ref={r => (this.inputRef = r)}
             />

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -1,70 +1,76 @@
 import React, {PropTypes, Component} from 'react'
-import ConfirmButtons from 'shared/components/ConfirmButtons'
+import {
+  DASHBOARD_NAME_MAX_LENGTH,
+  NEW_DASHBOARD,
+} from 'src/dashboards/constants/index'
 
 class DashboardEditHeader extends Component {
   constructor(props) {
     super(props)
 
-    const {dashboard: {name}} = props
     this.state = {
-      name,
+      reset: false,
     }
   }
 
-  handleChange = e => {
-    this.setState({name: e.target.value})
-  }
+  handleInputBlur = e => {
+    const {onSave, onCancel} = this.props
+    const {reset} = this.state
 
-  handleFormSubmit = e => {
-    e.preventDefault()
-    const name = e.target.name.value
-    this.props.onSave(name)
-  }
-
-  handleKeyUp = e => {
-    const {onCancel} = this.props
-    if (e.key === 'Escape') {
+    if (reset) {
       onCancel()
+    } else {
+      const newName = e.target.value || NEW_DASHBOARD.name
+      onSave(newName)
+    }
+    this.setState({reset: false})
+  }
+
+  handleKeyDown = e => {
+    if (e.key === 'Enter') {
+      this.inputRef.blur()
+    }
+    if (e.key === 'Escape') {
+      this.inputRef.value = this.props.dashboardName
+      this.setState({reset: true}, () => this.inputRef.blur())
     }
   }
 
   render() {
-    const {onSave, onCancel} = this.props
-    const {name} = this.state
+    const {onEditDashboard, isEditMode, dashboardName} = this.props
 
     return (
-      <div className="page-header full-width">
-        <div className="page-header__container">
-          <form
-            className="page-header__left"
-            style={{flex: '1 0 0%'}}
-            onSubmit={this.handleFormSubmit}
-          >
-            <input
-              className="page-header--editing"
-              name="name"
-              value={name}
-              placeholder="Name this Dashboard"
-              onKeyUp={this.handleKeyUp}
+      <div className="dashboard-title">
+        {isEditMode
+          ? <input
+              maxLength={DASHBOARD_NAME_MAX_LENGTH}
+              type="text"
+              className="dashboard-title--input form-control"
+              defaultValue={dashboardName}
+              autoComplete="off"
               autoFocus={true}
               spellCheck={false}
-              autoComplete="off"
-              onChange={this.handleChange}
+              onBlur={this.handleInputBlur}
+              onKeyDown={this.handleKeyDown}
+              placeholder="Name this Dashboard"
+              ref={r => (this.inputRef = r)}
             />
-          </form>
-          <ConfirmButtons item={name} onConfirm={onSave} onCancel={onCancel} />
-        </div>
+          : <h1 onClick={onEditDashboard}>
+              {dashboardName}
+            </h1>}
       </div>
     )
   }
 }
 
-const {shape, func} = PropTypes
+const {bool, func, string} = PropTypes
 
 DashboardEditHeader.propTypes = {
-  dashboard: shape({}),
-  onCancel: func.isRequired,
+  dashboardName: string.isRequired,
   onSave: func.isRequired,
+  onCancel: func.isRequired,
+  isEditMode: bool,
+  onEditDashboard: func.isRequired,
 }
 
 export default DashboardEditHeader

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -31,7 +31,7 @@ class DashboardEditHeader extends Component {
       this.inputRef.blur()
     }
     if (e.key === 'Escape') {
-      this.inputRef.value = this.props.dashboardName
+      this.inputRef.value = this.props.activeDashboard
       this.setState({reset: true}, () => this.inputRef.blur())
     }
   }
@@ -41,7 +41,7 @@ class DashboardEditHeader extends Component {
   }
 
   render() {
-    const {onEditDashboard, isEditMode, dashboardName} = this.props
+    const {onEditDashboard, isEditMode, activeDashboard} = this.props
 
     return (
       <div className="dashboard-title">
@@ -50,7 +50,7 @@ class DashboardEditHeader extends Component {
               maxLength={DASHBOARD_NAME_MAX_LENGTH}
               type="text"
               className="dashboard-title--input form-control input-sm"
-              defaultValue={dashboardName}
+              defaultValue={activeDashboard}
               autoComplete="off"
               autoFocus={true}
               spellCheck={false}
@@ -61,7 +61,7 @@ class DashboardEditHeader extends Component {
               ref={r => (this.inputRef = r)}
             />
           : <h1 onClick={onEditDashboard}>
-              {dashboardName}
+              {activeDashboard}
             </h1>}
       </div>
     )
@@ -71,7 +71,7 @@ class DashboardEditHeader extends Component {
 const {bool, func, string} = PropTypes
 
 DashboardEditHeader.propTypes = {
-  dashboardName: string.isRequired,
+  activeDashboard: string.isRequired,
   onSave: func.isRequired,
   onCancel: func.isRequired,
   isEditMode: bool,

--- a/ui/src/dashboards/components/DashboardHeaderEdit.js
+++ b/ui/src/dashboards/components/DashboardHeaderEdit.js
@@ -49,7 +49,7 @@ class DashboardEditHeader extends Component {
           ? <input
               maxLength={DASHBOARD_NAME_MAX_LENGTH}
               type="text"
-              className="dashboard-title--input form-control"
+              className="dashboard-title--input form-control input-sm"
               defaultValue={dashboardName}
               autoComplete="off"
               autoFocus={true}

--- a/ui/src/dashboards/components/DashboardSwitcher.js
+++ b/ui/src/dashboards/components/DashboardSwitcher.js
@@ -28,10 +28,6 @@ class DashboardSwitcher extends Component {
     const {dashboards, currentDashboard, sourceID} = this.props
     const {isOpen} = this.state
 
-    if (dashboards.length <= 1) {
-      return null
-    }
-
     return (
       <div
         className={classnames('dropdown dashboard-switcher', {open: isOpen})}

--- a/ui/src/dashboards/components/DashboardSwitcher.js
+++ b/ui/src/dashboards/components/DashboardSwitcher.js
@@ -26,45 +26,9 @@ class DashboardSwitcher extends Component {
   }
 
   render() {
-    const {dashboards, currentDashboard, sourceID, hosts, appParam} = this.props
+    const {activeDashboard, names} = this.props
     const {isOpen} = this.state
-
-    let dropdownItems
-
-    if (hosts) {
-      dropdownItems = hosts.map((host, i) => {
-        return (
-          <li className="dropdown-item" key={i}>
-            <Link
-              to={`/sources/${sourceID}/hosts/${host + appParam}`}
-              onClick={this.handleCloseMenu}
-            >
-              {host}
-            </Link>
-          </li>
-        )
-      })
-    }
-
-    if (dashboards) {
-      dropdownItems = _.sortBy(dashboards, d =>
-        d.name.toLowerCase()
-      ).map((d, i) =>
-        <li
-          className={classnames('dropdown-item', {
-            active: d.name === currentDashboard,
-          })}
-          key={i}
-        >
-          <Link
-            to={`/sources/${sourceID}/dashboards/${d.id}`}
-            onClick={this.handleCloseMenu}
-          >
-            {d.name}
-          </Link>
-        </li>
-      )
-    }
+    const sorted = _.sortBy(names, ({name}) => name.toLowerCase())
 
     return (
       <div
@@ -77,21 +41,49 @@ class DashboardSwitcher extends Component {
           <span className="icon dash-f" />
         </button>
         <ul className="dropdown-menu">
-          {dropdownItems}
+          {sorted.map(({name, link}) =>
+            <NameLink
+              key={link}
+              name={name}
+              link={link}
+              activeName={activeDashboard}
+              onClose={this.handleCloseMenu}
+            />
+          )}
         </ul>
       </div>
     )
   }
 }
 
-const {arrayOf, shape, string} = PropTypes
+const NameLink = ({name, link, activeName, onClose}) =>
+  <li
+    className={classnames('dropdown-item', {
+      active: name === activeName,
+    })}
+  >
+    <Link to={link} onClick={onClose}>
+      {name}
+    </Link>
+  </li>
+
+const {arrayOf, func, shape, string} = PropTypes
 
 DashboardSwitcher.propTypes = {
-  currentDashboard: string.isRequired,
-  dashboards: arrayOf(shape({})).isRequired,
-  sourceID: string.isRequired,
-  hosts: shape({}),
-  appParam: string,
+  activeDashboard: string.isRequired,
+  names: arrayOf(
+    shape({
+      link: string.isRequired,
+      name: string.isRequired,
+    })
+  ).isRequired,
+}
+
+NameLink.propTypes = {
+  name: string.isRequired,
+  link: string.isRequired,
+  activeName: string.isRequired,
+  onClose: func.isRequired,
 }
 
 export default OnClickOutside(DashboardSwitcher)

--- a/ui/src/dashboards/components/DashboardSwitcher.js
+++ b/ui/src/dashboards/components/DashboardSwitcher.js
@@ -1,0 +1,75 @@
+import React, {Component, PropTypes} from 'react'
+import {Link} from 'react-router'
+import classnames from 'classnames'
+import OnClickOutside from 'shared/components/OnClickOutside'
+
+class DashboardSwitcher extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      isOpen: false,
+    }
+  }
+
+  handleToggleMenu = () => {
+    this.setState({isOpen: !this.state.isOpen})
+  }
+
+  handleCloseMenu = () => {
+    this.setState({isOpen: false})
+  }
+
+  handleClickOutside = () => {
+    this.setState({isOpen: false})
+  }
+
+  render() {
+    const {dashboards, currentDashboard, sourceID} = this.props
+    const {isOpen} = this.state
+
+    if (dashboards.length <= 1) {
+      return null
+    }
+
+    return (
+      <div
+        className={classnames('dropdown dashboard-switcher', {open: isOpen})}
+      >
+        <button
+          className="btn btn-square btn-default btn-sm dropdown-toggle"
+          onClick={this.handleToggleMenu}
+        >
+          <span className="icon dash-f" />
+        </button>
+        <ul className="dropdown-menu">
+          {dashboards.map((d, i) =>
+            <li
+              className={classnames('dropdown-item', {
+                active: d.name === currentDashboard,
+              })}
+              key={i}
+            >
+              <Link
+                to={`/sources/${sourceID}/dashboards/${d.id}`}
+                onClick={this.handleCloseMenu}
+              >
+                {d.name}
+              </Link>
+            </li>
+          )}
+        </ul>
+      </div>
+    )
+  }
+}
+
+const {arrayOf, shape, string} = PropTypes
+
+DashboardSwitcher.propTypes = {
+  currentDashboard: string.isRequired,
+  dashboards: arrayOf(shape({})).isRequired,
+  sourceID: string.isRequired,
+}
+
+export default OnClickOutside(DashboardSwitcher)

--- a/ui/src/dashboards/components/DashboardSwitcher.js
+++ b/ui/src/dashboards/components/DashboardSwitcher.js
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react'
 import {Link} from 'react-router'
+import _ from 'lodash'
 import classnames from 'classnames'
 import OnClickOutside from 'shared/components/OnClickOutside'
 
@@ -39,7 +40,7 @@ class DashboardSwitcher extends Component {
           <span className="icon dash-f" />
         </button>
         <ul className="dropdown-menu">
-          {dashboards.map((d, i) =>
+          {_.sortBy(dashboards, d => d.name.toLowerCase()).map((d, i) =>
             <li
               className={classnames('dropdown-item', {
                 active: d.name === currentDashboard,

--- a/ui/src/dashboards/components/DashboardSwitcher.js
+++ b/ui/src/dashboards/components/DashboardSwitcher.js
@@ -26,8 +26,45 @@ class DashboardSwitcher extends Component {
   }
 
   render() {
-    const {dashboards, currentDashboard, sourceID} = this.props
+    const {dashboards, currentDashboard, sourceID, hosts, appParam} = this.props
     const {isOpen} = this.state
+
+    let dropdownItems
+
+    if (hosts) {
+      dropdownItems = hosts.map((host, i) => {
+        return (
+          <li className="dropdown-item" key={i}>
+            <Link
+              to={`/sources/${sourceID}/hosts/${host + appParam}`}
+              onClick={this.handleCloseMenu}
+            >
+              {host}
+            </Link>
+          </li>
+        )
+      })
+    }
+
+    if (dashboards) {
+      dropdownItems = _.sortBy(dashboards, d =>
+        d.name.toLowerCase()
+      ).map((d, i) =>
+        <li
+          className={classnames('dropdown-item', {
+            active: d.name === currentDashboard,
+          })}
+          key={i}
+        >
+          <Link
+            to={`/sources/${sourceID}/dashboards/${d.id}`}
+            onClick={this.handleCloseMenu}
+          >
+            {d.name}
+          </Link>
+        </li>
+      )
+    }
 
     return (
       <div
@@ -40,21 +77,7 @@ class DashboardSwitcher extends Component {
           <span className="icon dash-f" />
         </button>
         <ul className="dropdown-menu">
-          {_.sortBy(dashboards, d => d.name.toLowerCase()).map((d, i) =>
-            <li
-              className={classnames('dropdown-item', {
-                active: d.name === currentDashboard,
-              })}
-              key={i}
-            >
-              <Link
-                to={`/sources/${sourceID}/dashboards/${d.id}`}
-                onClick={this.handleCloseMenu}
-              >
-                {d.name}
-              </Link>
-            </li>
-          )}
+          {dropdownItems}
         </ul>
       </div>
     )
@@ -67,6 +90,8 @@ DashboardSwitcher.propTypes = {
   currentDashboard: string.isRequired,
   dashboards: arrayOf(shape({})).isRequired,
   sourceID: string.isRequired,
+  hosts: shape({}),
+  appParam: string,
 }
 
 export default OnClickOutside(DashboardSwitcher)

--- a/ui/src/dashboards/components/VisualizationName.js
+++ b/ui/src/dashboards/components/VisualizationName.js
@@ -1,17 +1,20 @@
 import React, {Component, PropTypes} from 'react'
 
+import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants/index'
+
 class VisualizationName extends Component {
   constructor(props) {
     super(props)
 
     this.state = {
       reset: false,
+      isEditing: false,
     }
   }
 
   handleInputBlur = reset => e => {
     this.props.onCellRename(reset ? this.props.defaultName : e.target.value)
-    this.setState({reset: false})
+    this.setState({reset: false, isEditing: false})
   }
 
   handleKeyDown = e => {
@@ -24,21 +27,39 @@ class VisualizationName extends Component {
     }
   }
 
+  handleEditMode = () => {
+    this.setState({isEditing: true})
+  }
+
+  handleFocus = e => {
+    e.target.select()
+  }
+
   render() {
     const {defaultName} = this.props
-    const {reset} = this.state
+    const {reset, isEditing} = this.state
+    const graphNameClass =
+      defaultName === NEW_DEFAULT_DASHBOARD_CELL.name
+        ? 'graph-name graph-name__untitled'
+        : 'graph-name'
 
     return (
       <div className="graph-heading">
-        <input
-          type="text"
-          className="form-control input-md"
-          defaultValue={defaultName}
-          onBlur={this.handleInputBlur(reset)}
-          onKeyDown={this.handleKeyDown}
-          placeholder="Name this Cell..."
-          ref={r => (this.inputRef = r)}
-        />
+        {isEditing
+          ? <input
+              type="text"
+              className="form-control input-sm"
+              defaultValue={defaultName}
+              onBlur={this.handleInputBlur(reset)}
+              onKeyDown={this.handleKeyDown}
+              placeholder="Name this Cell..."
+              autoFocus={true}
+              onFocus={this.handleFocus}
+              ref={r => (this.inputRef = r)}
+            />
+          : <div className={graphNameClass} onClick={this.handleEditMode}>
+              {defaultName}
+            </div>}
       </div>
     )
   }

--- a/ui/src/dashboards/constants/index.js
+++ b/ui/src/dashboards/constants/index.js
@@ -109,3 +109,5 @@ export const TOOLTIP_CONTENT = {
 
 export const TYPE_QUERY_CONFIG = 'queryConfig'
 export const TYPE_IFQL = 'ifql'
+
+export const DASHBOARD_NAME_MAX_LENGTH = 50

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -317,6 +317,7 @@ class DashboardPage extends Component {
           autoRefresh={autoRefresh}
           isHidden={inPresentationMode}
           onAddCell={this.handleAddCell}
+          onManualRefresh={onManualRefresh}
           zoomedTimeRange={zoomedTimeRange}
           onSave={this.handleRenameDashboard}
           onCancel={this.handleCancelEditDashboard}

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -308,7 +308,6 @@ class DashboardPage extends Component {
             />
           : null}
         <DashboardHeader
-          source={source}
           sourceID={sourceID}
           dashboard={dashboard}
           dashboards={dashboards}

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -1,5 +1,4 @@
 import React, {PropTypes, Component} from 'react'
-import {Link} from 'react-router'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 
@@ -312,6 +311,7 @@ class DashboardPage extends Component {
           source={source}
           sourceID={sourceID}
           dashboard={dashboard}
+          dashboards={dashboards}
           timeRange={timeRange}
           isEditMode={isEditMode}
           autoRefresh={autoRefresh}
@@ -327,17 +327,7 @@ class DashboardPage extends Component {
           handleChooseTimeRange={this.handleChooseTimeRange}
           onToggleTempVarControls={this.handleToggleTempVarControls}
           handleClickPresentationButton={handleClickPresentationButton}
-        >
-          {dashboards
-            ? dashboards.map((d, i) =>
-                <li className="dropdown-item" key={i}>
-                  <Link to={`/sources/${sourceID}/dashboards/${d.id}`}>
-                    {d.name}
-                  </Link>
-                </li>
-              )
-            : null}
-        </DashboardHeader>
+        />
         {dashboard
           ? <Dashboard
               source={source}

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -8,7 +8,6 @@ import Dygraph from 'src/external/dygraph'
 import OverlayTechnologies from 'shared/components/OverlayTechnologies'
 import CellEditorOverlay from 'src/dashboards/components/CellEditorOverlay'
 import DashboardHeader from 'src/dashboards/components/DashboardHeader'
-import DashboardHeaderEdit from 'src/dashboards/components/DashboardHeaderEdit'
 import Dashboard from 'src/dashboards/components/Dashboard'
 import TemplateVariableManager from 'src/dashboards/components/template_variables/Manager'
 import ManualRefresh from 'src/shared/components/ManualRefresh'
@@ -309,40 +308,36 @@ class DashboardPage extends Component {
               editQueryStatus={dashboardActions.editCellQueryStatus}
             />
           : null}
-        {isEditMode
-          ? <DashboardHeaderEdit
-              dashboard={dashboard}
-              onSave={this.handleRenameDashboard}
-              onCancel={this.handleCancelEditDashboard}
-            />
-          : <DashboardHeader
-              source={source}
-              sourceID={sourceID}
-              dashboard={dashboard}
-              timeRange={timeRange}
-              zoomedTimeRange={zoomedTimeRange}
-              autoRefresh={autoRefresh}
-              isHidden={inPresentationMode}
-              onAddCell={this.handleAddCell}
-              onEditDashboard={this.handleEditDashboard}
-              buttonText={dashboard ? dashboard.name : ''}
-              showTemplateControlBar={showTemplateControlBar}
-              handleChooseAutoRefresh={handleChooseAutoRefresh}
-              onManualRefresh={onManualRefresh}
-              handleChooseTimeRange={this.handleChooseTimeRange}
-              onToggleTempVarControls={this.handleToggleTempVarControls}
-              handleClickPresentationButton={handleClickPresentationButton}
-            >
-              {dashboards
-                ? dashboards.map((d, i) =>
-                    <li className="dropdown-item" key={i}>
-                      <Link to={`/sources/${sourceID}/dashboards/${d.id}`}>
-                        {d.name}
-                      </Link>
-                    </li>
-                  )
-                : null}
-            </DashboardHeader>}
+        <DashboardHeader
+          source={source}
+          sourceID={sourceID}
+          dashboard={dashboard}
+          timeRange={timeRange}
+          isEditMode={isEditMode}
+          autoRefresh={autoRefresh}
+          isHidden={inPresentationMode}
+          onAddCell={this.handleAddCell}
+          zoomedTimeRange={zoomedTimeRange}
+          onSave={this.handleRenameDashboard}
+          onCancel={this.handleCancelEditDashboard}
+          onEditDashboard={this.handleEditDashboard}
+          dashboardName={dashboard ? dashboard.name : ''}
+          showTemplateControlBar={showTemplateControlBar}
+          handleChooseAutoRefresh={handleChooseAutoRefresh}
+          handleChooseTimeRange={this.handleChooseTimeRange}
+          onToggleTempVarControls={this.handleToggleTempVarControls}
+          handleClickPresentationButton={handleClickPresentationButton}
+        >
+          {dashboards
+            ? dashboards.map((d, i) =>
+                <li className="dropdown-item" key={i}>
+                  <Link to={`/sources/${sourceID}/dashboards/${d.id}`}>
+                    {d.name}
+                  </Link>
+                </li>
+              )
+            : null}
+        </DashboardHeader>
         {dashboard
           ? <Dashboard
               source={source}

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -39,12 +39,13 @@ class DashboardPage extends Component {
       selectedCell: null,
       isTemplating: false,
       zoomedTimeRange: {zoomedLower: null, zoomedUpper: null},
+      names: [],
     }
   }
 
   async componentDidMount() {
     const {
-      params: {dashboardID},
+      params: {dashboardID, sourceID},
       dashboardActions: {
         getDashboardsAsync,
         updateTempVarValues,
@@ -61,6 +62,13 @@ class DashboardPage extends Component {
     // Refresh and persists influxql generated template variable values
     await updateTempVarValues(source, dashboard)
     await putDashboardByID(dashboardID)
+
+    const names = dashboards.map(d => ({
+      name: d.name,
+      link: `/sources/${sourceID}/dashboards/${d.id}`,
+    }))
+
+    this.setState({names})
   }
 
   handleOpenTemplateManager = () => {
@@ -277,7 +285,7 @@ class DashboardPage extends Component {
       templatesIncludingDashTime = []
     }
 
-    const {selectedCell, isEditMode, isTemplating} = this.state
+    const {selectedCell, isEditMode, isTemplating, names} = this.state
 
     return (
       <div className="page">
@@ -308,6 +316,7 @@ class DashboardPage extends Component {
             />
           : null}
         <DashboardHeader
+          names={names}
           sourceID={sourceID}
           dashboard={dashboard}
           dashboards={dashboards}
@@ -321,7 +330,7 @@ class DashboardPage extends Component {
           onSave={this.handleRenameDashboard}
           onCancel={this.handleCancelEditDashboard}
           onEditDashboard={this.handleEditDashboard}
-          dashboardName={dashboard ? dashboard.name : ''}
+          activeDashboard={dashboard ? dashboard.name : ''}
           showTemplateControlBar={showTemplateControlBar}
           handleChooseAutoRefresh={handleChooseAutoRefresh}
           handleChooseTimeRange={this.handleChooseTimeRange}

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -182,7 +182,7 @@ class HostPage extends Component {
       <div className="page">
         <DashboardHeader
           source={source}
-          buttonText={hostID}
+          dashboardName={hostID}
           timeRange={timeRange}
           autoRefresh={autoRefresh}
           isHidden={inPresentationMode}

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -1,5 +1,4 @@
 import React, {PropTypes, Component} from 'react'
-import {Link} from 'react-router'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import _ from 'lodash'
@@ -178,10 +177,15 @@ class HostPage extends Component {
     const {layouts, timeRange, hosts} = this.state
     const appParam = app ? `?app=${app}` : ''
 
+    const hostsList = Object.keys(hosts)
+
     return (
       <div className="page">
         <DashboardHeader
+          sourceID={id}
           source={source}
+          hosts={hostsList}
+          appParam={appParam}
           dashboardName={hostID}
           timeRange={timeRange}
           autoRefresh={autoRefresh}
@@ -190,17 +194,7 @@ class HostPage extends Component {
           handleChooseTimeRange={this.handleChooseTimeRange}
           handleChooseAutoRefresh={handleChooseAutoRefresh}
           handleClickPresentationButton={handleClickPresentationButton}
-        >
-          {Object.keys(hosts).map((host, i) => {
-            return (
-              <li className="dropdown-item" key={i}>
-                <Link to={`/sources/${id}/hosts/${host + appParam}`}>
-                  {host}
-                </Link>
-              </li>
-            )
-          })}
-        </DashboardHeader>
+        />
         <FancyScrollbar
           className={classnames({
             'page-contents': true,

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -28,7 +28,7 @@ class HostPage extends Component {
     super(props)
     this.state = {
       layouts: [],
-      hosts: [],
+      hosts: {},
       timeRange: timeRanges.find(tr => tr.lower === 'now() - 1h'),
       dygraphs: [],
     }
@@ -47,6 +47,7 @@ class HostPage extends Component {
       mappings,
       source.telegraf
     )
+
     const measurements = await getMeasurementsForHost(source, params.hostID)
 
     const host = newHosts[this.props.params.hostID]
@@ -164,35 +165,30 @@ class HostPage extends Component {
 
   render() {
     const {
-      source,
       autoRefresh,
-      source: {id},
       onManualRefresh,
-      params: {hostID},
+      params: {hostID, sourceID},
       inPresentationMode,
       handleChooseAutoRefresh,
-      location: {query: {app}},
       handleClickPresentationButton,
     } = this.props
     const {layouts, timeRange, hosts} = this.state
-    const appParam = app ? `?app=${app}` : ''
-
-    const hostsList = Object.keys(hosts)
+    const names = _.map(hosts, ({name}) => ({
+      name,
+      link: `/sources/${sourceID}/hosts/${name}`,
+    }))
 
     return (
       <div className="page">
         <DashboardHeader
-          sourceID={id}
-          source={source}
-          hosts={hostsList}
-          appParam={appParam}
-          dashboardName={hostID}
+          names={names}
           timeRange={timeRange}
+          activeDashboard={hostID}
           autoRefresh={autoRefresh}
           isHidden={inPresentationMode}
           onManualRefresh={onManualRefresh}
-          handleChooseTimeRange={this.handleChooseTimeRange}
           handleChooseAutoRefresh={handleChooseAutoRefresh}
+          handleChooseTimeRange={this.handleChooseTimeRange}
           handleClickPresentationButton={handleClickPresentationButton}
         />
         <FancyScrollbar

--- a/ui/src/style/components/graph.scss
+++ b/ui/src/style/components/graph.scss
@@ -49,15 +49,30 @@ $graph-gutter: 16px;
   color: $g13-mist;
   border-radius: 4px;
   border: 2px solid transparent;
+  position: relative;
   transition:
     background-color 0.25s ease,
     border-color 0.25s ease,
     color 0.25s ease;
 
+  &:after {
+    content: "\f058";
+    font-family: 'icomoon';
+    position: absolute;
+    font-size: 15px;
+    top: 50%;
+    right: 11px;
+    transform: translateY(-50%);
+    opacity: 0;
+    transition: opacity 0.25s ease;
+    color: $g11-sidewalk;
+  }
   &:hover {
     cursor: text;
     background-color: $g5-pepper;
     color: $g20-white;
+
+    &:after {opacity: 1;}
   }
 }
 .graph-name__untitled {

--- a/ui/src/style/components/graph.scss
+++ b/ui/src/style/components/graph.scss
@@ -27,13 +27,41 @@ $graph-gutter: 16px;
   justify-content: space-between;
   height: $graph-heading-height;
   top: $graph-gutter;
-  padding: 0 16px;
+  padding: 0 7px;
   transition:
     background-color 0.25s ease;
 
   .toggle-btn {
     text-transform: capitalize;
   }
+}
+.graph-heading > input[type="text"].form-control,
+.graph-name {
+  font-weight: 600;
+  font-size: 14px;
+  padding: 0 11px;
+}
+.graph-name {
+  width: 100%;
+  height: 30px;
+  line-height: 26px;
+  background-color: transparent;
+  color: $g13-mist;
+  border-radius: 4px;
+  border: 2px solid transparent;
+  transition:
+    background-color 0.25s ease,
+    border-color 0.25s ease,
+    color 0.25s ease;
+
+  &:hover {
+    cursor: text;
+    background-color: $g5-pepper;
+    color: $g20-white;
+  }
+}
+.graph-name__untitled {
+  font-style: italic;
 }
 .graph-title {
   font-size: 14px;

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -340,8 +340,48 @@ $tick-script-overlay-margin: 30px;
   -----------------------------------------------------------------------------
 */
 .dropdown.dashboard-switcher {
-  margin-right: 4px;
+  margin-right: 10px;
 }
 .dropdown.dashboard-switcher .btn.dropdown-toggle {
   justify-content: center;
+}
+
+/*
+  Dashboard Name Editing
+  -----------------------------------------------------------------------------
+*/
+.page-header__left.page-header__dash-editable,
+.dashboard-title,
+.dashboard-title input[type="text"].form-control.dashboard-title--input {
+  flex: 1 0 0;
+}
+.dashboard-title {
+  display: flex;
+
+  input[type="text"].form-control.dashboard-title--input,
+  input[type="text"].form-control.dashboard-title--input:focus {
+    border: 0;
+    border-radius: 0;
+    padding: 0;
+    font-size: $page-header-size;
+    font-weight: $page-header-weight;
+    color: $c-pool;
+    box-shadow: none;
+    background-color: transparent;
+  }
+
+  h1 {
+    margin: 0;
+    letter-spacing: 0;
+    text-transform: none;
+    font-size: $page-header-size;
+    font-weight: $page-header-weight;
+    transition: color 0.25s ease;
+
+    &:hover {
+      cursor: text;
+      color: $c-pool;
+    }
+  }
+
 }

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -360,6 +360,8 @@ $tick-script-overlay-margin: 30px;
 
   input[type="text"].form-control.dashboard-title--input,
   input[type="text"].form-control.dashboard-title--input:focus {
+    position: relative;
+    top: -1px;
     border: 0;
     border-radius: 0;
     padding: 0;
@@ -378,9 +380,19 @@ $tick-script-overlay-margin: 30px;
     font-weight: $page-header-weight;
     transition: color 0.25s ease;
 
+    &:after {
+      display: inline-block;
+      margin-left: 4px;
+      content: "\f058";
+      font-family: 'icomoon';
+      color: $g5-pepper;
+      transition: color 0.25s ease;
+    }
+
     &:hover {
       cursor: text;
       color: $c-pool;
+      &:after {color: $c-pool;}
     }
   }
 

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -326,11 +326,22 @@ $tick-script-overlay-margin: 30px;
 .autorefresh-dropdown {
   display: flex;
   flex-wrap: nowrap;
-  
+
   &.paused .dropdown {
     margin-right: 4px;
   }
   &.paused .dropdown > .btn.dropdown-toggle {
     width: 126px;
   }
+}
+
+/*
+  Dashboard Switcher
+  -----------------------------------------------------------------------------
+*/
+.dropdown.dashboard-switcher {
+  margin-right: 4px;
+}
+.dropdown.dashboard-switcher .btn.dropdown-toggle {
+  justify-content: center;
 }

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -340,10 +340,13 @@ $tick-script-overlay-margin: 30px;
   -----------------------------------------------------------------------------
 */
 .dropdown.dashboard-switcher {
-  margin-right: 10px;
+  margin-right: 4px;
 }
 .dropdown.dashboard-switcher .btn.dropdown-toggle {
   justify-content: center;
+}
+.dropdown.dashboard-switcher + h1.page-header__title {
+  margin-left: 6px;
 }
 
 /*
@@ -352,47 +355,47 @@ $tick-script-overlay-margin: 30px;
 */
 .page-header__left.page-header__dash-editable,
 .dashboard-title,
-.dashboard-title input[type="text"].form-control.dashboard-title--input {
+.dashboard-title input[type="text"].form-control.dashboard-title--input,
+.dashboard-title h1 {
   flex: 1 0 0;
 }
 .dashboard-title {
   display: flex;
 
   input[type="text"].form-control.dashboard-title--input,
-  input[type="text"].form-control.dashboard-title--input:focus {
-    position: relative;
-    top: -1px;
-    border: 0;
-    border-radius: 0;
-    padding: 0;
+  input[type="text"].form-control.dashboard-title--input:focus,
+  h1 {
     font-size: $page-header-size;
     font-weight: $page-header-weight;
-    color: $c-pool;
-    box-shadow: none;
-    background-color: transparent;
+    padding: 0 7px;
+  }
+
+  input[type="text"].form-control.dashboard-title--input,
+  input[type="text"].form-control.dashboard-title--input:focus {
+    font-size: $page-header-size;
+    font-weight: $page-header-weight;
   }
 
   h1 {
+    @include no-user-select();
+    border: 2px solid $g0-obsidian;
+    color: $g17-whisper;
+    height: 30px;
+    line-height: 28px;
+    border-radius: 4px;
     margin: 0;
     letter-spacing: 0;
     text-transform: none;
-    font-size: $page-header-size;
-    font-weight: $page-header-weight;
-    transition: color 0.25s ease;
-
-    &:after {
-      display: inline-block;
-      margin-left: 4px;
-      content: "\f058";
-      font-family: 'icomoon';
-      color: $g5-pepper;
-      transition: color 0.25s ease;
-    }
+    transition:
+      color 0.25s ease,
+      background-color 0.25s ease,
+      border-color 0.25s ease;
 
     &:hover {
       cursor: text;
-      color: $c-pool;
-      &:after {color: $c-pool;}
+      color: $g20-white;
+      background-color: $g3-castle;
+      border-color: $g3-castle;
     }
   }
 

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -353,6 +353,8 @@ $tick-script-overlay-margin: 30px;
   Dashboard Name Editing
   -----------------------------------------------------------------------------
 */
+$dash-editable-header-padding: 7px;
+
 .page-header__left.page-header__dash-editable,
 .dashboard-title,
 .dashboard-title input[type="text"].form-control.dashboard-title--input,
@@ -367,7 +369,7 @@ $tick-script-overlay-margin: 30px;
   h1 {
     font-size: $page-header-size;
     font-weight: $page-header-weight;
-    padding: 0 7px;
+    padding: 0 $dash-editable-header-padding;
   }
 
   input[type="text"].form-control.dashboard-title--input,
@@ -378,6 +380,7 @@ $tick-script-overlay-margin: 30px;
 
   h1 {
     @include no-user-select();
+    position: relative;
     border: 2px solid $g0-obsidian;
     color: $g17-whisper;
     height: 30px;
@@ -391,11 +394,28 @@ $tick-script-overlay-margin: 30px;
       background-color 0.25s ease,
       border-color 0.25s ease;
 
+    &:after {
+      content: "\f058";
+      font-family: 'icomoon';
+      position: absolute;
+      font-size: 15px;
+      top: 50%;
+      right: $dash-editable-header-padding;
+      transform: translateY(-50%);
+      opacity: 0;
+      transition: opacity 0.25s ease;
+      color: $g11-sidewalk;
+    }
+
     &:hover {
       cursor: text;
       color: $g20-white;
       background-color: $g3-castle;
       border-color: $g3-castle;
+
+      &:after {
+        opacity: 1;
+      }
     }
   }
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1991 
Connect #2064 
Connect #2097 

### The Problem
- Running out of space in the Dashboard page header
- Renaming a dashboard does not automatically select text in input (unexpected behavior)

### The Solution
- Remove `Rename` button
- Add dashboard switching dropdown next to Dashboard name (preserve switching functionality)
- Click on dashboard name to rename
- `ESC` cancels rename
- `Enter` or `Blur` saves rename
- Maximum length of dashboard name is 50 characters (based on `1440x900` screen size)
- Dashboard name input automatically selects all text on edit

### Preview
![screen shot 2017-10-10 at 3 19 35 pm](https://user-images.githubusercontent.com/2433762/31413819-0f99c5de-add0-11e7-82c5-dbd791dbe4c7.png)
More space efficient

![dash-switcher](https://user-images.githubusercontent.com/2433762/31413861-35616d26-add0-11e7-8046-e4211589e9e2.gif)
Switching between dashboards (is alphabetically sorted as well)

![dash-rename-4](https://user-images.githubusercontent.com/2433762/31747669-ddf3b73e-b422-11e7-8fe0-d42015674a15.gif)
Click to rename dashboard

### Design Considerations
- This fundamentally changes how users will accomplish 2 tasks, will add a learning curve for existing users
- Users previously clicked on the dashboard name to switch
  - Might accidentally discover how renaming works
  - New means of renaming is in the exact same spot
- Using the `text` cursor on the dashboard name to indicate it can be edited
- Added a `Pencil` icon to the right of the name that highlights on hover, also indicating editability 
- This renaming pattern is inconsistent with other parts of the UI
  - Works well in this instance, going to try it out and if it goes well might re-use elsewhere or update to match other patterns


