### PR TITLE
Prevent SuperAdmin from modifying their own status

### DIFF
--- a/server/users.go
+++ b/server/users.go
@@ -283,7 +283,7 @@ func (s *Service) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	// If the user being updated is the user making the request and they are
 	// changing their SuperAdmin status, return an unauthorized error
-	if ctxUser.ID == u.ID && req.SuperAdmin != u.SuperAdmin {
+	if ctxUser.ID == u.ID && u.SuperAdmin == true && req.SuperAdmin == false {
 		Error(w, http.StatusUnauthorized, "user cannot modify their own SuperAdmin status", s.Logger)
 		return
 	}

--- a/ui/src/admin/components/chronograf/UsersTableRow.js
+++ b/ui/src/admin/components/chronograf/UsersTableRow.js
@@ -59,6 +59,7 @@ const UsersTableRow = ({
             active={user.superAdmin}
             onToggle={onChangeSuperAdmin(user)}
             size="xs"
+            disabled={userIsMe}
           />
         </td>
       </Authorized>

--- a/ui/src/shared/components/SlideToggle.js
+++ b/ui/src/shared/components/SlideToggle.js
@@ -14,7 +14,11 @@ class SlideToggle extends Component {
   }
 
   handleClick = () => {
-    const {onToggle} = this.props
+    const {onToggle, disabled} = this.props
+
+    if (disabled) {
+      return
+    }
 
     this.setState({active: !this.state.active}, () => {
       onToggle(this.state.active)
@@ -22,15 +26,15 @@ class SlideToggle extends Component {
   }
 
   render() {
-    const {size} = this.props
+    const {size, disabled} = this.props
     const {active} = this.state
 
-    const classNames = active
-      ? `slide-toggle slide-toggle__${size} active`
-      : `slide-toggle slide-toggle__${size}`
+    const className = `slide-toggle slide-toggle__${size} ${active
+      ? 'active'
+      : null} ${disabled ? 'disabled' : null}`
 
     return (
-      <div className={classNames} onClick={this.handleClick}>
+      <div className={className} onClick={this.handleClick}>
         <div className="slide-toggle--knob" />
       </div>
     )
@@ -46,6 +50,7 @@ SlideToggle.propTypes = {
   active: bool,
   size: string,
   onToggle: func.isRequired,
+  disabled: bool,
 }
 
 export default SlideToggle

--- a/ui/src/style/components/slide-toggle.scss
+++ b/ui/src/style/components/slide-toggle.scss
@@ -29,12 +29,30 @@
   }
 }
 
+/* Active State */
 .slide-toggle.active .slide-toggle--knob {
   background-color: $c-rainforest;
   transform: translate(100%,-50%);
 }
 .slide-toggle.active:hover .slide-toggle--knob {
   background-color: $c-honeydew;
+}
+
+/* Disabled State */
+.slide-toggle.disabled {
+  &,
+  &:hover,
+  &.active,
+  &.active:hover {
+    background-color: $g6-smoke;
+    cursor: not-allowed;
+  }
+  .slide-toggle--knob,
+  &:hover .slide-toggle--knob,
+  &.active .slide-toggle--knob,
+  &.active:hover .slide-toggle--knob {
+    background-color: $g3-castle;
+  }
 }
 
 /* Size Modifiers */


### PR DESCRIPTION
Previously it was possible for SuperAdmins to remove their own status.
This could create an application state where there were no super admins.
This is not an acceptable application state.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [ ] Tests pass

Connect #2638


