### PR TITLE
Allow for empty MetaURL in UpdateSource

### DIFF
--- a/server/sources.go
+++ b/server/sources.go
@@ -53,6 +53,9 @@ func newSourceResponse(src chronograf.Source) sourceResponse {
 		},
 	}
 
+	// MetaURL is currently a string, but eventually, we'd like to change it
+	// to a slice. Checking len(src.MetaURL) is functionally equivalent to
+	// checking if it is equal to the empty string.
 	if src.Type == chronograf.InfluxEnterprise && len(src.MetaURL) != 0 {
 		res.Links.Roles = fmt.Sprintf("%s/%d/roles", httpAPISrcs, src.ID)
 	}
@@ -243,7 +246,9 @@ func (h *Service) UpdateSource(w http.ResponseWriter, r *http.Request) {
 	if req.URL != "" {
 		src.URL = req.URL
 	}
-	if req.MetaURL != "" {
+	// If the supplied MetaURL is different from the
+	// one supplied on the request, update the value
+	if req.MetaURL != src.MetaURL {
 		src.MetaURL = req.MetaURL
 	}
 	if req.Type != "" {


### PR DESCRIPTION
Currently, if an empty source is supplied, then the source's meta url
will not be updated. Now, if the MetaURL is supplied and is different
than the one that is currently on the source, the value will be updated.
Even in the case of empty string meta urls.


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass

Connect #2000 

Related to https://github.com/influxdata/chronograf/pull/2457


