### PR TITLE
Attempting to access missing dashboard should redirect user to `/sources/:sources_id/dashboards`

### DIFF
--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -67,7 +67,7 @@ class DashboardPage extends Component {
     )
 
     if (!dashboard) {
-      router.push(`/sources/${source.id}/dashboards`)
+      return router.push(`/sources/${source.id}/dashboards`)
     }
 
     // Refresh and persists influxql generated template variable values.

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -16,6 +16,7 @@ import TemplateVariableManager from 'src/dashboards/components/template_variable
 import ManualRefresh from 'src/shared/components/ManualRefresh'
 
 import {errorThrown as errorThrownAction} from 'shared/actions/errors'
+import {publishNotification} from 'shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 
 import * as dashboardActionCreators from 'src/dashboards/actions'
@@ -59,6 +60,7 @@ class DashboardPage extends Component {
       meRole,
       isUsingAuth,
       router,
+      notify,
     } = this.props
 
     const dashboards = await getDashboardsAsync()
@@ -67,7 +69,8 @@ class DashboardPage extends Component {
     )
 
     if (!dashboard) {
-      return router.push(`/sources/${source.id}/dashboards`)
+      router.push(`/sources/${source.id}/dashboards`)
+      return notify('error', `Dashboard ${dashboardID} could not be found`)
     }
 
     // Refresh and persists influxql generated template variable values.
@@ -463,6 +466,7 @@ DashboardPage.propTypes = {
   meRole: string,
   isUsingAuth: bool.isRequired,
   router: shape().isRequired,
+  notify: func.isRequired,
 }
 
 const mapStateToProps = (state, {params: {dashboardID}}) => {
@@ -510,6 +514,7 @@ const mapDispatchToProps = dispatch => ({
   handleClickPresentationButton: presentationButtonDispatcher(dispatch),
   dashboardActions: bindActionCreators(dashboardActionCreators, dispatch),
   errorThrown: bindActionCreators(errorThrownAction, dispatch),
+  notify: bindActionCreators(publishNotification, dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -1,5 +1,6 @@
 import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
+import {withRouter} from 'react-router'
 import {bindActionCreators} from 'redux'
 
 import _ from 'lodash'
@@ -57,12 +58,17 @@ class DashboardPage extends Component {
       source,
       meRole,
       isUsingAuth,
+      router,
     } = this.props
 
     const dashboards = await getDashboardsAsync()
     const dashboard = dashboards.find(
       d => d.id === idNormalizer(TYPE_ID, dashboardID)
     )
+
+    if (!dashboard) {
+      router.push(`/sources/${source.id}/dashboards`)
+    }
 
     // Refresh and persists influxql generated template variable values.
     // If using auth and role is Viewer, temp vars will be stale until dashboard
@@ -456,6 +462,7 @@ DashboardPage.propTypes = {
   onManualRefresh: func.isRequired,
   meRole: string,
   isUsingAuth: bool.isRequired,
+  router: shape().isRequired,
 }
 
 const mapStateToProps = (state, {params: {dashboardID}}) => {
@@ -506,5 +513,5 @@ const mapDispatchToProps = dispatch => ({
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  ManualRefresh(DashboardPage)
+  ManualRefresh(withRouter(DashboardPage))
 )


### PR DESCRIPTION
Connect #2544

### Problem
When explicitly navigating to `/sources/:source_id/dashboards/:dashboard_id` for a `dashboard_id` that doesn't exist yet, Chronograf would render a blank page and spit out errors in the dev console.

### Solution
Check for the dashboard on DashboardPage#componentDidMount, and redirect to `/sources/:source_id/dashboards` if missing.