### PR TITLE
Prevent inversion of graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UI Improvements
 ### Bug Fixes
 1. [#2528](https://github.com/influxdata/chronograf/pull/2528): Fix template rendering to ignore template if not in query 
+1. [#2554](https://github.com/influxdata/chronograf/pull/2554): Fix graph inversion if a user supplies a min y-bound > max y-bound
 
 ## v1.4.0.0-beta1 [2017-12-07]
 ### Features

--- a/ui/src/shared/parsing/getRangeForDygraph.js
+++ b/ui/src/shared/parsing/getRangeForDygraph.js
@@ -80,6 +80,11 @@ const getRange = (
     }
   }
 
+  // prevents inversion of graph
+  if (min > max) {
+    return [min, min + 1]
+  }
+
   return [min, max]
 }
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2541 

### The problem
When a user supplied a `min` y-axis range that is greater than the automatically generated `max` the graph inverted.  This seemed like odd behavior.  

### The Solution
@nhaugo and I talked about what to do should the user put themselves in that position and settled on adjusting the calculation of max in that case to be min + 1.  This prevents the jarring experience of seeing the graph invert, while also mathematically making sense so a graph can display in the first cartesian plane.  

### Repro Steps
Create a cell on a dashboard.  Pick a time series that has a consistent range that is easy to work with.  Might I suggest telegraf, cpu, usage_user.  Click the visualization tab in the Cell Editor Overlay.  Put in a min > 100.  Observe the graph no longer flipping.

### Notes
It was also suggested by @ebb-tide that we display the automatically calculated `min` and `max` to the user in the placeholder text.  This would make it a bit more clear to the user what those values actually are. 