### PR TITLE
Fix 'Create Dashboard' button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#2386](https://github.com/influxdata/chronograf/pull/2386): Fix queries that include regex, numbers and wildcard
 1. [#2398](https://github.com/influxdata/chronograf/pull/2398): Fix apps on hosts page from parsing tags with null values
 1. [#2408](https://github.com/influxdata/chronograf/pull/2408): Fix updated Dashboard names not updating dashboard list
+1. [#2444](https://github.com/influxdata/chronograf/pull/2444): Fix create dashboard button
 
 ### Features
 1. [#2384](https://github.com/influxdata/chronograf/pull/2384): Add filtering by name to Dashboard index page

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -16,13 +16,13 @@ class DashboardsPage extends Component {
     this.props.handleGetDashboards()
   }
 
-  async handleCreateDashbord() {
+  handleCreateDashbord = async () => {
     const {source: {id}, router: {push}} = this.props
     const {data} = await createDashboard(NEW_DASHBOARD)
     push(`/sources/${id}/dashboards/${data.id}`)
   }
 
-  handleDeleteDashboard(dashboard) {
+  handleDeleteDashboard = dashboard => {
     this.props.handleDeleteDashboard(dashboard)
   }
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2424 

### The problem
`this` was not bound properly in `handleCreateDashboard`, causing a runtime error when `this.props` was attempting to be accessed. 

### The Solution
Changed handlers in DashboardsPage to use arrow functions for proper this
binding.

