### PR TITLE
BUGFIX: Drag n drop cancelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#2122](https://github.com/influxdata/chronograf/pull/2122): Fix 'could not connect to source' bug on source creation with unsafe-ssl
 1. [#2093](https://github.com/influxdata/chronograf/pull/2093): Fix when exporting `SHOW DATABASES` CSV has bad data
 1. [#2098](https://github.com/influxdata/chronograf/pull/2098): Fix not-equal-to highlighting in Kapacitor Rule Builder
+1. [#2135](https://github.com/influxdata/chronograf/pull/2135): Fix drag and drop cancel button
 
 ### Features
 1. [#2083](https://github.com/influxdata/chronograf/pull/2083): Every dashboard can now have its own time range

--- a/ui/src/data_explorer/components/WriteDataForm.js
+++ b/ui/src/data_explorer/components/WriteDataForm.js
@@ -98,6 +98,7 @@ class WriteDataForm extends Component {
 
   handleCancelFile = () => {
     this.setState({uploadContent: ''})
+    this.fileInput.value = ''
   }
 
   handleDragOver = e => {

--- a/ui/src/data_explorer/components/WriteDataForm.js
+++ b/ui/src/data_explorer/components/WriteDataForm.js
@@ -79,6 +79,10 @@ class WriteDataForm extends Component {
       file = e.target.files[0]
     }
 
+    if (!file) {
+      return
+    }
+
     e.preventDefault()
     e.stopPropagation()
 


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2047

### The problem
The file input value wasn't getting reset on cancel, so some users couldn't upload a different file.

### The Solution
Reset the input value on cancel.  


