### PR TITLE
Add GENERIC_API_KEY to override of oauth2 responses to support azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Features
 1. [#2385](https://github.com/influxdata/chronograf/pull/2385): Add time shift feature to DataExplorer and Dashboards
+1. [#2400](https://github.com/influxdata/chronograf/pull/2400): Allow override of generic oauth2 keys for email
 
 ### UI Improvements
 

--- a/oauth2/generic_test.go
+++ b/oauth2/generic_test.go
@@ -34,6 +34,7 @@ func TestGenericPrincipalID(t *testing.T) {
 	prov := oauth2.Generic{
 		Logger: logger,
 		APIURL: mockAPI.URL,
+		APIKey: "email",
 	}
 	tt, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
 	if err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -79,6 +79,7 @@ type Server struct {
 	GenericAuthURL      string   `long:"generic-auth-url" description:"OAuth 2.0 provider's authorization endpoint URL" env:"GENERIC_AUTH_URL"`
 	GenericTokenURL     string   `long:"generic-token-url" description:"OAuth 2.0 provider's token endpoint URL" env:"GENERIC_TOKEN_URL"`
 	GenericAPIURL       string   `long:"generic-api-url" description:"URL that returns OpenID UserInfo compatible information." env:"GENERIC_API_URL"`
+	GenericAPIKey       string   `long:"generic-api-key" description:"JSON lookup key into OpenID UserInfo. (Azure should be userPrincipalName)" default:"email" env:"GENERIC_API_KEY"`
 
 	Auth0Domain        string   `long:"auth0-domain" description:"Subdomain of auth0.com used for Auth0 OAuth2 authentication" env:"AUTH0_DOMAIN"`
 	Auth0ClientID      string   `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
@@ -181,6 +182,7 @@ func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticato
 		AuthURL:        s.GenericAuthURL,
 		TokenURL:       s.GenericTokenURL,
 		APIURL:         s.GenericAPIURL,
+		APIKey:         s.GenericAPIKey,
 		Logger:         logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret)


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2387

### The problem
Azure oauth2 uses the key `userPrincipalName` rather than `email`

### The Solution
Expose a CLI option to allow people to override the key to extract the value.
`GENERIC_API_KEY` or `--generic-api-key`

Here is an example for azure:

```
export TENENT=YOUR_TENTENT
export GENERIC_NAME=azure
export GENERIC_CLIENT_ID=YOUR_ID
export GENERIC_CLIENT_SECRET="YOUR_SECRET"
export GENERIC_SCOPES=openid
export GENERIC_AUTH_URL="https://login.microsoftonline.com/$TENENT/oauth2/authorize?resource=https://graph.windows.net"
export GENERIC_TOKEN_URL=https://login.microsoftonline.com/$TENET/oauth2/token
export GENERIC_API_URL="https://graph.windows.net/$TENET/me?api-version=1.6"
export GENERIC_API_KEY="userPrincipalName"
export TOKEN_SECRET=secret
export PUBLIC_URL=http://localhost:8888
```
