### PR TITLE
Adds fractions of seconds to time field in csv export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v1.3.11.0 [unreleased]
 ### Bug Fixes
+1. [#2167](https://github.com/influxdata/chronograf/pull/2167): Add fractions of seconds to time field in csv export
 ### Features
 ### UI Improvements
 

--- a/ui/spec/shared/parsing/resultsToCSVSpec.js
+++ b/ui/spec/shared/parsing/resultsToCSVSpec.js
@@ -3,13 +3,16 @@ import {
   formatDate,
   dashboardtoCSV,
 } from 'shared/parsing/resultsToCSV'
+import moment from 'moment'
 
 describe('formatDate', () => {
   it('converts timestamp to an excel compatible date string', () => {
     const timestamp = 1000000000000
     const result = formatDate(timestamp)
     expect(result).to.be.a('string')
-    expect(+new Date(result)).to.equal(timestamp)
+    expect(moment(result, 'M/D/YYYY h:mm:ss.SSSSSSSSS A').valueOf()).to.equal(
+      timestamp
+    )
   })
 })
 

--- a/ui/src/shared/parsing/resultsToCSV.js
+++ b/ui/src/shared/parsing/resultsToCSV.js
@@ -2,7 +2,7 @@ import _ from 'lodash'
 import moment from 'moment'
 
 export const formatDate = timestamp =>
-  moment(timestamp).format('M/D/YYYY h:mm:ss A')
+  moment(timestamp).format('M/D/YYYY h:mm:ss.SSSSSSSSS A')
 
 export const resultsToCSV = results => {
   if (!_.get(results, ['0', 'series', '0'])) {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2141 

### The problem 
The resolution of csv download timestamps are on the order of seconds, even when sub-second grain data is available.

### The Solution
Added fractional second granularity to timestamps. 


