### PR TITLE
Add basic auth or JWT tokens for meta queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 1. [#2400](https://github.com/influxdata/chronograf/pull/2400): Allow override of generic oauth2 keys for email
 1. [#2456](https://github.com/influxdata/chronograf/pull/2456): Add boolean thresholds for kapacitor threshold alerts
 1. [#2460](https://github.com/influxdata/chronograf/pull/2460): Update kapacitor alerts to cast to float before sending to influx
+1. [#2479](https://github.com/influxdata/chronograf/pull/2479): Support authentication for Enterprise Meta Nodes
 
 ### UI Improvements
 

--- a/enterprise/enterprise.go
+++ b/enterprise/enterprise.go
@@ -51,13 +51,13 @@ type Client struct {
 }
 
 // NewClientWithTimeSeries initializes a Client with a known set of TimeSeries.
-func NewClientWithTimeSeries(lg chronograf.Logger, mu, username, password string, tls bool, series ...chronograf.TimeSeries) (*Client, error) {
+func NewClientWithTimeSeries(lg chronograf.Logger, mu string, authorizer influx.Authorizer, tls bool, series ...chronograf.TimeSeries) (*Client, error) {
 	metaURL, err := parseMetaURL(mu, tls)
 	if err != nil {
 		return nil, err
 	}
-	metaURL.User = url.UserPassword(username, password)
-	ctrl := NewMetaClient(metaURL)
+
+	ctrl := NewMetaClient(metaURL, authorizer)
 	c := &Client{
 		Ctrl: ctrl,
 		UsersStore: &UserStore{
@@ -83,15 +83,15 @@ func NewClientWithTimeSeries(lg chronograf.Logger, mu, username, password string
 // NewClientWithURL initializes an Enterprise client with a URL to a Meta Node.
 // Acceptable URLs include host:port combinations as well as scheme://host:port
 // varieties. TLS is used when the URL contains "https" or when the TLS
-// parameter is set. The latter option is provided for host:port combinations
-// Username and Password are used for Basic Auth
-func NewClientWithURL(mu, username, password string, tls bool, lg chronograf.Logger) (*Client, error) {
+// parameter is set.  authorizer will add the correct `Authorization` headers
+// on the out-bound request.
+func NewClientWithURL(mu string, authorizer influx.Authorizer, tls bool, lg chronograf.Logger) (*Client, error) {
 	metaURL, err := parseMetaURL(mu, tls)
 	if err != nil {
 		return nil, err
 	}
-	metaURL.User = url.UserPassword(username, password)
-	ctrl := NewMetaClient(metaURL)
+
+	ctrl := NewMetaClient(metaURL, authorizer)
 	return &Client{
 		Ctrl: ctrl,
 		UsersStore: &UserStore{

--- a/enterprise/enterprise_test.go
+++ b/enterprise/enterprise_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/enterprise"
+	"github.com/influxdata/chronograf/influx"
 	"github.com/influxdata/chronograf/log"
 )
 
@@ -75,7 +76,16 @@ func Test_Enterprise_IssuesQueries(t *testing.T) {
 func Test_Enterprise_AdvancesDataNodes(t *testing.T) {
 	m1 := NewMockTimeSeries("http://host-1.example.com:8086")
 	m2 := NewMockTimeSeries("http://host-2.example.com:8086")
-	cl, err := enterprise.NewClientWithTimeSeries(log.New(log.DebugLevel), "http://meta.example.com:8091", "marty", "thelake", false, chronograf.TimeSeries(m1), chronograf.TimeSeries(m2))
+	cl, err := enterprise.NewClientWithTimeSeries(
+		log.New(log.DebugLevel),
+		"http://meta.example.com:8091",
+		&influx.BasicAuth{
+			Username: "marty",
+			Password: "thelake",
+		},
+		false,
+		chronograf.TimeSeries(m1),
+		chronograf.TimeSeries(m2))
 	if err != nil {
 		t.Error("Unexpected error while initializing client: err:", err)
 	}
@@ -124,7 +134,14 @@ func Test_Enterprise_NewClientWithURL(t *testing.T) {
 	}
 
 	for _, testURL := range urls {
-		_, err := enterprise.NewClientWithURL(testURL.url, testURL.username, testURL.password, testURL.tls, log.New(log.DebugLevel))
+		_, err := enterprise.NewClientWithURL(
+			testURL.url,
+			&influx.BasicAuth{
+				Username: testURL.username,
+				Password: testURL.password,
+			},
+			testURL.tls,
+			log.New(log.DebugLevel))
 		if err != nil && !testURL.shouldErr {
 			t.Errorf("Unexpected error creating Client with URL %s and TLS preference %t. err: %s", testURL.url, testURL.tls, err.Error())
 		} else if err == nil && testURL.shouldErr {
@@ -135,7 +152,14 @@ func Test_Enterprise_NewClientWithURL(t *testing.T) {
 
 func Test_Enterprise_ComplainsIfNotOpened(t *testing.T) {
 	m1 := NewMockTimeSeries("http://host-1.example.com:8086")
-	cl, err := enterprise.NewClientWithTimeSeries(log.New(log.DebugLevel), "http://meta.example.com:8091", "docbrown", "1.21 gigawatts", false, chronograf.TimeSeries(m1))
+	cl, err := enterprise.NewClientWithTimeSeries(
+		log.New(log.DebugLevel),
+		"http://meta.example.com:8091",
+		&influx.BasicAuth{
+			Username: "docbrown",
+			Password: "1.21 gigawatts",
+		},
+		false, chronograf.TimeSeries(m1))
 	if err != nil {
 		t.Error("Expected ErrUnitialized, but was this err:", err)
 	}

--- a/enterprise/meta_test.go
+++ b/enterprise/meta_test.go
@@ -11,13 +11,16 @@ import (
 	"net/url"
 	"reflect"
 	"testing"
+	"time"
+
+	"github.com/influxdata/chronograf/influx"
 )
 
 func TestMetaClient_ShowCluster(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	tests := []struct {
@@ -128,7 +131,7 @@ func TestMetaClient_Users(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -265,7 +268,7 @@ func TestMetaClient_User(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -366,7 +369,7 @@ func TestMetaClient_CreateUser(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -437,7 +440,7 @@ func TestMetaClient_ChangePassword(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -509,7 +512,7 @@ func TestMetaClient_DeleteUser(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -578,7 +581,7 @@ func TestMetaClient_SetUserPerms(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -699,7 +702,7 @@ func TestMetaClient_Roles(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -798,7 +801,7 @@ func TestMetaClient_Role(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -881,7 +884,7 @@ func TestMetaClient_UserRoles(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -985,7 +988,7 @@ func TestMetaClient_CreateRole(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -1051,7 +1054,7 @@ func TestMetaClient_DeleteRole(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -1120,7 +1123,7 @@ func TestMetaClient_SetRolePerms(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -1241,7 +1244,7 @@ func TestMetaClient_SetRoleUsers(t *testing.T) {
 	type fields struct {
 		URL    *url.URL
 		client interface {
-			Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error)
+			Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error)
 		}
 	}
 	type args struct {
@@ -1361,7 +1364,7 @@ func NewMockClient(code int, body []byte, headers http.Header, err error) *MockC
 	}
 }
 
-func (c *MockClient) Do(URL *url.URL, path, method string, params map[string]string, body io.Reader) (*http.Response, error) {
+func (c *MockClient) Do(URL *url.URL, path, method string, authorizer influx.Authorizer, params map[string]string, body io.Reader) (*http.Response, error) {
 	if c == nil {
 		return nil, fmt.Errorf("NIL MockClient")
 	}
@@ -1451,5 +1454,73 @@ func Test_AuthedCheckRedirect_Do(t *testing.T) {
 
 	if got := res.Header.Get("Result"); got != "ok" {
 		t.Errorf("result = %q; want ok", got)
+	}
+}
+
+func Test_defaultClient_Do(t *testing.T) {
+	type args struct {
+		path       string
+		method     string
+		authorizer influx.Authorizer
+		params     map[string]string
+		body       io.Reader
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "test authorizer",
+			args: args{
+				path:   "/tictactoe",
+				method: "GET",
+				authorizer: &influx.BasicAuth{
+					Username: "Steven Falken",
+					Password: "JOSHUA",
+				},
+			},
+			want: "Basic U3RldmVuIEZhbGtlbjpKT1NIVUE=",
+		},
+		{
+			name: "test authorizer",
+			args: args{
+				path:   "/tictactoe",
+				method: "GET",
+				authorizer: &influx.BearerJWT{
+					Username:     "minifig",
+					SharedSecret: "legos",
+					Now:          func() time.Time { return time.Time{} },
+				},
+			},
+			want: "Bearer eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOi02MjEzNTU5Njc0MCwidXNlcm5hbWUiOiJtaW5pZmlnIn0.uwFGBQ3MykqEmk9Zx0sBdJGefcESVEXG_qt0C1J8b_aS62EAES-Q1FwtURsbITNvSnfzMxYFnkbSG0AA1pEzWw",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/tictactoe" {
+					t.Fatal("Expected request to '/query' but was", r.URL.Path)
+				}
+				got, ok := r.Header["Authorization"]
+				if !ok {
+					t.Fatal("No Authorization header")
+				}
+				if got[0] != tt.want {
+					t.Fatalf("Expected auth %s got %s", tt.want, got)
+				}
+				rw.Write([]byte(`{}`))
+			}))
+			defer ts.Close()
+
+			d := &defaultClient{}
+			u, _ := url.Parse(ts.URL)
+			_, err := d.Do(u, tt.args.path, tt.args.method, tt.args.authorizer, tt.args.params, tt.args.body)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("defaultClient.Do() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
 	}
 }

--- a/influx/authorization.go
+++ b/influx/authorization.go
@@ -54,6 +54,7 @@ func (b *BasicAuth) Set(r *http.Request) error {
 type BearerJWT struct {
 	Username     string
 	SharedSecret string
+	Now          Now
 }
 
 // Set adds an Authorization Bearer to the request if has a shared secret
@@ -70,7 +71,10 @@ func (b *BearerJWT) Set(r *http.Request) error {
 
 // Token returns the expected InfluxDB JWT signed with the sharedSecret
 func (b *BearerJWT) Token(username string) (string, error) {
-	return JWT(username, b.SharedSecret, time.Now)
+	if b.Now == nil {
+		b.Now = time.Now
+	}
+	return JWT(username, b.SharedSecret, b.Now)
 }
 
 // Now returns the current time

--- a/server/service.go
+++ b/server/service.go
@@ -51,7 +51,7 @@ func (c *InfluxClient) New(src chronograf.Source, logger chronograf.Logger) (chr
 	}
 	if src.Type == chronograf.InfluxEnterprise && src.MetaURL != "" {
 		tls := strings.Contains(src.MetaURL, "https")
-		return enterprise.NewClientWithTimeSeries(logger, src.MetaURL, src.Username, src.Password, tls, client)
+		return enterprise.NewClientWithTimeSeries(logger, src.MetaURL, influx.DefaultAuthorization(&src), tls, client)
 	}
 	return client, nil
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2389

### The problem
Meta queries did not use basic auth or bearer JWT tokens

### The Solution
Use the data node username and password or JWT token to authenticate to the meta nodes.


To test add these sections to enterprise configurations:

##### meta
```toml
[meta]
  meta-auth-enabled = true
```

##### data

```toml
[meta]
  meta-auth-enabled = true
```
