### PR TITLE
Multitenancy User Nav Polish

### DIFF
--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -4,6 +4,8 @@ import {bindActionCreators} from 'redux'
 
 import classnames from 'classnames'
 
+import FancyScrollbar from 'shared/components/FancyScrollbar'
+
 import {meChangeOrganizationAsync} from 'shared/actions/auth'
 
 import {SUPERADMIN_ROLE} from 'src/auth/Authorized'
@@ -49,22 +51,29 @@ class UserNavBlock extends Component {
             Logout
           </a>
           <div className="sidebar-menu--section">Switch Organizations</div>
-          {roles.map((r, i) => {
-            const isLinkCurrentOrg = currentOrganization.id === r.organization
-            return (
-              <span
-                key={i}
-                className={classnames({
-                  'sidebar-menu--item': true,
-                  active: isLinkCurrentOrg,
-                })}
-                onClick={this.handleChangeCurrentOrganization(r.organization)}
-              >
-                {organizations.find(o => o.id === r.organization).name}{' '}
-                <strong>({r.name})</strong>
-              </span>
-            )
-          })}
+          <FancyScrollbar
+            className="sidebar-menu--scrollbar"
+            autoHeight={true}
+            maxHeight={300}
+            autoHide={false}
+          >
+            {roles.map((r, i) => {
+              const isLinkCurrentOrg = currentOrganization.id === r.organization
+              return (
+                <span
+                  key={i}
+                  className={classnames({
+                    'sidebar-menu--item': true,
+                    active: isLinkCurrentOrg,
+                  })}
+                  onClick={this.handleChangeCurrentOrganization(r.organization)}
+                >
+                  {organizations.find(o => o.id === r.organization).name}{' '}
+                  <strong>({r.name})</strong>
+                </span>
+              )
+            })}
+          </FancyScrollbar>
           {customLinks
             ? <div className="sidebar-menu--section">Custom Links</div>
             : null}

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -29,6 +29,7 @@ class UserNavBlock extends Component {
           <div className="sidebar-menu--heading">
             {me.name}
           </div>
+          <div className="sidebar-menu--section">Account</div>
           <a className="sidebar-menu--item" href={logoutLink}>
             Logout
           </a>

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -30,7 +30,7 @@ class UserNavBlock extends Component {
         <div className="sidebar--square">
           <div className="sidebar--icon icon user" />
           {isSuperAdmin
-            ? <div className="sidebar--icon sidebar--icon__superadmin icon crown2" />
+            ? <span className="sidebar--icon sidebar--icon__superadmin icon crown2" />
             : null}
         </div>
         <div className="sidebar-menu">

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -6,6 +6,8 @@ import classnames from 'classnames'
 
 import {meChangeOrganizationAsync} from 'shared/actions/auth'
 
+import {SUPERADMIN_ROLE} from 'src/auth/Authorized'
+
 class UserNavBlock extends Component {
   handleChangeCurrentOrganization = organizationID => () => {
     const {links, meChangeOrganization} = this.props
@@ -18,18 +20,31 @@ class UserNavBlock extends Component {
       links: {external: {custom: customLinks}},
       me,
       me: {currentOrganization, organizations, roles},
+      me: {role},
     } = this.props
+
+    const isSuperAdmin = role === SUPERADMIN_ROLE
 
     return (
       <div className="sidebar--item">
         <div className="sidebar--square">
           <div className="sidebar--icon icon user" />
+          {isSuperAdmin
+            ? <div className="sidebar--icon sidebar--icon__superadmin icon crown2" />
+            : null}
         </div>
         <div className="sidebar-menu">
           <div className="sidebar-menu--heading">
             {me.name}
           </div>
           <div className="sidebar-menu--section">Account</div>
+          {isSuperAdmin
+            ? <div className="sidebar-menu--superadmin">
+                <div>
+                  <span className="icon crown2" /> You are a SuperAdmin
+                </div>
+              </div>
+            : null}
           <a className="sidebar-menu--item" href={logoutLink}>
             Logout
           </a>

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -36,7 +36,7 @@ class UserNavBlock extends Component {
             : null}
         </div>
         <div className="sidebar-menu">
-          <div className="sidebar-menu--heading">
+          <div className="sidebar-menu--heading sidebar--no-hover">
             {me.name}
           </div>
           <div className="sidebar-menu--section">Account</div>

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -27,6 +27,8 @@ class UserNavBlock extends Component {
 
     const isSuperAdmin = role === SUPERADMIN_ROLE
 
+    const isSmallViewport = window.visualViewport.height < 850
+
     return (
       <div className="sidebar--item">
         <div className="sidebar--square">
@@ -35,62 +37,129 @@ class UserNavBlock extends Component {
             ? <span className="sidebar--icon sidebar--icon__superadmin icon crown2" />
             : null}
         </div>
-        <div className="sidebar-menu">
-          <div className="sidebar-menu--heading sidebar--no-hover">
-            {me.name}
-          </div>
-          <div className="sidebar-menu--section">Account</div>
-          {isSuperAdmin
-            ? <div className="sidebar-menu--superadmin">
-                <div>
-                  <span className="icon crown2" /> You are a SuperAdmin
-                </div>
+        {isSmallViewport
+          ? <div className="sidebar-menu sidebar-menu--inverse">
+              {customLinks
+                ? <div className="sidebar-menu--section">Custom Links</div>
+                : null}
+              {customLinks
+                ? customLinks.map((link, i) =>
+                    <a
+                      key={i}
+                      className="sidebar-menu--item"
+                      href={link.url}
+                      target="_blank"
+                    >
+                      {link.name}
+                    </a>
+                  )
+                : null}
+              <div className="sidebar-menu--section">Switch Organizations</div>
+              <FancyScrollbar
+                className="sidebar-menu--scrollbar"
+                autoHeight={true}
+                maxHeight={isSmallViewport ? 105 : 300}
+                autoHide={false}
+              >
+                {roles.map((r, i) => {
+                  const isLinkCurrentOrg =
+                    currentOrganization.id === r.organization
+                  return (
+                    <span
+                      key={i}
+                      className={classnames({
+                        'sidebar-menu--item': true,
+                        active: isLinkCurrentOrg,
+                      })}
+                      onClick={this.handleChangeCurrentOrganization(
+                        r.organization
+                      )}
+                    >
+                      {
+                        organizations.find(o => o.id === r.organization).name
+                      }{' '}
+                      <strong>({r.name})</strong>
+                    </span>
+                  )
+                })}
+              </FancyScrollbar>
+              <div className="sidebar-menu--section">Account</div>
+              <a className="sidebar-menu--item" href={logoutLink}>
+                Logout
+              </a>
+              {isSuperAdmin
+                ? <div className="sidebar-menu--superadmin">
+                    <div>
+                      <span className="icon crown2" /> You are a SuperAdmin
+                    </div>
+                  </div>
+                : null}
+              <div className="sidebar-menu--heading sidebar--no-hover">
+                {me.name}
               </div>
-            : null}
-          <a className="sidebar-menu--item" href={logoutLink}>
-            Logout
-          </a>
-          <div className="sidebar-menu--section">Switch Organizations</div>
-          <FancyScrollbar
-            className="sidebar-menu--scrollbar"
-            autoHeight={true}
-            maxHeight={300}
-            autoHide={false}
-          >
-            {roles.map((r, i) => {
-              const isLinkCurrentOrg = currentOrganization.id === r.organization
-              return (
-                <span
-                  key={i}
-                  className={classnames({
-                    'sidebar-menu--item': true,
-                    active: isLinkCurrentOrg,
-                  })}
-                  onClick={this.handleChangeCurrentOrganization(r.organization)}
-                >
-                  {organizations.find(o => o.id === r.organization).name}{' '}
-                  <strong>({r.name})</strong>
-                </span>
-              )
-            })}
-          </FancyScrollbar>
-          {customLinks
-            ? <div className="sidebar-menu--section">Custom Links</div>
-            : null}
-          {customLinks
-            ? customLinks.map((link, i) =>
-                <a
-                  key={i}
-                  className="sidebar-menu--item"
-                  href={link.url}
-                  target="_blank"
-                >
-                  {link.name}
-                </a>
-              )
-            : null}
-          <div className="sidebar-menu--triangle" />
-        </div>
+              <div className="sidebar-menu--triangle" />
+            </div>
+          : <div className="sidebar-menu">
+              <div className="sidebar-menu--heading sidebar--no-hover">
+                {me.name}
+              </div>
+              <div className="sidebar-menu--section">Account</div>
+              {isSuperAdmin
+                ? <div className="sidebar-menu--superadmin">
+                    <div>
+                      <span className="icon crown2" /> You are a SuperAdmin
+                    </div>
+                  </div>
+                : null}
+              <a className="sidebar-menu--item" href={logoutLink}>
+                Logout
+              </a>
+              <div className="sidebar-menu--section">Switch Organizations</div>
+              <FancyScrollbar
+                className="sidebar-menu--scrollbar"
+                autoHeight={true}
+                maxHeight={isSmallViewport ? 100 : 300}
+                autoHide={false}
+              >
+                {roles.map((r, i) => {
+                  const isLinkCurrentOrg =
+                    currentOrganization.id === r.organization
+                  return (
+                    <span
+                      key={i}
+                      className={classnames({
+                        'sidebar-menu--item': true,
+                        active: isLinkCurrentOrg,
+                      })}
+                      onClick={this.handleChangeCurrentOrganization(
+                        r.organization
+                      )}
+                    >
+                      {
+                        organizations.find(o => o.id === r.organization).name
+                      }{' '}
+                      <strong>({r.name})</strong>
+                    </span>
+                  )
+                })}
+              </FancyScrollbar>
+              {customLinks
+                ? <div className="sidebar-menu--section">Custom Links</div>
+                : null}
+              {customLinks
+                ? customLinks.map((link, i) =>
+                    <a
+                      key={i}
+                      className="sidebar-menu--item"
+                      href={link.url}
+                      target="_blank"
+                    >
+                      {link.name}
+                    </a>
+                  )
+                : null}
+              <div className="sidebar-menu--triangle" />
+            </div>}
       </div>
     )
   }

--- a/ui/src/side_nav/components/UserNavBlock.js
+++ b/ui/src/side_nav/components/UserNavBlock.js
@@ -20,13 +20,6 @@ class UserNavBlock extends Component {
       me: {currentOrganization, organizations, roles},
     } = this.props
 
-    // TODO: find a better way to glean this information.
-    // Need this method for when a user is a superadmin,
-    // which doesn't reflect their role in the current org
-    const currentRole = roles.find(cr => {
-      return cr.organization === currentOrganization.id
-    }).name
-
     return (
       <div className="sidebar--item">
         <div className="sidebar--square">
@@ -34,9 +27,6 @@ class UserNavBlock extends Component {
         </div>
         <div className="sidebar-menu">
           <div className="sidebar-menu--heading">
-            {currentOrganization.name} ({currentRole})
-          </div>
-          <div className="sidebar-menu--section">
             {me.name}
           </div>
           <a className="sidebar-menu--item" href={logoutLink}>

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -243,7 +243,6 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
     padding: 4px 8px;
     align-items: center;
     border-radius: 3px;
-    // background-color: $c-ocean;
     @include gradient-h($c-pineapple,$c-tiger);
     color: $c-sapphire;
   }
@@ -256,4 +255,8 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
   &:hover {
     cursor: default;
   }
+}
+.fancy-scroll--container.sidebar-menu--scrollbar {
+  .fancy-scroll--thumb-h { @include gradient-h($g20-white,$c-neutrino); }
+  .fancy-scroll--thumb-v { @include gradient-v($g20-white,$c-neutrino); }
 }

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -226,3 +226,34 @@ $sidebar-menu--gutter: 18px;
     @include gradient-h($c-laser,$c-potassium);
   }
 }
+
+// SuperAdminIndicator
+span.icon.sidebar--icon.sidebar--icon__superadmin {
+  font-size: 10px;
+  top: 23%;
+}
+.sidebar-menu--superadmin {
+  padding: 4px $sidebar-menu--gutter;
+  font-size: 15px;
+  font-weight: 500;
+  @include no-user-select();
+
+  > div {
+    display: flex;
+    padding: 4px 8px;
+    align-items: center;
+    border-radius: 3px;
+    // background-color: $c-ocean;
+    @include gradient-h($c-pineapple,$c-tiger);
+    color: $c-sapphire;
+  }
+  span.icon {
+    display: inline-block;
+    margin-right: 6px;
+    position: relative;
+    top: -2px;
+  }
+  &:hover {
+    cursor: default;
+  }
+}

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -151,6 +151,10 @@ $sidebar-menu--gutter: 18px;
     cursor: pointer;
   }
 }
+.sidebar-menu--heading.sidebar--no-hover,
+.sidebar-menu--heading.sidebar--no-hover:hover {
+  cursor: default;
+}
 .sidebar-menu--item,
 .sidebar-menu--item:link,
 .sidebar-menu--item:active,

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -261,6 +261,6 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
   }
 }
 .fancy-scroll--container.sidebar-menu--scrollbar {
-  .fancy-scroll--thumb-h { @include gradient-h($g20-white,$c-neutrino); }
+  .fancy-scroll--thumb-h {display: none !important;}
   .fancy-scroll--thumb-v { @include gradient-v($g20-white,$c-neutrino); }
 }

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -140,6 +140,11 @@ $sidebar-menu--gutter: 18px;
   transition: opacity 0.25s ease;
   display: none;
   flex-direction: column;
+
+  &.sidebar-menu--inverse {
+    top: initial;
+    bottom: 0;
+  }
 }
 .sidebar-menu--heading,
 .sidebar-menu--item {
@@ -228,6 +233,11 @@ $sidebar-menu--gutter: 18px;
     width: 100%;
     height: 2px;
     @include gradient-h($c-laser,$c-potassium);
+  }
+
+  &:first-child:after {
+    display: none;
+    border-top-right-radius: $radius;
   }
 }
 


### PR DESCRIPTION
Connect #2248 

### The Problem
- Moving the admin nav items out of the user nav block requires a redesign
- When there are a lot of orgs, menu will extend off the screen

### The Solution
- [x] Revert to previous design in which the user's name is rendered as the nav header
- [x] Indicate to a user that they are a super admin
- [x] Scroll organizations list when it is too long

![screen shot 2017-11-10 at 12 03 02 pm](https://user-images.githubusercontent.com/2433762/32679356-0a3fe268-c61b-11e7-99db-d3c411ce3c41.png)

![sidenav-scroll-orgs](https://user-images.githubusercontent.com/2433762/32763419-62306538-c8b4-11e7-94d7-e4ff26ae5394.gif)


