### PR TITLE
Add support for insecure (self-signed) certificates for kapacitor proxy and influxdb write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v1.4.1.0 [unreleased]
+### Features
+### UI Improvements
+### Bug Fixes
+1. [#2689](https://github.com/influxdata/chronograf/pull/2689): Allow insecure (self-signed) certificates for kapacitor and influxdb
+
+
 ## v1.4.0.0 [2017-12-22]
 ### UI Improvements
 1. [#2652](https://github.com/influxdata/chronograf/pull/2652): Add page header with instructional copy when adding initial source for consistency and clearer UX


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2139 

### The problem
Our reverse proxy to influxdb's write and kapacitor's ping and config did not respect self-signed or insecure certificates.

### The Solution
Allows self-signed certificates for influxdb/kapacitor proxy 

