### PR TITLE
Highlight circles are back

### DIFF
--- a/ui/src/external/dygraph.js
+++ b/ui/src/external/dygraph.js
@@ -283,11 +283,13 @@ Dygraph.prototype.findClosestPoint = function(domX, domY) {
         minYDist = ydist
         closestRow = point.idx
         closestSeries = setIdx
+        closestPoint = point
       } else if (xdist === minXDist && ydist < minYDist) {
         minXDist = xdist
         minYDist = ydist
         closestRow = point.idx
         closestSeries = setIdx
+        closestPoint = point
       }
     }
   }

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -29,6 +29,7 @@ export default class Dygraph extends Component {
         x: null,
         series: [],
       },
+      pageX: null,
       sortType: '',
       filterText: '',
       isSynced: false,
@@ -36,7 +37,6 @@ export default class Dygraph extends Component {
       isAscending: true,
       isSnipped: false,
       isFilterVisible: false,
-      legendArrowPosition: 'top',
     }
   }
 
@@ -171,9 +171,8 @@ export default class Dygraph extends Component {
     dygraph.updateOptions(updateOptions)
 
     const {w} = this.dygraph.getArea()
-    this.resize()
-    this.dygraph.resize()
     this.props.setResolution(w)
+    this.resize()
   }
 
   handleZoom = (lower, upper) => {
@@ -298,6 +297,7 @@ export default class Dygraph extends Component {
   resize = () => {
     this.dygraph.resizeElements_()
     this.dygraph.predraw_()
+    this.dygraph.resize()
   }
 
   formatTimeRange = timeRange => {
@@ -341,64 +341,8 @@ export default class Dygraph extends Component {
     }
   }
 
-  highlightCallback = e => {
-    const chronografChromeSize = 60 // Width & Height of navigation page elements
-
-    // Move the Legend on hover
-    const graphRect = this.graphRef.getBoundingClientRect()
-    const legendRect = this.legendRef.getBoundingClientRect()
-
-    const graphWidth = graphRect.width + 32 // Factoring in padding from parent
-    const graphHeight = graphRect.height
-    const graphBottom = graphRect.bottom
-    const legendWidth = legendRect.width
-    const legendHeight = legendRect.height
-    const screenHeight = window.innerHeight
-    const legendMaxLeft = graphWidth - legendWidth / 2
-    const trueGraphX = e.pageX - graphRect.left
-
-    let legendLeft = trueGraphX
-
-    // Enforcing max & min legend offsets
-    if (trueGraphX < legendWidth / 2) {
-      legendLeft = legendWidth / 2
-    } else if (trueGraphX > legendMaxLeft) {
-      legendLeft = legendMaxLeft
-    }
-
-    // Disallow screen overflow of legend
-    const isLegendBottomClipped = graphBottom + legendHeight > screenHeight
-    const isLegendTopClipped =
-      legendHeight > graphRect.top - chronografChromeSize
-    const willLegendFitLeft = e.pageX - chronografChromeSize > legendWidth
-
-    let legendTop = graphHeight + 8
-    this.setState({legendArrowPosition: 'top'})
-
-    // If legend is only clipped on the bottom, position above graph
-    if (isLegendBottomClipped && !isLegendTopClipped) {
-      this.setState({legendArrowPosition: 'bottom'})
-      legendTop = -legendHeight
-    }
-    // If legend is clipped on top and bottom, posiition on either side of crosshair
-    if (isLegendBottomClipped && isLegendTopClipped) {
-      legendTop = 0
-
-      if (willLegendFitLeft) {
-        this.setState({legendArrowPosition: 'right'})
-        legendLeft = trueGraphX - legendWidth / 2
-        legendLeft -= 8
-      } else {
-        this.setState({legendArrowPosition: 'left'})
-        legendLeft = trueGraphX + legendWidth / 2
-        legendLeft += 32
-      }
-    }
-
-    this.legendRef.style.left = `${legendLeft}px`
-    this.legendRef.style.top = `${legendTop}px`
-
-    this.setState({isHidden: false})
+  highlightCallback = ({pageX}) => {
+    this.setState({isHidden: false, pageX})
   }
 
   legendFormatter = legend => {
@@ -424,12 +368,12 @@ export default class Dygraph extends Component {
   render() {
     const {
       legend,
+      pageX,
       sortType,
       isHidden,
       isSnipped,
       filterText,
       isAscending,
-      legendArrowPosition,
       isFilterVisible,
     } = this.state
 
@@ -437,6 +381,9 @@ export default class Dygraph extends Component {
       <div className="dygraph-child" onMouseLeave={this.deselectCrosshair}>
         <DygraphLegend
           {...legend}
+          graph={this.graphRef}
+          legend={this.legendRef}
+          pageX={pageX}
           sortType={sortType}
           onHide={this.handleHideLegend}
           isHidden={isHidden}
@@ -449,7 +396,6 @@ export default class Dygraph extends Component {
           legendRef={this.handleLegendRef}
           onToggleFilter={this.handleToggleFilter}
           onInputChange={this.handleLegendInputChange}
-          arrowPosition={legendArrowPosition}
         />
         <div
           ref={r => {

--- a/ui/src/shared/components/DygraphLegend.js
+++ b/ui/src/shared/components/DygraphLegend.js
@@ -2,6 +2,8 @@ import React, {PropTypes} from 'react'
 import _ from 'lodash'
 import classnames from 'classnames'
 
+import {makeLegendStyles} from 'shared/graphs/helpers'
+
 const removeMeasurement = (label = '') => {
   const [measurement] = label.match(/^(.*)[.]/g) || ['']
   return label.replace(measurement, '')
@@ -9,6 +11,9 @@ const removeMeasurement = (label = '') => {
 
 const DygraphLegend = ({
   xHTML,
+  pageX,
+  graph,
+  legend,
   series,
   onSort,
   onSnip,
@@ -20,7 +25,6 @@ const DygraphLegend = ({
   filterText,
   isAscending,
   onInputChange,
-  arrowPosition,
   isFilterVisible,
   onToggleFilter,
 }) => {
@@ -28,9 +32,11 @@ const DygraphLegend = ({
     series,
     ({y, label}) => (sortType === 'numeric' ? y : label)
   )
+
   const ordered = isAscending ? sorted : sorted.reverse()
   const filtered = ordered.filter(s => s.label.match(filterText))
   const hidden = isHidden ? 'hidden' : ''
+  const style = makeLegendStyles(graph, legend, pageX)
 
   const renderSortAlpha = (
     <div
@@ -65,9 +71,10 @@ const DygraphLegend = ({
 
   return (
     <div
-      className={`dygraph-legend dygraph-legend--${arrowPosition} ${hidden}`}
+      className={`dygraph-legend ${hidden}`}
       ref={legendRef}
       onMouseLeave={onHide}
+      style={style}
     >
       <div className="dygraph-legend--header">
         <div className="dygraph-legend--timestamp">
@@ -141,7 +148,9 @@ DygraphLegend.propTypes = {
       yHTML: string,
     })
   ),
-  dygraph: shape(),
+  pageX: number,
+  legend: shape({}),
+  graph: shape({}),
   onSnip: func.isRequired,
   onHide: func.isRequired,
   onSort: func.isRequired,
@@ -154,7 +163,6 @@ DygraphLegend.propTypes = {
   legendRef: func.isRequired,
   isSnipped: bool.isRequired,
   isFilterVisible: bool.isRequired,
-  arrowPosition: string.isRequired,
 }
 
 export default DygraphLegend

--- a/ui/src/shared/graphs/helpers.js
+++ b/ui/src/shared/graphs/helpers.js
@@ -114,6 +114,65 @@ export const barPlotter = e => {
   }
 }
 
+export const makeLegendStyles = (graph, legend, pageX) => {
+  if (!graph || !legend || pageX === null) {
+    return {}
+  }
+
+  // Move the Legend on hover
+  const chronografChromeSize = 60 // Width & Height of navigation page elements
+  const graphRect = graph.getBoundingClientRect()
+  const legendRect = legend.getBoundingClientRect()
+
+  const graphWidth = graphRect.width + 32 // Factoring in padding from parent
+  const graphHeight = graphRect.height
+  const graphBottom = graphRect.bottom
+  const legendWidth = legendRect.width
+  const legendHeight = legendRect.height
+  const screenHeight = window.innerHeight
+  const legendMaxLeft = graphWidth - legendWidth / 2
+  const trueGraphX = pageX - graphRect.left
+
+  let legendLeft = trueGraphX
+
+  // Enforcing max & min legend offsets
+  if (trueGraphX < legendWidth / 2) {
+    legendLeft = legendWidth / 2
+  } else if (trueGraphX > legendMaxLeft) {
+    legendLeft = legendMaxLeft
+  }
+
+  // Disallow screen overflow of legend
+  const isLegendBottomClipped = graphBottom + legendHeight > screenHeight
+  const isLegendTopClipped = legendHeight > graphRect.top - chronografChromeSize
+  const willLegendFitLeft = pageX - chronografChromeSize > legendWidth
+
+  let legendTop = graphHeight + 8
+
+  // If legend is only clipped on the bottom, position above graph
+  if (isLegendBottomClipped && !isLegendTopClipped) {
+    legendTop = -legendHeight
+  }
+
+  // If legend is clipped on top and bottom, posiition on either side of crosshair
+  if (isLegendBottomClipped && isLegendTopClipped) {
+    legendTop = 0
+
+    if (willLegendFitLeft) {
+      legendLeft = trueGraphX - legendWidth / 2
+      legendLeft -= 8
+    } else {
+      legendLeft = trueGraphX + legendWidth / 2
+      legendLeft += 32
+    }
+  }
+
+  return {
+    left: `${legendLeft}px`,
+    top: `${legendTop}px`,
+  }
+}
+
 export const OPTIONS = {
   rightGap: 0,
   axisLineWidth: 2,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2109 

### The problem
If a graph at the bottom of the page was hovered, the highlightPoint series circles did not show up.  See #2109 for a GIF.  

### The Solution
I really don't know what caused this problem.  I found that if I removed the positioning logic for the legend, the circles came back.  That wouldn't work because then we would have a static legend.  So, I moved the logic for calculating the legend position into the legend itself and that appears to have brought back the circles.  I don't know what that worked.  

![kapture 2017-10-26 at 14 13 21](https://user-images.githubusercontent.com/7582765/32077321-da89549c-ba57-11e7-9617-e069525acb83.gif)


