### PR TITLE
Prevent user joining private default org

### DIFF
--- a/server/me.go
+++ b/server/me.go
@@ -227,19 +227,6 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		defaultOrgID := fmt.Sprintf("%d", defaultOrg.ID)
-		// If a user was added via the API, they might not yet be a member of the default organization
-		// Here we check to verify that they are a user in the default organization
-		if !hasRoleInDefaultOrganization(usr, defaultOrgID) {
-			usr.Roles = append(usr.Roles, chronograf.Role{
-				Organization: defaultOrgID,
-				Name:         defaultOrg.DefaultRole,
-			})
-			if err := s.Store.Users(serverCtx).Update(serverCtx, usr); err != nil {
-				unknownErrorWithMessage(w, err, s.Logger)
-				return
-			}
-		}
 		orgs, err := s.usersOrganizations(serverCtx, usr)
 		if err != nil {
 			unknownErrorWithMessage(w, err, s.Logger)

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -169,8 +169,7 @@ func TestService_Me(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody: `{"name":"me","roles":[{"name":"viewer","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","public":true,"defaultRole":"viewer"}],"currentOrganization":{"id":"0","defaultRole":"viewer","name":"Default","public":true}}
-`,
+			wantBody:        `{"name":"me","provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"currentOrganization":{"id":"0","name":"Default","defaultRole":"viewer","public":true}}`, // This is kind of a wierd state, but I think it makes sense.
 		},
 		{
 			name: "Existing user - organization doesn't exist",
@@ -652,7 +651,7 @@ func TestService_UpdateMe(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"},{"name":"admin","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","public":true,"defaultRole":"admin"},{"id":"1337","name":"The ShillBillThrilliettas","public":true}],"currentOrganization":{"id":"1337","name":"The ShillBillThrilliettas","public":true}}`,
+			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"1337","name":"The ShillBillThrilliettas","public":true}],"currentOrganization":{"id":"1337","name":"The ShillBillThrilliettas","public":true}}`,
 		},
 		{
 			name: "Change the current User's organization",
@@ -727,7 +726,7 @@ func TestService_UpdateMe(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"},{"name":"editor","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","public":true,"defaultRole":"editor"},{"id":"1337","name":"The ThrillShilliettos","public":false}],"currentOrganization":{"id":"1337","name":"The ThrillShilliettos","public":false}}`,
+			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"1337","name":"The ThrillShilliettos","public":false}],"currentOrganization":{"id":"1337","name":"The ThrillShilliettos","public":false}}`,
 		},
 		{
 			name: "Unable to find requested user in valid organization",

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -107,7 +107,72 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"code":403,"message":"This organization is private. To gain access, you must be explicitly added by an administrator."}`,
 		},
 		{
-			name: "Existing user",
+			name: "Existing user - private default org",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				Logger:  log.New(log.DebugLevel),
+				OrganizationsStore: &mocks.OrganizationsStore{
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          0,
+							Name:        "Default",
+							DefaultRole: roles.ViewerRoleName,
+							Public:      false,
+						}, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						switch *q.ID {
+						case 0:
+							return &chronograf.Organization{
+								ID:          0,
+								Name:        "Default",
+								DefaultRole: roles.ViewerRoleName,
+								Public:      true,
+							}, nil
+						case 1:
+							return &chronograf.Organization{
+								ID:     1,
+								Name:   "The Bad Place",
+								Public: true,
+							}, nil
+						}
+						return nil, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return &chronograf.User{
+							Name:     "me",
+							Provider: "github",
+							Scheme:   "oauth2",
+						}, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "me",
+				Issuer:  "github",
+			},
+			wantStatus:      http.StatusForbidden,
+			wantContentType: "application/json",
+			wantBody:        `{"code":403,"message":"This organization is private. To gain access, you must be explicitly added by an administrator."}`,
+		},
+		{
+			name: "Existing user - default org public",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -169,7 +234,7 @@ func TestService_Me(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"me","provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"currentOrganization":{"id":"0","name":"Default","defaultRole":"viewer","public":true}}`, // This is kind of a wierd state, but I think it makes sense.
+			wantBody:        `{"name":"me","roles":[{"name":"viewer","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","defaultRole":"viewer","public":true}],"currentOrganization":{"id":"0","name":"Default","defaultRole":"viewer","public":true}}`,
 		},
 		{
 			name: "Existing user - organization doesn't exist",
@@ -651,7 +716,7 @@ func TestService_UpdateMe(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"1337","name":"The ShillBillThrilliettas","public":true}],"currentOrganization":{"id":"1337","name":"The ShillBillThrilliettas","public":true}}`,
+			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"},{"name":"admin","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","defaultRole":"admin","public":true},{"id":"1337","name":"The ShillBillThrilliettas","public":true}],"currentOrganization":{"id":"1337","name":"The ShillBillThrilliettas","public":true}}`,
 		},
 		{
 			name: "Change the current User's organization",
@@ -726,7 +791,7 @@ func TestService_UpdateMe(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"1337","name":"The ThrillShilliettos","public":false}],"currentOrganization":{"id":"1337","name":"The ThrillShilliettos","public":false}}`,
+			wantBody:        `{"name":"me","roles":[{"name":"admin","organization":"1337"},{"name":"editor","organization":"0"}],"provider":"github","scheme":"oauth2","links":{"self":"/chronograf/v1/users/0"},"organizations":[{"id":"0","name":"Default","defaultRole":"editor","public":true},{"id":"1337","name":"The ThrillShilliettos","public":false}],"currentOrganization":{"id":"1337","name":"The ThrillShilliettos","public":false}}`,
 		},
 		{
 			name: "Unable to find requested user in valid organization",


### PR DESCRIPTION
Previously, if an organization was private and a user was removed from
the default organization, then they would be re-added. This behavior was
so left over from when we thought of the default organization as the
place where all users would exist. This PR removes that behavior, unless 
the a user is a SuperAdmin or the organization is public.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2524 


