### PR TITLE
Dygraph Fork for Milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,11 @@
 ### Features
 1. [#2083](https://github.com/influxdata/chronograf/pull/2083): Every dashboard can now have its own time range
 1. [#2045](https://github.com/influxdata/chronograf/pull/2045): Add CSV download option in dashboard cells
+1. [#2127](https://github.com/influxdata/chronograf/pull/2127): Add CSV download option in dashboard cells
 
 ### UI Improvements
 1. [#2111](https://github.com/influxdata/chronograf/pull/2111): Increase size of Cell Editor query tabs to reveal more of their query strings
-1. [#2119](https://github.com/influxdata/chronograf/pull/2119): Add cancel button to Tickscript editor
+1. [#2119](https://github.com/influxdata/chronograf/pull/2119): Add support for graph zooming and point display on the millisecond-level
 
 ## v1.3.9.0 [2017-10-06]
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ### Features
 1. [#2083](https://github.com/influxdata/chronograf/pull/2083): Every dashboard can now have its own time range
 1. [#2045](https://github.com/influxdata/chronograf/pull/2045): Add CSV download option in dashboard cells
-1. [#2127](https://github.com/influxdata/chronograf/pull/2127): Add CSV download option in dashboard cells
 
 ### UI Improvements
 1. [#2111](https://github.com/influxdata/chronograf/pull/2111): Increase size of Cell Editor query tabs to reveal more of their query strings

--- a/ui/package.json
+++ b/ui/package.json
@@ -101,7 +101,7 @@
     "bootstrap": "^3.3.7",
     "calculate-size": "^1.1.1",
     "classnames": "^2.2.3",
-    "dygraphs": "^2.0.0",
+    "dygraphs": "influxdata/dygraphs",
     "eslint-plugin-babel": "^4.1.2",
     "fast.js": "^0.1.1",
     "fixed-data-table": "^0.6.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2516,9 +2516,9 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dygraphs@^2.0.0:
+dygraphs@influxdata/dygraphs:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dygraphs/-/dygraphs-2.0.0.tgz#30be283c7e32aa7536d4ea9da61ebe9f363d7c98"
+  resolved "https://codeload.github.com/influxdata/dygraphs/tar.gz/9cc90443f58c11b45473516a97d4bb3a68a620c2"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1449 

### The problem
Chronograf graphs in UI wouldn't label millisecond or sub-millisecond axes.

### The Solution
Fork Dygraphs to our own company GItHub account and apply changes from https://github.com/danvk/dygraphs/pull/777, and then point our project use that repository.
