### PR TITLE
Use serverContext for getting Config in NewUser

### DIFF
--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -111,34 +111,34 @@ func TestServer(t *testing.T) {
 			wants: wants{
 				statusCode: 200,
 				body: `
-					{
-					  "links": {
-					    "self": "/chronograf/v1/users"
-					  },
-					  "users": [
-					    {
-					      "links": {
-					        "self": "/chronograf/v1/users/1"
-					      },
-					      "id": "1",
-					      "name": "billibob",
-					      "provider": "github",
-					      "scheme": "oauth2",
-					      "superAdmin": true,
-					      "roles": [
-					        {
-					          "name": "admin",
-					          "organization": "0"
-					        }
-					      ]
-					    }
-					  ]
-					}`,
+{
+  "links": {
+    "self": "/chronograf/v1/users"
+  },
+  "users": [
+    {
+      "links": {
+        "self": "/chronograf/v1/users/1"
+      },
+      "id": "1",
+      "name": "billibob",
+      "provider": "github",
+      "scheme": "oauth2",
+      "superAdmin": true,
+      "roles": [
+        {
+          "name": "admin",
+          "organization": "0"
+        }
+      ]
+    }
+  ]
+}`,
 			},
 		},
 		{
 			name:    "POST /users",
-			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is true (the default case); User on Principal is a SuperAdmin",
+			subName: "Create a New User with SuperAdmin status; SuperAdminNewUsers is true (the default case); User on Principal is a SuperAdmin",
 			fields: fields{
 				Config: &chronograf.Config{
 					Auth: chronograf.AuthConfig{
@@ -208,7 +208,7 @@ func TestServer(t *testing.T) {
 		},
 		{
 			name:    "POST /users",
-			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is false; User on Principal is a SuperAdmin",
+			subName: "Create a New User with SuperAdmin status; SuperAdminNewUsers is false; User on Principal is a SuperAdmin",
 			fields: fields{
 				Config: &chronograf.Config{
 					Auth: chronograf.AuthConfig{
@@ -278,7 +278,7 @@ func TestServer(t *testing.T) {
 		},
 		{
 			name:    "POST /users",
-			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is false; User on Principal is not SuperAdmin",
+			subName: "Create a New User with SuperAdmin status; SuperAdminNewUsers is false; User on Principal is Admin, but not a SuperAdmin",
 			fields: fields{
 				Config: &chronograf.Config{
 					Auth: chronograf.AuthConfig{
@@ -348,7 +348,7 @@ func TestServer(t *testing.T) {
 		},
 		{
 			name:    "POST /users",
-			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is true; User on Principal is not a SuperAdmin",
+			subName: "Create a New User with SuperAdmin status; SuperAdminNewUsers is true; User on Principal is Admin, but not a SuperAdmin",
 			fields: fields{
 				Config: &chronograf.Config{
 					Auth: chronograf.AuthConfig{

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/bolt"
 	"github.com/influxdata/chronograf/oauth2"
+	"github.com/influxdata/chronograf/roles"
 	"github.com/influxdata/chronograf/server"
 )
 
@@ -28,6 +29,7 @@ func TestServer(t *testing.T) {
 		Servers       []chronograf.Server
 		Layouts       []chronograf.Layout
 		Dashboards    []chronograf.Dashboard
+		Config        *chronograf.Config
 	}
 	type args struct {
 		server    *server.Server
@@ -134,6 +136,275 @@ func TestServer(t *testing.T) {
 					}`,
 			},
 		},
