### PR TITLE
Set default tempVar :interval: with data explorer csv download call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## v1.4.2.x [unreleased]
+## v1.4.1.2 [2018-02-13]
 ### Features
 ### UI Improvements
 ### Bug Fixes
+1. [#2812](https://github.com/influxdata/chronograf/pull/2812): Set default tempVar :interval: with data explorer csv download call.
 
 ## v1.4.1.1 [2018-02-12]
 ### Features

--- a/ui/src/data_explorer/components/VisHeader.js
+++ b/ui/src/data_explorer/components/VisHeader.js
@@ -5,25 +5,14 @@ import _ from 'lodash'
 import {fetchTimeSeriesAsync} from 'shared/actions/timeSeries'
 import {resultsToCSV} from 'src/shared/parsing/resultsToCSV.js'
 import download from 'src/external/download.js'
+import {TEMPLATES} from 'src/data_explorer/constants'
 
 const getCSV = (query, errorThrown) => async () => {
   try {
-    const tempVars = [
-      {
-        id: 'interval',
-        type: 'autoGroupBy',
-        tempVar: ':interval:',
-        label: 'automatically determine the best group by time',
-        values: [
-          {value: '1000', type: 'resolution', selected: true},
-          {value: '3', type: 'pointsPerPixel', selected: true},
-        ],
-      },
-    ]
     const {results} = await fetchTimeSeriesAsync({
       source: query.host,
       query,
-      tempVars,
+      tempVars: TEMPLATES,
     })
     const {flag, name, CSVString} = resultsToCSV(results)
     if (flag === 'no_data') {

--- a/ui/src/data_explorer/components/VisHeader.js
+++ b/ui/src/data_explorer/components/VisHeader.js
@@ -8,7 +8,23 @@ import download from 'src/external/download.js'
 
 const getCSV = (query, errorThrown) => async () => {
   try {
-    const {results} = await fetchTimeSeriesAsync({source: query.host, query})
+    const tempVars = [
+      {
+        id: 'interval',
+        type: 'autoGroupBy',
+        tempVar: ':interval:',
+        label: 'automatically determine the best group by time',
+        values: [
+          {value: '1000', type: 'resolution', selected: true},
+          {value: '3', type: 'pointsPerPixel', selected: true},
+        ],
+      },
+    ]
+    const {results} = await fetchTimeSeriesAsync({
+      source: query.host,
+      query,
+      tempVars,
+    })
     const {flag, name, CSVString} = resultsToCSV(results)
     if (flag === 'no_data') {
       errorThrown('no data', 'There are no data to download.')


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2795

### The problem
CSV download query in data explorer has template variables that are not defined, causing fetchTimeSeriesAsync to error

### The Solution
pass default template variables with data explorer call to fetchTimeSeriesAsync.


