### PR TITLE
UX-IMPROVEMENT: Add Cancel button for tickscript editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### UI Improvements
 1. [#2111](https://github.com/influxdata/chronograf/pull/2111): Increase size of Cell Editor query tabs to reveal more of their query strings
+1. [#2119](https://github.com/influxdata/chronograf/pull/2119): Add cancel button to Tickscript editor
 
 ## v1.3.9.0 [2017-10-06]
 ### Bug Fixes

--- a/ui/src/kapacitor/components/Tickscript.js
+++ b/ui/src/kapacitor/components/Tickscript.js
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react'
+
 import TickscriptHeader from 'src/kapacitor/components/TickscriptHeader'
 import TickscriptEditor from 'src/kapacitor/components/TickscriptEditor'
 
@@ -48,7 +49,9 @@ const {arrayOf, bool, func, shape, string} = PropTypes
 
 Tickscript.propTypes = {
   onSave: func.isRequired,
-  source: shape(),
+  source: shape({
+    id: string,
+  }),
   task: shape({
     id: string,
     script: string,

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -1,4 +1,6 @@
 import React, {PropTypes} from 'react'
+import {Link} from 'react-router'
+
 import SourceIndicator from 'shared/components/SourceIndicator'
 import TickscriptType from 'src/kapacitor/components/TickscriptType'
 import MultiSelectDBDropdown from 'shared/components/MultiSelectDBDropdown'
@@ -11,6 +13,7 @@ const addName = list => list.map(l => ({...l, name: `${l.db}.${l.rp}`}))
 const TickscriptHeader = ({
   task: {id, type, dbrps},
   task,
+  source,
   onSave,
   onChangeType,
   onChangeID,
@@ -31,6 +34,12 @@ const TickscriptHeader = ({
           selectedItems={addName(dbrps)}
           onApply={onSelectDbrps}
         />
+        <Link
+          className="btn btn-sm btn-default"
+          to={`/sources/${source.id}/alert-rules`}
+        >
+          Cancel
+        </Link>
         <button
           className="btn btn-success btn-sm"
           title={id ? '' : 'ID your TICKscript to save'}
@@ -47,6 +56,9 @@ const {arrayOf, bool, func, shape, string} = PropTypes
 
 TickscriptHeader.propTypes = {
   onSave: func,
+  source: shape({
+    id: string,
+  }),
   onSelectDbrps: func.isRequired,
   task: shape({
     dbrps: arrayOf(


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2096 

### The problem
Could not cancel editing or creating a Tickscript.

### The Solution
Add a cancel button that returns users to the rules/tickscript index.


