### PR TITLE
Fix organizations UpdateHandler and OrganizationsStore Update method

### DIFF
--- a/bolt/organizations.go
+++ b/bolt/organizations.go
@@ -276,10 +276,9 @@ func (s *OrganizationsStore) Update(ctx context.Context, o *chronograf.Organizat
 		return chronograf.ErrOrganizationNameTaken
 	}
 	return s.client.db.Update(func(tx *bolt.Tx) error {
-		org.Name = o.Name
-		if v, err := internal.MarshalOrganization(org); err != nil {
+		if v, err := internal.MarshalOrganization(o); err != nil {
 			return err
-		} else if err := tx.Bucket(OrganizationsBucket).Put(u64tob(org.ID), v); err != nil {
+		} else if err := tx.Bucket(OrganizationsBucket).Put(u64tob(o.ID), v); err != nil {
 			return err
 		}
 		return nil

--- a/server/organizations.go
+++ b/server/organizations.go
@@ -34,7 +34,12 @@ func (r *organizationRequest) ValidUpdate() error {
 	if r.Name == "" && r.DefaultRole == "" {
 		return fmt.Errorf("No fields to update")
 	}
-	return r.ValidDefaultRole()
+
+	if r.DefaultRole != "" {
+		return r.ValidDefaultRole()
+	}
+
+	return nil
 }
 
 func (r *organizationRequest) ValidDefaultRole() error {
@@ -208,6 +213,10 @@ func (s *Service) UpdateOrganization(w http.ResponseWriter, r *http.Request) {
 
 	if req.Name != "" {
 		org.Name = req.Name
+	}
+
+	if req.DefaultRole != "" {
+		org.DefaultRole = req.DefaultRole
 	}
 
 	err = s.Store.Organizations(ctx).Update(ctx, org)

--- a/server/stores.go
+++ b/server/stores.go
@@ -181,6 +181,9 @@ func (s *Store) Organizations(ctx context.Context) chronograf.OrganizationsStore
 	if isServer := hasServerContext(ctx); isServer {
 		return s.OrganizationsStore
 	}
+	if isSuperAdmin := hasSuperAdminContext(ctx); isSuperAdmin {
+		return s.OrganizationsStore
+	}
 	if org, ok := hasOrganizationContext(ctx); ok {
 		return organizations.NewOrganizationsStore(s.OrganizationsStore, org)
 	}

--- a/ui/src/admin/actions/chronograf.js
+++ b/ui/src/admin/actions/chronograf.js
@@ -102,13 +102,7 @@ export const loadUsersAsync = url => async dispatch => {
 export const loadOrganizationsAsync = url => async dispatch => {
   try {
     const {data} = await getOrganizationsAJAX(url)
-
-    const orgs = data.organizations.map(o => {
-      o.defaultRole = o.defaultRole || 'member'
-      return o
-    })
-
-    dispatch(loadOrganizations({organizations: orgs}))
+    dispatch(loadOrganizations(data))
   } catch (error) {
     dispatch(errorThrown(error))
   }

--- a/ui/src/admin/actions/chronograf.js
+++ b/ui/src/admin/actions/chronograf.js
@@ -102,7 +102,13 @@ export const loadUsersAsync = url => async dispatch => {
 export const loadOrganizationsAsync = url => async dispatch => {
   try {
     const {data} = await getOrganizationsAJAX(url)
-    dispatch(loadOrganizations(data))
+
+    const orgs = data.organizations.map(o => {
+      o.defaultRole = o.defaultRole || 'member'
+      return o
+    })
+
+    dispatch(loadOrganizations({organizations: orgs}))
   } catch (error) {
     dispatch(errorThrown(error))
   }

--- a/ui/src/admin/components/chronograf/OrganizationsTable.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTable.js
@@ -24,9 +24,9 @@ class OrganizationsTable extends Component {
     this.setState({isCreatingOrganization: false})
   }
 
-  handleCreateOrganization = newOrganization => {
+  handleCreateOrganization = organization => {
     const {onCreateOrg} = this.props
-    onCreateOrg(newOrganization)
+    onCreateOrg(organization)
     this.setState({isCreatingOrganization: false})
   }
 

--- a/ui/src/admin/components/chronograf/OrganizationsTable.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTable.js
@@ -77,6 +77,7 @@ class OrganizationsTable extends Component {
                 ? <OrganizationsTableRowDefault
                     key={uuid.v4()}
                     organization={org}
+                    onChooseDefaultRole={onChooseDefaultRole}
                   />
                 : <OrganizationsTableRow
                     key={uuid.v4()}

--- a/ui/src/admin/components/chronograf/OrganizationsTable.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTable.js
@@ -31,7 +31,12 @@ class OrganizationsTable extends Component {
   }
 
   render() {
-    const {organizations, onDeleteOrg, onRenameOrg} = this.props
+    const {
+      organizations,
+      onDeleteOrg,
+      onRenameOrg,
+      onChooseDefaultRole,
+    } = this.props
     const {isCreatingOrganization} = this.state
 
     const tableTitle = `${organizations.length} Organization${organizations.length ===
@@ -78,6 +83,7 @@ class OrganizationsTable extends Component {
                     organization={org}
                     onDelete={onDeleteOrg}
                     onRename={onRenameOrg}
+                    onChooseDefaultRole={onChooseDefaultRole}
                   />
           )}
         </div>
@@ -98,5 +104,6 @@ OrganizationsTable.propTypes = {
   onCreateOrg: func.isRequired,
   onDeleteOrg: func.isRequired,
   onRenameOrg: func.isRequired,
+  onChooseDefaultRole: func.isRequired,
 }
 export default OrganizationsTable

--- a/ui/src/admin/components/chronograf/OrganizationsTableRow.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRow.js
@@ -4,7 +4,6 @@ import ConfirmButtons from 'shared/components/ConfirmButtons'
 import Dropdown from 'shared/components/Dropdown'
 
 import {USER_ROLES} from 'src/admin/constants/dummyUsers'
-import {MEMBER_ROLE} from 'src/auth/Authorized'
 
 class OrganizationsTableRow extends Component {
   constructor(props) {
@@ -14,7 +13,6 @@ class OrganizationsTableRow extends Component {
       isEditing: false,
       isDeleting: false,
       workingName: this.props.organization.name,
-      defaultRole: MEMBER_ROLE,
     }
   }
 
@@ -80,11 +78,12 @@ class OrganizationsTableRow extends Component {
   }
 
   handleChooseDefaultRole = role => {
-    this.setState({defaultRole: role.name})
+    const {organization, onChooseDefaultRole} = this.props
+    onChooseDefaultRole(organization, role.name)
   }
 
   render() {
-    const {workingName, isEditing, isDeleting, defaultRole} = this.state
+    const {workingName, isEditing, isDeleting} = this.state
     const {organization} = this.props
 
     const dropdownRolesItems = USER_ROLES.map(role => ({
@@ -122,7 +121,7 @@ class OrganizationsTableRow extends Component {
           <Dropdown
             items={dropdownRolesItems}
             onChoose={this.handleChooseDefaultRole}
-            selected={defaultRole}
+            selected={organization.defaultRole}
             className="dropdown-stretch"
           />
         </div>
@@ -151,9 +150,11 @@ OrganizationsTableRow.propTypes = {
   organization: shape({
     id: string, // when optimistically created, organization will not have an id
     name: string.isRequired,
+    defaultRole: string.isRequired,
   }).isRequired,
   onDelete: func.isRequired,
   onRename: func.isRequired,
+  onChooseDefaultRole: func.isRequired,
 }
 
 export default OrganizationsTableRow

--- a/ui/src/admin/components/chronograf/OrganizationsTableRowDefault.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRowDefault.js
@@ -1,34 +1,59 @@
-import React, {PropTypes} from 'react'
+import React, {PropTypes, Component} from 'react'
 
-import {MEMBER_ROLE} from 'src/auth/Authorized'
+import Dropdown from 'shared/components/Dropdown'
+
+import {USER_ROLES} from 'src/admin/constants/dummyUsers'
 
 // This is a non-editable organization row, used currently for DEFAULT_ORG
-const OrganizationsTableRowDefault = ({organization}) =>
-  <div className="orgs-table--org">
-    <div className="orgs-table--id">
-      {organization.id}
-    </div>
-    <div className="orgs-table--name-disabled">
-      {organization.name}
-    </div>
-    <div className="orgs-table--default-role-disabled">
-      {MEMBER_ROLE}
-    </div>
-    <button
-      className="btn btn-sm btn-default btn-square orgs-table--delete"
-      disabled={true}
-    >
-      <span className="icon trash" />
-    </button>
-  </div>
+class OrganizationsTableRowDefault extends Component {
+  handleChooseDefaultRole = role => {
+    const {organization, onChooseDefaultRole} = this.props
+    onChooseDefaultRole(organization, role.name)
+  }
 
-const {shape, string} = PropTypes
+  render() {
+    const {organization} = this.props
+
+    const dropdownRolesItems = USER_ROLES.map(role => ({
+      ...role,
+      text: role.name,
+    }))
+
+    return (
+      <div className="orgs-table--org">
+        <div className="orgs-table--id">
+          {organization.id}
+        </div>
+        <div className="orgs-table--name-disabled">
+          {organization.name}
+        </div>
+        <div className="orgs-table--default-role">
+          <Dropdown
+            items={dropdownRolesItems}
+            onChoose={this.handleChooseDefaultRole}
+            selected={organization.defaultRole}
+            className="dropdown-stretch"
+          />
+        </div>
+        <button
+          className="btn btn-sm btn-default btn-square orgs-table--delete"
+          disabled={true}
+        >
+          <span className="icon trash" />
+        </button>
+      </div>
+    )
+  }
+}
+
+const {func, shape, string} = PropTypes
 
 OrganizationsTableRowDefault.propTypes = {
   organization: shape({
     id: string,
     name: string.isRequired,
   }).isRequired,
+  onChooseDefaultRole: func.isRequired,
 }
 
 export default OrganizationsTableRowDefault

--- a/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
@@ -39,7 +39,7 @@ class OrganizationsTableRowNew extends Component {
     const {onCreateOrganization} = this.props
     const {name, defaultRole} = this.state
 
-    onCreateOrganization(name, defaultRole)
+    onCreateOrganization({name, defaultRole})
   }
 
   handleChooseDefaultRole = role => {

--- a/ui/src/admin/containers/OrganizationsPage.js
+++ b/ui/src/admin/containers/OrganizationsPage.js
@@ -14,9 +14,9 @@ class OrganizationsPage extends Component {
     loadOrganizationsAsync(links.organizations)
   }
 
-  handleCreateOrganization = organizationName => {
+  handleCreateOrganization = organization => {
     const {links, actions: {createOrganizationAsync}} = this.props
-    createOrganizationAsync(links.organizations, {name: organizationName})
+    createOrganizationAsync(links.organizations, organization)
   }
 
   handleRenameOrganization = (organization, name) => {

--- a/ui/src/admin/containers/OrganizationsPage.js
+++ b/ui/src/admin/containers/OrganizationsPage.js
@@ -29,6 +29,11 @@ class OrganizationsPage extends Component {
     deleteOrganizationAsync(organization)
   }
 
+  handleChooseDefaultRole = (organization, defaultRole) => {
+    const {actions: {updateOrganizationAsync}} = this.props
+    updateOrganizationAsync(organization, {...organization, defaultRole})
+  }
+
   render() {
     const {organizations} = this.props
 
@@ -38,6 +43,7 @@ class OrganizationsPage extends Component {
         onCreateOrg={this.handleCreateOrganization}
         onDeleteOrg={this.handleDeleteOrganization}
         onRenameOrg={this.handleRenameOrganization}
+        onChooseDefaultRole={this.handleChooseDefaultRole}
       />
     )
   }


### PR DESCRIPTION
Connect #2341 
Connect #2274

### The problem

1. Bolt OrganizationsStore was not properly updating all attributes
2. The organizationRequest `ValidUpdate` method did not properly validate the role
2. The new DefaultRole property was not set in UpdateOrganization

