### PR TITLE
server update to queryConfig to support field aliases and functions

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -495,10 +495,10 @@ type TriggerValues struct {
 
 // Field represent influxql fields and functions from the UI
 type Field struct {
-	Name  string  `json:"name"`
-	Type  string  `json:"type"`
-	Alias string  `json:"alias"`
-	Args  []Field `json:"args,omitempty"`
+	Name  interface{} `json:"name"`
+	Type  string      `json:"type"`
+	Alias string      `json:"alias"`
+	Args  []Field     `json:"args,omitempty"`
 }
 
 // GroupBy represents influxql group by tags from the UI

--- a/chronograf.go
+++ b/chronograf.go
@@ -495,8 +495,10 @@ type TriggerValues struct {
 
 // Field represent influxql fields and functions from the UI
 type Field struct {
-	Field string   `json:"field"`
-	Funcs []string `json:"funcs"`
+	Name  string   `json:"name"`
+	Type  string   `json:"type"`
+	Alias string   `json:"alias"`
+	Args  []string `json:"args"`
 }
 
 // GroupBy represents influxql group by tags from the UI

--- a/chronograf.go
+++ b/chronograf.go
@@ -495,7 +495,7 @@ type TriggerValues struct {
 
 // Field represent influxql fields and functions from the UI
 type Field struct {
-	Name  interface{} `json:"name"`
+	Value interface{} `json:"value"`
 	Type  string      `json:"type"`
 	Alias string      `json:"alias"`
 	Args  []Field     `json:"args,omitempty"`

--- a/chronograf.go
+++ b/chronograf.go
@@ -498,7 +498,7 @@ type Field struct {
 	Name  string  `json:"name"`
 	Type  string  `json:"type"`
 	Alias string  `json:"alias"`
-	Args  []Field `json:"args"`
+	Args  []Field `json:"args,omitempty"`
 }
 
 // GroupBy represents influxql group by tags from the UI

--- a/chronograf.go
+++ b/chronograf.go
@@ -495,10 +495,10 @@ type TriggerValues struct {
 
 // Field represent influxql fields and functions from the UI
 type Field struct {
-	Name  string   `json:"name"`
-	Type  string   `json:"type"`
-	Alias string   `json:"alias"`
-	Args  []string `json:"args"`
+	Name  string  `json:"name"`
+	Type  string  `json:"type"`
+	Alias string  `json:"alias"`
+	Args  []Field `json:"args"`
 }
 
 // GroupBy represents influxql group by tags from the UI

--- a/influx/query.go
+++ b/influx/query.go
@@ -152,18 +152,28 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				switch ref := arg.(type) {
 				case *influxql.VarRef:
 					fldArgs = append(fldArgs, chronograf.Field{
-						Name: ref.Val,
-						Type: "field",
+						Value: ref.Val,
+						Type:  "field",
 					})
 				case *influxql.IntegerLiteral:
 					fldArgs = append(fldArgs, chronograf.Field{
-						Name: ref.Val,
-						Type: "integer",
+						Value: ref.Val,
+						Type:  "integer",
 					})
 				case *influxql.NumberLiteral:
 					fldArgs = append(fldArgs, chronograf.Field{
-						Name: ref.Val,
-						Type: "number",
+						Value: ref.Val,
+						Type:  "number",
+					})
+				case *influxql.RegexLiteral:
+					fldArgs = append(fldArgs, chronograf.Field{
+						Value: ref.Val.String(),
+						Type:  "regex",
+					})
+				case *influxql.Wildcard:
+					fldArgs = append(fldArgs, chronograf.Field{
+						Value: "*",
+						Type:  "wildcard",
 					})
 				default:
 					return raw, nil
@@ -171,7 +181,7 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 			}
 
 			qc.Fields = append(qc.Fields, chronograf.Field{
-				Name:  f.Name,
+				Value: f.Name,
 				Type:  "func",
 				Alias: fld.Alias,
 				Args:  fldArgs,
@@ -181,7 +191,7 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				return raw, nil
 			}
 			qc.Fields = append(qc.Fields, chronograf.Field{
-				Name:  f.Val,
+				Value: f.Val,
 				Type:  "field",
 				Alias: fld.Alias,
 			})
@@ -460,6 +470,8 @@ var supportedFuncs = map[string]bool{
 	"spread":     true,
 	"stddev":     true,
 	"percentile": true,
+	"top":        true,
+	"bottom":     true,
 }
 
 // shortDur converts duration into the queryConfig duration format

--- a/influx/query.go
+++ b/influx/query.go
@@ -117,8 +117,6 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 			}
 			// Add fill to queryConfig only if there's a `GROUP BY time`
 			switch stmt.Fill {
-			default:
-				return raw, nil
 			case influxql.NullFill:
 				qc.Fill = "null"
 			case influxql.NoFill:
@@ -129,7 +127,8 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				qc.Fill = "previous"
 			case influxql.LinearFill:
 				qc.Fill = "linear"
-
+			default:
+				return raw, nil
 			}
 		case *influxql.VarRef:
 			qc.GroupBy.Tags = append(qc.GroupBy.Tags, v.Val)

--- a/influx/query.go
+++ b/influx/query.go
@@ -2,6 +2,7 @@ package influx
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -156,12 +157,12 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 					})
 				case *influxql.IntegerLiteral:
 					fldArgs = append(fldArgs, chronograf.Field{
-						Value: ref.Val,
+						Value: strconv.FormatInt(ref.Val, 10),
 						Type:  "integer",
 					})
 				case *influxql.NumberLiteral:
 					fldArgs = append(fldArgs, chronograf.Field{
-						Value: ref.Val,
+						Value: strconv.FormatFloat(ref.Val, 'f', -1, 64),
 						Type:  "number",
 					})
 				case *influxql.RegexLiteral:

--- a/influx/query.go
+++ b/influx/query.go
@@ -121,16 +121,12 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				return raw, nil
 			case influxql.NullFill:
 				qc.Fill = "null"
-
 			case influxql.NoFill:
 				qc.Fill = "none"
-
 			case influxql.NumberFill:
 				qc.Fill = fmt.Sprint(stmt.FillValue)
-
 			case influxql.PreviousFill:
 				qc.Fill = "previous"
-
 			case influxql.LinearFill:
 				qc.Fill = "linear"
 
@@ -167,7 +163,12 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				Name:  f.Name,
 				Type:  "func",
 				Alias: fld.Alias,
-				Args:  []string{ref.Val},
+				Args: []chronograf.Field{
+					{
+						Name: ref.Val,
+						Type: "field",
+					},
+				},
 			})
 		case *influxql.VarRef:
 			if f.Type != influxql.Unknown {
@@ -177,7 +178,6 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 				Name:  f.Val,
 				Type:  "field",
 				Alias: fld.Alias,
-				Args:  []string{},
 			})
 		}
 	}

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -1,9 +1,9 @@
 package influx
 
 import (
-	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/chronograf"
 )
 
