### PR TITLE
Use tag value in TableTag title

### DIFF
--- a/ui/src/data_explorer/components/Table.js
+++ b/ui/src/data_explorer/components/Table.js
@@ -88,6 +88,8 @@ class ChronoTable extends Component {
     )
   }
 
+  makeTabName = ({name, tags}) => (tags ? `${name}.${tags[name]}` : name)
+
   render() {
     const {containerWidth, height, query} = this.props
     const {series, columnWidths, isLoading, activeSeriesIndex} = this.state
@@ -121,11 +123,11 @@ class ChronoTable extends Component {
       <div style={{width: '100%', height: '100%', position: 'relative'}}>
         {series.length < maximumTabsCount
           ? <div className="table--tabs">
-              {series.map(({name}, i) =>
+              {series.map((s, i) =>
                 <TabItem
                   isActive={i === activeSeriesIndex}
                   key={i}
-                  name={name}
+                  name={this.makeTabName(s)}
                   index={i}
                   onClickTab={this.handleClickTab}
                 />


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1787 

### The problem
When grouping by tags, the DataExplorer table tabs all had the same title.

### The Solution
Use the corresponding tag values in tab titles as well.

![kapture 2017-10-23 at 13 49 35](https://user-images.githubusercontent.com/7582765/31912540-1775b01e-b7f9-11e7-998e-bd7519b4a4cf.gif)
