### PR TITLE
Re-depend on main dygraphs repo

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -103,7 +103,7 @@
     "bootstrap": "^3.3.7",
     "calculate-size": "^1.1.1",
     "classnames": "^2.2.3",
-    "dygraphs": "^2.0.1",
+    "dygraphs": "2.1.0",
     "eslint-plugin-babel": "^4.1.2",
     "fast.js": "^0.1.1",
     "fixed-data-table": "^0.6.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -103,7 +103,7 @@
     "bootstrap": "^3.3.7",
     "calculate-size": "^1.1.1",
     "classnames": "^2.2.3",
-    "dygraphs": "influxdata/dygraphs",
+    "dygraphs": "^2.0.1",
     "eslint-plugin-babel": "^4.1.2",
     "fast.js": "^0.1.1",
     "fixed-data-table": "^0.6.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2524,9 +2524,9 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dygraphs@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/dygraphs/-/dygraphs-2.0.1.tgz#ced5ea6a426aaf4fa8eba4c24fcf7bc314804284"
+dygraphs@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/dygraphs/-/dygraphs-2.1.0.tgz#2fbfd2c803ead02307df3faf8d4dd3ef55cb2075"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2524,9 +2524,9 @@ dot-prop@^3.0.0:
   dependencies:
     is-obj "^1.0.0"
 
-dygraphs@influxdata/dygraphs:
-  version "2.0.0"
-  resolved "https://codeload.github.com/influxdata/dygraphs/tar.gz/9cc90443f58c11b45473516a97d4bb3a68a620c2"
+dygraphs@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/dygraphs/-/dygraphs-2.0.1.tgz#ced5ea6a426aaf4fa8eba4c24fcf7bc314804284"
 
 ecc-jsbn@~0.1.1:
   version "0.1.1"


### PR DESCRIPTION
Connect #2413 

Now that dygraphs has support for millisecond-level granularity, we can depend on the dygraphs project again.