@@ -24,20 +24,24 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{},
+						Name: "usage_idle",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest_nice",
-						Funcs: []string{},
+						Name: "usage_guest_nice",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_system",
-						Funcs: []string{},
+						Name: "usage_system",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest",
-						Funcs: []string{},
+						Name: "usage_guest",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{},
@@ -55,18 +59,24 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
-							"median",
-						},
+						Name: "mean",
+						Type: "func",
+						Args: []string{"usage_idle"},
 					},
 					chronograf.Field{
-						Field: "usage_guest_nice",
-						Funcs: []string{
-							"count",
-							"mean",
-						},
+						Name: "median",
+						Type: "func",
+						Args: []string{"usage_idle"},
+					},
+					chronograf.Field{
+						Name: "count",
+						Type: "func",
+						Args: []string{"usage_guest_nice"},
+					},
+					chronograf.Field{
+						Name: "mean",
+						Type: "func",
+						Args: []string{"usage_guest_nice"},
 					},
 				},
 				Tags: map[string][]string{},
@@ -108,8 +118,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -144,8 +155,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -169,8 +181,9 @@ func TestConvert(t *testing.T) {
 				Tags:            map[string][]string{},
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				GroupBy: chronograf.GroupBy{
@@ -216,8 +229,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{},
@@ -236,8 +250,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -261,8 +276,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -305,8 +321,9 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_user",
-						Funcs: []string{},
+						Name: "usage_user",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -332,20 +349,24 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{},
+						Name: "usage_idle",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest_nice",
-						Funcs: []string{},
+						Name: "usage_guest_nice",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_system",
-						Funcs: []string{},
+						Name: "usage_system",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest",
-						Funcs: []string{},
+						Name: "usage_guest",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -379,20 +400,24 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{},
+						Name: "usage_idle",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest_nice",
-						Funcs: []string{},
+						Name: "usage_guest_nice",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_system",
-						Funcs: []string{},
+						Name: "usage_system",
+						Type: "field",
+						Args: []string{},
 					},
 					chronograf.Field{
-						Field: "usage_guest",
-						Funcs: []string{},
+						Name: "usage_guest",
+						Type: "field",
+						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -426,9 +451,10 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
+						Name: "mean",
+						Type: "func",
+						Args: []string{
+							"usage_idle",
 						},
 					},
 				},
@@ -453,9 +479,10 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
+						Name: "mean",
+						Type: "func",
+						Args: []string{
+							"usage_idle",
 						},
 					},
 				},
@@ -480,9 +507,10 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
+						Name: "mean",
+						Type: "func",
+						Args: []string{
+							"usage_idle",
 						},
 					},
 				},
@@ -507,9 +535,10 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
+						Name: "mean",
+						Type: "func",
+						Args: []string{
+							"usage_idle",
 						},
 					},
 				},
@@ -534,9 +563,10 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Field: "usage_idle",
-						Funcs: []string{
-							"mean",
+						Name: "mean",
+						Type: "func",
+						Args: []string{
+							"usage_idle",
 						},
 					},
 				},
@@ -573,8 +603,8 @@ func TestConvert(t *testing.T) {
 					t.Errorf("Convert() = %s, want %s", *got.RawText, tt.RawText)
 				}
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("Convert() = \n%#v\n want \n%#v\n", got, tt.want)
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("Convert() = %s", cmp.Diff(got, tt.want))
 			}
 		})
 	}

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -24,20 +24,20 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_idle",
-						Type: "field",
+						Value: "usage_idle",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest_nice",
-						Type: "field",
+						Value: "usage_guest_nice",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_system",
-						Type: "field",
+						Value: "usage_system",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest",
-						Type: "field",
+						Value: "usage_guest",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{},
@@ -55,42 +55,42 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
 					chronograf.Field{
-						Name: "median",
-						Type: "func",
+						Value: "median",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
 					chronograf.Field{
-						Name: "count",
-						Type: "func",
+						Value: "count",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_guest_nice",
-								Type: "field",
+								Value: "usage_guest_nice",
+								Type:  "field",
 							},
 						},
 					},
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_guest_nice",
-								Type: "field",
+								Value: "usage_guest_nice",
+								Type:  "field",
 							},
 						},
 					},
