### PR TITLE
Bugfix/alert rule save routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#2684](https://github.com/influxdata/chronograf/pull/2684): Fix TICKscript Sensu alerts when no group by tags selected
 1. [#2735](https://github.com/influxdata/chronograf/pull/2735): Remove cli options from systemd service file
 1. [#2761](https://github.com/influxdata/chronograf/pull/2761): Remove cli options from sysvinit service file
+1. [#2780](https://github.com/influxdata/chronograf/pull/2780): Fix routing on alert save
 
 ## v1.4.0.1 [2017-1-9]
 ### Features

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -77,14 +77,15 @@ class KapacitorRule extends Component {
 
   handleSaveToConfig = configName => () => {
     const {rule, configLink, router} = this.props
+    const pathname = `${configLink}#${configName}`
     if (this.validationError()) {
       router.push({
-        pathname: `${configLink}#${configName}`,
+        pathname,
       })
     } else if (rule.id === DEFAULT_RULE_ID) {
-      this.handleCreate(configLink)
+      this.handleCreate(pathname)
     } else {
-      this.handleEdit(configLink)
+      this.handleEdit(pathname)
     }
   }
 

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -91,7 +91,9 @@ class KapacitorRule extends Component {
       router.push({
         pathname,
       })
-    } else if (rule.id === DEFAULT_RULE_ID) {
+      return
+    }
+    if (rule.id === DEFAULT_RULE_ID) {
       this.handleCreate(pathname)
     } else {
       this.handleEdit(pathname)

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -75,6 +75,15 @@ class KapacitorRule extends Component {
       })
   }
 
+  handleSave = () => {
+    const {rule} = this.props
+    if (rule.id === DEFAULT_RULE_ID) {
+      this.handleCreate()
+    } else {
+      this.handleEdit()
+    }
+  }
+
   handleSaveToConfig = configName => () => {
     const {rule, configLink, router} = this.props
     const pathname = `${configLink}#${configName}`
@@ -161,19 +170,11 @@ class KapacitorRule extends Component {
     const {chooseTrigger, updateRuleValues} = ruleActions
     const {timeRange} = this.state
 
-    const onSave = () => {
-      if (rule.id === DEFAULT_RULE_ID) {
-        this.handleCreate()
-      } else {
-        this.handleEdit()
-      }
-    }
-
     return (
       <div className="page">
         <RuleHeader
           source={source}
-          onSave={onSave}
+          onSave={this.handleSave}
           validationError={this.validationError()}
         />
         <FancyScrollbar className="page-contents fancy-scroll--kapacitor">

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -159,13 +159,20 @@ class KapacitorRule extends Component {
     } = this.props
     const {chooseTrigger, updateRuleValues} = ruleActions
     const {timeRange} = this.state
+
+    const onSave = () => {
+      if (rule.id === DEFAULT_RULE_ID) {
+        this.handleCreate()
+      } else {
+        this.handleEdit()
+      }
+    }
+
     return (
       <div className="page">
         <RuleHeader
           source={source}
-          onSave={
-            rule.id === DEFAULT_RULE_ID ? this.handleCreate : this.handleEdit
-          }
+          onSave={onSave}
           validationError={this.validationError()}
         />
         <FancyScrollbar className="page-contents fancy-scroll--kapacitor">

--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -25,7 +25,7 @@ class KapacitorRule extends Component {
     this.setState({timeRange})
   }
 
-  handleCreate = link => {
+  handleCreate = pathname => {
     const {
       addFlashMessage,
       queryConfigs,
@@ -42,7 +42,7 @@ class KapacitorRule extends Component {
 
     createRule(kapacitor, newRule)
       .then(() => {
-        router.push(link || `/sources/${source.id}/alert-rules`)
+        router.push(pathname || `/sources/${source.id}/alert-rules`)
         addFlashMessage({type: 'success', text: 'Rule successfully created'})
       })
       .catch(() => {
@@ -53,7 +53,7 @@ class KapacitorRule extends Component {
       })
   }
 
-  handleEdit = link => {
+  handleEdit = pathname => {
     const {addFlashMessage, queryConfigs, rule, router, source} = this.props
     const updatedRule = Object.assign({}, rule, {
       query: queryConfigs[rule.queryID],
@@ -61,7 +61,7 @@ class KapacitorRule extends Component {
 
     editRule(updatedRule)
       .then(() => {
-        router.push(link || `/sources/${source.id}/alert-rules`)
+        router.push(pathname || `/sources/${source.id}/alert-rules`)
         addFlashMessage({
           type: 'success',
           text: `${rule.name} successfully saved!`,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2758 

### The problem
Alert Rule save button routes user to status page instead of alerts page.
also: "go to config" button routes user to main config page instead of specific config tab. 

### The Solution:
Alert Rule save button routes user to alerts page.
also: "go to config" button routes user to specific config tab. 




