### PR TITLE
Saving tickscript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## v1.4.1.0 [unreleased]
 ### Features
 1. [#2409](https://github.com/influxdata/chronograf/pull/2409): Allow adding multiple event handlers to a rule
-1. [#2709](https://github.com/influxdata/chronograf/pull/2709): Add "send test alert" button to test kapacitor alert configurations"
+1. [#2709](https://github.com/influxdata/chronograf/pull/2709): Add "send test alert" button to test kapacitor alert configurations
 1. [#2708](https://github.com/influxdata/chronograf/pull/2708): Link to specified kapacitor config panel from rule builder alert handlers
 ### UI Improvements
 1. [#2698](https://github.com/influxdata/chronograf/pull/2698): Improve clarity of terminology surrounding InfluxDB & Kapacitor connections
+1. [#2746](https://github.com/influxdata/chronograf/pull/2746): Separate saving TICKscript from exiting editor page
 ### Bug Fixes
 1. [#2684](https://github.com/influxdata/chronograf/pull/2684): Fix TICKscript Sensu alerts when no group by tags selected
 1. [#2735](https://github.com/influxdata/chronograf/pull/2735): Remove cli options from systemd service file

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -198,7 +198,7 @@ export const updateRuleStatus = (rule, status) => dispatch => {
 export const createTask = (kapacitor, task) => async dispatch => {
   try {
     const {data} = await createTaskAJAX(kapacitor, task)
-    dispatch(publishNotification('success', 'You made a TICKscript!'))
+    dispatch(publishNotification('success', 'TICKscript successfully created'))
     return data
   } catch (error) {
     if (!error) {
@@ -218,14 +218,13 @@ export const updateTask = (
 ) => async dispatch => {
   try {
     const {data} = await updateTaskAJAX(kapacitor, task, ruleID, sourceID)
-    dispatch(publishNotification('success', 'TICKscript updated successully'))
+    dispatch(publishNotification('success', 'TICKscript saved'))
     return data
   } catch (error) {
     if (!error) {
       dispatch(errorThrown('Could not communicate with server'))
       return
     }
-
     return error.data
   }
 }

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -195,12 +195,7 @@ export const updateRuleStatus = (rule, status) => dispatch => {
     })
 }
 
-export const createTask = (
-  kapacitor,
-  task,
-  router,
-  sourceID
-) => async dispatch => {
+export const createTask = (kapacitor, task) => async dispatch => {
   try {
     const {data} = await createTaskAJAX(kapacitor, task)
     dispatch(publishNotification('success', 'You made a TICKscript!'))
@@ -219,54 +214,10 @@ export const updateTask = (
   kapacitor,
   task,
   ruleID,
-  router,
   sourceID
 ) => async dispatch => {
   try {
     const {data} = await updateTaskAJAX(kapacitor, task, ruleID, sourceID)
-    dispatch(publishNotification('success', 'TICKscript updated successully'))
-    return data
-  } catch (error) {
-    if (!error) {
-      dispatch(errorThrown('Could not communicate with server'))
-      return
-    }
-
-    return error.data
-  }
-}
-
-export const createTaskExit = (
-  kapacitor,
-  task,
-  router,
-  sourceID
-) => async dispatch => {
-  try {
-    const {data} = await createTaskAJAX(kapacitor, task)
-    router.push(`/sources/${sourceID}/alert-rules`)
-    dispatch(publishNotification('success', 'TICKscript successfully created.'))
-    return data
-  } catch (error) {
-    if (!error) {
-      dispatch(errorThrown('Could not communicate with server'))
-      return
-    }
-
-    return error.data
-  }
-}
-
-export const updateTaskExit = (
-  kapacitor,
-  task,
-  ruleID,
-  router,
-  sourceID
-) => async dispatch => {
-  try {
-    const {data} = await updateTaskAJAX(kapacitor, task, ruleID, sourceID)
-    router.push(`/sources/${sourceID}/alert-rules`)
     dispatch(publishNotification('success', 'TICKscript updated successully'))
     return data
   } catch (error) {

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -203,7 +203,6 @@ export const createTask = (
 ) => async dispatch => {
   try {
     const {data} = await createTaskAJAX(kapacitor, task)
-    router.push(`/sources/${sourceID}/alert-rules`)
     dispatch(publishNotification('success', 'You made a TICKscript!'))
     return data
   } catch (error) {
@@ -217,6 +216,48 @@ export const createTask = (
 }
 
 export const updateTask = (
+  kapacitor,
+  task,
+  ruleID,
+  router,
+  sourceID
+) => async dispatch => {
+  try {
+    const {data} = await updateTaskAJAX(kapacitor, task, ruleID, sourceID)
+    dispatch(publishNotification('success', 'TICKscript updated successully'))
+    return data
+  } catch (error) {
+    if (!error) {
+      dispatch(errorThrown('Could not communicate with server'))
+      return
+    }
+
+    return error.data
+  }
+}
+
+export const createTaskExit = (
+  kapacitor,
+  task,
+  router,
+  sourceID
+) => async dispatch => {
+  try {
+    const {data} = await createTaskAJAX(kapacitor, task)
+    router.push(`/sources/${sourceID}/alert-rules`)
+    dispatch(publishNotification('success', 'TICKscript successfully created.'))
+    return data
+  } catch (error) {
+    if (!error) {
+      dispatch(errorThrown('Could not communicate with server'))
+      return
+    }
+
+    return error.data
+  }
+}
+
+export const updateTaskExit = (
   kapacitor,
   task,
   ruleID,

--- a/ui/src/kapacitor/components/LogsToggle.js
+++ b/ui/src/kapacitor/components/LogsToggle.js
@@ -1,16 +1,16 @@
 import React, {PropTypes} from 'react'
 
-const LogsToggle = ({areLogsVisible, onToggleLogsVisbility}) =>
+const LogsToggle = ({areLogsVisible, onToggleLogsVisibility}) =>
   <ul className="nav nav-tablist nav-tablist-sm nav-tablist-malachite logs-toggle">
     <li
       className={areLogsVisible ? null : 'active'}
-      onClick={onToggleLogsVisbility}
+      onClick={onToggleLogsVisibility}
     >
       Editor
     </li>
     <li
       className={areLogsVisible ? 'active' : null}
-      onClick={onToggleLogsVisbility}
+      onClick={onToggleLogsVisibility}
     >
       Editor + Logs
     </li>
@@ -20,7 +20,7 @@ const {bool, func} = PropTypes
 
 LogsToggle.propTypes = {
   areLogsVisible: bool,
-  onToggleLogsVisbility: func.isRequired,
+  onToggleLogsVisibility: func.isRequired,
 }
 
 export default LogsToggle

--- a/ui/src/kapacitor/components/Tickscript.js
+++ b/ui/src/kapacitor/components/Tickscript.js
@@ -18,7 +18,7 @@ const Tickscript = ({
   isNewTickscript,
   areLogsVisible,
   areLogsEnabled,
-  onToggleLogsVisbility,
+  onToggleLogsVisibility,
 }) =>
   <div className="page">
     <TickscriptHeader
@@ -26,7 +26,7 @@ const Tickscript = ({
       onSave={onSave}
       areLogsVisible={areLogsVisible}
       areLogsEnabled={areLogsEnabled}
-      onToggleLogsVisbility={onToggleLogsVisbility}
+      onToggleLogsVisibility={onToggleLogsVisibility}
       isNewTickscript={isNewTickscript}
     />
     <div className="page-contents--split">
@@ -58,7 +58,7 @@ Tickscript.propTypes = {
   }),
   areLogsVisible: bool,
   areLogsEnabled: bool,
-  onToggleLogsVisbility: func.isRequired,
+  onToggleLogsVisibility: func.isRequired,
   task: shape({
     id: string,
     script: string,

--- a/ui/src/kapacitor/components/Tickscript.js
+++ b/ui/src/kapacitor/components/Tickscript.js
@@ -11,7 +11,7 @@ const Tickscript = ({
   onExit,
   task,
   logs,
-  validation,
+  consoleMessage,
   onSelectDbrps,
   onChangeScript,
   onChangeType,
@@ -42,10 +42,13 @@ const Tickscript = ({
           onChangeID={onChangeID}
           task={task}
         />
-        <TickscriptEditorConsole validation={validation} />
         <TickscriptEditor
           script={task.tickscript}
           onChangeScript={onChangeScript}
+        />
+        <TickscriptEditorConsole
+          consoleMessage={consoleMessage}
+          unsavedChanges={unsavedChanges}
         />
       </div>
       {areLogsVisible ? <LogsTable logs={logs} /> : null}
@@ -71,7 +74,7 @@ Tickscript.propTypes = {
   }).isRequired,
   onChangeScript: func.isRequired,
   onSelectDbrps: func.isRequired,
-  validation: string,
+  consoleMessage: string,
   onChangeType: func.isRequired,
   onChangeID: func.isRequired,
   isNewTickscript: bool.isRequired,

--- a/ui/src/kapacitor/components/Tickscript.js
+++ b/ui/src/kapacitor/components/Tickscript.js
@@ -8,6 +8,7 @@ import LogsTable from 'src/kapacitor/components/LogsTable'
 
 const Tickscript = ({
   onSave,
+  onSaveAndExit,
   task,
   logs,
   validation,
@@ -15,6 +16,7 @@ const Tickscript = ({
   onChangeScript,
   onChangeType,
   onChangeID,
+  unsavedChanges,
   isNewTickscript,
   areLogsVisible,
   areLogsEnabled,
@@ -24,6 +26,8 @@ const Tickscript = ({
     <TickscriptHeader
       task={task}
       onSave={onSave}
+      unsavedChanges={unsavedChanges}
+      onSaveAndExit={onSaveAndExit}
       areLogsVisible={areLogsVisible}
       areLogsEnabled={areLogsEnabled}
       onToggleLogsVisibility={onToggleLogsVisibility}

--- a/ui/src/kapacitor/components/Tickscript.js
+++ b/ui/src/kapacitor/components/Tickscript.js
@@ -8,7 +8,7 @@ import LogsTable from 'src/kapacitor/components/LogsTable'
 
 const Tickscript = ({
   onSave,
-  onSaveAndExit,
+  onExit,
   task,
   logs,
   validation,
@@ -26,8 +26,8 @@ const Tickscript = ({
     <TickscriptHeader
       task={task}
       onSave={onSave}
+      onExit={onExit}
       unsavedChanges={unsavedChanges}
-      onSaveAndExit={onSaveAndExit}
       areLogsVisible={areLogsVisible}
       areLogsEnabled={areLogsEnabled}
       onToggleLogsVisibility={onToggleLogsVisibility}
@@ -57,6 +57,7 @@ const {arrayOf, bool, func, shape, string} = PropTypes
 Tickscript.propTypes = {
   logs: arrayOf(shape()).isRequired,
   onSave: func.isRequired,
+  onExit: func.isRequired,
   source: shape({
     id: string,
   }),
@@ -74,6 +75,7 @@ Tickscript.propTypes = {
   onChangeType: func.isRequired,
   onChangeID: func.isRequired,
   isNewTickscript: bool.isRequired,
+  unsavedChanges: bool,
 }
 
 export default Tickscript

--- a/ui/src/kapacitor/components/TickscriptEditorConsole.js
+++ b/ui/src/kapacitor/components/TickscriptEditorConsole.js
@@ -2,10 +2,32 @@ import React, {PropTypes} from 'react'
 
 const TickscriptEditorConsole = ({consoleMessage, unsavedChanges}) => {
   let consoleOutput
-    </div>
+  let consoleClass = 'tickscript-console--default'
 
+  if (!unsavedChanges) {
+    consoleOutput = 'TICKscript is valid'
+    consoleClass = 'tickscript-console--valid'
+  } else if (unsavedChanges && !consoleMessage) {
+    consoleOutput = 'You have unsaved changes, save to validate TICKscript'
+    consoleClass = 'tickscript-console--default'
+  } else if (unsavedChanges && consoleMessage) {
+    consoleOutput = consoleMessage
+    consoleClass = 'tickscript-console--error'
+  }
+  return (
+    <div className="tickscript-console">
+      <p className={consoleClass}>
+        {consoleOutput}
+      </p>
+    </div>
+  )
+}
+
+const {bool, string} = PropTypes
 
 TickscriptEditorConsole.propTypes = {
+  consoleMessage: string,
+  unsavedChanges: bool,
 }
 
 export default TickscriptEditorConsole

--- a/ui/src/kapacitor/components/TickscriptEditorConsole.js
+++ b/ui/src/kapacitor/components/TickscriptEditorConsole.js
@@ -1,19 +1,17 @@
 import React, {PropTypes} from 'react'
 
 const TickscriptEditorConsole = ({consoleMessage, unsavedChanges}) => {
-  let consoleOutput
-  let consoleClass = 'tickscript-console--default'
+  let consoleOutput = 'TICKscript is valid'
+  let consoleClass = 'tickscript-console--valid'
 
-  if (!unsavedChanges) {
-    consoleOutput = 'TICKscript is valid'
-    consoleClass = 'tickscript-console--valid'
-  } else if (unsavedChanges && !consoleMessage) {
-    consoleOutput = 'You have unsaved changes, save to validate TICKscript'
-    consoleClass = 'tickscript-console--default'
-  } else if (unsavedChanges && consoleMessage) {
+  if (consoleMessage) {
     consoleOutput = consoleMessage
     consoleClass = 'tickscript-console--error'
+  } else if (unsavedChanges) {
+    consoleOutput = 'You have unsaved changes, save to validate TICKscript'
+    consoleClass = 'tickscript-console--default'
   }
+
   return (
     <div className="tickscript-console">
       <p className={consoleClass}>

--- a/ui/src/kapacitor/components/TickscriptEditorConsole.js
+++ b/ui/src/kapacitor/components/TickscriptEditorConsole.js
@@ -1,22 +1,11 @@
 import React, {PropTypes} from 'react'
 
-const TickscriptEditorConsole = ({validation}) =>
-  <div className="tickscript-console">
-    <div className="tickscript-console--output">
-      {validation
-        ? <p>
-            {validation}
-          </p>
-        : <p className="tickscript-console--default">
-            Save your TICKscript to validate it
-          </p>}
+const TickscriptEditorConsole = ({consoleMessage, unsavedChanges}) => {
+  let consoleOutput
     </div>
-  </div>
 
-const {string} = PropTypes
 
 TickscriptEditorConsole.propTypes = {
-  validation: string,
 }
 
 export default TickscriptEditorConsole

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -2,10 +2,13 @@ import React, {PropTypes} from 'react'
 
 import SourceIndicator from 'shared/components/SourceIndicator'
 import LogsToggle from 'src/kapacitor/components/LogsToggle'
+import ConfirmButton from 'src/shared/components/ConfirmButton'
 
 const TickscriptHeader = ({
   task: {id},
   onSave,
+  onSaveAndExit,
+  unsavedChanges,
   areLogsVisible,
   areLogsEnabled,
   isNewTickscript,
@@ -24,14 +27,36 @@ const TickscriptHeader = ({
         />}
       <div className="page-header__right">
         <SourceIndicator />
-        <button
-          className="btn btn-success btn-sm"
-          title={id ? '' : 'ID your TICKscript to save'}
-          onClick={onSave}
-          disabled={!id}
-        >
-          {isNewTickscript ? 'Save New TICKscript' : 'Save TICKscript'}
-        </button>
+        {isNewTickscript
+          ? <button
+              className="btn btn-success btn-sm"
+              title="ID your TICKscript to save"
+              onClick={onSave}
+              disabled={!id}
+            >
+              Save New TICKscript
+            </button>
+          : <button
+              className="btn btn-success btn-sm"
+              title="You have unsaved changes"
+              onClick={onSave}
+              disabled={!unsavedChanges}
+            >
+              Save Changes
+            </button>}
+        {unsavedChanges
+          ? <ConfirmButton
+              text="Exit"
+              confirmText="This will discard unsaved changes"
+              confirmAction={onSaveAndExit}
+            />
+          : <button
+              className="btn btn-default btn-sm"
+              title="Return to Alert Rules Page"
+              onClick={onSaveAndExit}
+            >
+              Exit
+            </button>}
       </div>
     </div>
   </div>

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -9,7 +9,7 @@ const TickscriptHeader = ({
   areLogsVisible,
   areLogsEnabled,
   isNewTickscript,
-  onToggleLogsVisbility,
+  onToggleLogsVisibility,
 }) =>
   <div className="page-header full-width">
     <div className="page-header__container">
@@ -20,7 +20,7 @@ const TickscriptHeader = ({
         <LogsToggle
           areLogsVisible={areLogsVisible}
           areLogsEnabled={areLogsEnabled}
-          onToggleLogsVisbility={onToggleLogsVisbility}
+          onToggleLogsVisibility={onToggleLogsVisibility}
         />}
       <div className="page-header__right">
         <SourceIndicator />
@@ -43,7 +43,7 @@ TickscriptHeader.propTypes = {
   onSave: func,
   areLogsVisible: bool,
   areLogsEnabled: bool,
-  onToggleLogsVisbility: func.isRequired,
+  onToggleLogsVisibility: func.isRequired,
   task: shape({
     dbrps: arrayOf(
       shape({

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -30,7 +30,7 @@ const TickscriptHeader = ({
         {isNewTickscript
           ? <button
               className="btn btn-success btn-sm"
-              title="ID your TICKscript to save"
+              title="Name your TICKscript to save"
               onClick={onSave}
               disabled={!id}
             >
@@ -52,7 +52,7 @@ const TickscriptHeader = ({
             />
           : <button
               className="btn btn-default btn-sm"
-              title="Return to Alert Rules Page"
+              title="Return to Alert Rules"
               onClick={onExit}
             >
               Exit

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -7,7 +7,7 @@ import ConfirmButton from 'src/shared/components/ConfirmButton'
 const TickscriptHeader = ({
   task: {id},
   onSave,
-  onSaveAndExit,
+  onExit,
   unsavedChanges,
   areLogsVisible,
   areLogsEnabled,
@@ -48,12 +48,12 @@ const TickscriptHeader = ({
           ? <ConfirmButton
               text="Exit"
               confirmText="Discard unsaved changes?"
-              confirmAction={onSaveAndExit}
+              confirmAction={onExit}
             />
           : <button
               className="btn btn-default btn-sm"
               title="Return to Alert Rules Page"
-              onClick={onSaveAndExit}
+              onClick={onExit}
             >
               Exit
             </button>}
@@ -66,6 +66,7 @@ const {arrayOf, bool, func, shape, string} = PropTypes
 TickscriptHeader.propTypes = {
   isNewTickscript: bool,
   onSave: func,
+  onExit: func.isRequired,
   areLogsVisible: bool,
   areLogsEnabled: bool,
   onToggleLogsVisibility: func.isRequired,
@@ -77,6 +78,7 @@ TickscriptHeader.propTypes = {
       })
     ),
   }),
+  unsavedChanges: bool,
 }
 
 export default TickscriptHeader

--- a/ui/src/kapacitor/components/TickscriptHeader.js
+++ b/ui/src/kapacitor/components/TickscriptHeader.js
@@ -47,7 +47,7 @@ const TickscriptHeader = ({
         {unsavedChanges
           ? <ConfirmButton
               text="Exit"
-              confirmText="This will discard unsaved changes"
+              confirmText="Discard unsaved changes?"
               confirmAction={onSaveAndExit}
             />
           : <button

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -24,7 +24,7 @@ class TickscriptPage extends Component {
         dbrps: [],
         type: 'stream',
       },
-      validation: '',
+      consoleMessage: '',
       isEditingID: true,
       logs: [],
       areLogsEnabled: false,
@@ -173,8 +173,11 @@ class TickscriptPage extends Component {
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
       }
-      if (response) {
-        this.setState({unsavedChanges: false})
+      if (response && !response.code) {
+        this.setState({unsavedChanges: false, consoleMessage: ''})
+      }
+      if (response.code) {
+        this.setState({unsavedChanges: true, consoleMessage: response.message})
       }
     } catch (error) {
       console.error(error)
@@ -218,18 +221,18 @@ class TickscriptPage extends Component {
     const {source} = this.props
     const {
       task,
-      validation,
       logs,
       areLogsVisible,
       areLogsEnabled,
       unsavedChanges,
+      consoleMessage,
     } = this.state
     return (
       <Tickscript
         task={task}
         logs={logs}
         source={source}
-        validation={validation}
+        consoleMessage={consoleMessage}
         onSave={this.handleSave}
         unsavedChanges={unsavedChanges}
         onExit={this.handleExit}

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -184,36 +184,10 @@ class TickscriptPage extends Component {
     }
   }
 
-  handleSaveAndExit = async () => {
-    const {kapacitor, task} = this.state
-    const {
-      source: {id: sourceID},
-      router,
-      kapacitorActions: {createTaskExit, updateTaskExit},
-      params: {ruleID},
-    } = this.props
+  handleExit = () => {
+    const {source: {id: sourceID}, router} = this.props
 
-    let response
-
-    try {
-      if (this._isEditing()) {
-        response = await updateTaskExit(
-          kapacitor,
-          task,
-          ruleID,
-          router,
-          sourceID
-        )
-      } else {
-        response = await createTaskExit(kapacitor, task, router, sourceID)
-      }
-      if (response && response.code === 500) {
-        return this.setState({validation: response.message})
-      }
-    } catch (error) {
-      console.error(error)
-      throw error
-    }
+    return router.push(`/sources/${sourceID}/alert-rules`)
   }
 
   handleChangeScript = tickscript => {
@@ -258,7 +232,7 @@ class TickscriptPage extends Component {
         validation={validation}
         onSave={this.handleSave}
         unsavedChanges={unsavedChanges}
-        onSaveAndExit={this.handleSaveAndExit}
+        onExit={this.handleExit}
         isNewTickscript={!this._isEditing()}
         onSelectDbrps={this.handleSelectDbrps}
         onChangeScript={this.handleChangeScript}
@@ -289,8 +263,6 @@ TickscriptPage.propTypes = {
   kapacitorActions: shape({
     updateTask: func.isRequired,
     createTask: func.isRequired,
-    updateTaskExit: func.isRequired,
-    createTaskExit: func.isRequired,
     getRule: func.isRequired,
   }),
   router: shape({

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -198,15 +198,18 @@ class TickscriptPage extends Component {
   }
 
   handleSelectDbrps = dbrps => {
-    this.setState({task: {...this.state.task, dbrps}})
+    this.setState({task: {...this.state.task, dbrps}, unsavedChanges: true})
   }
 
   handleChangeType = type => () => {
-    this.setState({task: {...this.state.task, type}})
+    this.setState({task: {...this.state.task, type}, unsavedChanges: true})
   }
 
   handleChangeID = e => {
-    this.setState({task: {...this.state.task, id: e.target.value}})
+    this.setState({
+      task: {...this.state.task, id: e.target.value},
+      unsavedChanges: true,
+    })
   }
 
   handleToggleLogsVisibility = () => {

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -173,11 +173,9 @@ class TickscriptPage extends Component {
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
       }
-      if (response && response.code === 500) {
-        // check responses on failing??!
-        return this.setState({validation: response.message})
+      if (response) {
+        this.setState({unsavedChanges: false})
       }
-      this.setState({unsavedChanges: false})
     } catch (error) {
       console.error(error)
       throw error
@@ -226,7 +224,6 @@ class TickscriptPage extends Component {
       areLogsEnabled,
       unsavedChanges,
     } = this.state
-
     return (
       <Tickscript
         task={task}

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -173,11 +173,10 @@ class TickscriptPage extends Component {
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
       }
-      if (response && !response.code) {
-        this.setState({unsavedChanges: false, consoleMessage: ''})
-      }
       if (response.code) {
         this.setState({unsavedChanges: true, consoleMessage: response.message})
+      } else {
+        this.setState({unsavedChanges: false, consoleMessage: ''})
       }
     } catch (error) {
       console.error(error)

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -198,7 +198,7 @@ class TickscriptPage extends Component {
     this.setState({task: {...this.state.task, id: e.target.value}})
   }
 
-  handleToggleLogsVisbility = () => {
+  handleToggleLogsVisibility = () => {
     this.setState({areLogsVisible: !this.state.areLogsVisible})
   }
 
@@ -220,7 +220,7 @@ class TickscriptPage extends Component {
         onChangeID={this.handleChangeID}
         areLogsVisible={areLogsVisible}
         areLogsEnabled={areLogsEnabled}
-        onToggleLogsVisbility={this.handleToggleLogsVisbility}
+        onToggleLogsVisibility={this.handleToggleLogsVisibility}
       />
     )
   }

--- a/ui/src/shared/components/ConfirmButton.js
+++ b/ui/src/shared/components/ConfirmButton.js
@@ -1,0 +1,87 @@
+import React, {Component, PropTypes} from 'react'
+
+import OnClickOutside from 'shared/components/OnClickOutside'
+
+class ConfirmButton extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      expanded: false,
+    }
+  }
+
+  handleButtonClick = () => {
+    if (this.props.disabled) {
+      return
+    }
+    this.setState({expanded: !this.state.expanded})
+  }
+
+  handleConfirmClick = () => {
+    this.setState({expanded: false})
+    this.props.confirmAction()
+  }
+
+  handleClickOutside = () => {
+    this.setState({expanded: false})
+  }
+
+  render() {
+    const {
+      text,
+      confirmText,
+      type,
+      size,
+      square,
+      icon,
+      disabled,
+      customClass,
+    } = this.props
+    const {expanded} = this.state
+
+    const customClassString = customClass ? ` ${customClass}` : ''
+    const squareString = square ? ' btn-square' : ''
+    const expandedString = expanded ? ' expanded' : ''
+    const disabledString = disabled ? ' disabled' : ''
+
+    const classname = `confirm-button btn ${type} ${size}${customClassString}${squareString}${expandedString}${disabledString}`
+
+    return (
+      <div className={classname} onClick={this.handleButtonClick}>
+        {icon && <span className={`icon ${icon}`} />}
+        {text && text}
+        <div className="confirm-button--tooltip">
+          <div
+            className="confirm-button--confirmation"
+            onClick={this.handleConfirmClick}
+          >
+            {confirmText}
+          </div>
+        </div>
+      </div>
+    )
+  }
+}
+
+const {bool, func, string} = PropTypes
+
+ConfirmButton.defaultProps = {
+  confirmText: 'Confirm',
+  type: 'btn-default',
+  size: 'btn-sm',
+  square: false,
+}
+ConfirmButton.propTypes = {
+  text: string,
+  confirmText: string,
+  confirmAction: func.isRequired,
+  type: string,
+  size: string,
+  square: bool,
+  icon: string,
+  disabled: bool,
+  customClass: string,
+}
+
+export default OnClickOutside(ConfirmButton)

--- a/ui/src/shared/components/ConfirmButton.js
+++ b/ui/src/shared/components/ConfirmButton.js
@@ -27,6 +27,24 @@ class ConfirmButton extends Component {
     this.setState({expanded: false})
   }
 
+  calculatePosition = () => {
+    if (!this.buttonDiv || !this.tooltipDiv) {
+      return ''
+    }
+
+    const windowWidth = window.innerWidth
+    const buttonRect = this.buttonDiv.getBoundingClientRect()
+    const tooltipRect = this.tooltipDiv.getBoundingClientRect()
+
+    const rightGap = windowWidth - buttonRect.right
+
+    if (tooltipRect.width / 2 > rightGap) {
+      return 'left'
+    }
+
+    return 'bottom'
+  }
+
   render() {
     const {
       text,
@@ -42,19 +60,24 @@ class ConfirmButton extends Component {
 
     const customClassString = customClass ? ` ${customClass}` : ''
     const squareString = square ? ' btn-square' : ''
-    const expandedString = expanded ? ' expanded' : ''
+    const expandedString = expanded ? ' active' : ''
     const disabledString = disabled ? ' disabled' : ''
 
     const classname = `confirm-button btn ${type} ${size}${customClassString}${squareString}${expandedString}${disabledString}`
 
     return (
-      <div className={classname} onClick={this.handleButtonClick}>
+      <div
+        className={classname}
+        onClick={this.handleButtonClick}
+        ref={r => (this.buttonDiv = r)}
+      >
         {icon && <span className={`icon ${icon}`} />}
         {text && text}
-        <div className="confirm-button--tooltip">
+        <div className={`confirm-button--tooltip ${this.calculatePosition()}`}>
           <div
             className="confirm-button--confirmation"
             onClick={this.handleConfirmClick}
+            ref={r => (this.tooltipDiv = r)}
           >
             {confirmText}
           </div>

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -28,6 +28,7 @@
 
 // Components
 @import 'components/ceo-display-options';
+@import 'components/confirm-button';
 @import 'components/confirm-buttons';
 @import 'components/code-mirror-theme';
 @import 'components/color-dropdown';

--- a/ui/src/style/components/confirm-button.scss
+++ b/ui/src/style/components/confirm-button.scss
@@ -1,0 +1,55 @@
+/*
+    Confirm Button
+    ----------------------------------------------------------------------------
+    This button requires a second click to confirm the action
+*/
+
+.confirm-button {
+  .confirm-button--tooltip {
+    visibility: hidden;
+    transition: all;
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 50%;
+    transform: translateX(-50%);
+  }
+}
+.confirm-button--confirmation {
+  border-radius: 3px;
+  background-color: $c-curacao;
+  opacity: 0;
+  padding: 0 7px;
+  color: $g20-white;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  transition: opacity 0.25s ease, background-color 0.25s ease;
+
+  &:after {
+    content: '';
+    border: 8px solid transparent;
+    border-bottom-color: $c-curacao;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    transition: border-color 0.25s ease;
+    z-index: 100;
+  }
+
+  &:hover {
+    background-color: $c-dreamsicle;
+    cursor: pointer;
+  }
+  &:hover:after {
+    border-bottom-color: $c-dreamsicle;
+  }
+}
+.confirm-button.expanded {
+  .confirm-button--tooltip {
+    visibility: visible;
+  }
+  .confirm-button--confirmation {
+    opacity: 1;
+  }
+}

--- a/ui/src/style/components/confirm-button.scss
+++ b/ui/src/style/components/confirm-button.scss
@@ -9,9 +9,18 @@
     visibility: hidden;
     transition: all;
     position: absolute;
-    top: calc(100% + 8px);
-    left: 50%;
-    transform: translateX(-50%);
+
+    &.bottom {
+      top: calc(100% + 4px);
+      left: 50%;
+      transform: translateX(-50%);
+    }
+
+    &.left {
+      top: 50%;
+      right: calc(100% + 4px);
+      transform: translateY(-50%);
+    }
   }
 }
 .confirm-button--confirmation {
@@ -28,11 +37,7 @@
   &:after {
     content: '';
     border: 8px solid transparent;
-    border-bottom-color: $c-curacao;
     position: absolute;
-    bottom: 100%;
-    left: 50%;
-    transform: translateX(-50%);
     transition: border-color 0.25s ease;
     z-index: 100;
   }
@@ -41,11 +46,30 @@
     background-color: $c-dreamsicle;
     cursor: pointer;
   }
-  &:hover:after {
-    border-bottom-color: $c-dreamsicle;
-  }
 }
-.confirm-button.expanded {
+
+.confirm-button--tooltip.bottom .confirm-button--confirmation:after {
+  bottom: 100%;
+  left: 50%;
+  border-bottom-color: $c-curacao;
+  transform: translateX(-50%);
+}
+.confirm-button--tooltip.bottom .confirm-button--confirmation:hover:after {
+  border-bottom-color: $c-dreamsicle;
+}
+.confirm-button--tooltip.left .confirm-button--confirmation:after {
+  left: 100%;
+  top: 50%;
+  border-left-color: $c-curacao;
+  transform: translateY(-50%);
+}
+.confirm-button--tooltip.left .confirm-button--confirmation:hover:after {
+  border-left-color: $c-dreamsicle;
+}
+
+.confirm-button.active {
+  z-index: 999;
+
   .confirm-button--tooltip {
     visibility: visible;
   }

--- a/ui/src/style/pages/tickscript-editor.scss
+++ b/ui/src/style/pages/tickscript-editor.scss
@@ -3,28 +3,26 @@
     ----------------------------------------------------------------------------
 */
 
-$tickscript-console-height: 60px;
+$tickscript-controls-height: 60px;
 
 .tickscript {
   flex: 1 0 0;
+  position: relative;
 }
 .tickscript-controls,
 .tickscript-console,
 .tickscript-editor {
-  padding: 0;
-  margin: 0;
   width: 100%;
-  position: relative;
 }
-.tickscript-controls,
-.tickscript-console {
-  height: $tickscript-console-height;
+.tickscript-console,
+.tickscript-controls {
+  padding: 0 60px;
+  display: flex;
 }
 .tickscript-controls {
-  display: flex;
   align-items: center;
+  height: $tickscript-controls-height;
   justify-content: space-between;
-  padding: 0 60px;
   background-color: $g3-castle;
 }
 .tickscript-controls--name {
@@ -42,29 +40,42 @@ $tickscript-console-height: 60px;
 
   > * {margin-left: 8px;}
 }
-.tickscript-console--output {
-  padding: 0 60px;
-  font-family: $code-font;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  background-color: $g2-kevlar;
-  border-bottom: 2px solid $g3-castle;
-  position: relative;
-  height: 100%;
-  width: 100%;
-  border-radius: $radius $radius 0 0;
+.tickscript-console {
+  align-items: flex-start;
+  height: $tickscript-controls-height * 2.25;
+  border-top: 2px solid $g3-castle;
+  background-color: $g0-obsidian;
+  overflow-y: scroll;
+  @include custom-scrollbar($g0-obsidian,$g4-onyx);
 
   > p {
-    margin: 0;
+    position: relative;
+    padding-left: 16px;
+    font-family: $code-font;
+    margin: 11px 0;
+    font-weight: 700;
+    word-wrap: break-word;
+    word-break: break-word;
+
+    &:before {
+      content: '>';
+      position: absolute;
+      top: 0;
+      left: 0;
+    }
   }
 }
 .tickscript-console--default {
-  color: $g10-wolf;
-  font-style: italic;
+  color: $g13-mist;
+}
+.tickscript-console--valid {
+  color: $c-rainforest;
+}
+.tickscript-console--error {
+  color: $c-dreamsicle;
 }
 .tickscript-editor {
-  height: calc(100% - #{$tickscript-console-height * 2});
+  height: calc(100% - #{$tickscript-controls-height * 3.25});
 }
 
 /*


### PR DESCRIPTION
- [x] CHANGELOG.md updated with a link to the PR (not the Issue)
- [x] Rebased/mergable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2674 
Connect #2747
Connect #2709 

### The problem
It was difficult to iterate on TICKscripts because saving any changes routed user to Alert Rules page.  Also, TICKscript errors from Kapacitor were not being reported to user. 

### The Solution
Separate Save and Exit buttons, and display Kapacitor response messages in TICKscript editor console.