### PR TITLE
Remove cli defaults form sysvinit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 1. [#2684](https://github.com/influxdata/chronograf/pull/2684): Fix TICKscript Sensu alerts when no group by tags selected
 1. [#2735](https://github.com/influxdata/chronograf/pull/2735): Remove cli options from systemd service file
+1. [#2761](https://github.com/influxdata/chronograf/pull/2761): Remove cli options from sysvinit service file
 
 ## v1.4.0.1 [2017-1-9]
 ### Features

--- a/etc/scripts/init.sh
+++ b/etc/scripts/init.sh
@@ -12,9 +12,13 @@
 
 # Script to execute when starting
 SCRIPT="/usr/bin/chronograf"
+export HOST="0.0.0.0"
+export PORT="8888"
+export BOLT_PATH="/var/lib/chronograf/chronograf-v1.db"
+export CANNED_PATH="/usr/share/chronograf/canned"
 # Options to pass to the script on startup
 . /etc/default/chronograf
-SCRIPT_OPTS="--host 0.0.0.0 --port 8888 -b /var/lib/chronograf/chronograf-v1.db -c /usr/share/chronograf/canned ${CHRONOGRAF_OPTS}"
+SCRIPT_OPTS="${CHRONOGRAF_OPTS}"
 
 # User to run the process under
 RUNAS=chronograf


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2165

### The problem
Sysvinit used cli defaults instead of env vars

### The Solution
Change the cli options to env vars


