### PR TITLE
Fix positioning of CustomTimeIndicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 1. [#2652](https://github.com/influxdata/chronograf/pull/2652): Make page render successfully when attempting to edit a source
+1. [#2664](https://github.com/influxdata/chronograf/pull/2664): Fix CustomTimeIndicator positioning
 
 ## v1.4.0.0-rc2 [2017-12-21]
 ### UI Improvements

--- a/ui/src/shared/components/LayoutCell.js
+++ b/ui/src/shared/components/LayoutCell.js
@@ -57,6 +57,7 @@ class LayoutCell extends Component {
         <Authorized requiredRole={EDITOR_ROLE}>
           <LayoutCellMenu
             cell={cell}
+            queries={queries}
             dataExists={!!celldata.length}
             isDeleting={isDeleting}
             isEditable={isEditable}
@@ -67,11 +68,7 @@ class LayoutCell extends Component {
             onCSVDownload={this.handleCSVDownload}
           />
         </Authorized>
-        <LayoutCellHeader
-          queries={queries}
-          cellName={cell.name}
-          isEditable={isEditable}
-        />
+        <LayoutCellHeader cellName={cell.name} isEditable={isEditable} />
         <div className="dash-graph--container">
           {queries.length
             ? children

--- a/ui/src/shared/components/LayoutCellHeader.js
+++ b/ui/src/shared/components/LayoutCellHeader.js
@@ -1,14 +1,11 @@
 import React, {PropTypes} from 'react'
-
-import CustomTimeIndicator from 'shared/components/CustomTimeIndicator'
-
 import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants/index'
 
-const LayoutCellHeader = ({queries, isEditable, cellName}) => {
+const LayoutCellHeader = ({isEditable, cellName}) => {
   const cellNameIsDefault = cellName === NEW_DEFAULT_DASHBOARD_CELL.name
 
   const headingClass = `dash-graph--heading ${isEditable
-    ? 'dash-graph--heading-draggable'
+    ? 'dash-graph--draggable dash-graph--heading-draggable'
     : ''}`
 
   return (
@@ -21,20 +18,14 @@ const LayoutCellHeader = ({queries, isEditable, cellName}) => {
         }
       >
         {cellName}
-        <div className="dash-graph--custom-indicators">
-          {queries && queries.length
-            ? <CustomTimeIndicator queries={queries} />
-            : null}
-        </div>
       </span>
     </div>
   )
 }
 
-const {arrayOf, bool, shape, string} = PropTypes
+const {bool, string} = PropTypes
 
 LayoutCellHeader.propTypes = {
-  queries: arrayOf(shape()),
   isEditable: bool,
   cellName: string,
 }

--- a/ui/src/shared/components/LayoutCellMenu.js
+++ b/ui/src/shared/components/LayoutCellMenu.js
@@ -1,61 +1,62 @@
 import React, {PropTypes} from 'react'
 import OnClickOutside from 'react-onclickoutside'
+import CustomTimeIndicator from 'shared/components/CustomTimeIndicator'
 
 const LayoutCellMenu = OnClickOutside(
   ({
-    isDeleting,
-    onEdit,
-    onDeleteClick,
-    onDelete,
-    onCSVDownload,
-    dataExists,
     cell,
+    onEdit,
+    queries,
+    onDelete,
+    isEditable,
+    dataExists,
+    isDeleting,
+    onDeleteClick,
+    onCSVDownload,
   }) =>
-    <div
-      className={
-        isDeleting
-          ? 'dash-graph-context dash-graph-context__deleting'
-          : 'dash-graph-context'
-      }
-    >
-      <div className="dash-graph-context--button" onClick={onEdit(cell)}>
-        <span className="icon pencil" />
+    <div className="dash-graph-context">
+      <div
+        className={`${isEditable
+          ? 'dash-graph--custom-indicators dash-graph--draggable'
+          : 'dash-graph--custom-indicators'}`}
+      >
+        {queries && queries.length && <CustomTimeIndicator queries={queries} />}
       </div>
-      {dataExists
-        ? <div
-            className="dash-graph-context--button"
-            onClick={onCSVDownload(cell)}
-          >
-            <span className="icon download" />
+      {isEditable &&
+        <div clasnName="dash-graph--buttons">
+          <div className="dash-graph-context--button" onClick={onEdit(cell)}>
+            <span className="icon pencil" />
           </div>
-        : null}
-      {isDeleting
-        ? <div className="dash-graph-context--button active">
-            <span className="icon trash" />
+          {dataExists &&
             <div
-              className="dash-graph-context--confirm"
-              onClick={onDelete(cell)}
+              className="dash-graph-context--button"
+              onClick={onCSVDownload(cell)}
             >
-              Confirm
-            </div>
-          </div>
-        : <div className="dash-graph-context--button" onClick={onDeleteClick}>
-            <span className="icon trash" />
-          </div>}
+              <span className="icon download" />
+            </div>}
+          {isDeleting
+            ? <div className="dash-graph-context--button active">
+                <span className="icon trash" />
+                <div
+                  className="dash-graph-context--confirm"
+                  onClick={onDelete(cell)}
+                >
+                  Confirm
+                </div>
+              </div>
+            : <div
+                className="dash-graph-context--button"
+                onClick={onDeleteClick}
+              >
+                <span className="icon trash" />
+              </div>}
+        </div>}
     </div>
 )
 
-const LayoutCellMenuContainer = props => {
-  if (!props.isEditable) {
-    return null
-  }
+const {arrayOf, bool, func, shape} = PropTypes
 
-  return <LayoutCellMenu {...props} />
-}
-
-const {bool, func, shape} = PropTypes
-
-LayoutCellMenuContainer.propTypes = {
+LayoutCellMenu.propTypes = {
   isDeleting: bool,
   onEdit: func,
   onDelete: func,
@@ -63,8 +64,7 @@ LayoutCellMenuContainer.propTypes = {
   cell: shape(),
   isEditable: bool,
   dataExists: bool,
+  queries: arrayOf(shape()),
 }
 
-LayoutCellMenu.propTypes = LayoutCellMenuContainer.propTypes
-
-export default LayoutCellMenuContainer
+export default LayoutCellMenu

--- a/ui/src/shared/components/LayoutCellMenu.js
+++ b/ui/src/shared/components/LayoutCellMenu.js
@@ -20,10 +20,10 @@ const LayoutCellMenu = OnClickOutside(
           ? 'dash-graph--custom-indicators dash-graph--draggable'
           : 'dash-graph--custom-indicators'}`}
       >
-        {queries && queries.length && <CustomTimeIndicator queries={queries} />}
+        {queries && <CustomTimeIndicator queries={queries} />}
       </div>
       {isEditable &&
-        <div clasnName="dash-graph--buttons">
+        <div className="dash-graph-context--buttons">
           <div className="dash-graph-context--button" onClick={onEdit(cell)}>
             <span className="icon pencil" />
           </div>

--- a/ui/src/shared/components/LayoutRenderer.js
+++ b/ui/src/shared/components/LayoutRenderer.js
@@ -106,7 +106,7 @@ class LayoutRenderer extends Component {
             useCSSTransforms={false}
             onResize={this.handleCellResize}
             onLayoutChange={this.handleLayoutChange}
-            draggableHandle={'.dash-graph--name'}
+            draggableHandle={'.dash-graph--draggable'}
             isDraggable={isDashboard}
             isResizable={isDashboard}
           >

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -186,13 +186,15 @@ $dash-graph-options-arrow: 8px;
 .dash-graph--name.dash-graph--name__default {
   font-style: italic;
 }
+.dash-graph--draggable {
+  cursor: move !important;
+}
 .dash-graph--custom-indicators {
   height: 24px;
   border-radius: 3px;
-  position: absolute;
   top: 3px;
-  right: 0;
   display: flex;
+  cursor: default;
 
   > .custom-indicator,
   > .source-indicator {
@@ -224,6 +226,9 @@ $dash-graph-options-arrow: 8px;
   display: flex;
   align-items: center;
   flex-wrap: nowrap;
+}
+.dash-graph-context--buttons {
+  display: flex;
 }
 .dash-graph-context--button {
   width: 24px;


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2661 

### The problem
![image](https://user-images.githubusercontent.com/7582765/34506423-6b50827a-efe1-11e7-8295-a2a3c66a34c2.png)

### The Solution
This hasn't been the only time we have had to fix the `CustomTimeIndicator`.  This is mostly due  (IMHO) to it being in the wrong place.  For easy-peasy styling the `CustomTimeIndicator` should really be a sibling with the rest of the display flexed context menu buttons.  So, should the button sizes change, adjust, or be plain ol' removed the CTI can change along with it.  

I think the original decision to not put the CTI where it was was to make it 'draggable'.  Fortunately, the `ReactGridLayout` API makes it super easy to indicate which elements should be draggable with an arbitrary classname.  I chose `dash-graph--draggable` whose only job is to indicate which elements are draggable (in this case the cell header and the CTI) and style the cursor with 'move'.  

### Editable Graph
![screen shot 2018-01-02 at 5 33 49 pm](https://user-images.githubusercontent.com/7582765/34506664-b9679f46-efe3-11e7-9318-fcd52d54992d.png)

### Not Editable Graph
![screen shot 2018-01-02 at 5 34 37 pm](https://user-images.githubusercontent.com/7582765/34506667-bb55fa00-efe3-11e7-9f64-c259aba1d419.png)

### Repro
A quick way to test both cases is to pass a boolean literal to the `isEditable` prop in the `Layout` component.