### PR TITLE
Fix SourcePage render & render Page Header for user context when adding initial source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## v1.4.0.0 [unreleased]
 ### Features
+
 ### UI Improvements
+1. [#2652](https://github.com/influxdata/chronograf/pull/2652): Add page header with instructional copy when adding initial source for consistency and clearer UX
+
 ### Bug Fixes
+1. [#2652](https://github.com/influxdata/chronograf/pull/2652): Make page render successfully when attempting to edit a source
 
 ## v1.4.0.0-rc2 [2017-12-21]
 ### UI Improvements

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -203,22 +203,22 @@ class SourcePage extends Component {
     return (
       <div className={`${isInitialSource ? '' : 'page'}`}>
         <Notifications />
-        {isInitialSource
-          ? null
-          : <div className="page-header">
-              <div className="page-header__container page-header__source-page">
-                <div className="page-header__col-md-8">
-                  <div className="page-header__left">
-                    <h1 className="page-header__title">
-                      {editMode ? 'Edit Source' : 'Add a New Source'}
-                    </h1>
-                  </div>
-                  <div className="page-header__right">
-                    <SourceIndicator />
-                  </div>
-                </div>
+        <div className="page-header">
+          <div className="page-header__container page-header__source-page">
+            <div className="page-header__col-md-8">
+              <div className="page-header__left">
+                <h1 className="page-header__title">
+                  {editMode ? 'Edit Source' : 'Add a New Source'}
+                </h1>
               </div>
-            </div>}
+              {isInitialSource
+                ? null
+                : <div className="page-header__right">
+                    <SourceIndicator />
+                  </div>}
+            </div>
+          </div>
+        </div>
         <FancyScrollbar className="page-contents">
           <div className="container-fluid">
             <div className="row">

--- a/ui/src/sources/containers/SourcePage.js
+++ b/ui/src/sources/containers/SourcePage.js
@@ -201,45 +201,43 @@ class SourcePage extends Component {
     }
 
     return (
-      <div>
+      <div className={`${isInitialSource ? '' : 'page'}`}>
         <Notifications />
-        <div className={`${isInitialSource ? '' : 'page'}`}>
-          {isInitialSource
-            ? null
-            : <div className="page-header">
-                <div className="page-header__container page-header__source-page">
-                  <div className="page-header__col-md-8">
-                    <div className="page-header__left">
-                      <h1 className="page-header__title">
-                        {editMode ? 'Edit Source' : 'Add a New Source'}
-                      </h1>
-                    </div>
-                    <div className="page-header__right">
-                      <SourceIndicator />
-                    </div>
+        {isInitialSource
+          ? null
+          : <div className="page-header">
+              <div className="page-header__container page-header__source-page">
+                <div className="page-header__col-md-8">
+                  <div className="page-header__left">
+                    <h1 className="page-header__title">
+                      {editMode ? 'Edit Source' : 'Add a New Source'}
+                    </h1>
                   </div>
-                </div>
-              </div>}
-          <FancyScrollbar className="page-contents">
-            <div className="container-fluid">
-              <div className="row">
-                <div className="col-md-8 col-md-offset-2">
-                  <div className="panel panel-minimal">
-                    <SourceForm
-                      source={source}
-                      editMode={editMode}
-                      onInputChange={this.handleInputChange}
-                      onSubmit={this.handleSubmit}
-                      onBlurSourceURL={this.handleBlurSourceURL}
-                      isInitialSource={isInitialSource}
-                      gotoPurgatory={this.gotoPurgatory}
-                    />
+                  <div className="page-header__right">
+                    <SourceIndicator />
                   </div>
                 </div>
               </div>
+            </div>}
+        <FancyScrollbar className="page-contents">
+          <div className="container-fluid">
+            <div className="row">
+              <div className="col-md-8 col-md-offset-2">
+                <div className="panel panel-minimal">
+                  <SourceForm
+                    source={source}
+                    editMode={editMode}
+                    onInputChange={this.handleInputChange}
+                    onSubmit={this.handleSubmit}
+                    onBlurSourceURL={this.handleBlurSourceURL}
+                    isInitialSource={isInitialSource}
+                    gotoPurgatory={this.gotoPurgatory}
+                  />
+                </div>
+              </div>
             </div>
-          </FancyScrollbar>
-        </div>
+          </div>
+        </FancyScrollbar>
       </div>
     )
   }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #2649
Connect #2651

### The problem
1. The Source edit page was no longer rendering successfully.
1. The Source edit page did not communicate direction to the user as to what to do when adding their initial source, and the styles of the page header were inconsistent with the rest of the app.

### The Solution
1. Fix the rendering by removing the outer `<div>` & make `<Notifications />` a sibling component on `<SourcePage>`.
1. Narrow the scope of rendering logic for `isInitialSource` to ensure a Page Header with `Add a new source` copy is always included when the user is adding their initial source.