+		{
+			name:    "POST /users",
+			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is true (the default case); User on Principal is a SuperAdmin",
+			fields: fields{
+				Config: &chronograf.Config{
+					Auth: chronograf.AuthConfig{
+						SuperAdminNewUsers: true,
+					},
+				},
+				Users: []chronograf.User{
+					{
+						ID:         1, // This is artificial, but should be reflective of the users actual ID
+						Name:       "billibob",
+						Provider:   "github",
+						Scheme:     "oauth2",
+						SuperAdmin: true,
+						Roles: []chronograf.Role{
+							{
+								Name:         "admin",
+								Organization: "0",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				server: &server.Server{
+					GithubClientID:     "not empty",
+					GithubClientSecret: "not empty",
+				},
+				method: "POST",
+				path:   "/chronograf/v1/users",
+				payload: &chronograf.User{
+					Name:     "user",
+					Provider: "provider",
+					Scheme:   "oauth2",
+					Roles: []chronograf.Role{
+						{
+							Name:         roles.EditorRoleName,
+							Organization: "0",
+						},
+					},
+				},
+				principal: oauth2.Principal{
+					Organization: "0",
+					Subject:      "billibob",
+					Issuer:       "github",
+				},
+			},
+			wants: wants{
+				statusCode: 201,
+				body: `
+{
+  "links": {
+    "self": "/chronograf/v1/users/2"
+  },
+  "id": "2",
+  "name": "user",
+  "provider": "provider",
+  "scheme": "oauth2",
+  "superAdmin": true,
+  "roles": [
+    {
+      "name": "editor",
+      "organization": "0"
+    }
+  ]
+}`,
+			},
+		},
+		{
+			name:    "POST /users",
+			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is false; User on Principal is a SuperAdmin",
+			fields: fields{
+				Config: &chronograf.Config{
+					Auth: chronograf.AuthConfig{
+						SuperAdminNewUsers: false,
+					},
+				},
+				Users: []chronograf.User{
+					{
+						ID:         1, // This is artificial, but should be reflective of the users actual ID
+						Name:       "billibob",
+						Provider:   "github",
+						Scheme:     "oauth2",
+						SuperAdmin: true,
+						Roles: []chronograf.Role{
+							{
+								Name:         "admin",
+								Organization: "0",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				server: &server.Server{
+					GithubClientID:     "not empty",
+					GithubClientSecret: "not empty",
+				},
+				method: "POST",
+				path:   "/chronograf/v1/users",
+				payload: &chronograf.User{
+					Name:     "user",
+					Provider: "provider",
+					Scheme:   "oauth2",
+					Roles: []chronograf.Role{
+						{
+							Name:         roles.EditorRoleName,
+							Organization: "0",
+						},
+					},
+				},
+				principal: oauth2.Principal{
+					Organization: "0",
+					Subject:      "billibob",
+					Issuer:       "github",
+				},
+			},
+			wants: wants{
+				statusCode: 201,
+				body: `
+{
+  "links": {
+    "self": "/chronograf/v1/users/2"
+  },
+  "id": "2",
+  "name": "user",
+  "provider": "provider",
+  "scheme": "oauth2",
+  "superAdmin": false,
+  "roles": [
+    {
+      "name": "editor",
+      "organization": "0"
+    }
+  ]
+}`,
+			},
+		},
+		{
+			name:    "POST /users",
+			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is false; User on Principal is not SuperAdmin",
+			fields: fields{
+				Config: &chronograf.Config{
+					Auth: chronograf.AuthConfig{
+						SuperAdminNewUsers: false,
+					},
+				},
+				Users: []chronograf.User{
+					{
+						ID:         1, // This is artificial, but should be reflective of the users actual ID
+						Name:       "billibob",
+						Provider:   "github",
+						Scheme:     "oauth2",
+						SuperAdmin: false,
+						Roles: []chronograf.Role{
+							{
+								Name:         "admin",
+								Organization: "0",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				server: &server.Server{
+					GithubClientID:     "not empty",
+					GithubClientSecret: "not empty",
+				},
+				method: "POST",
+				path:   "/chronograf/v1/users",
+				payload: &chronograf.User{
+					Name:     "user",
+					Provider: "provider",
+					Scheme:   "oauth2",
+					Roles: []chronograf.Role{
+						{
+							Name:         roles.EditorRoleName,
+							Organization: "0",
+						},
+					},
+				},
+				principal: oauth2.Principal{
+					Organization: "0",
+					Subject:      "billibob",
+					Issuer:       "github",
+				},
+			},
+			wants: wants{
+				statusCode: 201,
+				body: `
+{
+  "links": {
+    "self": "/chronograf/v1/users/2"
+  },
+  "id": "2",
+  "name": "user",
+  "provider": "provider",
+  "scheme": "oauth2",
+  "superAdmin": false,
+  "roles": [
+    {
+      "name": "editor",
+      "organization": "0"
+    }
+  ]
+}`,
+			},
+		},
+		{
+			name:    "POST /users",
+			subName: "Create a New User as a SuperAdmin; SuperAdminNewUsers is true; User on Principal is not a SuperAdmin",
+			fields: fields{
+				Config: &chronograf.Config{
+					Auth: chronograf.AuthConfig{
+						SuperAdminNewUsers: true,
+					},
+				},
+				Users: []chronograf.User{
+					{
+						ID:         1, // This is artificial, but should be reflective of the users actual ID
+						Name:       "billibob",
+						Provider:   "github",
+						Scheme:     "oauth2",
+						SuperAdmin: false,
+						Roles: []chronograf.Role{
+							{
+								Name:         "admin",
+								Organization: "0",
+							},
+						},
+					},
+				},
+			},
+			args: args{
+				server: &server.Server{
+					GithubClientID:     "not empty",
+					GithubClientSecret: "not empty",
+				},
+				method: "POST",
+				path:   "/chronograf/v1/users",
+				payload: &chronograf.User{
+					Name:       "user",
+					Provider:   "provider",
+					Scheme:     "oauth2",
+					SuperAdmin: true,
+					Roles: []chronograf.Role{
+						{
+							Name:         roles.EditorRoleName,
+							Organization: "0",
+						},
+					},
+				},
+				principal: oauth2.Principal{
+					Organization: "0",
+					Subject:      "billibob",
+					Issuer:       "github",
+				},
+			},
+			wants: wants{
+				statusCode: 401,
+				body: `
+{
+  "code": 401,
+  "message": "User does not have authorization required to set SuperAdmin status"
+}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -155,6 +426,13 @@ func TestServer(t *testing.T) {
 			boltdb := bolt.NewClient()
 			boltdb.Path = boltFile
 			_ = boltdb.Open(ctx)
+
+			if tt.fields.Config != nil {
+				if err := boltdb.ConfigStore.Update(ctx, tt.fields.Config); err != nil {
+					t.Fatalf("failed to update global application config", err)
+					return
+				}
+			}
 
 			// Populate Organizations
 			for i, organization := range tt.fields.Organizations {

--- a/server/users.go
+++ b/server/users.go
@@ -158,7 +158,8 @@ func (s *Service) NewUser(w http.ResponseWriter, r *http.Request) {
 
 	ctx := r.Context()
 
-	cfg, err := s.Store.Config(ctx).Get(ctx)
+	serverCtx := serverContext(ctx)
+	cfg, err := s.Store.Config(serverCtx).Get(serverCtx)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, err.Error(), s.Logger)
 		return


### PR DESCRIPTION
When we introduced #2552 I failed to realize that this would actually prevent admin users from being able to create new users.

  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect https://github.com/influxdata/chronograf/issues/2583

### The problem
We look up server configuration using the request context in `NewUser`. If the requesting user is not a SuperAdmin the request to access the Config will fail. This means that Admins will not be able to create any new users.

### The Solution

Use the server context to request access to the config.

