### PR TITLE
Fix the hoverline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1. [#2423](https://github.com/influxdata/chronograf/pull/2423): Gracefully scale Template Variables Manager overlay on smaller displays
 1. [#2426](https://github.com/influxdata/chronograf/pull/2426): Fix Influx Enterprise users from deletion in race condition
 1. [#2466](https://github.com/influxdata/chronograf/pull/2466): Fix supplying a role link to sources that do not have a metaURL
+1. [#2477](https://github.com/influxdata/chronograf/pull/2477): Fix hoverline intermittently not rendering
 
 ### Features
 1. [#2188](https://github.com/influxdata/chronograf/pull/2188): Add Kapacitor logs to the TICKscript editor
@@ -28,6 +29,7 @@
 1. [#2385](https://github.com/influxdata/chronograf/pull/2385): Add time shift feature to DataExplorer and Dashboards
 1. [#2400](https://github.com/influxdata/chronograf/pull/2400): Allow override of generic oauth2 keys for email
 1. [#2460](https://github.com/influxdata/chronograf/pull/2460): Update kapacitor alerts to cast to float before sending to influx
+1. [#2477](https://github.com/influxdata/chronograf/pull/2477): Improve performance of hoverline rendering
 
 ### UI Improvements
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -34,13 +34,14 @@ class DashboardPage extends Component {
     super(props)
 
     this.state = {
-      dygraphs: [],
       isEditMode: false,
       selectedCell: null,
       isTemplating: false,
       zoomedTimeRange: {zoomedLower: null, zoomedUpper: null},
     }
   }
+
+  dygraphs = []
 
   async componentDidMount() {
     const {
@@ -170,16 +171,19 @@ class DashboardPage extends Component {
   }
 
   synchronizer = dygraph => {
-    const dygraphs = [...this.state.dygraphs, dygraph].filter(d => d.graphDiv)
+    const dygraphs = [...this.dygraphs, dygraph].filter(d => d.graphDiv)
     const {dashboards, params: {dashboardID}} = this.props
 
     const dashboard = dashboards.find(
       d => d.id === idNormalizer(TYPE_ID, dashboardID)
     )
 
+    // Get only the graphs that can sync the hover line
+    const graphsToSync = dashboard.cells.filter(c => c.type !== 'single-stat')
+
     if (
       dashboard &&
-      dygraphs.length === dashboard.cells.length &&
+      dygraphs.length === graphsToSync.length &&
       dashboard.cells.length > 1
     ) {
       Dygraph.synchronize(dygraphs, {
@@ -189,7 +193,7 @@ class DashboardPage extends Component {
       })
     }
 
-    this.setState({dygraphs})
+    this.dygraphs = dygraphs
   }
 
   handleToggleTempVarControls = () => {

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -355,7 +355,8 @@ export default class Dygraph extends Component {
   }
 
   highlightCallback = ({pageX}) => {
-    this.setState({isHidden: false, pageX})
+    this.pageX = pageX
+    this.setState({isHidden: false})
   }
 
   legendFormatter = legend => {
@@ -381,7 +382,6 @@ export default class Dygraph extends Component {
   render() {
     const {
       legend,
-      pageX,
       sortType,
       isHidden,
       isSnipped,
@@ -396,7 +396,7 @@ export default class Dygraph extends Component {
           {...legend}
           graph={this.graphRef}
           legend={this.legendRef}
-          pageX={pageX}
+          pageX={this.pageX}
           sortType={sortType}
           onHide={this.handleHideLegend}
           isHidden={isHidden}


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2258

### The problem
1) Due to the async nature of this.setState(), not all of the graphs were being passed to Dygraph's public `synchronize` function 

2) The guard clause over `Dygraph.synchronize` was catching if there was a non-Dygraph type visualization in the Dashboard

### Notes
For repro steps see the connected issue.  We also improved the performance of the hoverline rendering the `<Dygraph>` component's `pageX` state off of state and into a class property.  This would update quite frequently (which it should) and cause slow / async `setState` calls.  A quick performance evaluation changes most calls of `hightlightCallback` to drop from 90ms to 30ms.
