### PR TITLE
Prevent console error from failed ES6 destructuring when ERROR_THROWN is not from HTTP

### DIFF
--- a/ui/src/shared/middleware/errors.js
+++ b/ui/src/shared/middleware/errors.js
@@ -1,3 +1,5 @@
+import _ from 'lodash'
+
 import {authExpired} from 'shared/actions/auth'
 import {publishNotification as notify} from 'shared/actions/notifications'
 
@@ -17,13 +19,11 @@ const errorsMiddleware = store => next => action => {
   const {auth: {me}} = store.getState()
 
   if (action.type === 'ERROR_THROWN') {
-    const {
-      error: {status, auth, data: {message}},
-      altText,
-      alertType = 'error',
-    } = action
+    const {error, error: {status, auth}, altText, alertType = 'error'} = action
 
     if (status === HTTP_FORBIDDEN) {
+      const message = _.get(error, 'data.message', '')
+
       const organizationWasRemoved =
         message === `user's current organization was not found` // eslint-disable-line quotes
       const wasSessionTimeout = me !== null


### PR DESCRIPTION
  - [ ] Rebased/mergable
  - [ ] Tests pass

Connect #2568 

### The problem
When ERROR_THROWN actions were created by non-AJAX requests, the errors middleware would fail. This is because we were destructuring `error.data.message` on every error, rather than only failed AJAX requests.

This bug was introduced in our client work in #2399.

### The Solution
- Only access error.data.message upon AJAX requests (and actually only 403s currently)
- Use lodash to avoid nested destructuring altogether

