### PR TITLE
Fix cannot connect to source false error flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.11.0 [unreleased]
 ### Bug Fixes
+1. [#2158](https://github.com/influxdata/chronograf/pull/2158): Fix 'Cannot connect to source' false error flag on Dashboard page
 ### Features
 ### UI Improvements
 

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -281,7 +281,8 @@ export const updateTempVarValues = (source, dashboard) => async dispatch => {
 
     results.forEach(({data}, i) => {
       const {type, query, id} = tempsWithQueries[i]
-      const vals = parsers[type](data, query.tagKey || query.measurement)[type]
+      const parsed = parsers[type](data, query.tagKey || query.measurement)
+      const vals = parsed[type]
       dispatch(editTemplateVariableValues(dashboard.id, id, vals))
     })
   } catch (error) {

--- a/ui/src/shared/parsing/index.js
+++ b/ui/src/shared/parsing/index.js
@@ -1,3 +1,4 @@
+import _ from 'lodash'
 import databases from 'shared/parsing/showDatabases'
 import measurements from 'shared/parsing/showMeasurements'
 import fieldKeys from 'shared/parsing/showFieldKeys'
@@ -8,16 +9,19 @@ const parsers = {
   databases,
   measurements: data => {
     const {errors, measurementSets} = measurements(data)
-    return {errors, measurements: measurementSets[0].measurements}
+    return {
+      errors,
+      measurements: _.get(measurementSets, ['0', 'measurements'], []),
+    }
   },
   fieldKeys: (data, key) => {
     const {errors, fieldSets} = fieldKeys(data)
-    return {errors, fieldKeys: fieldSets[key]}
+    return {errors, fieldKeys: _.get(fieldSets, key, [])}
   },
   tagKeys,
   tagValues: (data, key) => {
     const {errors, tags} = tagValues(data)
-    return {errors, tagValues: tags[key]}
+    return {errors, tagValues: _.get(tags, key, [])}
   },
 }
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2129 

### The problem
When cells on a dashboard are all individually connected to a source that does not have the same template variable resources as another source.   i.e. a source does not have a 'telegraf' database and template variables are dynamically generated from telegraf's tagKeys.  A "cannot connect to source" error is displayed. 

### The Solution
Don't blindly key into `tagValues`, `fieldKeys`, or `measurements` when parsing them for template variables.  If they do not exist return their respective empty states: `[]`


