### PR TITLE
Prevent admin users from deleting super admins from org

### DIFF
--- a/server/users.go
+++ b/server/users.go
@@ -198,6 +198,16 @@ func (s *Service) RemoveUser(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusNotFound, err.Error(), s.Logger)
 		return
 	}
+
+	// If the user making the request is not a super admin and the user they're
+	// trying to delete is a super admin, return not authorized error.
+	//
+	// For the sake of clarity, we have used u.SuperAdmin == true even though it is equivalent
+	// to u.SuperAdmin == true
+	if isSuperAdmin := hasSuperAdminContext(ctx); !isSuperAdmin && u.SuperAdmin == true {
+		Error(w, http.StatusUnauthorized, "User is not authorized", s.Logger)
+		return
+	}
 	if err := s.Store.Users(ctx).Delete(ctx, u); err != nil {
 		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
 		return


### PR DESCRIPTION
Previously it was possible for an admin of an organization to delete a user from the current organization. The SuperAdmin still had all of the expected privileges, but was not a part of any organizations. This resulted in unexpected behavior where an Admin of the DefaultOrganization was able to remove a super admin from the default organization.

Connect #2263

