### PR TITLE
Switch orgs from manage sources

### DIFF
--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -138,18 +138,7 @@ const SourceForm = ({
             </label>
           </div>
         : null}
-      {isUsingAuth
-        ? <div className="form-group form-group-submit col-xs-12 col-sm-4 col-sm-offset-2">
-            <button className="btn btn-block btn-default">
-              <span className="icon shuffle" /> Switch Orgs
-            </button>
-          </div>
-        : null}
-      <div
-        className={`form-group form-group-submit ${isUsingAuth
-          ? 'col-xs-12 col-sm-4'
-          : 'col-xs-12 col-sm-6 col-sm-offset-3'}`}
-      >
+      <div className="form-group form-group-submit text-center col-xs-12 col-sm-6 col-sm-offset-3">
         <button
           className={classnames('btn btn-block', {
             'btn-primary': editMode,
@@ -162,6 +151,11 @@ const SourceForm = ({
         </button>
 
         <br />
+        {isUsingAuth
+          ? <button className="btn btn-link btn-sm">
+              <span className="icon shuffle" /> Switch Orgs
+            </button>
+          : null}
       </div>
     </form>
   </div>

--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -138,7 +138,18 @@ const SourceForm = ({
             </label>
           </div>
         : null}
-      <div className="form-group form-group-submit col-xs-12 col-sm-6 col-sm-offset-3 text-center">
+      {isUsingAuth
+        ? <div className="form-group form-group-submit col-xs-12 col-sm-4 col-sm-offset-2">
+            <button className="btn btn-block btn-default">
+              <span className="icon shuffle" /> Switch Orgs
+            </button>
+          </div>
+        : null}
+      <div
+        className={`form-group form-group-submit ${isUsingAuth
+          ? 'col-xs-12 col-sm-4'
+          : 'col-xs-12 col-sm-6 col-sm-offset-3'}`}
+      >
         <button
           className={classnames('btn btn-block', {
             'btn-primary': editMode,
@@ -146,8 +157,10 @@ const SourceForm = ({
           })}
           type="submit"
         >
+          <span className={`icon ${editMode ? 'checkmark' : 'plus'}`} />
           {editMode ? 'Save Changes' : 'Add Source'}
         </button>
+
         <br />
       </div>
     </form>

--- a/ui/src/sources/components/SourceForm.js
+++ b/ui/src/sources/components/SourceForm.js
@@ -14,6 +14,7 @@ const SourceForm = ({
   onInputChange,
   onBlurSourceURL,
   isUsingAuth,
+  gotoPurgatory,
   isInitialSource,
   me,
 }) =>
@@ -152,7 +153,7 @@ const SourceForm = ({
 
         <br />
         {isUsingAuth
-          ? <button className="btn btn-link btn-sm">
+          ? <button className="btn btn-link btn-sm" onClick={gotoPurgatory}>
               <span className="icon shuffle" /> Switch Orgs
             </button>
           : null}
@@ -186,6 +187,7 @@ SourceForm.propTypes = {
   }),
   isUsingAuth: bool,
   isInitialSource: bool,
+  gotoPurgatory: func,
 }
 
 const mapStateToProps = ({auth: {isUsingAuth, me}}) => ({isUsingAuth, me})

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -100,6 +100,11 @@ class SourcePage extends Component {
     notify('error', `${bannerText}: ${error}`)
   }
 
+  gotoPurgatory = () => {
+    const {router} = this.props
+    router.push('/purgatory')
+  }
+
   _normalizeSource({source}) {
     const url = source.url.trim()
     if (source.url.startsWith('http')) {
@@ -224,6 +229,7 @@ class SourcePage extends Component {
                     onSubmit={this.handleSubmit}
                     onBlurSourceURL={this.handleBlurSourceURL}
                     isInitialSource={isInitialSource}
+                    gotoPurgatory={this.gotoPurgatory}
                   />
                 </div>
               </div>


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2523 

### The problem
There is no way to leave the create sources page other than creating a source for this organization. 

### The Solution
Create a new button that allows user to switch organizations without creating a source.

