### PR TITLE
Add make run-dev-clean build option that cleans build files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,12 @@ else
 	@touch .jsdep
 endif
 
+.remove-files:
+	rm -rf ui/build && mkdir ui/build
+
+.build-go:
+	go build -o ${BINARY} ${LDFLAGS} ./cmd/chronograf/main.go
+
 gen: internal.pb.go
 
 internal.pb.go: bolt/internal/internal.proto
@@ -105,6 +111,8 @@ run: ${BINARY}
 
 run-dev: chronogiraffe
 	./chronograf -d --log-level=debug
+
+run-dev-clean: .remove-files .build-go run-dev
 
 clean:
 	if [ -f ${BINARY} ] ; then rm ${BINARY} ; fi


### PR DESCRIPTION
  - [ ] Rebased/mergable
  - [ ] Tests pass

Connect #1607 

### The problem
Running make-dev can be increasingly and painfully slow as your `ui/build` folder grows, hampering and frustrating time to development.

### The Solution
Add a new `make run-dev-clean` command line option, which will `rm -rf ui/build` and then proceed to perform a `make run-dev` equivalent, resulting in consistently faster server builds for development.

