### PR TITLE
Add support for millisecond groupbys

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -301,17 +302,15 @@ func (g *GroupByVar) String() string {
 	// The function is: ((total_seconds * millisecond_converstion) / group_by) = pixels / 3
 	// Number of points given the pixels
 	pixels := float64(g.Resolution) / 3.0
-	// Move the milliseconds to the other side of the equation
-	pixels = pixels / 1000.0
-	// Remove the number of pixels from the number of seconds
-	groupby := float64(g.Duration/time.Second) / pixels
-	if groupby < 1000.0 {
-		// If groupby is less than 1 second
-		return "time(" + strconv.Itoa(int(groupby)) + "ms)"
+	msPerPixel := float64(g.Duration/time.Millisecond) / pixels
+	secPerPixel := float64(g.Duration/time.Second) / pixels
+	if secPerPixel < 1.0 {
+		log.Printf("%s", "time("+strconv.FormatInt(int64(msPerPixel), 10)+"ms)")
+		return "time(" + strconv.FormatInt(int64(msPerPixel), 10) + "ms)"
 	}
 	// If groupby is more than 1 second round to the second
-	seconds := int(groupby) / 1000
-	return "time(" + strconv.Itoa(seconds) + "s)"
+	log.Printf("%s", "time("+strconv.FormatInt(int64(secPerPixel), 10)+"s)")
+	return "time(" + strconv.FormatInt(int64(secPerPixel), 10) + "s)"
 }
 
 func (g *GroupByVar) Name() string {

--- a/chronograf.go
+++ b/chronograf.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"regexp"
 	"strconv"
@@ -305,11 +304,12 @@ func (g *GroupByVar) String() string {
 	msPerPixel := float64(g.Duration/time.Millisecond) / pixels
 	secPerPixel := float64(g.Duration/time.Second) / pixels
 	if secPerPixel < 1.0 {
-		log.Printf("%s", "time("+strconv.FormatInt(int64(msPerPixel), 10)+"ms)")
+		if msPerPixel < 1.0 {
+			msPerPixel = 1.0
+		}
 		return "time(" + strconv.FormatInt(int64(msPerPixel), 10) + "ms)"
 	}
 	// If groupby is more than 1 second round to the second
-	log.Printf("%s", "time("+strconv.FormatInt(int64(secPerPixel), 10)+"s)")
 	return "time(" + strconv.FormatInt(int64(secPerPixel), 10) + "s)"
 }
 

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -285,6 +285,15 @@ func TestGroupByVarString(t *testing.T) {
 			},
 			want: "time(107ms)",
 		},
+		{
+			name: "String() milliseconds if less than one millisecond",
+			tvar: &chronograf.GroupByVar{
+				Resolution:        100000,
+				ReportingInterval: 10 * time.Second,
+				Duration:          time.Second,
+			},
+			want: "time(1ms)",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -277,7 +277,7 @@ func TestGroupByVarString(t *testing.T) {
 			want: "time(370s)",
 		},
 		{
-			name: "String() outputs a minimum of 1s intervals",
+			name: "String() milliseconds if less than one second intervals",
 			tvar: &chronograf.GroupByVar{
 				Resolution:        100000,
 				ReportingInterval: 10 * time.Second,

--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -274,7 +274,7 @@ func TestGroupByVarString(t *testing.T) {
 				ReportingInterval: 10 * time.Second,
 				Duration:          24 * time.Hour,
 			},
-			want: "time(369s)",
+			want: "time(370s)",
 		},
 		{
 			name: "String() outputs a minimum of 1s intervals",
@@ -283,7 +283,7 @@ func TestGroupByVarString(t *testing.T) {
 				ReportingInterval: 10 * time.Second,
 				Duration:          time.Hour,
 			},
-			want: "time(1s)",
+			want: "time(107ms)",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1449 

### The problem
Group by time rounded up to the second on sub-second queries
### The Solution
Add support for millisecond group bys

