### PR TITLE
Add cleanup step to js dev builds to remove unused files

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -77,6 +77,7 @@
     "mocha-loader": "^0.7.1",
     "mustache": "^2.2.1",
     "node-sass": "^4.5.3",
+    "on-build-webpack": "^0.1.0",
     "postcss-browser-reporter": "^0.4.0",
     "postcss-calc": "^5.2.0",
     "postcss-loader": "^0.8.0",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5134,6 +5134,10 @@ object.values@^1.0.3:
     function-bind "^1.1.0"
     has "^1.0.1"
 
+on-build-webpack@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/on-build-webpack/-/on-build-webpack-0.1.0.tgz#a287c0e17766e6141926e5f2cbb0d8bb53b76814"
+
 on-finished@~2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.3.0.tgz#20f1336481b083cd75337992a16971aa2d906947"


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1607 

Webpack leaves unused files around each time it does  a build.  This patch removes stale files each time a dev build is created.

cc @jaredscheib 


