### PR TITLE
Link directly to the right config tab from handler section in rule creator.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Features
 1. [#2409](https://github.com/influxdata/chronograf/pull/2409): Allow adding multiple event handlers to a rule
 1. [#2709](https://github.com/influxdata/chronograf/pull/2709): Add "send test alert" button to test kapacitor alert configurations"
+1. [#2708](https://github.com/influxdata/chronograf/pull/2708): Link to specified kapacitor config panel from rule builder alert handlers
 ### UI Improvements
 1. [#2698](https://github.com/influxdata/chronograf/pull/2698): Improve clarity of terminology surrounding InfluxDB & Kapacitor connections
 

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -133,6 +133,10 @@ const Root = React.createClass({
               <Route path="tickscript/:ruleID" component={TickscriptPage} />
               <Route path="kapacitors/new" component={KapacitorPage} />
               <Route path="kapacitors/:id/edit" component={KapacitorPage} />
+              <Route
+                path="kapacitors/:id/edit:hash"
+                component={KapacitorPage}
+              />
               <Route path="kapacitor-tasks" component={KapacitorTasksPage} />
               <Route path="admin-chronograf" component={AdminChronografPage} />
               <Route path="admin-influxdb" component={AdminInfluxDBPage} />

--- a/ui/src/kapacitor/components/AlertTabs.js
+++ b/ui/src/kapacitor/components/AlertTabs.js
@@ -123,16 +123,23 @@ class AlertTabs extends Component {
 
     return cleanProps
   }
+  getInitialIndex = (supportedConfigs, routerLocation) => {
+    if (routerLocation && routerLocation.hash) {
+      const hash = _.replace(routerLocation.hash, '#', '')
+      const index = _.indexOf(_.keys(supportedConfigs), hash)
+      return index >= 0 ? index : 0
+    }
+    return 0
+  }
 
   render() {
     const {configSections} = this.state
-    const {locationState} = this.props
+    const {routerLocation} = this.props
     if (!configSections) {
       return null
     }
     const supportedConfigs = {
       alerta: {
-        index: 0,
         type: 'Alerta',
         enabled: this.getEnabled(configSections, 'alerta'),
         renderComponent: () =>
@@ -144,7 +151,6 @@ class AlertTabs extends Component {
           />,
       },
       hipchat: {
-        index: 1,
         type: 'HipChat',
         enabled: this.getEnabled(configSections, 'hipchat'),
         renderComponent: () =>
@@ -156,7 +162,6 @@ class AlertTabs extends Component {
           />,
       },
       opsgenie: {
-        index: 2,
         type: 'OpsGenie',
         enabled: this.getEnabled(configSections, 'opsgenie'),
         renderComponent: () =>
@@ -168,7 +173,6 @@ class AlertTabs extends Component {
           />,
       },
       pagerduty: {
-        index: 3,
         type: 'PagerDuty',
         enabled: this.getEnabled(configSections, 'pagerduty'),
         renderComponent: () =>
@@ -180,7 +184,6 @@ class AlertTabs extends Component {
           />,
       },
       pushover: {
-        index: 4,
         type: 'Pushover',
         enabled: this.getEnabled(configSections, 'pushover'),
         renderComponent: () =>
@@ -192,7 +195,6 @@ class AlertTabs extends Component {
           />,
       },
       sensu: {
-        index: 5,
         type: 'Sensu',
         enabled: this.getEnabled(configSections, 'sensu'),
         renderComponent: () =>
@@ -204,7 +206,6 @@ class AlertTabs extends Component {
           />,
       },
       slack: {
-        index: 6,
         type: 'Slack',
         enabled: this.getEnabled(configSections, 'slack'),
         renderComponent: () =>
@@ -216,7 +217,6 @@ class AlertTabs extends Component {
           />,
       },
       smtp: {
-        index: 7,
         type: 'SMTP',
         enabled: this.getEnabled(configSections, 'smtp'),
         renderComponent: () =>
@@ -228,7 +228,6 @@ class AlertTabs extends Component {
           />,
       },
       talk: {
-        index: 8,
         type: 'Talk',
         enabled: this.getEnabled(configSections, 'talk'),
         renderComponent: () =>
@@ -240,7 +239,6 @@ class AlertTabs extends Component {
           />,
       },
       telegram: {
-        index: 9,
         type: 'Telegram',
         enabled: this.getEnabled(configSections, 'telegram'),
         renderComponent: () =>
@@ -252,7 +250,6 @@ class AlertTabs extends Component {
           />,
       },
       victorops: {
-        index: 10,
         type: 'VictorOps',
         enabled: this.getEnabled(configSections, 'victorops'),
         renderComponent: () =>
@@ -264,7 +261,6 @@ class AlertTabs extends Component {
           />,
       },
     }
-
     return (
       <div>
         <div className="panel panel-minimal">
@@ -275,9 +271,7 @@ class AlertTabs extends Component {
 
         <Tabs
           tabContentsClass="config-endpoint"
-          initialIndex={
-            locationState ? supportedConfigs[locationState.configName].index : 0
-          }
+          initialIndex={this.getInitialIndex(supportedConfigs, routerLocation)}
         >
           <TabList customClass="config-endpoint--tabs">
             {_.reduce(
@@ -329,7 +323,7 @@ AlertTabs.propTypes = {
     }).isRequired,
   }),
   addFlashMessage: func.isRequired,
-  locationState: shape({}),
+  routerLocation: shape({pathname: string, hash: string}).isRequired,
 }
 
 export default AlertTabs

--- a/ui/src/kapacitor/components/AlertTabs.js
+++ b/ui/src/kapacitor/components/AlertTabs.js
@@ -125,12 +125,13 @@ class AlertTabs extends Component {
 
   render() {
     const {configSections} = this.state
-
+    const {locationState} = this.props
     if (!configSections) {
       return null
     }
     const supportedConfigs = {
       alerta: {
+        index: 0,
         type: 'Alerta',
         enabled: this.getEnabled(configSections, 'alerta'),
         renderComponent: () =>
@@ -142,6 +143,7 @@ class AlertTabs extends Component {
           />,
       },
       hipchat: {
+        index: 1,
         type: 'HipChat',
         enabled: this.getEnabled(configSections, 'hipchat'),
         renderComponent: () =>
@@ -153,6 +155,7 @@ class AlertTabs extends Component {
           />,
       },
       opsgenie: {
+        index: 2,
         type: 'OpsGenie',
         enabled: this.getEnabled(configSections, 'opsgenie'),
         renderComponent: () =>
@@ -164,6 +167,7 @@ class AlertTabs extends Component {
           />,
       },
       pagerduty: {
+        index: 3,
         type: 'PagerDuty',
         enabled: this.getEnabled(configSections, 'pagerduty'),
         renderComponent: () =>
@@ -175,6 +179,7 @@ class AlertTabs extends Component {
           />,
       },
       pushover: {
+        index: 4,
         type: 'Pushover',
         enabled: this.getEnabled(configSections, 'pushover'),
         renderComponent: () =>
@@ -186,6 +191,7 @@ class AlertTabs extends Component {
           />,
       },
       sensu: {
+        index: 5,
         type: 'Sensu',
         enabled: this.getEnabled(configSections, 'sensu'),
         renderComponent: () =>
@@ -197,6 +203,7 @@ class AlertTabs extends Component {
           />,
       },
       slack: {
+        index: 6,
         type: 'Slack',
         enabled: this.getEnabled(configSections, 'slack'),
         renderComponent: () =>
@@ -208,6 +215,7 @@ class AlertTabs extends Component {
           />,
       },
       smtp: {
+        index: 7,
         type: 'SMTP',
         enabled: this.getEnabled(configSections, 'smtp'),
         renderComponent: () =>
@@ -219,6 +227,7 @@ class AlertTabs extends Component {
           />,
       },
       talk: {
+        index: 8,
         type: 'Talk',
         enabled: this.getEnabled(configSections, 'talk'),
         renderComponent: () =>
@@ -230,6 +239,7 @@ class AlertTabs extends Component {
           />,
       },
       telegram: {
+        index: 9,
         type: 'Telegram',
         enabled: this.getEnabled(configSections, 'telegram'),
         renderComponent: () =>
@@ -241,6 +251,7 @@ class AlertTabs extends Component {
           />,
       },
       victorops: {
+        index: 10,
         type: 'VictorOps',
         enabled: this.getEnabled(configSections, 'victorops'),
         renderComponent: () =>
@@ -261,7 +272,12 @@ class AlertTabs extends Component {
           </div>
         </div>
 
-        <Tabs tabContentsClass="config-endpoint">
+        <Tabs
+          tabContentsClass="config-endpoint"
+          initialIndex={
+            locationState ? supportedConfigs[locationState.configName].index : 0
+          }
+        >
           <TabList customClass="config-endpoint--tabs">
             {_.reduce(
               configSections,
@@ -312,6 +328,7 @@ AlertTabs.propTypes = {
     }).isRequired,
   }),
   addFlashMessage: func.isRequired,
+  locationState: shape({}),
 }
 
 export default AlertTabs

--- a/ui/src/kapacitor/components/AlertTabs.js
+++ b/ui/src/kapacitor/components/AlertTabs.js
@@ -123,18 +123,16 @@ class AlertTabs extends Component {
 
     return cleanProps
   }
-  getInitialIndex = (supportedConfigs, routerLocation) => {
-    if (routerLocation && routerLocation.hash) {
-      const hash = _.replace(routerLocation.hash, '#', '')
-      const index = _.indexOf(_.keys(supportedConfigs), hash)
-      return index >= 0 ? index : 0
-    }
-    return 0
+
+  getInitialIndex = (supportedConfigs, hash) => {
+    const index = _.indexOf(_.keys(supportedConfigs), _.replace(hash, '#', ''))
+    return index >= 0 ? index : 0
   }
 
   render() {
     const {configSections} = this.state
-    const {routerLocation} = this.props
+    const {hash} = this.props
+
     if (!configSections) {
       return null
     }
@@ -271,7 +269,7 @@ class AlertTabs extends Component {
 
         <Tabs
           tabContentsClass="config-endpoint"
-          initialIndex={this.getInitialIndex(supportedConfigs, routerLocation)}
+          initialIndex={this.getInitialIndex(supportedConfigs, hash)}
         >
           <TabList customClass="config-endpoint--tabs">
             {_.reduce(
@@ -323,7 +321,7 @@ AlertTabs.propTypes = {
     }).isRequired,
   }),
   addFlashMessage: func.isRequired,
-  routerLocation: shape({pathname: string, hash: string}).isRequired,
+  hash: string.isRequired,
 }
 
 export default AlertTabs

--- a/ui/src/kapacitor/components/HandlerOptions.js
+++ b/ui/src/kapacitor/components/HandlerOptions.js
@@ -65,7 +65,7 @@ class HandlerOptions extends Component {
           <EmailHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('smtp')}
             validationError={validationError}
             updateDetails={updateDetails}
             rule={rule}
@@ -76,7 +76,7 @@ class HandlerOptions extends Component {
           <AlertaHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('alerta')}
             validationError={validationError}
           />
         )
@@ -85,7 +85,7 @@ class HandlerOptions extends Component {
           <HipchatHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('hipchat')}
             validationError={validationError}
           />
         )
@@ -94,7 +94,7 @@ class HandlerOptions extends Component {
           <OpsgenieHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('opsgenie')}
             validationError={validationError}
           />
         )
@@ -103,7 +103,7 @@ class HandlerOptions extends Component {
           <PagerdutyHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('pagerduty')}
             validationError={validationError}
           />
         )
@@ -112,7 +112,7 @@ class HandlerOptions extends Component {
           <PushoverHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('pushover')}
             validationError={validationError}
           />
         )
@@ -121,7 +121,7 @@ class HandlerOptions extends Component {
           <SensuHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('sensu')}
             validationError={validationError}
           />
         )
@@ -130,7 +130,7 @@ class HandlerOptions extends Component {
           <SlackHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('slack')}
             validationError={validationError}
           />
         )
@@ -139,7 +139,7 @@ class HandlerOptions extends Component {
           <TalkHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('talk')}
             validationError={validationError}
           />
         )
@@ -148,7 +148,7 @@ class HandlerOptions extends Component {
           <TelegramHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('telegram')}
             validationError={validationError}
           />
         )
@@ -157,7 +157,7 @@ class HandlerOptions extends Component {
           <VictoropsHandler
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
-            onGoToConfig={onGoToConfig}
+            onGoToConfig={onGoToConfig('victorops')}
             validationError={validationError}
           />
         )

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -109,7 +109,13 @@ class KapacitorForm extends Component {
 
   // TODO: move these to another page.  they dont belong on this page
   renderAlertOutputs() {
-    const {exists, kapacitor, addFlashMessage, source} = this.props
+    const {
+      exists,
+      kapacitor,
+      addFlashMessage,
+      source,
+      locationState,
+    } = this.props
 
     if (exists) {
       return (
@@ -117,6 +123,7 @@ class KapacitorForm extends Component {
           source={source}
           kapacitor={kapacitor}
           addFlashMessage={addFlashMessage}
+          locationState={locationState}
         />
       )
     }
@@ -154,6 +161,7 @@ KapacitorForm.propTypes = {
   source: shape({}).isRequired,
   addFlashMessage: func.isRequired,
   exists: bool.isRequired,
+  locationState: shape({}),
 }
 
 export default KapacitorForm

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -109,13 +109,7 @@ class KapacitorForm extends Component {
 
   // TODO: move these to another page.  they dont belong on this page
   renderAlertOutputs() {
-    const {
-      exists,
-      kapacitor,
-      addFlashMessage,
-      source,
-      routerLocation,
-    } = this.props
+    const {exists, kapacitor, addFlashMessage, source, hash} = this.props
 
     if (exists) {
       return (
@@ -123,7 +117,7 @@ class KapacitorForm extends Component {
           source={source}
           kapacitor={kapacitor}
           addFlashMessage={addFlashMessage}
-          routerLocation={routerLocation}
+          hash={hash}
         />
       )
     }
@@ -161,7 +155,7 @@ KapacitorForm.propTypes = {
   source: shape({}).isRequired,
   addFlashMessage: func.isRequired,
   exists: bool.isRequired,
-  routerLocation: shape({pathname: string, hash: string}).isRequired,
+  hash: string.isRequired,
 }
 
 export default KapacitorForm

--- a/ui/src/kapacitor/components/KapacitorForm.js
+++ b/ui/src/kapacitor/components/KapacitorForm.js
@@ -114,7 +114,7 @@ class KapacitorForm extends Component {
       kapacitor,
       addFlashMessage,
       source,
-      locationState,
+      routerLocation,
     } = this.props
 
     if (exists) {
@@ -123,7 +123,7 @@ class KapacitorForm extends Component {
           source={source}
           kapacitor={kapacitor}
           addFlashMessage={addFlashMessage}
-          locationState={locationState}
+          routerLocation={routerLocation}
         />
       )
     }
@@ -161,7 +161,7 @@ KapacitorForm.propTypes = {
   source: shape({}).isRequired,
   addFlashMessage: func.isRequired,
   exists: bool.isRequired,
-  locationState: shape({}),
+  routerLocation: shape({pathname: string, hash: string}).isRequired,
 }
 
 export default KapacitorForm

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -79,8 +79,7 @@ class KapacitorRule extends Component {
     const {rule, configLink, router} = this.props
     if (this.validationError()) {
       router.push({
-        pathname: configLink,
-        state: {configName},
+        pathname: `${configLink}#${configName}`,
       })
     } else if (rule.id === DEFAULT_RULE_ID) {
       this.handleCreate(configLink)

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -75,10 +75,13 @@ class KapacitorRule extends Component {
       })
   }
 
-  handleSaveToConfig = () => {
+  handleSaveToConfig = configName => () => {
     const {rule, configLink, router} = this.props
     if (this.validationError()) {
-      router.push(configLink)
+      router.push({
+        pathname: configLink,
+        state: {configName},
+      })
     } else if (rule.id === DEFAULT_RULE_ID) {
       this.handleCreate(configLink)
     } else {

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -138,7 +138,6 @@ class KapacitorPage extends Component {
   render() {
     const {source, addFlashMessage, location} = this.props
     const {kapacitor, exists} = this.state
-
     return (
       <KapacitorForm
         onSubmit={this.handleSubmit}
@@ -148,7 +147,7 @@ class KapacitorPage extends Component {
         source={source}
         addFlashMessage={addFlashMessage}
         exists={exists}
-        locationState={location.state}
+        routerLocation={location}
       />
     )
   }
@@ -169,7 +168,7 @@ KapacitorPage.propTypes = {
     url: string.isRequired,
     kapacitors: array,
   }),
-  location: shape({}),
+  location: shape({pathname: string, hash: string}).isRequired,
 }
 
 export default withRouter(KapacitorPage)

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -136,7 +136,8 @@ class KapacitorPage extends Component {
   }
 
   render() {
-    const {source, addFlashMessage, location} = this.props
+    const {source, addFlashMessage, location, params} = this.props
+    const hash = (location && location.hash) || (params && params.hash) || ''
     const {kapacitor, exists} = this.state
     return (
       <KapacitorForm
@@ -147,7 +148,7 @@ class KapacitorPage extends Component {
         source={source}
         addFlashMessage={addFlashMessage}
         exists={exists}
-        routerLocation={location}
+        hash={hash}
       />
     )
   }

--- a/ui/src/kapacitor/containers/KapacitorPage.js
+++ b/ui/src/kapacitor/containers/KapacitorPage.js
@@ -136,7 +136,7 @@ class KapacitorPage extends Component {
   }
 
   render() {
-    const {source, addFlashMessage} = this.props
+    const {source, addFlashMessage, location} = this.props
     const {kapacitor, exists} = this.state
 
     return (
@@ -148,6 +148,7 @@ class KapacitorPage extends Component {
         source={source}
         addFlashMessage={addFlashMessage}
         exists={exists}
+        locationState={location.state}
       />
     )
   }
@@ -168,6 +169,7 @@ KapacitorPage.propTypes = {
     url: string.isRequired,
     kapacitors: array,
   }),
+  location: shape({}),
 }
 
 export default withRouter(KapacitorPage)


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2535  

### The problem
All links from alert handler tabs in alert rule builder go to the same config panel. taking user out of context of their workflow. 

### The Solution
Send a state object during router.push and pass it down in order to lookup initial Alert Tab while loading kapacitor configuration page. 


