### PR TITLE
Migrate all orphaned resources to DefaultOrg

### DIFF
--- a/bolt/client.go
+++ b/bolt/client.go
@@ -83,10 +83,19 @@ func (c *Client) Open(ctx context.Context) error {
 	}
 
 	// Runtime migrations
-	if err := c.DashboardsStore.Migrate(ctx); err != nil {
+	if err := c.OrganizationsStore.Migrate(ctx); err != nil {
 		return err
 	}
-	if err := c.OrganizationsStore.Migrate(ctx); err != nil {
+	if err := c.SourcesStore.Migrate(ctx); err != nil {
+		return err
+	}
+	if err := c.ServersStore.Migrate(ctx); err != nil {
+		return err
+	}
+	if err := c.LayoutsStore.Migrate(ctx); err != nil {
+		return err
+	}
+	if err := c.DashboardsStore.Migrate(ctx); err != nil {
 		return err
 	}
 

--- a/bolt/layouts.go
+++ b/bolt/layouts.go
@@ -2,6 +2,7 @@ package bolt
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/boltdb/bolt"
 	"github.com/influxdata/chronograf"
@@ -18,6 +19,31 @@ var LayoutsBucket = []byte("Layout")
 type LayoutsStore struct {
 	client *Client
 	IDs    chronograf.ID
+}
+
+func (s *LayoutsStore) Migrate(ctx context.Context) error {
+	layouts, err := s.All(ctx)
+	if err != nil {
+		return err
+	}
+
+	defaultOrg, err := s.client.OrganizationsStore.DefaultOrganization(ctx)
+	if err != nil {
+		return err
+	}
+
+	defaultOrgID := fmt.Sprintf("%d", defaultOrg.ID)
+
+	for _, layout := range layouts {
+		if layout.Organization == "" {
+			layout.Organization = defaultOrgID
+			if err := s.Update(ctx, layout); err != nil {
+				return nil
+			}
+		}
+	}
+
+	return nil
 }
 
 // All returns all known layouts

--- a/bolt/sources.go
+++ b/bolt/sources.go
@@ -7,6 +7,7 @@ import (
 	"github.com/boltdb/bolt"
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/bolt/internal"
+	"github.com/influxdata/chronograf/roles"
 )
 
 // Ensure SourcesStore implements chronograf.SourcesStore.
@@ -36,9 +37,12 @@ func (s *SourcesStore) Migrate(ctx context.Context) error {
 	for _, source := range sources {
 		if source.Organization == "" {
 			source.Organization = defaultOrgID
-			if err := s.Update(ctx, source); err != nil {
-				return nil
-			}
+		}
+		if source.Role == "" {
+			source.Role = roles.ViewerRoleName
+		}
+		if err := s.Update(ctx, source); err != nil {
+			return nil
 		}
 	}
 

--- a/server/dashboards.go
+++ b/server/dashboards.go
@@ -34,10 +34,11 @@ func newDashboardResponse(d chronograf.Dashboard) *dashboardResponse {
 	templates := newTemplateResponses(dd.ID, dd.Templates)
 
 	return &dashboardResponse{
-		ID:        dd.ID,
-		Name:      dd.Name,
-		Cells:     cells,
-		Templates: templates,
+		ID:           dd.ID,
+		Name:         dd.Name,
+		Cells:        cells,
+		Templates:    templates,
+		Organization: d.Organization,
 		Links: dashboardLinks{
 			Self:      fmt.Sprintf("%s/%d", base, dd.ID),
 			Cells:     fmt.Sprintf("%s/%d/cells", base, dd.ID),

--- a/server/dashboards_test.go
+++ b/server/dashboards_test.go
@@ -213,6 +213,7 @@ func Test_newDashboardResponse(t *testing.T) {
 		{
 			name: "creates a dashboard response",
 			d: chronograf.Dashboard{
+				Organization: "0",
 				Cells: []chronograf.DashboardCell{
 					{
 						ID: "a",
@@ -248,7 +249,8 @@ func Test_newDashboardResponse(t *testing.T) {
 				},
 			},
 			want: &dashboardResponse{
-				Templates: []templateResponse{},
+				Organization: "0",
+				Templates:    []templateResponse{},
 				Cells: []dashboardCellResponse{
 					dashboardCellResponse{
 						Links: dashboardCellLinks{

--- a/server/me.go
+++ b/server/me.go
@@ -268,7 +268,8 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 				Organization: fmt.Sprintf("%d", defaultOrg.ID),
 			},
 		},
-		SuperAdmin: s.firstUser(),
+		// TODO(desa): this needs a better name
+		SuperAdmin: s.newUsersAreSuperAdmin(),
 	}
 
 	newUser, err := s.Store.Users(serverCtx).Add(serverCtx, user)
@@ -299,7 +300,6 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 	encodeJSON(w, http.StatusOK, res, s.Logger)
 }
 
-// TODO(desa): very slow
 func (s *Service) firstUser() bool {
 	serverCtx := serverContext(context.Background())
 	users, err := s.Store.Users(serverCtx).All(serverCtx)
@@ -308,6 +308,9 @@ func (s *Service) firstUser() bool {
 	}
 
 	return len(users) == 0
+}
+func (s *Service) newUsersAreSuperAdmin() bool {
+	return !s.NewUsersNotSuperAdmin
 }
 
 func (s *Service) usersOrganizations(ctx context.Context, u *chronograf.User) ([]chronograf.Organization, error) {

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -21,10 +21,11 @@ type MockUsers struct{}
 
 func TestService_Me(t *testing.T) {
 	type fields struct {
-		UsersStore         chronograf.UsersStore
-		OrganizationsStore chronograf.OrganizationsStore
-		Logger             chronograf.Logger
-		UseAuth            bool
+		UsersStore            chronograf.UsersStore
+		OrganizationsStore    chronograf.OrganizationsStore
+		Logger                chronograf.Logger
+		UseAuth               bool
+		NewUsersNotSuperAdmin bool
 	}
 	type args struct {
 		w *httptest.ResponseRecorder
@@ -46,8 +47,9 @@ func TestService_Me(t *testing.T) {
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
 			},
 			fields: fields{
-				UseAuth: true,
-				Logger:  log.New(log.DebugLevel),
+				UseAuth:               true,
+				NewUsersNotSuperAdmin: true,
+				Logger:                log.New(log.DebugLevel),
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
@@ -142,10 +144,6 @@ func TestService_Me(t *testing.T) {
 					},
 				},
 				UsersStore: &mocks.UsersStore{
-					AllF: func(ctx context.Context) ([]chronograf.User, error) {
-						// This function gets to verify that there is at least one first user
-						return []chronograf.User{{}}, nil
-					},
 					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
 						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
 							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
@@ -177,8 +175,9 @@ func TestService_Me(t *testing.T) {
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
 			},
 			fields: fields{
-				UseAuth: true,
-				Logger:  log.New(log.DebugLevel),
+				UseAuth:               true,
+				NewUsersNotSuperAdmin: false,
+				Logger:                log.New(log.DebugLevel),
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
@@ -198,10 +197,53 @@ func TestService_Me(t *testing.T) {
 					},
 				},
 				UsersStore: &mocks.UsersStore{
-					AllF: func(ctx context.Context) ([]chronograf.User, error) {
-						// This function gets to verify that there is at least one first user
-						return []chronograf.User{{}}, nil
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return nil, chronograf.ErrUserNotFound
 					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody: `{"name":"secret","superAdmin":true,"roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}
+`,
+		},
+		{
+			name: "New user - New users not super admin",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth:               true,
+				NewUsersNotSuperAdmin: true,
+				Logger:                log.New(log.DebugLevel),
+				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID: 0,
+						}, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   0,
+							Name: "The Bad Place",
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
 					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
 						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
 							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
@@ -232,7 +274,8 @@ func TestService_Me(t *testing.T) {
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
 			},
 			fields: fields{
-				UseAuth: true,
+				UseAuth:               true,
+				NewUsersNotSuperAdmin: true,
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
@@ -249,10 +292,6 @@ func TestService_Me(t *testing.T) {
 					},
 				},
 				UsersStore: &mocks.UsersStore{
-					AllF: func(ctx context.Context) ([]chronograf.User, error) {
-						// This function gets to verify that there is at least one first user
-						return []chronograf.User{{}}, nil
-					},
 					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
 						return nil, chronograf.ErrUserNotFound
 					},
@@ -280,8 +319,9 @@ func TestService_Me(t *testing.T) {
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
 			},
 			fields: fields{
-				UseAuth: false,
-				Logger:  log.New(log.DebugLevel),
+				UseAuth:               false,
+				NewUsersNotSuperAdmin: true,
+				Logger:                log.New(log.DebugLevel),
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
@@ -295,8 +335,9 @@ func TestService_Me(t *testing.T) {
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
 			},
 			fields: fields{
-				UseAuth: true,
-				Logger:  log.New(log.DebugLevel),
+				UseAuth:               true,
+				NewUsersNotSuperAdmin: true,
+				Logger:                log.New(log.DebugLevel),
 			},
 			wantStatus: http.StatusUnprocessableEntity,
 			principal: oauth2.Principal{
@@ -358,8 +399,9 @@ func TestService_Me(t *testing.T) {
 				UsersStore:         tt.fields.UsersStore,
 				OrganizationsStore: tt.fields.OrganizationsStore,
 			},
-			Logger:  tt.fields.Logger,
-			UseAuth: tt.fields.UseAuth,
+			Logger:                tt.fields.Logger,
+			UseAuth:               tt.fields.UseAuth,
+			NewUsersNotSuperAdmin: tt.fields.NewUsersNotSuperAdmin,
 		}
 
 		s.Me(tt.args.w, tt.args.r)

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -217,7 +217,7 @@ func TestService_Me(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody: `{"name":"secret","superAdmin":true,"roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}
+			wantBody: `{"name":"secret","superAdmin":true,"roles":[{"name":"viewer","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"The Gnarly Default","defaultRole":"viewer","public":true}],"currentOrganization":{"id":"0","name":"The Gnarly Default","defaultRole":"viewer","public":true}}
 `,
 		},
 		{
@@ -233,13 +233,18 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID: 0,
+							ID:          0,
+							Name:        "The Gnarly Default",
+							DefaultRole: roles.ViewerRoleName,
+							Public:      true,
 						}, nil
 					},
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   0,
-							Name: "The Bad Place",
+							ID:          0,
+							Name:        "The Gnarly Default",
+							DefaultRole: roles.ViewerRoleName,
+							Public:      true,
 						}, nil
 					},
 				},

--- a/server/server.go
+++ b/server/server.go
@@ -58,7 +58,7 @@ type Server struct {
 	TokenSecret  string        `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
 	AuthDuration time.Duration `long:"auth-duration" default:"720h" description:"Total duration of cookie life for authentication (in hours). 0 means authentication expires on browser close." env:"AUTH_DURATION"`
 	// TODO(desa): think of a better name
-	NewUsersNotSuperAdmin bool `long:"new-users-not-super-admin" description:"All new users will not be given the Super Admin privilege" env:"NEW_USRES_NOT_SUPER_ADMIN"`
+	NewUsersNotSuperAdmin bool `long:"new-users-not-superadmin" description:"All new users will not be given the SuperAdmin status" env:"NEW_USERS_NOT_SUPERADMIN"`
 
 	GithubClientID     string   `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
 	GithubClientSecret string   `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`

--- a/server/server.go
+++ b/server/server.go
@@ -57,6 +57,8 @@ type Server struct {
 	CannedPath   string        `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
 	TokenSecret  string        `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
 	AuthDuration time.Duration `long:"auth-duration" default:"720h" description:"Total duration of cookie life for authentication (in hours). 0 means authentication expires on browser close." env:"AUTH_DURATION"`
+	// TODO(desa): think of a better name
+	NewUsersNotSuperAdmin bool `long:"new-users-not-super-admin" description:"All new users will not be given the Super Admin privilege" env:"NEW_USRES_NOT_SUPER_ADMIN"`
 
 	GithubClientID     string   `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
 	GithubClientSecret string   `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`
@@ -300,6 +302,8 @@ func (s *Server) Serve(ctx context.Context) error {
 		return err
 	}
 	service := openService(ctx, s.BoltPath, layoutBuilder, sourcesBuilder, kapacitorBuilder, logger, s.useAuth())
+	// TODO(desa): better name
+	service.NewUsersNotSuperAdmin = s.NewUsersNotSuperAdmin
 	if err := service.HandleNewSources(ctx, s.NewSources); err != nil {
 		logger.
 			WithField("component", "server").

--- a/server/service.go
+++ b/server/service.go
@@ -15,7 +15,9 @@ type Service struct {
 	TimeSeriesClient TimeSeriesClient
 	Logger           chronograf.Logger
 	UseAuth          bool
-	Databases        chronograf.Databases
+	// TODO(desa): better name
+	NewUsersNotSuperAdmin bool
+	Databases             chronograf.Databases
 }
 
 // TimeSeriesClient returns the correct client for a time series database.


### PR DESCRIPTION
When users upgrade, all of their bolt resources will not belong to any
organization. This PR introduces a migration path where any orphaned,
resources without an organization, will become owned by the default
organization.

Connect #2198 
Connect #2311 

