### PR TITLE
Update mysql pre-canned dashboard to use last value over a second derivative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [#2426](https://github.com/influxdata/chronograf/pull/2426): Fix Influx Enterprise users from deletion in race condition
 1. [#2467](https://github.com/influxdata/chronograf/pull/2467): Fix oauth2 logout link not having basepath
 1. [#2466](https://github.com/influxdata/chronograf/pull/2466): Fix supplying a role link to sources that do not have a metaURL
+1. [#2483](https://github.com/influxdata/chronograf/pull/2483): Update MySQL pre-canned dashboard to have query derivative correctly
 
 
 ### Features

--- a/canned/mysql.json
+++ b/canned/mysql.json
@@ -13,7 +13,7 @@
       "name": "MySQL – Reads/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"commands_select\")) AS selects_per_second FROM mysql",
+          "query": "SELECT non_negative_derivative(last(\"commands_select\"), 1s) AS selects_per_second FROM mysql",
           "groupbys": [
             "\"server\""
           ],
@@ -30,7 +30,7 @@
       "name": "MySQL – Writes/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"commands_insert\")) AS inserts_per_second, non_negative_derivative(max(\"commands_update\")) AS updates_per_second, non_negative_derivative(max(\"commands_delete\")) AS deletes_per_second FROM mysql",
+          "query": "SELECT non_negative_derivative(last(\"commands_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"commands_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"commands_delete\"), 1s) AS deletes_per_second FROM mysql",
           "groupbys": [
             "\"server\""
           ],
@@ -47,7 +47,7 @@
       "name": "MySQL – Connections/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"threads_connected\")) AS cxn_per_second, non_negative_derivative(max(\"threads_running\")) AS threads_running_per_second FROM mysql",
+          "query": "SELECT non_negative_derivative(last(\"threads_connected\"), 1s) AS cxn_per_second, non_negative_derivative(last(\"threads_running\"), 1s) AS threads_running_per_second FROM mysql",
           "groupbys": [
             "\"server\""
           ],
@@ -64,7 +64,7 @@
       "name": "MySQL – Connections Errors/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"connection_errors_max_connections\")) AS cxn_errors_per_second, non_negative_derivative(max(\"connection_errors_internal\")) AS internal_cxn_errors_per_second, non_negative_derivative(max(\"aborted_connects\")) AS cxn_aborted_per_second FROM mysql",
+          "query": "SELECT non_negative_derivative(last(\"connection_errors_max_connections\"), 1s) AS cxn_errors_per_second, non_negative_derivative(last(\"connection_errors_internal\"), 1s) AS internal_cxn_errors_per_second, non_negative_derivative(last(\"aborted_connects\"), 1s) AS cxn_aborted_per_second FROM mysql",
           "groupbys": [
             "\"server\""
           ],


### PR DESCRIPTION

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2315

### The problem
Mysql pre-canned dashboard wasn't using a bounded derivative giving incorrect results.

### The Solution
Add a time boundary for the derivative and change from max to last.


