### PR TITLE
Add organization flag to chronoctl for orgs

### DIFF
--- a/cmd/chronoctl/add.go
+++ b/cmd/chronoctl/add.go
@@ -2,17 +2,18 @@ package main
 
 import (
 	"context"
+	"strings"
 
 	"github.com/influxdata/chronograf"
 )
 
 type AddCommand struct {
-	BoltPath string  `short:"b" long:"bolt-path" description:"Full path to boltDB file (e.g. './chronograf-v1.db')" env:"BOLT_PATH" default:"chronograf-v1.db"`
-	ID       *uint64 `short:"i" long:"id" description:"Users ID. Must be id for existing user"`
-	Username string  `short:"n" long:"name" description:"Users name. Must be Oauth-able email address or username"`
-	Provider string  `short:"p" long:"provider" description:"Name of the Auth provider (e.g. google, github, auth0, or generic)"`
-	Scheme   string  `short:"s" long:"scheme" description:"Authentication scheme that matches auth provider (e.g. oauth or ldap)"`
-	//Organizations string `short:"o" long:"orgs" description:"A comma separated list of organizations that the user should be added to"`
+	BoltPath      string  `short:"b" long:"bolt-path" description:"Full path to boltDB file (e.g. './chronograf-v1.db')" env:"BOLT_PATH" default:"chronograf-v1.db"`
+	ID            *uint64 `short:"i" long:"id" description:"Users ID. Must be id for existing user"`
+	Username      string  `short:"n" long:"name" description:"Users name. Must be Oauth-able email address or username"`
+	Provider      string  `short:"p" long:"provider" description:"Name of the Auth provider (e.g. google, github, auth0, or generic)"`
+	Scheme        string  `short:"s" long:"scheme" description:"Authentication scheme that matches auth provider (e.g. oauth or ldap)"`
+	Organizations string  `short:"o" long:"orgs" description:"A comma separated list of organizations that the user should be added to" default:"default"`
 }
 
 var addCommand AddCommand
@@ -59,7 +60,35 @@ func (l *AddCommand) Execute(args []string) error {
 	}
 
 	// TODO(desa): Apply mapping to user and update their roles
-	// TODO(desa): Add a flag that allows the user to specify an organization to join
+	roles := []chronograf.Role{}
+OrgLoop:
+	for _, org := range strings.Split(l.Organizations, ",") {
+		// Check to see is user is already a part of the organization
+		for _, r := range user.Roles {
+			if r.Organization == org {
+				continue OrgLoop
+			}
+		}
+
+		orgQuery := chronograf.OrganizationQuery{
+			ID: &org,
+		}
+		o, err := c.OrganizationsStore.Get(ctx, orgQuery)
+		if err != nil {
+			return err
+		}
+
+		role := chronograf.Role{
+			Organization: org,
+			Name:         o.DefaultRole,
+		}
+		roles = append(roles, role)
+	}
+
+	user.Roles = append(user.Roles, roles...)
+	if err = c.UsersStore.Update(ctx, user); err != nil {
+		return err
+	}
 
 	w := NewTabWriter()
 	WriteHeaders(w)


### PR DESCRIPTION
This flag allows users to have a comma delimited list of organization
IDs that the user should given a role in.

  - [ ] Rebased/mergable


Connect #2744 

### The problem

Previously users couldn't specify organizations that the superadmin user should be added to. This created a situation where super admins could not auth into the application.

### The Solution

Allow users to specify a comma separated list of organization IDs that the user should be a part of.


