### PR TITLE
Style query tabs to utilize available space more effectively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#2083](https://github.com/influxdata/chronograf/pull/2083): Every dashboard can now have its own time range
 
 ### UI Improvements
+1. [#2111](https://github.com/influxdata/chronograf/pull/2111): Increase size of Cell Editor query tabs to reveal more of their query strings
 
 ## v1.3.9.0 [2017-10-06]
 ### Bug Fixes

--- a/ui/src/style/components/query-maker.scss
+++ b/ui/src/style/components/query-maker.scss
@@ -23,7 +23,7 @@ $query-maker--gutter: 16px;
 $query-maker--tabs-height: 44px;
 $query-maker--tabs-header-text: $g18-cloud;
 
-$query-maker--tab-width: 138px;
+$query-maker--tab-width: 340px;
 $query-maker--tab-text: $g11-sidewalk;
 $query-maker--tab-text-hover: $g15-platinum;
 $query-maker--tab-text-active: $g18-cloud;
@@ -94,30 +94,16 @@ $query-editor-tab-active: $g3-castle;
   height: $query-maker--tabs-height;
   margin: 0 2px 0 0;
   max-width: $query-maker--tab-width;
-  flex: 1 0 0%;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
+  flex: 1 0 0;
   color: $query-maker--tab-text;
   background: $query-maker--tab-bg;
-  cursor: pointer;
-  padding: 0 9px 0 12px;
+  position: relative;
   transition:
       color 0.25s ease,
       background-color 0.25s ease;
 
-  > label {
-    font-size: 15px;
-    font-weight: 600;
-    margin: 0;
-    white-space: nowrap;
-    overflow: hidden;
-    width: ($query-maker--tab-width - 42px);
-    text-overflow: ellipsis;
-    @include no-user-select();
-    cursor: pointer;
-  }
   &:hover {
+    cursor: pointer;
     color: $query-maker--tab-text-hover;
     background-color: $query-maker--tab-bg-hover;
   }
@@ -126,14 +112,31 @@ $query-editor-tab-active: $g3-castle;
     background: $query-maker--tab-bg-active;
   }
 }
+.query-maker--tab > label,
+.query-maker--delete {
+  top: 50%;
+  transform: translateY(-50%);
+  position: absolute;
+}
+.query-maker--tab > label {
+  left: 12px;
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  width: calc(100% - #{$query-maker--tabs-height});
+  text-overflow: ellipsis;
+  @include no-user-select();
+  cursor: inherit !important;
+}
 .query-maker--delete {
   margin: 0;
   width: 18px;
   height: 18px;
   background-color: transparent;
-  display: inline-block;
-  vertical-align: text-top;
-  position: relative;
+  display: block;
+  right: 9px;
 
   &:before,
   &:after {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2110 

### The Problem
- Query tabs are fairly tiny
- Tough to distinguish each tab by the truncated query string

### The Solution
- Increase maximum tab width from `135px` to `340px`
- Decrease tab font size from `15px` to `14px` (allows more of the string to be visible)
- Adjust how the tabs fill available space; prevent overflow of tabs

### Preview
![query-tabs-compacting](https://user-images.githubusercontent.com/2433762/31473653-cd847f5a-aeaa-11e7-8782-04e5a35314aa.gif)
Behaves just like browser tabs

![larger-query-tabs](https://user-images.githubusercontent.com/2433762/31473661-d9a9c7b8-aeaa-11e7-8834-425e6a4e1352.gif)
Larger `max-width` is nice

![screen shot 2017-10-11 at 5 29 14 pm](https://user-images.githubusercontent.com/2433762/31473672-e70239cc-aeaa-11e7-8754-44cbcc063a03.png)
More of each query string is visible

