### PR TITLE
Fix GroupByTimeDropdown

### DIFF
--- a/ui/src/dashboards/components/QueryMaker.js
+++ b/ui/src/dashboards/components/QueryMaker.js
@@ -58,7 +58,7 @@ const QueryMaker = ({
       : <EmptyQuery onAddQuery={onAddQuery} />}
   </div>
 
-const {arrayOf, bool, func, number, shape, string} = PropTypes
+const {arrayOf, func, number, shape, string} = PropTypes
 
 QueryMaker.propTypes = {
   source: shape({
@@ -71,7 +71,6 @@ QueryMaker.propTypes = {
     upper: string,
     lower: string,
   }).isRequired,
-  isInDataExplorer: bool,
   actions: shape({
     chooseNamespace: func.isRequired,
     chooseMeasurement: func.isRequired,

--- a/ui/src/data_explorer/components/GroupByTimeDropdown.js
+++ b/ui/src/data_explorer/components/GroupByTimeDropdown.js
@@ -1,53 +1,48 @@
 import React, {PropTypes} from 'react'
+import {withRouter} from 'react-router'
 
 import groupByTimeOptions from 'hson!src/data_explorer/data/groupByTimes.hson'
 
 import Dropdown from 'shared/components/Dropdown'
 
-import {DEFAULT_DASHBOARD_GROUP_BY_INTERVAL} from 'shared/constants'
+import {AUTO_GROUP_BY} from 'shared/constants'
 
-const {bool, func, string} = PropTypes
+const {func, string, shape} = PropTypes
 
-const GroupByTimeDropdown = React.createClass({
-  propTypes: {
-    selected: string,
-    onChooseGroupByTime: func.isRequired,
-    isInRuleBuilder: bool,
-    isInDataExplorer: bool,
-  },
+const isInRuleBuilder = pathname => pathname.includes('alert-rules')
+const isInDataExplorer = pathname => pathname.includes('data-explorer')
 
-  render() {
-    const {
-      selected,
-      onChooseGroupByTime,
-      isInRuleBuilder,
-      isInDataExplorer,
-    } = this.props
+const getOptions = pathname =>
+  isInDataExplorer(pathname) || isInRuleBuilder(pathname)
+    ? groupByTimeOptions.filter(({menuOption}) => menuOption !== AUTO_GROUP_BY)
+    : groupByTimeOptions
 
-    let validOptions = groupByTimeOptions
-    if (isInDataExplorer || isInRuleBuilder) {
-      validOptions = validOptions.filter(
-        ({menuOption}) => menuOption !== DEFAULT_DASHBOARD_GROUP_BY_INTERVAL
-      )
-    }
+const GroupByTimeDropdown = ({
+  selected,
+  onChooseGroupByTime,
+  location: {pathname},
+}) =>
+  <div className="group-by-time">
+    <label className="group-by-time--label">Group by:</label>
+    <Dropdown
+      className="group-by-time--dropdown"
+      menuClass={isInRuleBuilder(pathname) ? 'dropdown-malachite' : null}
+      buttonColor={isInRuleBuilder(pathname) ? 'btn-default' : 'btn-info'}
+      items={getOptions(pathname).map(groupBy => ({
+        ...groupBy,
+        text: groupBy.menuOption,
+      }))}
+      onChoose={onChooseGroupByTime}
+      selected={selected || 'Time'}
+    />
+  </div>
 
-    return (
-      <div className="group-by-time">
-        <label className="group-by-time--label">Group by:</label>
-        <Dropdown
-          className="group-by-time--dropdown"
-          menuClass={isInRuleBuilder ? 'dropdown-malachite' : null}
-          buttonColor={isInRuleBuilder ? 'btn-default' : 'btn-info'}
-          items={validOptions.map(groupBy => ({
-            ...groupBy,
-            text: groupBy.menuOption,
-          }))}
-          onChoose={onChooseGroupByTime}
-          selected={selected || 'Time'}
-        />
-      </div>
-    )
-  },
-})
+GroupByTimeDropdown.propTypes = {
+  location: shape({
+    pathname: string.isRequired,
+  }).isRequired,
+  selected: string,
+  onChooseGroupByTime: func.isRequired,
+}
 
-export default GroupByTimeDropdown
+export default withRouter(GroupByTimeDropdown)

--- a/ui/src/shared/components/FieldList.js
+++ b/ui/src/shared/components/FieldList.js
@@ -131,7 +131,6 @@ class FieldList extends Component {
     const {
       query: {database, measurement, fields = [], groupBy, fill},
       isKapacitorRule,
-      isInDataExplorer,
     } = this.props
 
     const hasAggregates = numFunctions(fields) > 0
@@ -148,8 +147,6 @@ class FieldList extends Component {
                   isOpen={!hasGroupByTime}
                   selected={groupBy.time}
                   onChooseGroupByTime={this.handleGroupByTime}
-                  isInRuleBuilder={isKapacitorRule}
-                  isInDataExplorer={isInDataExplorer}
                 />
                 {isKapacitorRule
                   ? null
@@ -221,7 +218,6 @@ FieldList.propTypes = {
   onFill: func,
   applyFuncsToField: func.isRequired,
   isKapacitorRule: bool,
-  isInDataExplorer: bool,
   querySource: shape({
     links: shape({
       proxy: string.isRequired,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2150 

### The problem
In the GroupByTimeDropdown menu, auto was being displayed and automatically selected in the Data Explorer. This probably broken on the Rule Builder also, once a function had been selected.

### The Solution
Remove isInDataExplorer props. Refactor GroupByTimeDropdown to SFC. Fix isInDataExplorer and isInRuleBuilder methods.

