### PR TITLE
support for RS256/JWKS verification, support for id_token parsing

### DIFF
--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -190,6 +190,27 @@ func (j *JWT) ValidClaims(jwtToken Token, lifespan time.Duration, alg gojwt.Keyf
 	}, nil
 }
 
+// get claims from id_token
+func (j *JWT) GetClaims(tokenString string) (gojwt.MapClaims, error) {
+    var claims gojwt.MapClaims
+
+    token, err := gojwt.Parse(tokenString, j.KeyFunc)
+    if err != nil {
+        return nil, err
+    }
+
+    if !token.Valid {
+        return nil, fmt.Errorf("token is not valid")
+    }
+
+    claims, ok := token.Claims.(gojwt.MapClaims)
+    if !ok {
+        return nil, fmt.Errorf("token has no claims")
+    }
+
+    return claims, nil
+}
+
 // Create creates a signed JWT token from user that expires at Principal's ExpireAt time.
 func (j *JWT) Create(ctx context.Context, user Principal) (Token, error) {
 	// Create a new token object, specifying signing method and the claims

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -4,6 +4,11 @@ import (
 	"context"
 	"fmt"
 	"time"
+	"io/ioutil"
+	"encoding/json"
+	"encoding/base64"
+	"crypto/x509"
+	"net/http"
 
 	gojwt "github.com/dgrijalva/jwt-go"
 )
@@ -14,13 +19,17 @@ var _ Tokenizer = &JWT{}
 // JWT represents a javascript web token that can be validated or marshaled into string.
 type JWT struct {
 	Secret string
+    Jwksurl string
 	Now    func() time.Time
 }
 
-// NewJWT creates a new JWT using time.Now; secret is used for signing and validating.
-func NewJWT(secret string) *JWT {
+// NewJWT creates a new JWT using time.Now
+// secret is used for signing and validating signatures (HS256/HMAC)
+// jwksurl is used for validating RS256 signatures.
+func NewJWT(secret string, jwksurl string) *JWT {
 	return &JWT{
 		Secret: secret,
+        Jwksurl: jwksurl,
 		Now:    DefaultNowTime,
 	}
 }
@@ -53,14 +62,91 @@ func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, lifespan time.
 	gojwt.TimeFunc = j.Now
 
 	// Check for expected signing method.
-	alg := func(token *gojwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		return []byte(j.Secret), nil
-	}
+    alg := j.KeyFunc
 
 	return j.ValidClaims(jwtToken, lifespan, alg)
+}
+
+// key verification for HMAC an RSA/RS256
+func (j *JWT) KeyFunc(token *gojwt.Token) (interface{}, error) {
+    if _, ok := token.Method.(*gojwt.SigningMethodHMAC); ok {
+        return []byte(j.Secret), nil
+    } else if _, ok := token.Method.(*gojwt.SigningMethodRSA); ok {
+        return j.KeyFuncRS256(token)
+    }
+    return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+}
+
+// For the id_token, the recommended signature algorithm is RS256, which
+// means we need to verify the token against a public key. This public key
+// is available from the key discovery service in JSON Web Key (JWK).
+// JWK is specified in RFC 7517.
+// 
+// The location of the key discovery service (JWKSURL) is published in the
+// OpenID Provider Configuration Information at /.well-known/openid-configuration
+// implements rfc7517 section 4.7 "x5c" (X.509 Certificate Chain) Parameter
+
+// JWKS nested struct
+type JWK struct {
+    Kty     string      `json:"kty"`
+    Use     string      `json:"use"`
+    Alg     string      `json:"alg"`
+    Kid     string      `json:"kid"`
+    X5t     string      `json:"x5t"`
+    N       string      `json:"n"`
+    E       string      `json:"e"`
+    X5c     []string    `json:"x5c"`
+}
+
+type JWKS struct {
+    Keys    []JWK       `json:"keys"`
+}
+
+// for RS256 signed JWT tokens, lookup the signing key in the key discovery service
+func (j *JWT) KeyFuncRS256(token *gojwt.Token) (interface{}, error) {
+    // Don't forget to validate the alg is what you expect:
+    if _, ok := token.Method.(*gojwt.SigningMethodRSA); !ok {
+        return nil, fmt.Errorf("Unsupported signing method: %v", token.Header["alg"])
+    }
+
+    // read JWKS document from key discovery service
+    rr, err := http.Get(j.Jwksurl)
+    if err != nil {
+        return nil, err
+    }
+    defer rr.Body.Close()
+    body, err := ioutil.ReadAll(rr.Body)
+    if err != nil {
+        return nil, err
+    }
+
+    // parse json to struct
+    var jwks JWKS
+    if err := json.Unmarshal([]byte(body), &jwks); err != nil {
+        return nil, err
+    }
+
+    // extract cert when kid and alg match
+    var cert_pkix []byte
+    for _, jwk := range jwks.Keys {
+        if token.Header["kid"] == jwk.Kid && token.Header["alg"] == jwk.Alg {
+            // FIXME: optionally walk the key chain, see rfc7517 section 4.7
+            cert_pkix, err = base64.StdEncoding.DecodeString(jwk.X5c[0])
+            if err != nil {
+                return nil, fmt.Errorf("base64 decode error for JWK kid", token.Header["kid"])
+            }
+        }
+    }
+    if cert_pkix == nil {
+        return nil, fmt.Errorf("no signing key found for kid", token.Header["kid"])
+    }
+
+    // parse certificate (from PKIX format) and return signing key
+    cert, err := x509.ParseCertificate(cert_pkix)
+    if err != nil {
+        return nil, err
+    }
+    return cert.PublicKey, nil
 }
 
 // ValidClaims validates a token with StandardClaims

--- a/oauth2/mux.go
+++ b/oauth2/mux.go
@@ -116,14 +116,40 @@ func (j *AuthMux) Callback() http.Handler {
 			return
 		}
 
-		// Using the token get the principal identifier from the provider
-		oauthClient := conf.Client(r.Context(), token)
-		id, err := j.Provider.PrincipalID(oauthClient)
-		if err != nil {
-			log.Error("Unable to get principal identifier ", err.Error())
-			http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)
-			return
-		}
+        // if we received an extra id_token, inspect it
+        var id string
+        if tokenString, ok := token.Extra("id_token").(string); ok {
+            log.Debug("token provides extra id_token")
+            if provider, ok := j.Provider.(ExtendedProvider); ok {
+                log.Debug("provider implements PrincipalIDFromClaims()")
+                claims, err := j.Tokens.GetClaims(tokenString)
+                if err != nil {
+                    log.Error("parsing extra id_token failed:", err)
+                    http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)
+                    return
+                }
+                log.Debug("found claims: ", claims)
+                if id, err = provider.PrincipalIDFromClaims(claims); err != nil {
+                    log.Error("claim not found:", err)
+                    http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)
+                    return
+                }
+            } else {
+                log.Debug("provider does not implement PrincipalIDFromClaims()")
+            }
+        }
+
+        // otherwise perform an additional lookup
+        if id == "" {
+            // Using the token get the principal identifier from the provider
+            oauthClient := conf.Client(r.Context(), token)
+            id, err = j.Provider.PrincipalID(oauthClient)
+            if err != nil {
+                log.Error("Unable to get principal identifier ", err.Error())
+                http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)
+                return
+            }
+        }
 
 		p := Principal{
 			Subject: id,

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"golang.org/x/oauth2"
+	gojwt "github.com/dgrijalva/jwt-go"
 )
 
 type principalKey string
