### PR TITLE
Fix organization default role being stale on chrono users page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Features
 ### UI Improvements
-1. [#2502](https://github.com/influxdata/chronograf/pull/2502): Fix cursor flashing between default and pointer
 
 ### Bug Fixes
 1. [#2572](https://github.com/influxdata/chronograf/pull/2572): Have new Chronograf users role dropdown default to the current organizations default role
@@ -12,6 +11,7 @@
 ### UI Improvements
 ### Bug Fixes
 1. [#2528](https://github.com/influxdata/chronograf/pull/2528): Fix template rendering to ignore template if not in query 
+1. [#2502](https://github.com/influxdata/chronograf/pull/2502): Fix cursor flashing between default and pointer
 
 ## v1.4.0.0-beta1 [2017-12-07]
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,9 @@
-## v1.4.1.0 [unreleased]
-
-### Features
-### UI Improvements
-
-### Bug Fixes
-1. [#2572](https://github.com/influxdata/chronograf/pull/2572): Have new Chronograf users role dropdown default to the current organizations default role
 
 ## v1.4.0.0-beta2 [unreleased]
 ### Features
 ### UI Improvements
 ### Bug Fixes
 1. [#2528](https://github.com/influxdata/chronograf/pull/2528): Fix template rendering to ignore template if not in query 
-1. [#2502](https://github.com/influxdata/chronograf/pull/2502): Fix cursor flashing between default and pointer
 
 ## v1.4.0.0-beta1 [2017-12-07]
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.4.1.0 [unreleased]
+
+### Features
+### UI Improvements
+1. [#2502](https://github.com/influxdata/chronograf/pull/2502): Fix cursor flashing between default and pointer
+
+### Bug Fixes
+1. [#2572](https://github.com/influxdata/chronograf/pull/2572): Have new Chronograf users role dropdown default to the current organizations default role
+
 ## v1.4.0.0-beta2 [unreleased]
 ### Features
 ### UI Improvements

--- a/ui/src/admin/components/chronograf/AdminTabs.js
+++ b/ui/src/admin/components/chronograf/AdminTabs.js
@@ -71,6 +71,13 @@ const AdminTabs = ({
 
 const {arrayOf, bool, func, shape, string} = PropTypes
 
+AdminTabs.defaultProps = {
+  organization: {
+    name: '',
+    id: '0',
+  },
+}
+
 AdminTabs.propTypes = {
   meRole: string.isRequired,
   meID: string.isRequired,

--- a/ui/src/admin/components/chronograf/UsersTable.js
+++ b/ui/src/admin/components/chronograf/UsersTable.js
@@ -1,8 +1,11 @@
 import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
 
 import uuid from 'node-uuid'
 
 import Authorized, {SUPERADMIN_ROLE} from 'src/auth/Authorized'
+import {getMeAsync} from 'shared/actions/auth'
 
 import UsersTableHeader from 'src/admin/components/chronograf/UsersTableHeader'
 import UsersTableRowNew from 'src/admin/components/chronograf/UsersTableRowNew'
@@ -17,6 +20,12 @@ class UsersTable extends Component {
     this.state = {
       isCreatingUser: false,
     }
+  }
+
+  componentDidMount() {
+    // TODO: update the {me: currentOrganization} and {organizations: []} at the same time
+    // updates the current organization.
+    this.props.getMe({shouldResetMe: false})
   }
 
   handleChangeUserRole = (user, currentRole) => newRole => {
@@ -134,5 +143,11 @@ UsersTable.propTypes = {
   onDeleteUser: func.isRequired,
   meID: string.isRequired,
   notify: func.isRequired,
+  getMe: func.isRequired,
 }
-export default UsersTable
+
+const mapDispatchToProps = dispatch => ({
+  getMe: bindActionCreators(getMeAsync, dispatch),
+})
+
+export default connect(null, mapDispatchToProps)(UsersTable)

--- a/ui/src/admin/components/chronograf/UsersTable.js
+++ b/ui/src/admin/components/chronograf/UsersTable.js
@@ -22,12 +22,6 @@ class UsersTable extends Component {
     }
   }
 
-  componentDidMount() {
-    // TODO: update the {me: currentOrganization} and {organizations: []} at the same time
-    // updates the current organization.
-    this.props.getMe({shouldResetMe: false})
-  }
-
   handleChangeUserRole = (user, currentRole) => newRole => {
     this.props.onUpdateUserRole(user, currentRole, newRole)
   }

--- a/ui/src/admin/components/chronograf/UsersTable.js
+++ b/ui/src/admin/components/chronograf/UsersTable.js
@@ -1,11 +1,8 @@
 import React, {Component, PropTypes} from 'react'
-import {connect} from 'react-redux'
-import {bindActionCreators} from 'redux'
 
 import uuid from 'node-uuid'
 
 import Authorized, {SUPERADMIN_ROLE} from 'src/auth/Authorized'
-import {getMeAsync} from 'shared/actions/auth'
 
 import UsersTableHeader from 'src/admin/components/chronograf/UsersTableHeader'
 import UsersTableRowNew from 'src/admin/components/chronograf/UsersTableRowNew'
@@ -137,11 +134,6 @@ UsersTable.propTypes = {
   onDeleteUser: func.isRequired,
   meID: string.isRequired,
   notify: func.isRequired,
-  getMe: func.isRequired,
 }
 
-const mapDispatchToProps = dispatch => ({
-  getMe: bindActionCreators(getMeAsync, dispatch),
-})
-
-export default connect(null, mapDispatchToProps)(UsersTable)
+export default UsersTable

--- a/ui/src/admin/components/chronograf/UsersTableRowNew.js
+++ b/ui/src/admin/components/chronograf/UsersTableRowNew.js
@@ -7,7 +7,6 @@ import SlideToggle from 'shared/components/SlideToggle'
 
 import {USERS_TABLE} from 'src/admin/constants/chronografTableSizing'
 import {USER_ROLES} from 'src/admin/constants/chronografAdmin'
-import {MEMBER_ROLE} from 'src/auth/Authorized'
 
 class UsersTableRowNew extends Component {
   constructor(props) {
@@ -17,7 +16,7 @@ class UsersTableRowNew extends Component {
       name: '',
       provider: '',
       scheme: 'oauth2',
-      role: MEMBER_ROLE,
+      role: this.props.organization.defaultRole,
       superAdmin: false,
     }
   }

--- a/ui/src/admin/containers/AdminChronografPage.js
+++ b/ui/src/admin/containers/AdminChronografPage.js
@@ -64,7 +64,18 @@ class AdminChronografPage extends Component {
   }
 
   render() {
-    const {users, meCurrentOrganization, meRole, meID, notify} = this.props
+    const {
+      users,
+      meRole,
+      meID,
+      notify,
+      organizations,
+      meCurrentOrganization,
+    } = this.props
+
+    const organization = organizations.find(
+      o => o.id === meCurrentOrganization.id
+    )
 
     return (
       <div className="page">
@@ -84,7 +95,7 @@ class AdminChronografPage extends Component {
                     meID={meID}
                     // UsersTable
                     users={users}
-                    organization={meCurrentOrganization}
+                    organization={organization}
                     onCreateUser={this.handleCreateUser}
                     onUpdateUserRole={this.handleUpdateUserRole}
                     onUpdateUserSuperAdmin={this.handleUpdateUserSuperAdmin}
@@ -107,6 +118,7 @@ AdminChronografPage.propTypes = {
     users: string.isRequired,
   }),
   users: arrayOf(shape),
+  organizations: arrayOf(shape),
   meCurrentOrganization: shape({
     id: string.isRequired,
     name: string.isRequired,
@@ -128,18 +140,19 @@ AdminChronografPage.propTypes = {
 
 const mapStateToProps = ({
   links,
-  adminChronograf: {users},
+  adminChronograf: {users, organizations},
   auth: {
     me,
     me: {currentOrganization: meCurrentOrganization, role: meRole, id: meID},
   },
 }) => ({
-  links,
-  users,
-  meCurrentOrganization,
-  meRole,
   me,
   meID,
+  links,
+  users,
+  meRole,
+  organizations,
+  meCurrentOrganization,
 })
 
 const mapDispatchToProps = dispatch => ({


### PR DESCRIPTION

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2537 

### The problem
The 'currentOrganization' namespaced in the auth reducer does not get
updated when chronograf organizations reducer gets updated.  This
results in temporarily stale state until `/me` is hit and the 'me auth'
state trickles through the application.

### The Solution
Force an update to `/me` in the `componentDidMount` of the `UsersTable`.  

### Notes
This is a temporary solution.  I've opened up a ticket to solve this f.o.r.e.v.e.r.


