### PR TITLE
Allow for different canned resource paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 1. [#2689](https://github.com/influxdata/chronograf/pull/2689): Allow insecure (self-signed) certificates for kapacitor and influxdb
 
 
+## v1.4.0.1 [unreleased]
+### UI Improvements
+1. [#2690](https://github.com/influxdata/chronograf/pull/2690): Add separate CLI flag for canned sources, kapacitors, dashboards, and organizations
+
 ## v1.4.0.0 [2017-12-22]
 ### UI Improvements
 1. [#2652](https://github.com/influxdata/chronograf/pull/2652): Add page header with instructional copy when adding initial source for consistency and clearer UX

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -1457,6 +1457,7 @@ func TestServer(t *testing.T) {
 
 			// Use testdata directory for the canned data
 			tt.args.server.CannedPath = "testdata"
+			tt.args.server.ResourcesPath = "testdata"
 
 			// This is so that we can use staticly generate jwts
 			tt.args.server.TokenSecret = "secret"

--- a/server/server.go
+++ b/server/server.go
@@ -52,11 +52,12 @@ type Server struct {
 
 	NewSources string `long:"new-sources" description:"Config for adding a new InfluxDB source and Kapacitor server, in JSON as an array of objects, and surrounded by single quotes. E.g. --new-sources='[{\"influxdb\":{\"name\":\"Influx 1\",\"username\":\"user1\",\"password\":\"pass1\",\"url\":\"http://localhost:8086\",\"metaUrl\":\"http://metaurl.com\",\"type\":\"influx-enterprise\",\"insecureSkipVerify\":false,\"default\":true,\"telegraf\":\"telegraf\",\"sharedSecret\":\"cubeapples\"},\"kapacitor\":{\"name\":\"Kapa 1\",\"url\":\"http://localhost:9092\",\"active\":true}}]'" env:"NEW_SOURCES" hidden:"true"`
 
-	Develop      bool          `short:"d" long:"develop" description:"Run server in develop mode."`
-	BoltPath     string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (e.g. './chronograf-v1.db')" env:"BOLT_PATH" default:"chronograf-v1.db"`
-	CannedPath   string        `short:"c" long:"canned-path" description:"Path to directory of pre-canned dashboards and application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
-	TokenSecret  string        `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
-	AuthDuration time.Duration `long:"auth-duration" default:"720h" description:"Total duration of cookie life for authentication (in hours). 0 means authentication expires on browser close." env:"AUTH_DURATION"`
+	Develop       bool          `short:"d" long:"develop" description:"Run server in develop mode."`
+	BoltPath      string        `short:"b" long:"bolt-path" description:"Full path to boltDB file (e.g. './chronograf-v1.db')" env:"BOLT_PATH" default:"chronograf-v1.db"`
+	CannedPath    string        `short:"c" long:"canned-path" description:"Path to directory of pre-canned application layouts (/usr/share/chronograf/canned)" env:"CANNED_PATH" default:"canned"`
+	ResourcesPath string        `long:"resources-path" description:"Path to directory of pre-canned dashboards, sources, kapacitors, and organizations (/usr/share/chronograf/resources)" env:"RESOURCES_PATH" default:"canned"`
+	TokenSecret   string        `short:"t" long:"token-secret" description:"Secret to sign tokens" env:"TOKEN_SECRET"`
+	AuthDuration  time.Duration `long:"auth-duration" default:"720h" description:"Total duration of cookie life for authentication (in hours). 0 means authentication expires on browser close." env:"AUTH_DURATION"`
 
 	GithubClientID     string   `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
 	GithubClientSecret string   `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`
@@ -289,7 +290,7 @@ func (s *Server) newBuilders(logger chronograf.Logger) builders {
 		Dashboards: &MultiDashboardBuilder{
 			Logger: logger,
 			ID:     idgen.NewTime(),
-			Path:   s.CannedPath,
+			Path:   s.ResourcesPath,
 		},
 		Sources: &MultiSourceBuilder{
 			InfluxDBURL:      s.InfluxDBURL,
@@ -297,7 +298,7 @@ func (s *Server) newBuilders(logger chronograf.Logger) builders {
 			InfluxDBPassword: s.InfluxDBPassword,
 			Logger:           logger,
 			ID:               idgen.NewTime(),
-			Path:             s.CannedPath,
+			Path:             s.ResourcesPath,
 		},
 		Kapacitors: &MultiKapacitorBuilder{
 			KapacitorURL:      s.KapacitorURL,
@@ -305,11 +306,11 @@ func (s *Server) newBuilders(logger chronograf.Logger) builders {
 			KapacitorPassword: s.KapacitorPassword,
 			Logger:            logger,
 			ID:                idgen.NewTime(),
-			Path:              s.CannedPath,
+			Path:              s.ResourcesPath,
 		},
 		Organizations: &MultiOrganizationBuilder{
 			Logger: logger,
-			Path:   s.CannedPath,
+			Path:   s.ResourcesPath,
 		},
 	}
 }


### PR DESCRIPTION
Previously, users had to place all canned resources (layouts,
dashboards, sources, kapacitors, and organizations) in a single
directory. This work introduces a way to specify two directories.
One for application layouts and one for the other resources.

Users may still place all resources in a single directory if they'd
like.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass


Connect #



  