### PR TITLE
Give SuperAdmin DefaultRole on PUT /me

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@
 ### Bug Fixes
 
 ## v1.4.0.0-rc2 [unreleased]
+### UI Improvements
+1. [#2632](https://github.com/influxdata/chronograf/pull/2632): Tell user which organization they switched into and what role they have whenever they switch, including on Source Page
+
 ### Bug Fixes
 1. [#2639](https://github.com/influxdata/chronograf/pull/2639): Prevent SuperAdmin from modifying their own status
+1. [#2632](https://github.com/influxdata/chronograf/pull/2632): Give SuperAdmin DefaultRole when switching to organization where they have no role
 
 ## v1.4.0.0-rc1 [2017-12-19]
 ### Features

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -1301,7 +1301,7 @@ func TestServer(t *testing.T) {
       "organization": "default"
     },
     {
-      "name": "admin",
+      "name": "viewer",
       "organization": "1"
     }
   ],

--- a/server/me.go
+++ b/server/me.go
@@ -11,7 +11,6 @@ import (
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/oauth2"
 	"github.com/influxdata/chronograf/organizations"
-	"github.com/influxdata/chronograf/roles"
 )
 
 type meLinks struct {
@@ -96,7 +95,7 @@ func (s *Service) UpdateMe(auth oauth2.Authenticator) func(http.ResponseWriter, 
 		}
 
 		// validate that the organization exists
-		_, err = s.Store.Organizations(serverCtx).Get(serverCtx, chronograf.OrganizationQuery{ID: &req.Organization})
+		org, err := s.Store.Organizations(serverCtx).Get(serverCtx, chronograf.OrganizationQuery{ID: &req.Organization})
 		if err != nil {
 			Error(w, http.StatusBadRequest, err.Error(), s.Logger)
 			return
@@ -151,8 +150,8 @@ func (s *Service) UpdateMe(auth oauth2.Authenticator) func(http.ResponseWriter, 
 			// If the user is a super admin give them an admin role in the
 			// requested organization.
 			u.Roles = append(u.Roles, chronograf.Role{
-				Organization: req.Organization,
-				Name:         roles.AdminRoleName,
+				Organization: org.ID,
+				Name:         org.DefaultRole,
 			})
 			if err := s.Store.Users(serverCtx).Update(serverCtx, u); err != nil {
 				unknownErrorWithMessage(w, err, s.Logger)

--- a/ui/src/admin/components/chronograf/OrganizationsTable.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTable.js
@@ -44,7 +44,6 @@ class OrganizationsTable extends Component {
       currentOrganization,
       authConfig: {superAdminNewUsers},
       onChangeAuthConfig,
-      me,
     } = this.props
     const {isCreatingOrganization} = this.state
 
@@ -93,7 +92,6 @@ class OrganizationsTable extends Component {
               onRename={onRenameOrg}
               onChooseDefaultRole={onChooseDefaultRole}
               currentOrganization={currentOrganization}
-              userHasRoleInOrg={!!me.organizations.find(o => org.id === o.id)}
             />
           )}
           <Authorized requiredRole={SUPERADMIN_ROLE}>
@@ -145,15 +143,6 @@ OrganizationsTable.propTypes = {
   onChangeAuthConfig: func.isRequired,
   authConfig: shape({
     superAdminNewUsers: bool,
-  }),
-  me: shape({
-    organizations: arrayOf(
-      shape({
-        id: string.isRequired,
-        name: string.isRequired,
-        defaultRole: string.isRequired,
-      })
-    ),
   }),
 }
 export default OrganizationsTable

--- a/ui/src/admin/components/chronograf/OrganizationsTableRow.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRow.js
@@ -39,19 +39,9 @@ class OrganizationsTableRow extends Component {
   }
 
   handleChangeCurrentOrganization = async () => {
-    const {
-      router,
-      links,
-      meChangeOrganization,
-      organization,
-      userHasRoleInOrg,
-    } = this.props
+    const {router, links, meChangeOrganization, organization} = this.props
 
-    await meChangeOrganization(
-      links.me,
-      {organization: organization.id},
-      {userHasRoleInOrg}
-    )
+    await meChangeOrganization(links.me, {organization: organization.id})
     router.push('')
   }
 
@@ -204,7 +194,7 @@ class OrganizationsTableRow extends Component {
   }
 }
 
-const {arrayOf, bool, func, shape, string} = PropTypes
+const {arrayOf, func, shape, string} = PropTypes
 
 OrganizationsTableRow.propTypes = {
   organization: shape({
@@ -235,7 +225,6 @@ OrganizationsTableRow.propTypes = {
     }),
   }),
   meChangeOrganization: func.isRequired,
-  userHasRoleInOrg: bool.isRequired,
 }
 
 OrganizationsTableRowDeleteButton.propTypes = {

--- a/ui/src/shared/actions/auth.js
+++ b/ui/src/shared/actions/auth.js
@@ -5,6 +5,8 @@ import {linksReceived} from 'shared/actions/links'
 import {publishAutoDismissingNotification} from 'shared/dispatchers'
 import {errorThrown} from 'shared/actions/errors'
 
+import {LONG_NOTIFICATION_DISMISS_DELAY} from 'shared/constants'
+
 export const authExpired = auth => ({
   type: 'AUTH_EXPIRED',
   payload: {
@@ -84,18 +86,20 @@ export const getMeAsync = ({shouldResetMe = false} = {}) => async dispatch => {
 
 export const meChangeOrganizationAsync = (
   url,
-  organization,
-  {userHasRoleInOrg = true} = {}
+  organization
 ) => async dispatch => {
   dispatch(meChangeOrganizationRequested())
   try {
     const {data: me, auth, logoutLink} = await updateMeAJAX(url, organization)
+    const currentRole = me.roles.find(
+      r => r.organization === me.currentOrganization.id
+    )
     dispatch(
       publishAutoDismissingNotification(
         'success',
-        `Now signed in to ${me.currentOrganization.name}${userHasRoleInOrg
-          ? ''
-          : ' with Admin role.'}`
+        `Now logged in to '${me.currentOrganization
+          .name}' as '${currentRole.name}'`,
+        LONG_NOTIFICATION_DISMISS_DELAY
       )
     )
     dispatch(meChangeOrganizationCompleted())

--- a/ui/src/shared/constants/index.js
+++ b/ui/src/shared/constants/index.js
@@ -387,6 +387,7 @@ export const PRESENTATION_MODE_ANIMATION_DELAY = 0 // In milliseconds.
 export const PRESENTATION_MODE_NOTIFICATION_DELAY = 2000 // In milliseconds.
 
 export const SHORT_NOTIFICATION_DISMISS_DELAY = 2000 // in milliseconds
+export const LONG_NOTIFICATION_DISMISS_DELAY = 4000 // in milliseconds
 
 export const REVERT_STATE_DELAY = 1500 // ms
 

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -10,6 +10,7 @@ import {
 import {publishNotification} from 'shared/actions/notifications'
 import {connect} from 'react-redux'
 
+import Notifications from 'shared/components/Notifications'
 import SourceForm from 'src/sources/components/SourceForm'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 import SourceIndicator from 'shared/components/SourceIndicator'
@@ -200,42 +201,45 @@ class SourcePage extends Component {
     }
 
     return (
-      <div className={`${isInitialSource ? '' : 'page'}`}>
-        {isInitialSource
-          ? null
-          : <div className="page-header">
-              <div className="page-header__container page-header__source-page">
-                <div className="page-header__col-md-8">
-                  <div className="page-header__left">
-                    <h1 className="page-header__title">
-                      {editMode ? 'Edit Source' : 'Add a New Source'}
-                    </h1>
-                  </div>
-                  <div className="page-header__right">
-                    <SourceIndicator />
+      <div>
+        <Notifications />
+        <div className={`${isInitialSource ? '' : 'page'}`}>
+          {isInitialSource
+            ? null
+            : <div className="page-header">
+                <div className="page-header__container page-header__source-page">
+                  <div className="page-header__col-md-8">
+                    <div className="page-header__left">
+                      <h1 className="page-header__title">
+                        {editMode ? 'Edit Source' : 'Add a New Source'}
+                      </h1>
+                    </div>
+                    <div className="page-header__right">
+                      <SourceIndicator />
+                    </div>
                   </div>
                 </div>
-              </div>
-            </div>}
-        <FancyScrollbar className="page-contents">
-          <div className="container-fluid">
-            <div className="row">
-              <div className="col-md-8 col-md-offset-2">
-                <div className="panel panel-minimal">
-                  <SourceForm
-                    source={source}
-                    editMode={editMode}
-                    onInputChange={this.handleInputChange}
-                    onSubmit={this.handleSubmit}
-                    onBlurSourceURL={this.handleBlurSourceURL}
-                    isInitialSource={isInitialSource}
-                    gotoPurgatory={this.gotoPurgatory}
-                  />
+              </div>}
+          <FancyScrollbar className="page-contents">
+            <div className="container-fluid">
+              <div className="row">
+                <div className="col-md-8 col-md-offset-2">
+                  <div className="panel panel-minimal">
+                    <SourceForm
+                      source={source}
+                      editMode={editMode}
+                      onInputChange={this.handleInputChange}
+                      onSubmit={this.handleSubmit}
+                      onBlurSourceURL={this.handleBlurSourceURL}
+                      isInitialSource={isInitialSource}
+                      gotoPurgatory={this.gotoPurgatory}
+                    />
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        </FancyScrollbar>
+          </FancyScrollbar>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
Previously, SuperAdmins were given the admin role in an organization
when they switched into it (via a PUT to /me). This is undesireable for
the comonitoring organization. This PR gives SuperAdmins the default
role for the organization when they switch into it.


Additionally, this makes it so that when any user switches organizations, they see a longer-displayed notification that clarifies which organization and what role they have switched into, using the terminology `logged in`. And this will happen regardless of whether they were a SuperAdmin or not, and whether (if SuperAdmin) that SuperAdmin had a role in the org before or not.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass

Connect #2641
Connect https://github.com/influxdata/chronograf/issues/2636