### PR TITLE
Fix template rendering to ignore template if not in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Features
 ### UI Improvements
 ### Bug Fixes
+1. [#2528](https://github.com/influxdata/chronograf/pull/2528): Fix template rendering to ignore template if not in query 
 
 ## v1.4.0.0-beta1 [2017-12-07]
 ### Features

--- a/influx/templates.go
+++ b/influx/templates.go
@@ -38,6 +38,12 @@ func RenderTemplate(query string, t chronograf.TemplateVar, now time.Time) (stri
 	if len(t.Values) == 0 {
 		return query, nil
 	}
+
+	// we only need to render the template if the template exists in the query
+	if !strings.Contains(query, t.Var) {
+		return query, nil
+	}
+
 	switch t.Values[0].Type {
 	case "tagKey", "fieldKey", "measurement", "database":
 		return strings.Replace(query, t.Var, `"`+t.Values[0].Value+`"`, -1), nil


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2527 

### The problem
The app sends in stale template variables to the data explorer and the server did not weed them out.

### The Solution
Server now does not try to render a template variable if the template variable is not in the query.

There may be some follow on app bugs regarding why the app is sending stale data.


