### PR TITLE
Add auto refresh widget to hosts list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 1. [#2409](https://github.com/influxdata/chronograf/pull/2409): Allow adding multiple event handlers to a rule
 1. [#2709](https://github.com/influxdata/chronograf/pull/2709): Add "send test alert" button to test kapacitor alert configurations"
 1. [#2708](https://github.com/influxdata/chronograf/pull/2708): Link to specified kapacitor config panel from rule builder alert handlers
+1. [#2722](https://github.com/influxdata/chronograf/pull/2722): Add auto refresh widget to hosts list page
 ### UI Improvements
 1. [#2698](https://github.com/influxdata/chronograf/pull/2698): Improve clarity of terminology surrounding InfluxDB & Kapacitor connections
 ### Bug Fixes

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -1,6 +1,5 @@
 import React, {PropTypes, Component} from 'react'
 import {connect} from 'react-redux'
-import {withRouter} from 'react-router'
 import {bindActionCreators} from 'redux'
 import _ from 'lodash'
 
@@ -185,5 +184,5 @@ const mapDispatchToProps = dispatch => ({
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(
-  ManualRefresh(withRouter(HostsPage))
+  ManualRefresh(HostsPage)
 )


### PR DESCRIPTION
  - [X] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] Rebased/mergable
  - [X] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #

### The problem

There is no auto refresh widget on the hosts list page. 
This prevents having a real time summary of hosts and their status.

### The Solution

This PR just adds the widget on the hosts list page as well as the required bindings.

