### PR TITLE
Add shadow-utils to release RPM generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#1077](https://github.com/influxdata/chronograf/pull/2087): Fix Chronograf requiring Telegraf's CPU and system plugins to ensure that all Apps appear on the HOST LIST page.
 1. [#2222](https://github.com/influxdata/chronograf/pull/2222): Fix template variables in dashboard query building.
 1. [#2291](https://github.com/influxdata/chronograf/pull/2291): Fix several kapacitor alert creation panics.
+1. [#2303](https://github.com/influxdata/chronograf/pull/2303): Add shadow-utils to RPM release packages
 
 ### Features
 ### UI Improvements

--- a/etc/build.py
+++ b/etc/build.py
@@ -674,7 +674,7 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils"
+                            fpm_command += "--depends coreutils --depends shadow-utils"
                         # TODO: Check for changelog
                         # elif package_type == "deb":
                         #     fpm_command += "--deb-changelog {} ".format(os.path.join(os.getcwd(), "CHANGELOG.md"))


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2302 

### The problem
RPM generation via fpm did not have shadow-utils

### The Solution
Added shadow-utils as a dependency.

