### PR TITLE
WIP Refactor getMe & refresh me for SideNav upon change organizations

### DIFF
--- a/ui/spec/shared/reducers/authSpec.js
+++ b/ui/spec/shared/reducers/authSpec.js
@@ -4,7 +4,7 @@ import {
   authExpired,
   authRequested,
   authReceived,
-  meRequested,
+  meGetRequested,
   meReceivedNotUsingAuth,
 } from 'shared/actions/auth'
 
@@ -51,8 +51,8 @@ describe('Shared.Reducers.authReducer', () => {
     expect(reducedState.isAuthLoading).to.equal(false)
   })
 
-  it('should handle ME_REQUESTED', () => {
-    const reducedState = authReducer(initialState, meRequested())
+  it('should handle ME_GET_REQUESTED', () => {
+    const reducedState = authReducer(initialState, meGetRequested())
 
     expect(reducedState.isMeLoading).to.equal(true)
   })

--- a/ui/spec/shared/reducers/authSpec.js
+++ b/ui/spec/shared/reducers/authSpec.js
@@ -5,7 +5,7 @@ import {
   authRequested,
   authReceived,
   meGetRequested,
-  meReceivedNotUsingAuth,
+  meGetCompletedNotUsingAuth,
 } from 'shared/actions/auth'
 
 const defaultAuth = {
@@ -57,11 +57,11 @@ describe('Shared.Reducers.authReducer', () => {
     expect(reducedState.isMeLoading).to.equal(true)
   })
 
-  it('should handle ME_RECEIVED__NON_AUTH', () => {
+  it('should handle ME_GET_COMPLETED__NON_AUTH', () => {
     const loadingState = {...initialState, isMeLoading: true}
     const reducedState = authReducer(
       loadingState,
-      meReceivedNotUsingAuth(defaultMe)
+      meGetCompletedNotUsingAuth(defaultMe)
     )
 
     expect(reducedState.me).to.deep.equal(defaultMe)

--- a/ui/src/admin/containers/OrganizationsPage.js
+++ b/ui/src/admin/containers/OrganizationsPage.js
@@ -2,6 +2,8 @@ import React, {Component, PropTypes} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 
+import {getMeAsync} from 'shared/actions/auth'
+
 import * as adminChronografActionCreators from 'src/admin/actions/chronograf'
 import {publishAutoDismissingNotification} from 'shared/dispatchers'
 
@@ -10,23 +12,30 @@ import OrganizationsTable from 'src/admin/components/chronograf/OrganizationsTab
 class OrganizationsPage extends Component {
   componentDidMount() {
     const {links, actions: {loadOrganizationsAsync}} = this.props
-
     loadOrganizationsAsync(links.organizations)
   }
 
-  handleCreateOrganization = organizationName => {
+  handleCreateOrganization = async organizationName => {
     const {links, actions: {createOrganizationAsync}} = this.props
-    createOrganizationAsync(links.organizations, {name: organizationName})
+    await createOrganizationAsync(links.organizations, {name: organizationName})
+    this.refreshMe()
   }
 
-  handleRenameOrganization = (organization, name) => {
+  handleRenameOrganization = async (organization, name) => {
     const {actions: {updateOrganizationAsync}} = this.props
-    updateOrganizationAsync(organization, {...organization, name})
+    await updateOrganizationAsync(organization, {...organization, name})
+    this.refreshMe()
   }
 
   handleDeleteOrganization = organization => {
     const {actions: {deleteOrganizationAsync}} = this.props
     deleteOrganizationAsync(organization)
+    this.refreshMe()
+  }
+
+  refreshMe = () => {
+    const {getMe} = this.props
+    getMe({allowReset: false})
   }
 
   render() {
@@ -73,6 +82,7 @@ const mapStateToProps = ({links, adminChronograf: {organizations}}) => ({
 const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators(adminChronografActionCreators, dispatch),
   notify: bindActionCreators(publishAutoDismissingNotification, dispatch),
+  getMe: bindActionCreators(getMeAsync, dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrganizationsPage)

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -6,6 +6,7 @@ import {Provider} from 'react-redux'
 import {Router, Route, useRouterHistory} from 'react-router'
 import {createHistory} from 'history'
 import {syncHistoryWithStore} from 'react-router-redux'
+import {bindActionCreators} from 'redux'
 
 import configureStore from 'src/store/configureStore'
 import {loadLocalStorage} from 'src/localStorage'
@@ -34,18 +35,9 @@ import {AdminChronografPage, AdminInfluxDBPage} from 'src/admin'
 import {SourcePage, ManageSources} from 'src/sources'
 import NotFound from 'shared/components/NotFound'
 
-import {getMe} from 'shared/apis'
+import {getMeAsync} from 'shared/actions/auth'
 
 import {disablePresentationMode} from 'shared/actions/app'
-import {
-  authRequested,
-  authReceived,
-  meRequested,
-  meReceivedNotUsingAuth,
-  meReceivedUsingAuth,
-  logoutLinkReceived,
-} from 'shared/actions/auth'
-import {linksReceived} from 'shared/actions/links'
 import {errorThrown} from 'shared/actions/errors'
 
 import 'src/style/chronograf.scss'
@@ -87,45 +79,24 @@ const Root = React.createClass({
   },
 
   async checkAuth() {
-    dispatch(authRequested())
-    dispatch(meRequested())
     try {
-      await this.startHeartbeat({shouldDispatchResponse: true})
+      await this.startHeartbeat({allowReset: true})
     } catch (error) {
       dispatch(errorThrown(error))
     }
   },
 
-  async startHeartbeat({shouldDispatchResponse}) {
-    try {
-      // These non-me objects are added to every response by some AJAX trickery
-      const {
-        data: me,
-        auth,
-        logoutLink,
-        external,
-        users,
-        organizations,
-        meLink,
-      } = await getMe()
-      if (shouldDispatchResponse) {
-        const isUsingAuth = !!logoutLink
-        dispatch(
-          isUsingAuth ? meReceivedUsingAuth(me) : meReceivedNotUsingAuth(me)
-        )
-        dispatch(authReceived(auth))
-        dispatch(logoutLinkReceived(logoutLink))
-        dispatch(linksReceived({external, users, organizations, me: meLink}))
-      }
+  getMe: bindActionCreators(getMeAsync, dispatch),
 
-      setTimeout(() => {
-        if (store.getState().auth.me !== null) {
-          this.startHeartbeat({shouldDispatchResponse: false})
-        }
-      }, HEARTBEAT_INTERVAL)
-    } catch (error) {
-      dispatch(errorThrown(error))
-    }
+  async startHeartbeat(config) {
+    // TODO: use destructure syntax with default {} value -- couldn't figure it out
+    await this.getMe({allowReset: config && config.allowReset})
+
+    setTimeout(() => {
+      if (store.getState().auth.me !== null) {
+        this.startHeartbeat()
+      }
+    }, HEARTBEAT_INTERVAL)
   },
 
   flushErrorsQueue() {

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -27,15 +27,15 @@ export const meGetRequested = () => ({
   type: 'ME_GET_REQUESTED',
 })
 
-export const meReceivedNotUsingAuth = me => ({
-  type: 'ME_RECEIVED__NON_AUTH',
+export const meGetCompletedNotUsingAuth = me => ({
+  type: 'ME_GET_COMPLETED__NON_AUTH',
   payload: {
     me,
   },
 })
 
-export const meReceivedUsingAuth = me => ({
-  type: 'ME_RECEIVED__AUTH',
+export const meGetCompletedUsingAuth = me => ({
+  type: 'ME_GET_COMPLETED__AUTH',
   payload: {
     me,
   },
@@ -83,7 +83,9 @@ export const getMeAsync = ({allowReset}) => async dispatch => {
     } = await getMeAJAX()
     console.log('allowReset', allowReset)
     const isUsingAuth = !!logoutLink
-    dispatch(isUsingAuth ? meReceivedUsingAuth(me) : meReceivedNotUsingAuth(me))
+    dispatch(
+      isUsingAuth ? meGetCompletedUsingAuth(me) : meGetCompletedNotUsingAuth(me)
+    )
     dispatch(authReceived(auth))
     dispatch(logoutLinkReceived(logoutLink))
     dispatch(linksReceived({external, users, organizations, me: meLink}))
@@ -107,7 +109,7 @@ export const meChangeOrganizationAsync = (
       )
     )
     dispatch(meChangeOrganizationCompleted())
-    dispatch(meReceivedUsingAuth(data))
+    dispatch(meGetCompletedUsingAuth(data))
   } catch (error) {
     dispatch(errorThrown(error))
     dispatch(meChangeOrganizationFailed())

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -1,4 +1,6 @@
-import {updateMe as updateMeAJAX} from 'shared/apis/auth'
+import {getMe as getMeAJAX, updateMe as updateMeAJAX} from 'shared/apis/auth'
+
+import {linksReceived} from 'shared/actions/links'
 
 import {publishAutoDismissingNotification} from 'shared/dispatchers'
 import {errorThrown} from 'shared/actions/errors'
@@ -21,8 +23,8 @@ export const authReceived = auth => ({
   },
 })
 
-export const meRequested = () => ({
-  type: 'ME_REQUESTED',
+export const meGetRequested = () => ({
+  type: 'ME_GET_REQUESTED',
 })
 
 export const meReceivedNotUsingAuth = me => ({
@@ -37,6 +39,10 @@ export const meReceivedUsingAuth = me => ({
   payload: {
     me,
   },
+})
+
+export const meGetFailed = () => ({
+  type: 'ME_GET_FAILED',
 })
 
 export const meChangeOrganizationRequested = () => ({
@@ -57,6 +63,35 @@ export const logoutLinkReceived = logoutLink => ({
     logoutLink,
   },
 })
+
+export const getMeAsync = ({allowReset}) => async dispatch => {
+  console.log(allowReset)
+  if (allowReset) {
+    dispatch(authRequested())
+    dispatch(meGetRequested())
+  }
+  try {
+    // These non-me objects are added to every response by some AJAX trickery
+    const {
+      data: me,
+      auth,
+      logoutLink,
+      external,
+      users,
+      organizations,
+      meLink,
+    } = await getMeAJAX()
+    console.log('allowReset', allowReset)
+    const isUsingAuth = !!logoutLink
+    dispatch(isUsingAuth ? meReceivedUsingAuth(me) : meReceivedNotUsingAuth(me))
+    dispatch(authReceived(auth))
+    dispatch(logoutLinkReceived(logoutLink))
+    dispatch(linksReceived({external, users, organizations, me: meLink}))
+  } catch (error) {
+    dispatch(errorThrown(error))
+    dispatch(meGetFailed())
+  }
+}
 
 export const meChangeOrganizationAsync = (
   url,

--- a/ui/src/shared/apis/auth.js
+++ b/ui/src/shared/apis/auth.js
@@ -1,5 +1,12 @@
 import AJAX from 'src/utils/ajax'
 
+export function getMe() {
+  return AJAX({
+    resource: 'me',
+    method: 'GET',
+  })
+}
+
 export const updateMe = async (url, updatedMe) => {
   try {
     return await AJAX({

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -8,13 +8,6 @@ export function fetchLayouts() {
   })
 }
 
-export function getMe() {
-  return AJAX({
-    resource: 'me',
-    method: 'GET',
-  })
-}
-
 export function getSources() {
   return AJAX({
     resource: 'sources',

--- a/ui/src/shared/reducers/auth.js
+++ b/ui/src/shared/reducers/auth.js
@@ -25,7 +25,7 @@ const authReducer = (state = initialState, action) => {
       const {auth: {links}} = action.payload
       return {...state, links, isAuthLoading: false}
     }
-    case 'ME_REQUESTED': {
+    case 'ME_GET_REQUESTED': {
       return {...state, isMeLoading: true}
     }
     case 'ME_RECEIVED__NON_AUTH': {

--- a/ui/src/shared/reducers/auth.js
+++ b/ui/src/shared/reducers/auth.js
@@ -28,7 +28,7 @@ const authReducer = (state = initialState, action) => {
     case 'ME_GET_REQUESTED': {
       return {...state, isMeLoading: true}
     }
-    case 'ME_RECEIVED__NON_AUTH': {
+    case 'ME_GET_COMPLETED__NON_AUTH': {
       const {me} = action.payload
       return {
         ...state,
@@ -36,7 +36,7 @@ const authReducer = (state = initialState, action) => {
         isMeLoading: false,
       }
     }
-    case 'ME_RECEIVED__AUTH': {
+    case 'ME_GET_COMPLETED__AUTH': {
       const {me, me: {currentOrganization}} = action.payload
       return {
         ...state,


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2344 

### The problem
Couldn't navigate to other orgs without refresh after adding an org because Side Nav User Nav Block doesn't update when organizations change.

### The Solution
Refactor me is gotten, and refresh me after changing orgs.

