### PR TITLE
Remove explicit default org ID use

### DIFF
--- a/bolt/organizations.go
+++ b/bolt/organizations.go
@@ -16,10 +16,14 @@ var _ chronograf.OrganizationsStore = &OrganizationsStore{}
 // OrganizationsBucket is the bucket where organizations are stored.
 var OrganizationsBucket = []byte("OrganizationsV1")
 
-// DefaultOrganizationID is the ID of the default organization.
-const DefaultOrganizationID uint64 = 0
-const DefaultOrganizationName string = "Default"
-const DefaultOrganizationRole string = "member"
+const (
+	// DefaultOrganizationID is the ID of the default organization.
+	DefaultOrganizationID uint64 = 0
+	// DefaultOrganizationName is the Name of the default organization
+	DefaultOrganizationName string = "Default"
+	// DefaultOrganizationRole is the DefaultRole for the Default organization
+	DefaultOrganizationRole string = "member"
+)
 
 // OrganizationsStore uses bolt to store and retrieve Organizations
 type OrganizationsStore struct {

--- a/bolt/organizations.go
+++ b/bolt/organizations.go
@@ -16,6 +16,11 @@ var _ chronograf.OrganizationsStore = &OrganizationsStore{}
 // OrganizationsBucket is the bucket where organizations are stored.
 var OrganizationsBucket = []byte("OrganizationsV1")
 
+// DefaultOrganizationID is the ID of the default organization.
+const DefaultOrganizationID uint64 = 0
+const DefaultOrganizationName string = "__default"
+const DefaultOrganizationRole string = "member"
+
 // OrganizationsStore uses bolt to store and retrieve Organizations
 type OrganizationsStore struct {
 	client *Client
@@ -23,10 +28,15 @@ type OrganizationsStore struct {
 
 // Migrate sets the default organization at runtime
 func (s *OrganizationsStore) Migrate(ctx context.Context) error {
+	return s.CreateDefault(ctx)
+}
+
+// CreateDefault does a findOrCreate on the default organization
+func (s *OrganizationsStore) CreateDefault(ctx context.Context) error {
 	o := chronograf.Organization{
-		ID:          0,
-		Name:        "__default",
-		DefaultRole: "member",
+		ID:          DefaultOrganizationID,
+		Name:        DefaultOrganizationName,
+		DefaultRole: DefaultOrganizationRole,
 	}
 	return s.client.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(OrganizationsBucket)
@@ -52,6 +62,19 @@ func (s *OrganizationsStore) nameIsUnique(ctx context.Context, name string) bool
 	default:
 		return false
 	}
+}
+
+// DefaultOrganizationID returns the ID of the default organization
+func (s *OrganizationsStore) DefaultOrganization(ctx context.Context) (*chronograf.Organization, error) {
+	var org chronograf.Organization
+	if err := s.client.db.View(func(tx *bolt.Tx) error {
+		v := tx.Bucket(OrganizationsBucket).Get(u64tob(DefaultOrganizationID))
+		return internal.UnmarshalOrganization(v, &org)
+	}); err != nil {
+		return nil, err
+	}
+
+	return &org, nil
 }
 
 // Add creates a new Organization in the OrganizationsStore

--- a/bolt/organizations.go
+++ b/bolt/organizations.go
@@ -119,6 +119,9 @@ func (s *OrganizationsStore) All(ctx context.Context) ([]chronograf.Organization
 
 // Delete the organization from OrganizationsStore
 func (s *OrganizationsStore) Delete(ctx context.Context, o *chronograf.Organization) error {
+	if o.ID == DefaultOrganizationID {
+		return chronograf.ErrCannotDeleteDefaultOrganization
+	}
 	_, err := s.get(ctx, o.ID)
 	if err != nil {
 		return err

--- a/bolt/organizations.go
+++ b/bolt/organizations.go
@@ -18,7 +18,7 @@ var OrganizationsBucket = []byte("OrganizationsV1")
 
 // DefaultOrganizationID is the ID of the default organization.
 const DefaultOrganizationID uint64 = 0
-const DefaultOrganizationName string = "__default"
+const DefaultOrganizationName string = "Default"
 const DefaultOrganizationRole string = "member"
 
 // OrganizationsStore uses bolt to store and retrieve Organizations

--- a/bolt/organizations_test.go
+++ b/bolt/organizations_test.go
@@ -184,8 +184,8 @@ func TestOrganizationsStore_All(t *testing.T) {
 			},
 			want: []chronograf.Organization{
 				{
-					Name:        "__default",
-					DefaultRole: "member",
+					Name:        bolt.DefaultOrganizationName,
+					DefaultRole: bolt.DefaultOrganizationRole,
 				},
 				{
 					Name: "EE - Evil Empire",

--- a/bolt/organizations_test.go
+++ b/bolt/organizations_test.go
@@ -393,6 +393,44 @@ func TestOrganizationStore_Delete(t *testing.T) {
 	}
 }
 
+func TestOrganizationStore_DeleteDefaultOrg(t *testing.T) {
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Delete the default organization",
+			args: args{
+				ctx: context.Background(),
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		client, err := NewTestClient()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := client.Open(context.TODO()); err != nil {
+			t.Fatal(err)
+		}
+		defer client.Close()
+		s := client.OrganizationsStore
+
+		defaultOrg, err := s.DefaultOrganization(tt.args.ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := s.Delete(tt.args.ctx, defaultOrg); (err != nil) != tt.wantErr {
+			t.Errorf("%q. OrganizationsStore.Delete() error = %v, wantErr %v", tt.name, err, tt.wantErr)
+		}
+	}
+}
+
 func TestOrganizationsStore_Add(t *testing.T) {
 	type fields struct {
 		orgs []chronograf.Organization

--- a/chronograf.go
+++ b/chronograf.go
@@ -20,19 +20,20 @@ import (
 
 // General errors.
 const (
-	ErrUpstreamTimeout       = Error("request to backend timed out")
-	ErrSourceNotFound        = Error("source not found")
-	ErrServerNotFound        = Error("server not found")
-	ErrLayoutNotFound        = Error("layout not found")
-	ErrDashboardNotFound     = Error("dashboard not found")
-	ErrUserNotFound          = Error("user not found")
-	ErrOrganizationNotFound  = Error("organization not found")
-	ErrLayoutInvalid         = Error("layout is invalid")
-	ErrAlertNotFound         = Error("alert not found")
-	ErrAuthentication        = Error("user not authenticated")
-	ErrUninitialized         = Error("client uninitialized. Call Open() method")
-	ErrInvalidAxis           = Error("Unexpected axis in cell. Valid axes are 'x', 'y', and 'y2'")
-	ErrOrganizationNameTaken = Error("organization name is taken")
+	ErrUpstreamTimeout                 = Error("request to backend timed out")
+	ErrSourceNotFound                  = Error("source not found")
+	ErrServerNotFound                  = Error("server not found")
+	ErrLayoutNotFound                  = Error("layout not found")
+	ErrDashboardNotFound               = Error("dashboard not found")
+	ErrUserNotFound                    = Error("user not found")
+	ErrOrganizationNotFound            = Error("organization not found")
+	ErrLayoutInvalid                   = Error("layout is invalid")
+	ErrAlertNotFound                   = Error("alert not found")
+	ErrAuthentication                  = Error("user not authenticated")
+	ErrUninitialized                   = Error("client uninitialized. Call Open() method")
+	ErrInvalidAxis                     = Error("Unexpected axis in cell. Valid axes are 'x', 'y', and 'y2'")
+	ErrOrganizationNameTaken           = Error("organization name is taken")
+	ErrCannotDeleteDefaultOrganization = Error("cannot delete default organization")
 )
 
 // Error is a domain error encountered while processing chronograf requests
@@ -806,4 +807,8 @@ type OrganizationsStore interface {
 	Get(context.Context, OrganizationQuery) (*Organization, error)
 	// Update updates an Organization in the OrganizationsStore
 	Update(context.Context, *Organization) error
+	// CreateDefault creates the default organization
+	CreateDefault(ctx context.Context) error
+	// DefaultOrganization returns the DefaultOrganization
+	DefaultOrganization(ctx context.Context) (*Organization, error)
 }

--- a/mocks/organizations.go
+++ b/mocks/organizations.go
@@ -9,11 +9,21 @@ import (
 var _ chronograf.OrganizationsStore = &OrganizationsStore{}
 
 type OrganizationsStore struct {
-	AllF    func(context.Context) ([]chronograf.Organization, error)
-	AddF    func(context.Context, *chronograf.Organization) (*chronograf.Organization, error)
-	DeleteF func(context.Context, *chronograf.Organization) error
-	GetF    func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error)
-	UpdateF func(context.Context, *chronograf.Organization) error
+	AllF                 func(context.Context) ([]chronograf.Organization, error)
+	AddF                 func(context.Context, *chronograf.Organization) (*chronograf.Organization, error)
+	DeleteF              func(context.Context, *chronograf.Organization) error
+	GetF                 func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error)
+	UpdateF              func(context.Context, *chronograf.Organization) error
+	CreateDefaultF       func(context.Context) error
+	DefaultOrganizationF func(context.Context) (*chronograf.Organization, error)
+}
+
+func (s *OrganizationsStore) CreateDefault(ctx context.Context) error {
+	return s.CreateDefaultF(ctx)
+}
+
+func (s *OrganizationsStore) DefaultOrganization(ctx context.Context) (*chronograf.Organization, error) {
+	return s.DefaultOrganizationF(ctx)
 }
 
 func (s *OrganizationsStore) Add(ctx context.Context, o *chronograf.Organization) (*chronograf.Organization, error) {

--- a/noop/organizations.go
+++ b/noop/organizations.go
@@ -12,6 +12,14 @@ var _ chronograf.OrganizationsStore = &OrganizationsStore{}
 
 type OrganizationsStore struct{}
 
+func (s *OrganizationsStore) CreateDefault(context.Context) error {
+	return fmt.Errorf("failed to add organization")
+}
+
+func (s *OrganizationsStore) DefaultOrganization(context.Context) (*chronograf.Organization, error) {
+	return nil, fmt.Errorf("failed to retrieve default organization")
+}
+
 func (s *OrganizationsStore) All(context.Context) ([]chronograf.Organization, error) {
 	return nil, fmt.Errorf("no organizations found")
 }

--- a/server/auth.go
+++ b/server/auth.go
@@ -61,6 +61,14 @@ func AuthorizedUser(
 ) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !useAuth {
+			ctx := r.Context()
+			defaultOrg, err := store.Organizations(ctx).DefaultOrganization(ctx)
+			if err != nil {
+				unknownErrorWithMessage(w, err, logger)
+				return
+			}
+			ctx = context.WithValue(ctx, organizations.ContextKey, fmt.Sprintf("%d", defaultOrg.ID))
+			r = r.WithContext(ctx)
 			next(w, r)
 			return
 		}

--- a/server/auth.go
+++ b/server/auth.go
@@ -88,7 +88,12 @@ func AuthorizedUser(
 
 		// This is as if the user was logged into the default organization
 		if p.Organization == "" {
-			p.Organization = "0"
+			defaultOrg, err := store.Organizations(ctx).DefaultOrganization(ctx)
+			if err != nil {
+				unknownErrorWithMessage(w, err, logger)
+				return
+			}
+			p.Organization = fmt.Sprintf("%d", defaultOrg.ID)
 		}
 
 		// validate that the organization exists

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -85,9 +85,15 @@ func TestAuthorizedUser(t *testing.T) {
 		{
 			name: "Not using auth",
 			fields: fields{
-				UsersStore:         &mocks.UsersStore{},
-				OrganizationsStore: &mocks.OrganizationsStore{},
-				Logger:             clog.New(clog.DebugLevel),
+				UsersStore: &mocks.UsersStore{},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID: 0,
+						}, nil
+					},
+				},
+				Logger: clog.New(clog.DebugLevel),
 			},
 			args: args{
 				useAuth: false,

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -117,6 +117,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -164,6 +170,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -211,6 +223,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -258,6 +276,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -305,6 +329,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -352,6 +382,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -399,6 +435,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -446,6 +488,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -493,6 +541,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -535,6 +589,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -577,6 +637,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -619,6 +685,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -665,6 +737,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -757,6 +835,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -804,6 +888,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -851,6 +941,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -898,6 +994,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -946,6 +1048,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -994,6 +1102,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1042,6 +1156,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1090,6 +1210,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1137,6 +1263,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1180,6 +1312,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1226,6 +1364,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1273,6 +1417,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -1330,6 +1480,12 @@ func TestAuthorizedUser(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")

--- a/server/auth_test.go
+++ b/server/auth_test.go
@@ -119,8 +119,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -172,8 +171,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -225,8 +223,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -278,8 +275,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -331,8 +327,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -384,8 +379,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -437,8 +431,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -490,8 +483,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -543,8 +535,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -591,8 +582,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -639,8 +629,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -687,8 +676,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -739,8 +727,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -837,8 +824,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -890,8 +876,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -943,8 +928,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -996,8 +980,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1050,8 +1033,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1104,8 +1086,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1158,8 +1139,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1212,8 +1192,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1265,8 +1244,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1314,8 +1292,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1366,8 +1343,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1419,8 +1395,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -1482,8 +1457,7 @@ func TestAuthorizedUser(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -192,7 +192,8 @@ func TestValidDashboardRequest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		err := ValidDashboardRequest(&tt.d)
+		// TODO(desa): this Okay?
+		err := ValidDashboardRequest(&tt.d, "0")
 		if (err != nil) != tt.wantErr {
 			t.Errorf("%q. ValidDashboardRequest() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 			continue

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -50,8 +50,7 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -102,8 +101,7 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -152,8 +150,7 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -311,8 +308,7 @@ func TestService_MeOrganizations(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -371,8 +367,7 @@ func TestService_MeOrganizations(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -423,8 +418,7 @@ func TestService_MeOrganizations(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
@@ -484,8 +478,7 @@ func TestService_MeOrganizations(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID: 0,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -48,6 +48,12 @@ func TestService_Me(t *testing.T) {
 				UseAuth: true,
 				Logger:  log.New(log.DebugLevel),
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
 							ID:   0,
@@ -94,6 +100,12 @@ func TestService_Me(t *testing.T) {
 				UseAuth: true,
 				Logger:  log.New(log.DebugLevel),
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
 							ID:   0,
@@ -138,6 +150,12 @@ func TestService_Me(t *testing.T) {
 			fields: fields{
 				UseAuth: true,
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
 							ID:   0,
@@ -291,6 +309,12 @@ func TestService_MeOrganizations(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -345,6 +369,12 @@ func TestService_MeOrganizations(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -391,6 +421,12 @@ func TestService_MeOrganizations(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						if q.ID == nil {
 							return nil, fmt.Errorf("Invalid organization query: missing ID")
@@ -446,6 +482,12 @@ func TestService_MeOrganizations(t *testing.T) {
 					},
 				},
 				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return nil, chronograf.ErrOrganizationNotFound
 					},
@@ -468,8 +510,6 @@ func TestService_MeOrganizations(t *testing.T) {
 				UsersStore:         tt.fields.UsersStore,
 				OrganizationsStore: tt.fields.OrganizationsStore,
 			},
-			//UsersStore:             tt.fields.UsersStore,
-			//OrganizationUsersStore: tt.fields.OrganizationUsersStore,
 			Logger:  tt.fields.Logger,
 			UseAuth: tt.fields.UseAuth,
 		}


### PR DESCRIPTION
Encodes DefaultOg logic into the OrganizationsStore interface.

Prevents user from removing default organization.

Connect #2202 
Connect #2209 


