### PR TITLE
Update queryConfig render to support wildcard, re, int, num

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [#2303](https://github.com/influxdata/chronograf/pull/2303): Add shadow-utils to RPM release packages
 1. [#2292](https://github.com/influxdata/chronograf/pull/2292): Source extra command line options from defaults file
 1. [#2329](https://github.com/influxdata/chronograf/pull/2329): Include tag values alongside measurement name in Data Explorer result tabs
+1. [#2386](https://github.com/influxdata/chronograf/pull/2386): Fix queries that include regex, numbers and wildcard
 
 ### Features
 ### UI Improvements

--- a/ui/src/utils/influxql.js
+++ b/ui/src/utils/influxql.js
@@ -77,6 +77,18 @@ function _buildFields(fieldFuncs) {
         case 'field': {
           return f.value === '*' ? '*' : `"${f.value}"`
         }
+        case 'wildcard': {
+          return '*'
+        }
+        case 'regex': {
+          return `/${f.value}/`
+        }
+        case 'number': {
+          return `${f.value}`
+        }
+        case 'integer': {
+          return `${f.value}`
+        }
         case 'func': {
           const args = _buildFields(f.args)
           const alias = f.alias ? ` AS "${f.alias}"` : ''


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2369 

### The problem
Query config rendering to InfluxQL did not support wildcard, integer, number and regex types
returned from the chronograf server.

### The Solution
Added support to render wildcard, integer, number and regex.