### PR TITLE
Add hot module reload to dev builds (make run-hmr)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: assets dep clean test gotest gotestrace jstest run run-dev ctags continuous
+.PHONY: assets dep clean test gotest gotestrace jstest run run-dev run-hmr ctags
 
 VERSION ?= $(shell git describe --always --tags)
 COMMIT ?= $(shell git rev-parse --short=8 HEAD)
@@ -23,14 +23,42 @@ ${BINARY}: $(SOURCES) .bindata .jsdep .godep
 	go build -o ${BINARY} ${LDFLAGS} ./cmd/chronograf/main.go
 
 define CHRONOGIRAFFE
-             ._ o o
-             \_`-)|_
-          ,""      _\_
-        ,"  ## |   0 0.
-      ," ##   ,-\__    `.
-    ,"       /     `--._;) - "HAI, I'm Chronogiraffe. Let's be friends!"
-  ,"     ## /
-,"   ##    /
+             tLf          iCf.
+            .CCC.         tCC:
+             CGG;         CGG:
+tG0Gt:       GGGGGGGGGGGGGGGG1        .,:,
+LG1,,:1CC: .GGL;iLC1iii1LCi;GG1  .1GCL1iGG1
+ LG1:::;i1CGGt;;;;;;L0t;;;;;;GGGC1;;::,iGC
+   ,ii:. 1GG1iiii;;tfiC;;;;;;;GGCfCGCGGC,
+        fGCiiiiGi1Lt;;iCLL,i;;;CGt
+       fGG11iiii1C1iiiiiGt1;;;;;CGf
+       .GGLLL1i1CitfiiL1iCi;;iLCGGt
+        .CGL11LGCCCCCCCLLCGG1;1GG;
+          CGL1tf1111iiiiiiL1ifGG,
+           LGCff1fCt1tCfiiCiCGC
+            LGGf111111111iCGGt
+             fGGGGGGGGGGGGGGi
+              ifii111111itL
+              ;f1i11111iitf
+              ;f1iiiiiii1tf
+              :fi111iii11tf
+              :fi111ii1i1tf
+              :f111111ii1tt
+              ,L111111ii1tt
+              .Li1111i1111CCCCCCCCCCCCCCLt;
+               L111ii11111ittttt1tttttittti1fC;
+               f1111ii111i1ttttt1;iii1ittt1ttttCt.
+               tt11ii111tti1ttt1tt1;11;;;;iitttifCCCL,
+               11i1i11ttttti;1t1;;;ttt1;;ii;itti;L,;CCL
+               ;f;;;;1tttti;;ttti;;;;;;;;;;;1tt1ifi .CCi
+               ,L;itti;;;it;;;;;tt1;;;t1;;;;;;ii;t; :CC,
+                L;;;;iti;;;;;;;;;;;;;;;;;;;;;;;i;L, ;CC.
+                ti;;;iLLfffi;;;;;ittt11i;;;;;;;;;L   tCCfff;
+                it;;;;;;L,ti;;;;;1Ltttft1t;;;;;;1t    ;CCCL;
+                :f;;;;;;L.ti;;;;;tftttf1,f;;;;;;f:    ;CC1:
+                .L;;;;;;L.t1;;;;;tt111fi,f;;;;;;L.
+                 1Li;;iL1 :Ci;;;tL1i1fC, Lt;;;;Li
+                  .;tt;     ifLt:;fLf;    ;LCCt,
 endef
 export CHRONOGIRAFFE
 chronogiraffe: ${BINARY}
@@ -105,6 +133,9 @@ run: ${BINARY}
 
 run-dev: chronogiraffe
 	./chronograf -d --log-level=debug
+
+run-hmr:
+	cd ui && npm run start:hmr
 
 clean:
 	if [ -f ${BINARY} ] ; then rm ${BINARY} ; fi

--- a/ui/package.json
+++ b/ui/package.json
@@ -12,6 +12,7 @@
     "build": "yarn run clean && env NODE_ENV=production webpack --optimize-minimize --config ./webpack/prodConfig.js",
     "build:dev": "webpack --config ./webpack/devConfig.js",
     "start": "webpack --watch --config ./webpack/devConfig.js",
+    "start:hmr": "webpack-dev-server --open --config ./webpack/devConfig.js",
     "lint": "esw src/",
     "test": "karma start",
     "test:integration": "nightwatch tests --skip",

--- a/ui/webpack/devConfig.js
+++ b/ui/webpack/devConfig.js
@@ -19,7 +19,7 @@ module.exports = {
   output: {
     publicPath: '/',
     path: path.resolve(__dirname, '../build'),
-    filename: '[name].[chunkhash].dev.js',
+    filename: '[name].[hash].dev.js',
   },
   resolve: {
     alias: {
@@ -88,6 +88,7 @@ module.exports = {
     failOnError: false,
   },
   plugins: [
+    new webpack.HotModuleReplacementPlugin(),
     new webpack.ProvidePlugin({
       $: 'jquery',
       jQuery: 'jquery',
@@ -132,4 +133,22 @@ module.exports = {
   ],
   postcss: require('./postcss'),
   target: 'web',
+  devServer: {
+    hot: true,
+    historyApiFallback: true,
+    clientLogLevel: "info",
+    stats: { colors: true },
+    contentBase: 'build',
+    quiet: false,
+    watchOptions: {
+      aggregateTimeout: 300,
+      poll: 1000
+    },
+    proxy: {
+      '/chronograf/v1': {
+        target: 'http://localhost:8888',
+        secure: false,
+      },
+    },
+  },
 }


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


### The problem
Slower to develop javascript than it should be because chronograf didn't have hot module reloading.

### The Solution

Add hot module reloading to webpack configuration.

If you are make inclined:
```sh
make run-hmr
```

or if you are npm inclined:

```sh
npm run start:hmr
```

This starts the webpack dev server with HMR on port 8080.  It proxies API requests to the normal chronograf server (`make run-dev`)

![hmr](https://user-images.githubusercontent.com/1922921/32408669-30a7154e-c16a-11e7-95a3-c28f134568ef.gif)

