### PR TITLE
Fix field name not displaying in KapacitorRule builder

### DIFF
--- a/ui/src/kapacitor/components/Threshold.js
+++ b/ui/src/kapacitor/components/Threshold.js
@@ -1,10 +1,19 @@
 import React, {PropTypes} from 'react'
 import {OPERATORS} from 'src/kapacitor/constants'
 import Dropdown from 'shared/components/Dropdown'
+import _ from 'lodash'
 
 const mapToItems = (arr, type) => arr.map(text => ({text, type}))
 const operators = mapToItems(OPERATORS, 'operator')
 const noopSubmit = e => e.preventDefault()
+const getField = ({fields}) => {
+  const alias = _.get(fields, ['0', 'alias'], false)
+  if (!alias) {
+    return _.get(fields, ['0', 'value'], 'Select a Time-Series')
+  }
+
+  return alias
+}
 
 const Threshold = ({
   rule: {values: {operator, value, rangeValue}},
@@ -15,7 +24,7 @@ const Threshold = ({
   <div className="rule-section--row rule-section--row-first rule-section--border-bottom">
     <p>Send Alert where</p>
     <span className="rule-builder--metric">
-      {query.fields.length ? query.fields[0].field : 'Select a Time-Series'}
+      {getField(query)}
     </span>
     <p>is</p>
     <Dropdown


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2147 

### The problem
Kapacitor rule builder attempting to access a field with the old shape

### The Solution
Update it to use the new shape

