### PR TITLE
Feature/kapa chunked logs

### DIFF
--- a/server/logger.go
+++ b/server/logger.go
@@ -7,39 +7,57 @@ import (
 	"github.com/influxdata/chronograf"
 )
 
-type logResponseWriter struct {
+// statusWriterFlusher captures the status header of an http.ResponseWriter
+// and is a flusher
+type statusWriter struct {
 	http.ResponseWriter
-
-	responseCode int
+	Flusher http.Flusher
+	status  int
 }
 
-func (l *logResponseWriter) WriteHeader(status int) {
-	l.responseCode = status
-	l.ResponseWriter.WriteHeader(status)
+func (w *statusWriter) WriteHeader(status int) {
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *statusWriter) Status() int { return w.status }
+
+// Flush is here because the underlying HTTP chunked transfer response writer
+// to implement http.Flusher.  Without it data is silently buffered.  This
+// was discovered when proxying kapacitor chunked logs.
+func (w *statusWriter) Flush() {
+	if w.Flusher != nil {
+		w.Flusher.Flush()
+	}
 }
 
 // Logger is middleware that logs the request
 func Logger(logger chronograf.Logger, next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 		now := time.Now()
-		logger.
-			WithField("component", "server").
+		logger.WithField("component", "server").
 			WithField("remote_addr", r.RemoteAddr).
 			WithField("method", r.Method).
 			WithField("url", r.URL).
-			Info("Request")
+			Debug("Request")
 
-		lrr := &logResponseWriter{w, 0}
-		next.ServeHTTP(lrr, r)
+		sw := &statusWriter{
+			ResponseWriter: w,
+		}
+		if f, ok := w.(http.Flusher); ok {
+			sw.Flusher = f
+		}
+		next.ServeHTTP(sw, r)
 		later := time.Now()
 		elapsed := later.Sub(now)
 
 		logger.
 			WithField("component", "server").
 			WithField("remote_addr", r.RemoteAddr).
+			WithField("method", r.Method).
 			WithField("response_time", elapsed.String()).
-			WithField("code", lrr.responseCode).
-			Info("Response: ", http.StatusText(lrr.responseCode))
+			WithField("status", sw.Status()).
+			Info("Response: ", http.StatusText(sw.Status()))
 	}
 	return http.HandlerFunc(fn)
 }

--- a/server/prefixing_redirector.go
+++ b/server/prefixing_redirector.go
@@ -9,7 +9,8 @@ import (
 
 type interceptingResponseWriter struct {
 	http.ResponseWriter
-	Prefix string
+	Flusher http.Flusher
+	Prefix  string
 }
 
 func (i *interceptingResponseWriter) WriteHeader(status int) {
@@ -25,11 +26,26 @@ func (i *interceptingResponseWriter) WriteHeader(status int) {
 	i.ResponseWriter.WriteHeader(status)
 }
 
-// PrefixingRedirector alters the Location header of downstream http.Handlers
+// Flush is here because the underlying HTTP chunked transfer response writer
+// to implement http.Flusher.  Without it data is silently buffered.  This
+// was discovered when proxying kapacitor chunked logs.
+func (i *interceptingResponseWriter) Flush() {
+	if i.Flusher != nil {
+		i.Flusher.Flush()
+	}
+}
+
+// PrefixedRedirect alters the Location header of downstream http.Handlers
 // to include a specified prefix
 func PrefixedRedirect(prefix string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		iw := &interceptingResponseWriter{w, prefix}
+		iw := &interceptingResponseWriter{
+			ResponseWriter: w,
+			Prefix:         prefix,
+		}
+		if flusher, ok := w.(http.Flusher); ok {
+			iw.Flusher = flusher
+		}
 		next.ServeHTTP(iw, r)
 	})
 }

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -35,20 +36,21 @@ func (h *Service) KapacitorProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	u, err := url.Parse(srv.URL)
+	// To preserve any HTTP query arguments to the kapacitor path,
+	// we concat and parse them into u.
+	uri := singleJoiningSlash(srv.URL, path)
+	u, err := url.Parse(uri)
 	if err != nil {
 		msg := fmt.Sprintf("Error parsing kapacitor url: %v", err)
 		Error(w, http.StatusUnprocessableEntity, msg, h.Logger)
 		return
 	}
 
-	u.Path = path
-
 	director := func(req *http.Request) {
 		// Set the Host header of the original Kapacitor URL
 		req.Host = u.Host
-
 		req.URL = u
+
 		// Because we are acting as a proxy, kapacitor needs to have the basic auth information set as
 		// a header directly
 		if srv.Username != "" && srv.Password != "" {
@@ -83,4 +85,16 @@ func (h *Service) KapacitorProxyGet(w http.ResponseWriter, r *http.Request) {
 // KapacitorProxyDelete proxies DELETE to kapacitor
 func (h *Service) KapacitorProxyDelete(w http.ResponseWriter, r *http.Request) {
 	h.KapacitorProxy(w, r)
+}
+
+func singleJoiningSlash(a, b string) string {
+	aslash := strings.HasSuffix(a, "/")
+	bslash := strings.HasPrefix(b, "/")
+	if aslash && bslash {
+		return a + b[1:]
+	}
+	if !aslash && !bslash {
+		return a + "/" + b
+	}
+	return a + b
 }

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 )
 
 // KapacitorProxy proxies requests to kapacitor using the path query parameter.
@@ -54,8 +55,12 @@ func (h *Service) KapacitorProxy(w http.ResponseWriter, r *http.Request) {
 			req.SetBasicAuth(srv.Username, srv.Password)
 		}
 	}
+
+	// Without a FlushInterval the HTTP Chunked response for kapacitor logs is
+	// buffered and flushed every 30 seconds.
 	proxy := &httputil.ReverseProxy{
-		Director: director,
+		Director:      director,
+		FlushInterval: time.Second,
 	}
 	proxy.ServeHTTP(w, r)
 }


### PR DESCRIPTION

  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem

1. Kapacitor proxy didn't accept url query parameters.  
2. Kapacitor proxy needs to flush every once in a while to support chunking 
3. Logger/Redirector middleware does not support flushing

### The Solution

Proxy allows URL query parameters.
Proxy flushes every one second (logs can be delayed up to a second)
Logger/Redirector have been refactored a little bit to support flusher, but, I really don't like the pattern and am thinking about removing them altogether.


