### PR TITLE
Prevent render of Configure Kapacitor & Create Dashboard buttons to Viewer users

### DIFF
--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -56,13 +56,15 @@ const DashboardsTable = ({
         <h4 style={{marginTop: '90px'}}>
           Looks like you don’t have any dashboards
         </h4>
-        <button
-          className="btn btn-sm btn-primary"
-          onClick={onCreateDashboard}
-          style={{marginBottom: '90px'}}
-        >
-          <span className="icon plus" /> Create Dashboard
-        </button>
+        <Authorized requiredRole={EDITOR_ROLE}>
+          <button
+            className="btn btn-sm btn-primary"
+            onClick={onCreateDashboard}
+            style={{marginBottom: '90px'}}
+          >
+            <span className="icon plus" /> Create Dashboard
+          </button>
+        </Authorized>
       </div>
 }
 

--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -6,6 +6,27 @@ import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
 
 import DeleteConfirmTableCell from 'shared/components/DeleteConfirmTableCell'
 
+const AuthorizedEmptyState = ({onCreateDashboard}) =>
+  <div className="generic-empty-state">
+    <h4 style={{marginTop: '90px'}}>
+      Looks like you don’t have any dashboards
+    </h4>
+    <br />
+    <button
+      className="btn btn-sm btn-primary"
+      onClick={onCreateDashboard}
+      style={{marginBottom: '90px'}}
+    >
+      <span className="icon plus" /> Create Dashboard
+    </button>
+  </div>
+
+const unauthorizedEmptyState = (
+  <div className="generic-empty-state">
+    <h4 style={{margin: '90px 0'}}>Looks like you don’t have any dashboards</h4>
+  </div>
+)
+
 const DashboardsTable = ({
   dashboards,
   onDeleteDashboard,
@@ -52,20 +73,12 @@ const DashboardsTable = ({
           )}
         </tbody>
       </table>
-    : <div className="generic-empty-state">
-        <h4 style={{marginTop: '90px'}}>
-          Looks like you don’t have any dashboards
-        </h4>
-        <Authorized requiredRole={EDITOR_ROLE}>
-          <button
-            className="btn btn-sm btn-primary"
-            onClick={onCreateDashboard}
-            style={{marginBottom: '90px'}}
-          >
-            <span className="icon plus" /> Create Dashboard
-          </button>
-        </Authorized>
-      </div>
+    : <Authorized
+        requiredRole={EDITOR_ROLE}
+        replaceWithIfNotAuthorized={unauthorizedEmptyState}
+      >
+        <AuthorizedEmptyState onCreateDashboard={onCreateDashboard} />
+      </Authorized>
 }
 
 const {arrayOf, func, shape, string} = PropTypes
@@ -75,6 +88,10 @@ DashboardsTable.propTypes = {
   onDeleteDashboard: func.isRequired,
   onCreateDashboard: func.isRequired,
   dashboardLink: string.isRequired,
+}
+
+AuthorizedEmptyState.propTypes = {
+  onCreateDashboard: func.isRequired,
 }
 
 export default DashboardsTable

--- a/ui/src/shared/components/NoKapacitorError.js
+++ b/ui/src/shared/components/NoKapacitorError.js
@@ -1,6 +1,8 @@
 import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 
+import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
+
 const NoKapacitorError = React.createClass({
   propTypes: {
     source: PropTypes.shape({
@@ -16,9 +18,11 @@ const NoKapacitorError = React.createClass({
           The current source does not have an associated Kapacitor instance
           <br />
           <br />
-          <Link to={path} className="btn btn-sm btn-primary">
-            Configure Kapacitor
-          </Link>
+          <Authorized requiredRole={EDITOR_ROLE}>
+            <Link to={path} className="btn btn-sm btn-primary">
+              Configure Kapacitor
+            </Link>
+          </Authorized>
         </p>
       </div>
     )

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -57,6 +57,7 @@
   justify-content: center;
   color: $g12-forge;
   padding: 20px 0;
+  @include no-user-select();
 
   h4,
   h5 {


### PR DESCRIPTION
- [x] Connect #2421 
- [x] Connect #1917 
- [x] Connect #2464

I added these two items to #2146 retroactively.

### The problem
1. Configure Kapacitor button mistakenly showed on empty Alerts table for Viewers.
1. Create Dashboards button mistakenly shows on empty Dashboards table.

### The Solution
Show both only to Editors and above.