@@ -134,8 +134,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -170,8 +170,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -195,8 +195,8 @@ func TestConvert(t *testing.T) {
 				Tags:            map[string][]string{},
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				GroupBy: chronograf.GroupBy{
@@ -242,8 +242,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{},
@@ -262,8 +262,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -287,8 +287,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{
@@ -331,8 +331,8 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_user",
-						Type: "field",
+						Value: "usage_user",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{
@@ -358,20 +358,20 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_idle",
-						Type: "field",
+						Value: "usage_idle",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest_nice",
-						Type: "field",
+						Value: "usage_guest_nice",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_system",
-						Type: "field",
+						Value: "usage_system",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest",
-						Type: "field",
+						Value: "usage_guest",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{
@@ -405,20 +405,20 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "usage_idle",
-						Type: "field",
+						Value: "usage_idle",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest_nice",
-						Type: "field",
+						Value: "usage_guest_nice",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_system",
-						Type: "field",
+						Value: "usage_system",
+						Type:  "field",
 					},
 					chronograf.Field{
-						Name: "usage_guest",
-						Type: "field",
+						Value: "usage_guest",
+						Type:  "field",
 					},
 				},
 				Tags: map[string][]string{
@@ -452,12 +452,12 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
@@ -483,12 +483,12 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
@@ -507,19 +507,20 @@ func TestConvert(t *testing.T) {
 		},
 		{
 			name:     "Test implicit null fill accepted and made explicit",
-			influxQL: `SELECT mean("usage_idle") FROM "telegraf"."autogen"."cpu" WHERE time > now() - 15m GROUP BY time(1m)`,
+			influxQL: `SELECT mean("usage_idle") as "mean_usage_idle" FROM "telegraf"."autogen"."cpu" WHERE time > now() - 15m GROUP BY time(1m)`,
 			want: chronograf.QueryConfig{
 				Database:        "telegraf",
 				Measurement:     "cpu",
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
+						Alias: "mean_usage_idle",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
@@ -537,6 +538,122 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name:     "Test percentile with a number parameter",
+			influxQL: `SELECT percentile("usage_idle", 3.14) as "mean_usage_idle" FROM "telegraf"."autogen"."cpu" WHERE time > now() - 15m GROUP BY time(1m)`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "percentile",
+						Type:  "func",
+						Alias: "mean_usage_idle",
+						Args: []chronograf.Field{
+							{
+								Value: "usage_idle",
+								Type:  "field",
+							},
+							chronograf.Field{
+								Value: 3.14,
+								Type:  "number",
+							},
+						},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Time: "1m",
+					Tags: []string{},
+				},
+				Tags:            map[string][]string{},
+				AreTagsAccepted: false,
+				Fill:            "null",
+				Range: &chronograf.DurationRange{
+					Lower: "now() - 15m",
+				},
+			},
+		},
+		{
+			name:     "Test top with 2 arguments",
+			influxQL: `SELECT TOP("water_level","location",2) FROM "h2o_feet"`,
+			want: chronograf.QueryConfig{
+				Measurement: "h2o_feet",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "top",
+						Type:  "func",
+						Args: []chronograf.Field{
+							{
+								Value: "water_level",
+								Type:  "field",
+							},
+							chronograf.Field{
+								Value: "location",
+								Type:  "field",
+							},
+							chronograf.Field{
+								Value: int64(2),
+								Type:  "integer",
+							},
+						},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+				Tags:            map[string][]string{},
+				AreTagsAccepted: false,
+			},
+		},
+		{
+			name:     "count of a regex",
+			influxQL: ` SELECT COUNT(/water/) FROM "h2o_feet"`,
+			want: chronograf.QueryConfig{
+				Measurement: "h2o_feet",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "count",
+						Type:  "func",
+						Args: []chronograf.Field{
+							{
+								Value: "water",
+								Type:  "regex",
+							},
+						},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+				Tags:            map[string][]string{},
+				AreTagsAccepted: false,
+			},
+		},
+		{
+			name:     "count of a wildcard",
+			influxQL: ` SELECT COUNT(*) FROM "h2o_feet"`,
+			want: chronograf.QueryConfig{
+				Measurement: "h2o_feet",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "count",
+						Type:  "func",
+						Args: []chronograf.Field{
+							{
+								Value: "*",
+								Type:  "wildcard",
+							},
+						},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+				Tags:            map[string][]string{},
+				AreTagsAccepted: false,
+			},
+		},
+		{
 			name:     "Test fill number (int) accepted",
 			influxQL: `SELECT mean("usage_idle") FROM "telegraf"."autogen"."cpu" WHERE time > now() - 15m GROUP BY time(1m) FILL(1337)`,
 			want: chronograf.QueryConfig{
@@ -545,12 +662,12 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},
@@ -576,12 +693,12 @@ func TestConvert(t *testing.T) {
 				RetentionPolicy: "autogen",
 				Fields: []chronograf.Field{
 					chronograf.Field{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_idle",
-								Type: "field",
+								Value: "usage_idle",
+								Type:  "field",
 							},
 						},
 					},

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -26,22 +26,18 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_idle",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest_nice",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_system",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{},
@@ -61,22 +57,42 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{"usage_idle"},
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
+						},
 					},
 					chronograf.Field{
 						Name: "median",
 						Type: "func",
-						Args: []string{"usage_idle"},
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
+						},
 					},
 					chronograf.Field{
 						Name: "count",
 						Type: "func",
-						Args: []string{"usage_guest_nice"},
+						Args: []chronograf.Field{
+							{
+								Name: "usage_guest_nice",
+								Type: "field",
+							},
+						},
 					},
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{"usage_guest_nice"},
+						Args: []chronograf.Field{
+							{
+								Name: "usage_guest_nice",
+								Type: "field",
+							},
+						},
 					},
 				},
 				Tags: map[string][]string{},
@@ -120,7 +136,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -157,7 +172,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -183,7 +197,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				GroupBy: chronograf.GroupBy{
@@ -231,7 +244,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{},
@@ -252,7 +264,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{"host": []string{"myhost"}},
@@ -278,7 +289,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -323,7 +333,6 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_user",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -351,22 +360,18 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_idle",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest_nice",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_system",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -402,22 +407,18 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "usage_idle",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest_nice",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_system",
 						Type: "field",
-						Args: []string{},
 					},
 					chronograf.Field{
 						Name: "usage_guest",
 						Type: "field",
-						Args: []string{},
 					},
 				},
 				Tags: map[string][]string{
@@ -453,8 +454,11 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{
-							"usage_idle",
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
 						},
 					},
 				},
@@ -481,8 +485,11 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{
-							"usage_idle",
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
 						},
 					},
 				},
@@ -509,8 +516,11 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{
-							"usage_idle",
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
 						},
 					},
 				},
@@ -537,8 +547,11 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{
-							"usage_idle",
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
 						},
 					},
 				},
@@ -565,8 +578,11 @@ func TestConvert(t *testing.T) {
 					chronograf.Field{
 						Name: "mean",
 						Type: "func",
-						Args: []string{
-							"usage_idle",
+						Args: []chronograf.Field{
+							{
+								Name: "usage_idle",
+								Type: "field",
+							},
 						},
 					},
 				},

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -555,7 +555,7 @@ func TestConvert(t *testing.T) {
 								Type:  "field",
 							},
 							chronograf.Field{
-								Value: 3.14,
+								Value: "3.14",
 								Type:  "number",
 							},
 						},
