### PR TITLE
Allow user to delete themselves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 1. [#2708](https://github.com/influxdata/chronograf/pull/2708): Link to specified kapacitor config panel from rule builder alert handlers
 1. [#2722](https://github.com/influxdata/chronograf/pull/2722): Add auto refresh widget to hosts list page
 1. [#2765](https://github.com/influxdata/chronograf/pull/2765): Update to go 1.9.3 and node 6.12.3 for releases
-1. [#2703](https://github.com/influxdata/chronograf/pull/2703): Add global users page visible only to super admins 
+1. [#2703](https://github.com/influxdata/chronograf/pull/2703): Add global users page visible only to super admins
+1. [#2777](https://github.com/influxdata/chronograf/pull/2777): Allow user to delete themselves
 ### UI Improvements
 1. [#2698](https://github.com/influxdata/chronograf/pull/2698): Improve clarity of terminology surrounding InfluxDB & Kapacitor connections
 1. [#2746](https://github.com/influxdata/chronograf/pull/2746): Separate saving TICKscript from exiting editor page

--- a/server/users.go
+++ b/server/users.go
@@ -225,15 +225,6 @@ func (s *Service) RemoveUser(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusNotFound, err.Error(), s.Logger)
 		return
 	}
-	ctxUser, ok := hasUserContext(ctx)
-	if !ok {
-		Error(w, http.StatusBadRequest, "failed to retrieve user from context", s.Logger)
-		return
-	}
-	if ctxUser.ID == u.ID {
-		Error(w, http.StatusForbidden, "user cannot delete themselves", s.Logger)
-		return
-	}
 	if err := s.Store.Users(ctx).Delete(ctx, u); err != nil {
 		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
 		return

--- a/server/users_test.go
+++ b/server/users_test.go
@@ -663,8 +663,8 @@ func TestService_RemoveUser(t *testing.T) {
 				},
 				id: "1339",
 			},
-			wantStatus: http.StatusForbidden,
-			wantBody:   `{"code":403,"message":"user cannot delete themselves"}`,
+			wantStatus: http.StatusNoContent,
+			wantBody:   ``,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Previously users were prevented from removing themselves.

Connect https://github.com/influxdata/chronograf/issues/2711


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

