### PR TITLE
Render static text instead of kapacitor switching dropdown for Viewers

### DIFF
--- a/ui/src/sources/components/InfluxTable.js
+++ b/ui/src/sources/components/InfluxTable.js
@@ -43,10 +43,16 @@ const kapacitorDropdown = (
     selected = kapacitorItems[0].text
   }
 
+  const unauthorizedDropdown = (
+    <div className="source-table--kapacitor__view-only">
+      {selected}
+    </div>
+  )
+
   return (
     <Authorized
       requiredRole={EDITOR_ROLE}
-      propsOverride={{addNew: null, actions: null}}
+      replaceWithIfNotAuthorized={unauthorizedDropdown}
     >
       <Dropdown
         className="dropdown-260"

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -180,6 +180,11 @@ br {
   border-left: 2px solid $g5-pepper;
   width: 278px;
 }
+.source-table--kapacitor__view-only {
+  @include no-user-select();
+  font-size: 14px;
+  font-weight: 600;
+}
 
 /*
   Styles for the Status Dashboard


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2422 

### The Problem
- Viewers are able to switch active Kapacitor configs

### The Solution
- Viewers see static text instead of a dropdown

### Preview
![screen shot 2017-12-11 at 4 56 49 pm](https://user-images.githubusercontent.com/2433762/33862560-2dc0f73c-de98-11e7-8dfe-2a79225d1324.png)