@@ -592,7 +592,7 @@ func TestConvert(t *testing.T) {
 								Type:  "field",
 							},
 							chronograf.Field{
-								Value: int64(2),
+								Value: "2",
 								Type:  "integer",
 							},
 						},

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -630,6 +630,31 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name:     "count with aggregate",
+			influxQL: `SELECT COUNT(water) as "count_water" FROM "h2o_feet"`,
+			want: chronograf.QueryConfig{
+				Measurement: "h2o_feet",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "count",
+						Type:  "func",
+						Alias: "count_water",
+						Args: []chronograf.Field{
+							{
+								Value: "water",
+								Type:  "field",
+							},
+						},
+					},
+				},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+				Tags:            map[string][]string{},
+				AreTagsAccepted: false,
+			},
+		},
+		{
 			name:     "count of a wildcard",
 			influxQL: ` SELECT COUNT(*) FROM "h2o_feet"`,
 			want: chronograf.QueryConfig{

--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -422,15 +422,22 @@ func Reverse(script chronograf.TICKScript) (chronograf.AlertRule, error) {
 	} else {
 		rule.Query.GroupBy.Time = commonVars.Period
 		rule.Every = commonVars.Every
-		funcs := []string{}
 		if fieldFunc.Func != "" {
-			funcs = append(funcs, fieldFunc.Func)
-		}
-		rule.Query.Fields = []chronograf.Field{
-			{
-				Field: fieldFunc.Field,
-				Funcs: funcs,
-			},
+			rule.Query.Fields = []chronograf.Field{
+				{
+					Type: "func",
+					Name: fieldFunc.Func,
+					Args: []string{fieldFunc.Field},
+				},
+			}
+		} else {
+			rule.Query.Fields = []chronograf.Field{
+				{
+					Type: "field",
+					Name: fieldFunc.Field,
+					Args: []string{},
+				},
+			}
 		}
 	}
 

--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -425,12 +425,12 @@ func Reverse(script chronograf.TICKScript) (chronograf.AlertRule, error) {
 		if fieldFunc.Func != "" {
 			rule.Query.Fields = []chronograf.Field{
 				{
-					Type: "func",
-					Name: fieldFunc.Func,
+					Type:  "func",
+					Value: fieldFunc.Func,
 					Args: []chronograf.Field{
 						{
-							Name: fieldFunc.Field,
-							Type: "field",
+							Value: fieldFunc.Field,
+							Type:  "field",
 						},
 					},
 				},
@@ -438,8 +438,8 @@ func Reverse(script chronograf.TICKScript) (chronograf.AlertRule, error) {
 		} else {
 			rule.Query.Fields = []chronograf.Field{
 				{
-					Type: "field",
-					Name: fieldFunc.Field,
+					Type:  "field",
+					Value: fieldFunc.Field,
 				},
 			}
 		}

--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -427,7 +427,12 @@ func Reverse(script chronograf.TICKScript) (chronograf.AlertRule, error) {
 				{
 					Type: "func",
 					Name: fieldFunc.Func,
-					Args: []string{fieldFunc.Field},
+					Args: []chronograf.Field{
+						{
+							Name: fieldFunc.Field,
+							Type: "field",
+						},
+					},
 				},
 			}
 		} else {
@@ -435,7 +440,6 @@ func Reverse(script chronograf.TICKScript) (chronograf.AlertRule, error) {
 				{
 					Type: "field",
 					Name: fieldFunc.Field,
-					Args: []string{},
 				},
 			}
 		}

--- a/kapacitor/ast_test.go
+++ b/kapacitor/ast_test.go
@@ -4,6 +4,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/chronograf"
 )
 
@@ -112,10 +113,9 @@ func TestReverse(t *testing.T) {
 					Measurement:     "cpu",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{
-								"mean",
-							},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					GroupBy: chronograf.GroupBy{
@@ -220,9 +220,10 @@ func TestReverse(t *testing.T) {
 					Measurement:     "cpu",
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
-						chronograf.Field{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+						{
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -360,8 +361,9 @@ func TestReverse(t *testing.T) {
 					Measurement:     "haproxy",
 					Fields: []chronograf.Field{
 						{
-							Field: "status",
-							Funcs: []string{"last"},
+							Name: "last",
+							Args: []string{"status"},
+							Type: "func",
 						},
 					},
 					GroupBy: chronograf.GroupBy{
@@ -475,8 +477,9 @@ func TestReverse(t *testing.T) {
 					Measurement:     "haproxy",
 					Fields: []chronograf.Field{
 						{
-							Field: "status",
-							Funcs: []string{"last"},
+							Name: "last",
+							Args: []string{"status"},
+							Type: "func",
 						},
 					},
 					GroupBy: chronograf.GroupBy{
@@ -592,8 +595,9 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -717,8 +721,9 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -842,8 +847,9 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -955,8 +961,9 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{},
+							Name: "usage_user",
+							Args: []string{},
+							Type: "field",
 						},
 					},
 					Tags: map[string][]string{
@@ -1090,8 +1097,9 @@ trigger
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -1226,8 +1234,9 @@ trigger
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Field: "usage_user",
-							Funcs: []string{"mean"},
+							Name: "mean",
+							Args: []string{"usage_user"},
+							Type: "func",
 						},
 					},
 					Tags: map[string][]string{
@@ -1441,8 +1450,9 @@ trigger
 					Measurement:     "cq",
 					Fields: []chronograf.Field{
 						{
-							Field: "queryOk",
-							Funcs: []string{},
+							Name: "queryOk",
+							Args: []string{},
+							Type: "field",
 						},
 					},
 					GroupBy: chronograf.GroupBy{
@@ -1465,8 +1475,8 @@ trigger
 				if tt.want.Query != nil {
 					if got.Query == nil {
 						t.Errorf("Reverse() = got nil QueryConfig")
-					} else if !reflect.DeepEqual(*got.Query, *tt.want.Query) {
-						t.Errorf("Reverse() = QueryConfig not equal\n%#v\n, want \n%#v\n", *got.Query, *tt.want.Query)
+					} else if !cmp.Equal(*got.Query, *tt.want.Query) {
+						t.Errorf("Reverse() = QueryConfig not equal %s", cmp.Diff(*got.Query, *tt.want.Query))
 					}
 				}
 			}

--- a/kapacitor/ast_test.go
+++ b/kapacitor/ast_test.go
@@ -113,11 +113,11 @@ func TestReverse(t *testing.T) {
 					Measurement:     "cpu",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -226,11 +226,11 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -371,11 +371,11 @@ func TestReverse(t *testing.T) {
 					Measurement:     "haproxy",
 					Fields: []chronograf.Field{
 						{
-							Name: "last",
+							Value: "last",
 							Args: []chronograf.Field{
 								{
-									Name: "status",
-									Type: "field",
+									Value: "status",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -492,11 +492,11 @@ func TestReverse(t *testing.T) {
 					Measurement:     "haproxy",
 					Fields: []chronograf.Field{
 						{
-							Name: "last",
+							Value: "last",
 							Args: []chronograf.Field{
 								{
-									Name: "status",
-									Type: "field",
+									Value: "status",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -615,11 +615,11 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -746,11 +746,11 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -877,11 +877,11 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -996,8 +996,8 @@ func TestReverse(t *testing.T) {
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 					Tags: map[string][]string{
@@ -1131,11 +1131,11 @@ trigger
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -1273,11 +1273,11 @@ trigger
 					RetentionPolicy: "autogen",
 					Fields: []chronograf.Field{
 						{
-							Name: "mean",
+							Value: "mean",
 							Args: []chronograf.Field{
 								{
-									Name: "usage_user",
-									Type: "field",
+									Value: "usage_user",
+									Type:  "field",
 								},
 							},
 							Type: "func",
@@ -1494,8 +1494,8 @@ trigger
 					Measurement:     "cq",
 					Fields: []chronograf.Field{
 						{
-							Name: "queryOk",
-							Type: "field",
+							Value: "queryOk",
+							Type:  "field",
 						},
 					},
 					GroupBy: chronograf.GroupBy{

--- a/kapacitor/ast_test.go
+++ b/kapacitor/ast_test.go
@@ -114,7 +114,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -222,7 +227,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -362,7 +372,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "last",
-							Args: []string{"status"},
+							Args: []chronograf.Field{
+								{
+									Name: "status",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -478,7 +493,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "last",
-							Args: []string{"status"},
+							Args: []chronograf.Field{
+								{
+									Name: "status",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -596,7 +616,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -722,7 +747,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -848,7 +878,12 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -962,7 +997,6 @@ func TestReverse(t *testing.T) {
 					Fields: []chronograf.Field{
 						{
 							Name: "usage_user",
-							Args: []string{},
 							Type: "field",
 						},
 					},
@@ -1098,7 +1132,12 @@ trigger
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -1235,7 +1274,12 @@ trigger
 					Fields: []chronograf.Field{
 						{
 							Name: "mean",
-							Args: []string{"usage_user"},
+							Args: []chronograf.Field{
+								{
+									Name: "usage_user",
+									Type: "field",
+								},
+							},
 							Type: "func",
 						},
 					},
@@ -1451,7 +1495,6 @@ trigger
 					Fields: []chronograf.Field{
 						{
 							Name: "queryOk",
-							Args: []string{},
 							Type: "field",
 						},
 					},

--- a/kapacitor/client_test.go
+++ b/kapacitor/client_test.go
@@ -322,8 +322,8 @@ trigger
 							Measurement:     "cq",
 							Fields: []chronograf.Field{
 								{
-									Name: "queryOk",
-									Type: "field",
+									Value: "queryOk",
+									Type:  "field",
 								},
 							},
 							GroupBy: chronograf.GroupBy{
@@ -645,8 +645,8 @@ trigger
 						Measurement:     "cq",
 						Fields: []chronograf.Field{
 							{
-								Name: "queryOk",
-								Type: "field",
+								Value: "queryOk",
+								Type:  "field",
 							},
 						},
 						GroupBy: chronograf.GroupBy{

--- a/kapacitor/client_test.go
+++ b/kapacitor/client_test.go
@@ -322,8 +322,9 @@ trigger
 							Measurement:     "cq",
 							Fields: []chronograf.Field{
 								{
-									Field: "queryOk",
-									Funcs: []string{},
+									Name: "queryOk",
+									Type: "field",
+									Args: []string{},
 								},
 							},
 							GroupBy: chronograf.GroupBy{
@@ -645,8 +646,9 @@ trigger
 						Measurement:     "cq",
 						Fields: []chronograf.Field{
 							{
-								Field: "queryOk",
-								Funcs: []string{},
+								Name: "queryOk",
+								Type: "field",
+								Args: []string{},
 							},
 						},
 						GroupBy: chronograf.GroupBy{

--- a/kapacitor/client_test.go
+++ b/kapacitor/client_test.go
@@ -324,7 +324,6 @@ trigger
 								{
 									Name: "queryOk",
 									Type: "field",
-									Args: []string{},
 								},
 							},
 							GroupBy: chronograf.GroupBy{
@@ -648,7 +647,6 @@ trigger
 							{
 								Name: "queryOk",
 								Type: "field",
-								Args: []string{},
 							},
 						},
 						GroupBy: chronograf.GroupBy{

--- a/kapacitor/data.go
+++ b/kapacitor/data.go
@@ -41,10 +41,10 @@ func Data(rule chronograf.AlertRule) (string, error) {
 		}
 		value := ""
 		for _, field := range rule.Query.Fields {
-			if field.Type == "func" && len(field.Args) > 0 {
+			if field.Type == "func" && len(field.Args) > 0 && field.Args[0].Type == "field" {
 				// Only need a window if we have an aggregate function
 				value = value + "|window().period(period).every(every).align()\n"
-				value = value + fmt.Sprintf(`|%s('%s').as('value')`, field.Name, field.Args[0])
+				value = value + fmt.Sprintf(`|%s('%s').as('value')`, field.Name, field.Args[0].Name)
 				break // only support a single field
 			}
 			if value != "" {

--- a/kapacitor/data.go
+++ b/kapacitor/data.go
@@ -44,14 +44,14 @@ func Data(rule chronograf.AlertRule) (string, error) {
 			if field.Type == "func" && len(field.Args) > 0 && field.Args[0].Type == "field" {
 				// Only need a window if we have an aggregate function
 				value = value + "|window().period(period).every(every).align()\n"
-				value = value + fmt.Sprintf(`|%s('%s').as('value')`, field.Name, field.Args[0].Name)
+				value = value + fmt.Sprintf(`|%s('%s').as('value')`, field.Value, field.Args[0].Value)
 				break // only support a single field
 			}
 			if value != "" {
 				break // only support a single field
 			}
 			if field.Type == "field" {
-				value = fmt.Sprintf(`|eval(lambda: "%s").as('value')`, field.Name)
+				value = fmt.Sprintf(`|eval(lambda: "%s").as('value')`, field.Value)
 			}
 		}
 		if value == "" {

--- a/kapacitor/data.go
+++ b/kapacitor/data.go
@@ -41,14 +41,17 @@ func Data(rule chronograf.AlertRule) (string, error) {
 		}
 		value := ""
 		for _, field := range rule.Query.Fields {
-			for _, fnc := range field.Funcs {
+			if field.Type == "func" && len(field.Args) > 0 {
 				// Only need a window if we have an aggregate function
 				value = value + "|window().period(period).every(every).align()\n"
-				value = value + fmt.Sprintf(`|%s('%s').as('value')`, fnc, fld)
+				value = value + fmt.Sprintf(`|%s('%s').as('value')`, field.Name, field.Args[0])
 				break // only support a single field
 			}
 			if value != "" {
 				break // only support a single field
+			}
+			if field.Type == "field" {
+				value = fmt.Sprintf(`|eval(lambda: "%s").as('value')`, field.Name)
 			}
 		}
 		if value == "" {

--- a/kapacitor/influxout_test.go
+++ b/kapacitor/influxout_test.go
@@ -31,12 +31,12 @@ func TestInfluxOut(t *testing.T) {
 			Query: &chronograf.QueryConfig{
 				Fields: []chronograf.Field{
 					{
-						Name: "mean",
-						Type: "func",
+						Value: "mean",
+						Type:  "func",
 						Args: []chronograf.Field{
 							{
-								Name: "usage_user",
-								Type: "field",
+								Value: "usage_user",
+								Type:  "field",
 							},
 						},
 					},

--- a/kapacitor/influxout_test.go
+++ b/kapacitor/influxout_test.go
@@ -31,8 +31,9 @@ func TestInfluxOut(t *testing.T) {
 			Query: &chronograf.QueryConfig{
 				Fields: []chronograf.Field{
 					{
-						Field: "usage_user",
-						Funcs: []string{"mean"},
+						Name: "mean",
+						Type: "func",
+						Args: []string{"usage_user"},
 					},
 				},
 			},

--- a/kapacitor/influxout_test.go
+++ b/kapacitor/influxout_test.go
@@ -33,7 +33,12 @@ func TestInfluxOut(t *testing.T) {
 					{
 						Name: "mean",
 						Type: "func",
-						Args: []string{"usage_user"},
+						Args: []chronograf.Field{
+							{
+								Name: "usage_user",
+								Type: "field",
+							},
+						},
 					},
 				},
 			},

--- a/kapacitor/tickscripts_test.go
+++ b/kapacitor/tickscripts_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/chronograf"
 	"github.com/sergi/go-diff/diffmatchpatch"
 )
@@ -28,7 +29,12 @@ func TestGenerate(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -74,7 +80,12 @@ func TestThreshold(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -219,7 +230,12 @@ func TestThresholdStringCrit(t *testing.T) {
 				{
 					Name: "last",
 					Type: "func",
-					Args: []string{"status"},
+					Args: []chronograf.Field{
+						{
+							Name: "status",
+							Type: "field",
+						},
+					},
 				},
 			},
 			GroupBy: chronograf.GroupBy{
@@ -358,7 +374,12 @@ func TestThresholdStringCritGreater(t *testing.T) {
 				{
 					Name: "last",
 					Type: "func",
-					Args: []string{"status"},
+					Args: []chronograf.Field{
+						{
+							Name: "status",
+							Type: "field",
+						},
+					},
 				},
 			},
 			GroupBy: chronograf.GroupBy{
@@ -495,7 +516,12 @@ func TestThresholdDetail(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -643,7 +669,12 @@ func TestThresholdInsideRange(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -790,7 +821,12 @@ func TestThresholdOutsideRange(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -936,7 +972,6 @@ func TestThresholdNoAggregate(t *testing.T) {
 				{
 					Name: "usage_user",
 					Type: "field",
-					Args: []string{},
 				},
 			},
 			Tags: map[string][]string{
@@ -1074,7 +1109,12 @@ func TestRelative(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -1232,7 +1272,12 @@ func TestRelativeChange(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -1387,7 +1432,12 @@ func TestDeadman(t *testing.T) {
 				{
 					Name: "mean",
 					Type: "func",
-					Args: []string{"usage_user"},
+					Args: []chronograf.Field{
+						{
+							Name: "usage_user",
+							Type: "field",
+						},
+					},
 				},
 			},
 			Tags: map[string][]string{
@@ -1499,9 +1549,7 @@ trigger
 			continue
 		}
 		if got != tt.want {
-			diff := diffmatchpatch.New()
-			delta := diff.DiffMain(string(tt.want), string(got), true)
-			t.Errorf("%q\n%s", tt.name, diff.DiffPrettyText(delta))
+			t.Errorf("%q\n%s", tt.name, cmp.Diff(string(tt.want), string(got)))
 		}
 	}
 }

--- a/kapacitor/tickscripts_test.go
+++ b/kapacitor/tickscripts_test.go
@@ -26,8 +26,9 @@ func TestGenerate(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -71,8 +72,9 @@ func TestThreshold(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -215,8 +217,9 @@ func TestThresholdStringCrit(t *testing.T) {
 			Measurement:     "haproxy",
 			Fields: []chronograf.Field{
 				{
-					Field: "status",
-					Funcs: []string{"last"},
+					Name: "last",
+					Type: "func",
+					Args: []string{"status"},
 				},
 			},
 			GroupBy: chronograf.GroupBy{
@@ -353,8 +356,9 @@ func TestThresholdStringCritGreater(t *testing.T) {
 			Measurement:     "haproxy",
 			Fields: []chronograf.Field{
 				{
-					Field: "status",
-					Funcs: []string{"last"},
+					Name: "last",
+					Type: "func",
+					Args: []string{"status"},
 				},
 			},
 			GroupBy: chronograf.GroupBy{
@@ -489,8 +493,9 @@ func TestThresholdDetail(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -636,8 +641,9 @@ func TestThresholdInsideRange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -782,8 +788,9 @@ func TestThresholdOutsideRange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -927,8 +934,9 @@ func TestThresholdNoAggregate(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{},
+					Name: "usage_user",
+					Type: "field",
+					Args: []string{},
 				},
 			},
 			Tags: map[string][]string{
@@ -1064,8 +1072,9 @@ func TestRelative(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -1221,8 +1230,9 @@ func TestRelativeChange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{
@@ -1375,8 +1385,9 @@ func TestDeadman(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "usage_user",
-					Funcs: []string{"mean"},
+					Name: "mean",
+					Type: "func",
+					Args: []string{"usage_user"},
 				},
 			},
 			Tags: map[string][]string{

--- a/kapacitor/tickscripts_test.go
+++ b/kapacitor/tickscripts_test.go
@@ -27,12 +27,12 @@ func TestGenerate(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -78,12 +78,12 @@ func TestThreshold(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -228,12 +228,12 @@ func TestThresholdStringCrit(t *testing.T) {
 			Measurement:     "haproxy",
 			Fields: []chronograf.Field{
 				{
-					Name: "last",
-					Type: "func",
+					Value: "last",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "status",
-							Type: "field",
+							Value: "status",
+							Type:  "field",
 						},
 					},
 				},
@@ -372,12 +372,12 @@ func TestThresholdStringCritGreater(t *testing.T) {
 			Measurement:     "haproxy",
 			Fields: []chronograf.Field{
 				{
-					Name: "last",
-					Type: "func",
+					Value: "last",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "status",
-							Type: "field",
+							Value: "status",
+							Type:  "field",
 						},
 					},
 				},
@@ -514,12 +514,12 @@ func TestThresholdDetail(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -667,12 +667,12 @@ func TestThresholdInsideRange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -819,12 +819,12 @@ func TestThresholdOutsideRange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -970,8 +970,8 @@ func TestThresholdNoAggregate(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "usage_user",
-					Type: "field",
+					Value: "usage_user",
+					Type:  "field",
 				},
 			},
 			Tags: map[string][]string{
@@ -1107,12 +1107,12 @@ func TestRelative(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -1270,12 +1270,12 @@ func TestRelativeChange(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},
@@ -1430,12 +1430,12 @@ func TestDeadman(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "mean",
-					Type: "func",
+					Value: "mean",
+					Type:  "func",
 					Args: []chronograf.Field{
 						{
-							Name: "usage_user",
-							Type: "field",
+							Value: "usage_user",
+							Type:  "field",
 						},
 					},
 				},

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -154,7 +154,12 @@ func field(q *chronograf.QueryConfig) (string, error) {
 	if q != nil {
 		for _, field := range q.Fields {
 			if field.Type == "func" && len(field.Args) > 0 {
-				return field.Args[0], nil
+				for _, arg := range field.Args {
+					if arg.Type == "field" {
+						return arg.Name, nil
+					}
+				}
+				return "", fmt.Errorf("No fields set in query")
 			}
 			return field.Name, nil
 		}

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -156,12 +156,12 @@ func field(q *chronograf.QueryConfig) (string, error) {
 			if field.Type == "func" && len(field.Args) > 0 {
 				for _, arg := range field.Args {
 					if arg.Type == "field" {
-						return arg.Name, nil
+						return arg.Name.(string), nil
 					}
 				}
 				return "", fmt.Errorf("No fields set in query")
 			}
-			return field.Name, nil
+			return field.Name.(string), nil
 		}
 	}
 	return "", fmt.Errorf("No fields set in query")

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -133,7 +133,7 @@ func window(rule chronograf.AlertRule) string {
 	}
 	// Period only makes sense if the field has a been grouped via a time duration.
 	for _, field := range rule.Query.Fields {
-		if len(field.Funcs) > 0 {
+		if field.Type == "func" {
 			return fmt.Sprintf("var period = %s\nvar every = %s", rule.Query.GroupBy.Time, rule.Every)
 		}
 	}
@@ -153,7 +153,10 @@ func groupBy(q *chronograf.QueryConfig) string {
 func field(q *chronograf.QueryConfig) (string, error) {
 	if q != nil {
 		for _, field := range q.Fields {
-			return field.Field, nil
+			if field.Type == "func" && len(field.Args) > 0 {
+				return field.Args[0], nil
+			}
+			return field.Name, nil
 		}
 	}
 	return "", fmt.Errorf("No fields set in query")

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -156,12 +156,12 @@ func field(q *chronograf.QueryConfig) (string, error) {
 			if field.Type == "func" && len(field.Args) > 0 {
 				for _, arg := range field.Args {
 					if arg.Type == "field" {
-						return arg.Name.(string), nil
+						return arg.Value.(string), nil
 					}
 				}
 				return "", fmt.Errorf("No fields set in query")
 			}
-			return field.Name.(string), nil
+			return field.Value.(string), nil
 		}
 	}
 	return "", fmt.Errorf("No fields set in query")

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -156,12 +156,20 @@ func field(q *chronograf.QueryConfig) (string, error) {
 			if field.Type == "func" && len(field.Args) > 0 {
 				for _, arg := range field.Args {
 					if arg.Type == "field" {
-						return arg.Value.(string), nil
+						f, ok := arg.Value.(string)
+						if !ok {
+							return "", fmt.Errorf("field value %v is should be string but is %T", arg.Value, arg.Value)
+						}
+						return f, nil
 					}
 				}
 				return "", fmt.Errorf("No fields set in query")
 			}
-			return field.Value.(string), nil
+			f, ok := field.Value.(string)
+			if !ok {
+				return "", fmt.Errorf("field value %v is should be string but is %T", field.Value, field.Value)
+			}
+			return f, nil
 		}
 	}
 	return "", fmt.Errorf("No fields set in query")

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -151,28 +151,30 @@ func groupBy(q *chronograf.QueryConfig) string {
 }
 
 func field(q *chronograf.QueryConfig) (string, error) {
-	if q != nil {
-		for _, field := range q.Fields {
-			if field.Type == "func" && len(field.Args) > 0 {
-				for _, arg := range field.Args {
-					if arg.Type == "field" {
-						f, ok := arg.Value.(string)
-						if !ok {
-							return "", fmt.Errorf("field value %v is should be string but is %T", arg.Value, arg.Value)
-						}
-						return f, nil
-					}
-				}
-				return "", fmt.Errorf("No fields set in query")
-			}
-			f, ok := field.Value.(string)
-			if !ok {
-				return "", fmt.Errorf("field value %v is should be string but is %T", field.Value, field.Value)
-			}
-			return f, nil
-		}
+	if q == nil {
+		return "", fmt.Errorf("No fields set in query")
 	}
-	return "", fmt.Errorf("No fields set in query")
+	if len(q.Fields) != 1 {
+		return "", fmt.Errorf("expect only one field but found %d", len(q.Fields))
+	}
+	field := q.Fields[0]
+	if field.Type == "func" {
+		for _, arg := range field.Args {
+			if arg.Type == "field" {
+				f, ok := arg.Value.(string)
+				if !ok {
+					return "", fmt.Errorf("field value %v is should be string but is %T", arg.Value, arg.Value)
+				}
+				return f, nil
+			}
+		}
+		return "", fmt.Errorf("No fields set in query")
+	}
+	f, ok := field.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("field value %v is should be string but is %T", field.Value, field.Value)
+	}
+	return f, nil
 }
 
 func whereFilter(q *chronograf.QueryConfig) string {

--- a/kapacitor/vars_test.go
+++ b/kapacitor/vars_test.go
@@ -24,7 +24,6 @@ func TestVarsCritStringEqual(t *testing.T) {
 				{
 					Name: "status",
 					Type: "field",
-					Args: []string{},
 				},
 			},
 			GroupBy: chronograf.GroupBy{

--- a/kapacitor/vars_test.go
+++ b/kapacitor/vars_test.go
@@ -22,7 +22,9 @@ func TestVarsCritStringEqual(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Field: "status",
+					Name: "status",
+					Type: "field",
+					Args: []string{},
 				},
 			},
 			GroupBy: chronograf.GroupBy{

--- a/kapacitor/vars_test.go
+++ b/kapacitor/vars_test.go
@@ -22,8 +22,8 @@ func TestVarsCritStringEqual(t *testing.T) {
 			RetentionPolicy: "autogen",
 			Fields: []chronograf.Field{
 				{
-					Name: "status",
-					Type: "field",
+					Value: "status",
+					Type:  "field",
 				},
 			},
 			GroupBy: chronograf.GroupBy{

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -311,8 +311,8 @@ func Test_newDashboardResponse(t *testing.T) {
 										Measurement: "grays_sports_alamanc",
 										Fields: []chronograf.Field{
 											{
-												Type: "field",
-												Name: "winning_horses",
+												Type:  "field",
+												Value: "winning_horses",
 											},
 										},
 										GroupBy: chronograf.GroupBy{

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -311,8 +311,9 @@ func Test_newDashboardResponse(t *testing.T) {
 										Measurement: "grays_sports_alamanc",
 										Fields: []chronograf.Field{
 											{
-												Field: "winning_horses",
-												Funcs: []string{},
+												Type: "field",
+												Name: "winning_horses",
+												Args: []string{},
 											},
 										},
 										GroupBy: chronograf.GroupBy{

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -313,7 +313,6 @@ func Test_newDashboardResponse(t *testing.T) {
 											{
 												Type: "field",
 												Name: "winning_horses",
-												Args: []string{},
 											},
 										},
 										GroupBy: chronograf.GroupBy{

--- a/server/kapacitors.go
+++ b/server/kapacitors.go
@@ -382,8 +382,8 @@ func newAlertResponse(task *kapa.Task, srcID, kapaID int) *alertResponse {
 		}
 
 		for _, f := range res.Query.Fields {
-			if f.Funcs == nil {
-				f.Funcs = make([]string, 0)
+			if f.Type == "func" && f.Args == nil {
+				f.Args = make([]string, 0)
 			}
 		}
 
@@ -405,9 +405,8 @@ func ValidRuleRequest(rule chronograf.AlertRule) error {
 	}
 	var hasFuncs bool
 	for _, f := range rule.Query.Fields {
-		if len(f.Funcs) > 0 {
+		if f.Type == "func" && len(f.Args) > 0 {
 			hasFuncs = true
-			break
 		}
 	}
 	// All kapacitor rules with functions must have a window that is applied

--- a/server/kapacitors.go
+++ b/server/kapacitors.go
@@ -381,12 +381,6 @@ func newAlertResponse(task *kapa.Task, srcID, kapaID int) *alertResponse {
 			res.Query.Fields = make([]chronograf.Field, 0)
 		}
 
-		for _, f := range res.Query.Fields {
-			if f.Type == "func" && f.Args == nil {
-				f.Args = make([]string, 0)
-			}
-		}
-
 		if res.Query.GroupBy.Tags == nil {
 			res.Query.GroupBy.Tags = make([]string, 0)
 		}

--- a/server/kapacitors_test.go
+++ b/server/kapacitors_test.go
@@ -37,12 +37,12 @@ func TestValidRuleRequest(t *testing.T) {
 				Query: &chronograf.QueryConfig{
 					Fields: []chronograf.Field{
 						{
-							Name: "max",
-							Type: "func",
+							Value: "max",
+							Type:  "func",
 							Args: []chronograf.Field{
 								{
-									Name: "oldmanpeabody",
-									Type: "field",
+									Value: "oldmanpeabody",
+									Type:  "field",
 								},
 							},
 						},
@@ -58,12 +58,12 @@ func TestValidRuleRequest(t *testing.T) {
 				Query: &chronograf.QueryConfig{
 					Fields: []chronograf.Field{
 						{
-							Name: "max",
-							Type: "func",
+							Value: "max",
+							Type:  "func",
 							Args: []chronograf.Field{
 								{
-									Name: "oldmanpeabody",
-									Type: "field",
+									Value: "oldmanpeabody",
+									Type:  "field",
 								},
 							},
 						},

--- a/server/kapacitors_test.go
+++ b/server/kapacitors_test.go
@@ -39,7 +39,12 @@ func TestValidRuleRequest(t *testing.T) {
 						{
 							Name: "max",
 							Type: "func",
-							Args: []string{"oldmanpeabody"},
+							Args: []chronograf.Field{
+								{
+									Name: "oldmanpeabody",
+									Type: "field",
+								},
+							},
 						},
 					},
 				},
@@ -55,7 +60,12 @@ func TestValidRuleRequest(t *testing.T) {
 						{
 							Name: "max",
 							Type: "func",
-							Args: []string{"oldmanpeabody"},
+							Args: []chronograf.Field{
+								{
+									Name: "oldmanpeabody",
+									Type: "field",
+								},
+							},
 						},
 					},
 				},

--- a/server/kapacitors_test.go
+++ b/server/kapacitors_test.go
@@ -37,8 +37,9 @@ func TestValidRuleRequest(t *testing.T) {
 				Query: &chronograf.QueryConfig{
 					Fields: []chronograf.Field{
 						{
-							Field: "oldmanpeabody",
-							Funcs: []string{"max"},
+							Name: "max",
+							Type: "func",
+							Args: []string{"oldmanpeabody"},
 						},
 					},
 				},
@@ -52,8 +53,9 @@ func TestValidRuleRequest(t *testing.T) {
 				Query: &chronograf.QueryConfig{
 					Fields: []chronograf.Field{
 						{
-							Field: "oldmanpeabody",
-							Funcs: []string{"max"},
+							Name: "max",
+							Type: "func",
+							Args: []string{"oldmanpeabody"},
 						},
 					},
 				},

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2497,8 +2497,14 @@
         "retentionPolicy": "autogen",
         "fields": [
           {
-            "field": "usage_system",
-            "funcs": ["max"]
+            "value": "max",
+            "type": "func",
+            "args": [
+              {
+                "value": "usage_system",
+                "type": "field"
+              }
+            ]
           }
         ],
         "tags": {},
@@ -2552,19 +2558,7 @@
         "fields": {
           "type": "array",
           "items": {
-            "type": "object",
-            "properties": {
-              "field": {
-                "type": "string"
-              },
-              "funcs": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                }
-              }
-            },
-            "required": ["field", "funcs"]
+            "$ref": "#/definitions/Field"
           }
         },
         "range": {
@@ -2611,6 +2605,36 @@
           "description": "All properties attached to the kapacitor node",
           "items": {
             "$ref": "#/definitions/KapacitorProperty"
+          }
+        }
+      }
+    },
+    "Field": {
+      "type": "object",
+      "required": ["type", "value"],
+      "description": "Represents a field to be returned from an InfluxQL query",
+      "properties": {
+        "value": {
+          "description":
+            "value is the value of the field.  Meaning of the value is implied by the `type` key",
+          "type": "string"
+        },
+        "type": {
+          "description":
+            "type describes the field type. func is a function; field is a field reference",
+          "type": "string",
+          "enum": ["func", "field", "integer", "number", "regex", "wildcard"]
+        },
+        "alias": {
+          "description":
+            "Alias overrides the field name in the returned response.  Applies only if type is `func`",
+          "type": "string"
+        },
+        "args": {
+          "description": "Args are the arguments to the function",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Field"
           }
         }
       }
@@ -2706,8 +2730,14 @@
           "retentionPolicy": "autogen",
           "fields": [
             {
-              "field": "usage_system",
-              "funcs": ["max"]
+              "value": "max",
+              "type": "func",
+              "args": [
+                {
+                  "value": "usage_system",
+                  "type": "field"
+                }
+              ]
             }
           ],
           "tags": {},
@@ -2790,7 +2820,6 @@
               "opsgenie",
               "pagerduty",
               "victorops",
-              "smtp",
               "email",
               "exec",
               "log",
@@ -2960,6 +2989,12 @@
         }
       },
       "required": ["db", "rp"]
+    },
+    "Sources": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Source"
+      }
     },
     "Source": {
       "type": "object",
@@ -3787,7 +3822,7 @@
             "queries": [
               {
                 "query":
-                  "SELECT mean(\"usage_user\") AS \"usage_user\" FROM \"cpu\"",
+                  "SELECT mean(\"usage_user\") AS \"mean_usage_user\" FROM \"cpu\"",
                 "label": "%",
                 "queryConfig": {
                   "database": "",
@@ -3795,8 +3830,15 @@
                   "retentionPolicy": "",
                   "fields": [
                     {
-                      "field": "usage_user",
-                      "funcs": ["mean"]
+                      "value": "mean",
+                      "type": "func",
+                      "alias": "mean_usage_user",
+                      "args": [
+                        {
+                          "value": "usage_user",
+                          "type": "field"
+                        }
+                      ]
                     }
                   ],
                   "tags": {},


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2067 

### The problem
queryConfig does not support alias nor functions.

### The Solution
This PR adds alias and functions to the backend.

The response to the query below is now changed:
```sql
                  SELECT mean("usage_user") AS "mean_usage_user" FROM "cpu"
```

```json
                  "fields": [
                    {
                      "value": "mean",
                      "type": "func",
                      "alias": "mean_usage_user",
                      "args": [
                        {
                          "value": "usage_user",
                          "type": "field"
                        }
                      ]
                    }
                  ]
```
