### PR TITLE
y axis title undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UI Improvements
 ### Bug Fixes
 1. [#2528](https://github.com/influxdata/chronograf/pull/2528): Fix template rendering to ignore template if not in query 
+1. [#2563](https://github.com/influxdata/chronograf/pull/2563): Fix graph inversion if user input y-axis min greater than max
 
 ## v1.4.0.0-beta1 [2017-12-07]
 ### Features

--- a/ui/spec/shared/presenters/presentersSpec.js
+++ b/ui/spec/shared/presenters/presentersSpec.js
@@ -258,5 +258,12 @@ describe('Presenters', () => {
 
       expect(actual).to.equal('m1.derivative_mean_usage_system')
     })
+
+    it('returns a label of empty string if the query config is empty', () => {
+      const query = defaultQueryConfig({id: 1})
+      const actual = buildDefaultYLabel(query)
+
+      expect(actual).to.equal('')
+    })
   })
 })

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -40,7 +40,7 @@ const AxesOptions = ({
           <div className="form-group col-sm-12">
             <label htmlFor="prefix">Title</label>
             <OptIn
-              customPlaceholder={defaultYLabel}
+              customPlaceholder={defaultYLabel || 'y-axis title'}
               customValue={label}
               onSetValue={onSetLabel}
               type="text"

--- a/ui/src/shared/presenters/index.js
+++ b/ui/src/shared/presenters/index.js
@@ -114,6 +114,11 @@ function getRolesForUser(roles, user) {
 export const buildDefaultYLabel = queryConfig => {
   const {measurement} = queryConfig
   const fields = _.get(queryConfig, ['fields', '0'], [])
+  const isEmpty = !measurement && !fields.length
+
+  if (isEmpty) {
+    return ''
+  }
 
   const walkZerothArgs = f => {
     if (f.type === 'field') {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2516 

### The problem
The queryConfig being passed to the function creating these labels was empty.

### The Solution
Added functionality to the `buildDefaultYLabel` function to return if the queryConfig is 'empty'. 

### Notes
It should be noted that the reason this queryConfig is empty appears to be another bug regarding the parsing / saving of queries into queryConfigs.  Will update #2516 to elaborate.