### PR TITLE
Node-style callbacks instead of async/await/promisify in webpack build dir cleanup code

### DIFF
--- a/ui/webpack/devConfig.js
+++ b/ui/webpack/devConfig.js
@@ -124,7 +124,6 @@ module.exports = {
             fs.unlink(path.join(buildDir, file), unlinkErr => {
               if (unlinkErr) {
                 console.error('webpack cleanup error', unlinkErr)
-                return
               }
             })
           }


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2476 

### The problem
Build directory would get cluttered. We wrote a modern ES7-style async/await/promisified solution, but it didn't work on older Node.js.

### The Solution
Refactor webpack file cleanup script to use Node-style, error-first callback fs method calls.
Continues to keep build directory consistently clean.