@@ -90,4 +91,6 @@ type Tokenizer interface {
 	ValidPrincipal(ctx context.Context, token Token, lifespan time.Duration) (Principal, error)
 	// ExtendedPrincipal adds the extention to the principal's lifespan.
 	ExtendedPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error)
+	// GetClaims returns a map with verified claims
+	GetClaims(tokenString string) (gojwt.MapClaims, error)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -56,6 +56,7 @@ type Server struct {
 	BoltPath                string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (e.g. './chronograf-v1.db')" env:"BOLT_PATH" default:"chronograf-v1.db"`
 	CannedPath              string        `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
 	TokenSecret             string        `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
+    JwksUrl                 string        `long:"jwks-url" description:"URL that returns OpenID Key Discovery JWKS document." env:"JWKS_URL"`
 	AuthDuration            time.Duration `long:"auth-duration" default:"720h" description:"Total duration of cookie life for authentication (in hours). 0 means authentication expires on browser close." env:"AUTH_DURATION"`
 	SuperAdminFirstUserOnly bool          `long:"superadmin-first-user-only" description:"All new users will not be given the SuperAdmin status" env:"SUPERADMIN_FIRST_USER_ONLY"`
 
@@ -141,7 +142,7 @@ func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		Orgs:         s.GithubOrgs,
 		Logger:       logger,
 	}
-	jwt := oauth2.NewJWT(s.TokenSecret)
+	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksUrl)
 	ghMux := oauth2.NewAuthMux(&gh, auth, jwt, s.Basepath, logger)
 	return &gh, ghMux, s.UseGithub
 }
@@ -155,7 +156,7 @@ func (s *Server) googleOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		RedirectURL:  redirectURL,
 		Logger:       logger,
 	}
-	jwt := oauth2.NewJWT(s.TokenSecret)
+	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksUrl)
 	goMux := oauth2.NewAuthMux(&google, auth, jwt, s.Basepath, logger)
 	return &google, goMux, s.UseGoogle
 }
@@ -167,7 +168,7 @@ func (s *Server) herokuOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		Organizations: s.HerokuOrganizations,
 		Logger:        logger,
 	}
-	jwt := oauth2.NewJWT(s.TokenSecret)
+	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksUrl)
 	hMux := oauth2.NewAuthMux(&heroku, auth, jwt, s.Basepath, logger)
 	return &heroku, hMux, s.UseHeroku
 }
@@ -186,7 +187,7 @@ func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticato
 		APIKey:         s.GenericAPIKey,
 		Logger:         logger,
 	}
-	jwt := oauth2.NewJWT(s.TokenSecret)
+	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksUrl)
 	genMux := oauth2.NewAuthMux(&gen, auth, jwt, s.Basepath, logger)
 	return &gen, genMux, s.UseGenericOAuth2
 }
@@ -202,7 +203,7 @@ func (s *Server) auth0OAuth(logger chronograf.Logger, auth oauth2.Authenticator)
 
 	auth0, err := oauth2.NewAuth0(s.Auth0Domain, s.Auth0ClientID, s.Auth0ClientSecret, redirectURL.String(), s.Auth0Organizations, logger)
 
-	jwt := oauth2.NewJWT(s.TokenSecret)
+	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksUrl)
 	genMux := oauth2.NewAuthMux(&auth0, auth, jwt, s.Basepath, logger)
 
 	if err != nil {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #

### The problem
Active Directory Federation Services 4 (ADFS) implement OpenID Connect (OIDC) and return user information via an id_token and not at .../userinfo as the other OAuth2 providers do.
The id_token is signed using RS256 and requires RSA verification of the JSON Web Token.

### The Solution
This PR brings two things:
- support for RS256 signature verification using JWKS (RFC 7517)
- support for OIDC id_token (as implemented by Active Directory Federation Services (ADFS)) 


