### PR TITLE
Fix headers sent to Kapacitor proxy endpoint by clientside fetch

### DIFF
--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -101,10 +101,16 @@ export const updateTask = async (
   }
 }
 
+const kapacitorLogHeaders = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+}
+
 export const getLogStream = kapacitor =>
   fetch(`${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs`, {
     method: 'GET',
-    headers: {'Content-Type': 'application/json'},
+    headers: kapacitorLogHeaders,
+    credentials: 'include',
   })
 
 export const getLogStreamByRuleID = (kapacitor, ruleID) =>
@@ -112,7 +118,8 @@ export const getLogStreamByRuleID = (kapacitor, ruleID) =>
     `${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs?task=${ruleID}`,
     {
       method: 'GET',
-      headers: {'Content-Type': 'application/json'},
+      headers: kapacitorLogHeaders,
+      credentials: 'include',
     }
   )
 
@@ -121,6 +128,8 @@ export const pingKapacitorVersion = async kapacitor => {
     const result = await AJAX({
       method: 'GET',
       url: `${kapacitor.links.proxy}?path=/kapacitor/v1preview/ping`,
+      headers: kapacitorLogHeaders,
+      credentials: 'include',
     })
     const kapVersion = result.headers['x-kapacitor-version']
     return kapVersion === '' ? null : kapVersion


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2073 
Connect https://github.com/influxdata/kapacitor/pull/1703

### The problem
Kapacitor logs wouldn't show when using OAuth.

### The Solution
Send cookies along with fetch.
Also, added @nathanielc 's recommended "Accept" header.
