### PR TITLE
Add invisible hover triangle for user menu on small screens

### DIFF
--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -204,14 +204,24 @@ $sidebar-menu--gutter: 18px;
   opacity: 0.6;
 }
 // Invisible triangle for easier mouse movement when navigating to sub items
-.sidebar-menu--item + .sidebar-menu--triangle {
+.sidebar-menu--item + .sidebar-menu--triangle,
+.sidebar-menu--inverse .sidebar-menu--triangle {
   position: absolute;
+  z-index: -1;
+}
+.sidebar-menu--item + .sidebar-menu--triangle {
   width: 40px;
   height: 40px;
-  z-index: -1;
   top: $sidebar--width;
   left: 0px;
   transform: translate(-50%,-50%) rotate(45deg);
+}
+.sidebar-menu--inverse .sidebar-menu--triangle {
+  width: 50px;
+  height: 60px;
+  bottom: 12px;
+  left: 6px;
+  transform: translate(-50%,-50%) rotate(30deg);
 }
 
 .sidebar-menu--section {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2394 

### The Problem
- Invisible triangle does not appear for the user nav menu when on a small screen

### The Solution
- Added a style for the triangle when the screen is smaller and the menu inverts

