### PR TITLE
Source extra command line options from defaults file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 1. [#1077](https://github.com/influxdata/chronograf/pull/2087): Fix Chronograf requiring Telegraf's CPU and system plugins to ensure that all Apps appear on the HOST LIST page.
 1. [#2222](https://github.com/influxdata/chronograf/pull/2222): Fix template variables in dashboard query building.
 1. [#2291](https://github.com/influxdata/chronograf/pull/2291): Fix several kapacitor alert creation panics.
+1. [#2292](https://github.com/influxdata/chronograf/pull/2292): Source extra command line options from defaults file
+
 
 ### Features
 ### UI Improvements

--- a/etc/scripts/chronograf.service
+++ b/etc/scripts/chronograf.service
@@ -9,7 +9,7 @@ After=network-online.target
 User=chronograf
 Group=chronograf
 EnvironmentFile=-/etc/default/chronograf
-ExecStart=/usr/bin/chronograf --host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned
+ExecStart=/usr/bin/chronograf --host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned $CHRONOGRAF_OPTS
 KillMode=control-group
 Restart=on-failure
 

--- a/etc/scripts/init.sh
+++ b/etc/scripts/init.sh
@@ -13,7 +13,8 @@
 # Script to execute when starting
 SCRIPT="/usr/bin/chronograf"
 # Options to pass to the script on startup
-SCRIPT_OPTS="--host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned"
+. /etc/default/chronograf
+SCRIPT_OPTS="--host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned ${CHRONOGRAF_OPTS}"
 
 # User to run the process under
 RUNAS=chronograf


### PR DESCRIPTION
Minor change to the init script to source a /etc/defaults/chronograf file, which will allow you to specify extra startup command line options.

  - [x] Rebased/mergable
  - [ ] Tests pass

Connect #

### The problem

Can't override chronograf command line options when starting it as a service.

### The Solution

Modification to init / LSB script to source a file to add extra options.