### PR TITLE
Fix prebuilt warning with webpacks noParse

### DIFF
--- a/ui/webpack/devConfig.js
+++ b/ui/webpack/devConfig.js
@@ -25,6 +25,15 @@ module.exports = {
     },
   },
   module: {
+    noParse: [
+      path.resolve(
+        __dirname,
+        '..',
+        'node_modules',
+        'memoizerific',
+        'memoizerific.js'
+      ),
+    ],
     preLoaders: [
       {
         test: /\.js$/,


### PR DESCRIPTION
### The problem
![screen shot 2017-10-20 at 12 04 32 pm](https://user-images.githubusercontent.com/7582765/31837769-dfee2778-b58e-11e7-8711-233bb484848e.png)

### The Solution
Using webpacks `noParse` module.  Found the solution [here](https://stackoverflow.com/questions/39768099/how-to-ignore-seems-to-be-a-pre-built-javascript-file-try-to-require-the-orig/39768100)

@cryptoquick this look okay to you?