### PR TITLE
Fix loss of precision while zooming

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -109,6 +109,7 @@
     "jquery": "^3.1.0",
     "lodash": "^4.3.0",
     "moment": "^2.13.0",
+    "nano-date": "^2.0.1",
     "node-uuid": "^1.4.7",
     "query-string": "^5.0.0",
     "react": "^15.0.2",

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -1,9 +1,8 @@
 /* eslint-disable no-magic-numbers */
 import React, {Component, PropTypes} from 'react'
 import shallowCompare from 'react-addons-shallow-compare'
-
 import _ from 'lodash'
-import moment from 'moment'
+import NanoDate from 'nano-date'
 
 import Dygraphs from 'src/external/dygraph'
 import getRange, {getStackedRange} from 'shared/parsing/getRangeForDygraph'
@@ -305,8 +304,8 @@ export default class Dygraph extends Component {
     if (!timeRange) {
       return ''
     }
-
-    return moment(timeRange).utc().format()
+    const date = new NanoDate(timeRange)
+    return date.toISOString()
   }
 
   deselectCrosshair = () => {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1460,6 +1460,10 @@ bignumber.js@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
 
+bignumber.js@^4.0.4:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
+
 binary-extensions@^1.0.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
@@ -2059,6 +2063,10 @@ cookie-signature@1.0.6:
 cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
+
+core-decorators@^0.20.0:
+  version "0.20.0"
+  resolved "https://registry.yarnpkg.com/core-decorators/-/core-decorators-0.20.0.tgz#605896624053af8c28efbe735c25a301a61c65c5"
 
 core-js@^1.0.0:
   version "1.2.7"
@@ -4625,6 +4633,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-or-similar@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/map-or-similar/-/map-or-similar-1.5.0.tgz#6de2653174adfb5d9edc33c69d3e92a1b76faf08"
+
 marked-terminal@^1.6.2:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/marked-terminal/-/marked-terminal-1.7.0.tgz#c8c460881c772c7604b64367007ee5f77f125904"
@@ -4648,6 +4660,12 @@ math-expression-evaluator@^1.2.14:
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
+
+memoizerific@^1.11.2:
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.2.tgz#4e0ecb9c863fb3dba1eb167c85ce98d2d7694058"
+  dependencies:
+    map-or-similar "^1.5.0"
 
 memory-fs@^0.2.0:
   version "0.2.0"
@@ -4828,6 +4846,14 @@ mute-stream@0.0.5:
 nan@^2.3.0, nan@^2.3.2:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.5.0.tgz#aa8f1e34531d807e9e27755b234b4a6ec0c152a8"
+
+nano-date@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nano-date/-/nano-date-2.0.1.tgz#16ed1351f7b4d0ad190e8565ff767b78a50e57ae"
+  dependencies:
+    bignumber.js "^4.0.4"
+    core-decorators "^0.20.0"
+    memoizerific "^1.11.2"
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect https://github.com/influxdata/chronograf/pull/2127#issuecomment-337709798

### The problem
Zooming results in loss of precision that is not handled well.

### The Solution
Support zoom with millisecond precision. Add NanoDate library to do so. NanoDate supports microsecond and nanosecond precision, but only with some work.


