### PR TITLE
Refresh organizations in User nav after updating organizations

### DIFF
--- a/ui/spec/shared/reducers/authSpec.js
+++ b/ui/spec/shared/reducers/authSpec.js
@@ -4,7 +4,7 @@ import {
   authExpired,
   authRequested,
   authReceived,
-  meRequested,
+  meGetRequested,
   meReceivedNotUsingAuth,
 } from 'shared/actions/auth'
 
@@ -51,8 +51,8 @@ describe('Shared.Reducers.authReducer', () => {
     expect(reducedState.isAuthLoading).to.equal(false)
   })
 
-  it('should handle ME_REQUESTED', () => {
-    const reducedState = authReducer(initialState, meRequested())
+  it('should handle ME_GET_REQUESTED', () => {
+    const reducedState = authReducer(initialState, meGetRequested())
 
     expect(reducedState.isMeLoading).to.equal(true)
   })

--- a/ui/spec/shared/reducers/authSpec.js
+++ b/ui/spec/shared/reducers/authSpec.js
@@ -5,7 +5,7 @@ import {
   authRequested,
   authReceived,
   meGetRequested,
-  meReceivedNotUsingAuth,
+  meGetCompletedNotUsingAuth,
 } from 'shared/actions/auth'
 
 const defaultAuth = {
@@ -57,11 +57,11 @@ describe('Shared.Reducers.authReducer', () => {
     expect(reducedState.isMeLoading).to.equal(true)
   })
 
-  it('should handle ME_RECEIVED__NON_AUTH', () => {
+  it('should handle ME_GET_COMPLETED__NON_AUTH', () => {
     const loadingState = {...initialState, isMeLoading: true}
     const reducedState = authReducer(
       loadingState,
-      meReceivedNotUsingAuth(defaultMe)
+      meGetCompletedNotUsingAuth(defaultMe)
     )
 
     expect(reducedState.me).to.deep.equal(defaultMe)

--- a/ui/src/CheckSources.js
+++ b/ui/src/CheckSources.js
@@ -83,6 +83,20 @@ const CheckSources = React.createClass({
     this.setState({isFetching: false})
   },
 
+  shouldComponentUpdate(nextProps) {
+    const {auth: {isUsingAuth, me}} = nextProps
+    // don't update this component if currentOrganization is what has changed,
+    // or else the app will try to call showDatabases in componentWillUpdate,
+    // which will fail unless sources have been refreshed
+    if (
+      isUsingAuth &&
+      me.currentOrganization.id !== this.props.auth.me.currentOrganization.id
+    ) {
+      return false
+    }
+    return true
+  },
+
   async componentWillUpdate(nextProps, nextState) {
     const {
       router,
@@ -129,6 +143,8 @@ const CheckSources = React.createClass({
     if (!isFetching && !location.pathname.includes('/manage-sources')) {
       // Do simple query to proxy to see if the source is up.
       try {
+        // the guard around currentOrganization prevents this showDatabases
+        // invocation since sources haven't been refreshed yet
         await showDatabases(source.links.proxy)
       } catch (error) {
         errorThrown(error, 'Unable to connect to source')

--- a/ui/src/CheckSources.js
+++ b/ui/src/CheckSources.js
@@ -5,10 +5,9 @@ import {bindActionCreators} from 'redux'
 
 import {MEMBER_ROLE, VIEWER_ROLE} from 'src/auth/Authorized'
 
-import {getSources} from 'shared/apis'
 import {showDatabases} from 'shared/apis/metaQuery'
 
-import {loadSources as loadSourcesAction} from 'shared/actions/sources'
+import {getSourcesAsync} from 'shared/actions/sources'
 import {errorThrown as errorThrownAction} from 'shared/actions/errors'
 
 import {DEFAULT_HOME_PAGE} from 'shared/constants'
@@ -19,6 +18,7 @@ import {DEFAULT_HOME_PAGE} from 'shared/constants'
 const {arrayOf, bool, func, node, shape, string} = PropTypes
 const CheckSources = React.createClass({
   propTypes: {
+    getSources: func.isRequired,
     sources: arrayOf(
       shape({
         links: shape({
@@ -42,8 +42,6 @@ const CheckSources = React.createClass({
     location: shape({
       pathname: string.isRequired,
     }).isRequired,
-    loadSources: func.isRequired,
-    errorThrown: func.isRequired,
     auth: shape({
       isUsingAuth: bool,
       me: shape({
@@ -81,16 +79,8 @@ const CheckSources = React.createClass({
   },
 
   async componentWillMount() {
-    const {loadSources, errorThrown} = this.props
-
-    try {
-      const {data: {sources}} = await getSources()
-      loadSources(sources)
-      this.setState({isFetching: false})
-    } catch (error) {
-      errorThrown(error, 'Unable to connect to Chronograf server')
-      this.setState({isFetching: false})
-    }
+    await this.props.getSources()
+    this.setState({isFetching: false})
   },
 
   async componentWillUpdate(nextProps, nextState) {
@@ -178,7 +168,7 @@ const mapStateToProps = ({sources, auth, me}) => ({
 })
 
 const mapDispatchToProps = dispatch => ({
-  loadSources: bindActionCreators(loadSourcesAction, dispatch),
+  getSources: bindActionCreators(getSourcesAsync, dispatch),
   errorThrown: bindActionCreators(errorThrownAction, dispatch),
 })
 

--- a/ui/src/admin/containers/OrganizationsPage.js
+++ b/ui/src/admin/containers/OrganizationsPage.js
@@ -3,30 +3,37 @@ import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 
 import * as adminChronografActionCreators from 'src/admin/actions/chronograf'
-import {publishAutoDismissingNotification} from 'shared/dispatchers'
+import {getMeAsync} from 'shared/actions/auth'
 
 import OrganizationsTable from 'src/admin/components/chronograf/OrganizationsTable'
 
 class OrganizationsPage extends Component {
   componentDidMount() {
     const {links, actions: {loadOrganizationsAsync}} = this.props
-
     loadOrganizationsAsync(links.organizations)
   }
 
-  handleCreateOrganization = organization => {
+  handleCreateOrganization = async organization => {
     const {links, actions: {createOrganizationAsync}} = this.props
-    createOrganizationAsync(links.organizations, organization)
+    await createOrganizationAsync(links.organizations, organization)
+    this.refreshMe()
   }
 
-  handleRenameOrganization = (organization, name) => {
+  handleRenameOrganization = async (organization, name) => {
     const {actions: {updateOrganizationAsync}} = this.props
-    updateOrganizationAsync(organization, {...organization, name})
+    await updateOrganizationAsync(organization, {...organization, name})
+    this.refreshMe()
   }
 
   handleDeleteOrganization = organization => {
     const {actions: {deleteOrganizationAsync}} = this.props
     deleteOrganizationAsync(organization)
+    this.refreshMe()
+  }
+
+  refreshMe = () => {
+    const {getMe} = this.props
+    getMe({shouldResetMe: false})
   }
 
   handleTogglePublic = organization => {
@@ -40,6 +47,8 @@ class OrganizationsPage extends Component {
   handleChooseDefaultRole = (organization, defaultRole) => {
     const {actions: {updateOrganizationAsync}} = this.props
     updateOrganizationAsync(organization, {...organization, defaultRole})
+    // refreshMe is here to update the org's defaultRole in `me.organizations`
+    this.refreshMe()
   }
 
   render() {
@@ -77,7 +86,7 @@ OrganizationsPage.propTypes = {
     updateOrganizationAsync: func.isRequired,
     deleteOrganizationAsync: func.isRequired,
   }),
-  notify: func.isRequired,
+  getMe: func.isRequired,
 }
 
 const mapStateToProps = ({links, adminChronograf: {organizations}}) => ({
@@ -87,7 +96,7 @@ const mapStateToProps = ({links, adminChronograf: {organizations}}) => ({
 
 const mapDispatchToProps = dispatch => ({
   actions: bindActionCreators(adminChronografActionCreators, dispatch),
-  notify: bindActionCreators(publishAutoDismissingNotification, dispatch),
+  getMe: bindActionCreators(getMeAsync, dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(OrganizationsPage)

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -73,6 +73,9 @@ export const meChangeOrganizationAsync = (
     )
     dispatch(meChangeOrganizationCompleted())
     dispatch(meReceivedUsingAuth(data))
+    // TODO: reload sources upon me change org if non-refresh behavior preferred
+    // instead of current behavior on both invocations of meChangeOrganization,
+    // which is to refresh index via router.push('')
   } catch (error) {
     dispatch(errorThrown(error))
     dispatch(meChangeOrganizationFailed())

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -27,15 +27,15 @@ export const meGetRequested = () => ({
   type: 'ME_GET_REQUESTED',
 })
 
-export const meReceivedNotUsingAuth = me => ({
-  type: 'ME_RECEIVED__NON_AUTH',
+export const meGetCompletedNotUsingAuth = me => ({
+  type: 'ME_GET_COMPLETED__NON_AUTH',
   payload: {
     me,
   },
 })
 
-export const meReceivedUsingAuth = me => ({
-  type: 'ME_RECEIVED__AUTH',
+export const meGetCompletedUsingAuth = me => ({
+  type: 'ME_GET_COMPLETED__AUTH',
   payload: {
     me,
   },
@@ -85,7 +85,9 @@ export const getMeAsync = ({shouldResetMe}) => async dispatch => {
       meLink,
     } = await getMeAJAX()
     const isUsingAuth = !!logoutLink
-    dispatch(isUsingAuth ? meReceivedUsingAuth(me) : meReceivedNotUsingAuth(me))
+    dispatch(
+      isUsingAuth ? meGetCompletedUsingAuth(me) : meGetCompletedNotUsingAuth(me)
+    )
     dispatch(authReceived(auth))
     dispatch(logoutLinkReceived(logoutLink))
     dispatch(linksReceived({external, users, organizations, me: meLink}))
@@ -109,7 +111,7 @@ export const meChangeOrganizationAsync = (
       )
     )
     dispatch(meChangeOrganizationCompleted())
-    dispatch(meReceivedUsingAuth(data))
+    dispatch(meGetCompletedUsingAuth(data))
     // TODO: reload sources upon me change org if non-refresh behavior preferred
     // instead of current behavior on both invocations of meChangeOrganization,
     // which is to refresh index via router.push('')

--- a/ui/src/shared/actions/sources.js
+++ b/ui/src/shared/actions/sources.js
@@ -1,11 +1,12 @@
 import {
   deleteSource,
-  getSources,
+  getSources as getSourcesAJAX,
   getKapacitors as getKapacitorsAJAX,
   updateKapacitor as updateKapacitorAJAX,
   deleteKapacitor as deleteKapacitorAJAX,
 } from 'shared/apis'
 import {publishNotification} from './notifications'
+import {errorThrown} from 'shared/actions/errors'
 
 import {HTTP_NOT_FOUND} from 'shared/constants'
 
@@ -67,7 +68,7 @@ export const removeAndLoadSources = source => async dispatch => {
       }
     }
 
-    const {data: {sources: newSources}} = await getSources()
+    const {data: {sources: newSources}} = await getSourcesAJAX()
     dispatch(loadSources(newSources))
   } catch (err) {
     dispatch(
@@ -108,5 +109,14 @@ export const deleteKapacitorAsync = kapacitor => async dispatch => {
         'Internal Server Error. Could not delete Kapacitor config.'
       )
     )
+  }
+}
+
+export const getSourcesAsync = () => async dispatch => {
+  try {
+    const {data: {sources}} = await getSourcesAJAX()
+    dispatch(loadSources(sources))
+  } catch (error) {
+    dispatch(errorThrown(error))
   }
 }

--- a/ui/src/shared/apis/auth.js
+++ b/ui/src/shared/apis/auth.js
@@ -1,5 +1,12 @@
 import AJAX from 'src/utils/ajax'
 
+export function getMe() {
+  return AJAX({
+    resource: 'me',
+    method: 'GET',
+  })
+}
+
 export const updateMe = async (url, updatedMe) => {
   try {
     return await AJAX({

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -8,13 +8,6 @@ export function fetchLayouts() {
   })
 }
 
-export function getMe() {
-  return AJAX({
-    resource: 'me',
-    method: 'GET',
-  })
-}
-
 export function getSources() {
   return AJAX({
     resource: 'sources',

--- a/ui/src/shared/reducers/auth.js
+++ b/ui/src/shared/reducers/auth.js
@@ -25,7 +25,7 @@ const authReducer = (state = initialState, action) => {
       const {auth: {links}} = action.payload
       return {...state, links, isAuthLoading: false}
     }
-    case 'ME_REQUESTED': {
+    case 'ME_GET_REQUESTED': {
       return {...state, isMeLoading: true}
     }
     case 'ME_RECEIVED__NON_AUTH': {

--- a/ui/src/shared/reducers/auth.js
+++ b/ui/src/shared/reducers/auth.js
@@ -28,7 +28,7 @@ const authReducer = (state = initialState, action) => {
     case 'ME_GET_REQUESTED': {
       return {...state, isMeLoading: true}
     }
-    case 'ME_RECEIVED__NON_AUTH': {
+    case 'ME_GET_COMPLETED__NON_AUTH': {
       const {me} = action.payload
       return {
         ...state,
@@ -36,7 +36,7 @@ const authReducer = (state = initialState, action) => {
         isMeLoading: false,
       }
     }
-    case 'ME_RECEIVED__AUTH': {
+    case 'ME_GET_COMPLETED__AUTH': {
       const {me, me: {currentOrganization}} = action.payload
       return {
         ...state,


### PR DESCRIPTION
Should be considered after #2392, since this branch was rebased on top of that branch.

Connect #2344 

### The problem
User nav didn't reflect current state of organizations, after creating, updating, or deleting an organization. The user should:
1. be able to switch into new orgs immediately but couldn't;
2. see the names of orgs that they belong to match any updates to organization names;
3. not be able to switch into an org if it was just deleted.

### The Solution
Refactor how me is gotten, and refresh user side nav organizations  after updating organizations.