### PR TITLE
Allow new Organization names to include spaces

### DIFF
--- a/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
@@ -28,7 +28,7 @@ class OrganizationsTableRowNew extends Component {
   }
 
   handleInputChange = e => {
-    this.setState({name: e.target.value.trim()})
+    this.setState({name: e.target.value})
   }
 
   handleInputFocus = e => {
@@ -39,7 +39,7 @@ class OrganizationsTableRowNew extends Component {
     const {onCreateOrganization} = this.props
     const {name, defaultRole} = this.state
 
-    onCreateOrganization({name, defaultRole})
+    onCreateOrganization({name: name.trim(), defaultRole})
   }
 
   handleChooseDefaultRole = role => {


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #2531 

### The problem
Users could not create organizations with spaces in the name.

### The Solution
Allow organizations to be added with any number of spaces, and only trim whitespace upon submit rather than upon input value change.

