### PR TITLE
Update chronograf logrotate policy to not rotate if file is 0 bytes

### DIFF
--- a/etc/scripts/logrotate
+++ b/etc/scripts/logrotate
@@ -5,4 +5,5 @@
     dateext
     copytruncate
     compress
+    notifempty
 }


### PR DESCRIPTION
### The problem
Chronograf would create zero sized log files rather than ignore

### The Solution
Chronograf will not rotate unless there are logs.

