### PR TITLE
Update meta nodes to respect insecure skip verify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v1.4.2.0 [unreleased]
+1. [#2818](https://github.com/influxdata/chronograf/pull/2818): Allow self-signed certificates for Enterprise InfluxDB Meta nodes
 
 
 ## v1.4.1.2 [2018-02-13]

--- a/enterprise/enterprise.go
+++ b/enterprise/enterprise.go
@@ -51,13 +51,13 @@ type Client struct {
 }
 
 // NewClientWithTimeSeries initializes a Client with a known set of TimeSeries.
-func NewClientWithTimeSeries(lg chronograf.Logger, mu string, authorizer influx.Authorizer, tls bool, series ...chronograf.TimeSeries) (*Client, error) {
+func NewClientWithTimeSeries(lg chronograf.Logger, mu string, authorizer influx.Authorizer, tls, insecure bool, series ...chronograf.TimeSeries) (*Client, error) {
 	metaURL, err := parseMetaURL(mu, tls)
 	if err != nil {
 		return nil, err
 	}
 
-	ctrl := NewMetaClient(metaURL, authorizer)
+	ctrl := NewMetaClient(metaURL, insecure, authorizer)
 	c := &Client{
 		Ctrl: ctrl,
 		UsersStore: &UserStore{
@@ -85,13 +85,13 @@ func NewClientWithTimeSeries(lg chronograf.Logger, mu string, authorizer influx.
 // varieties. TLS is used when the URL contains "https" or when the TLS
 // parameter is set.  authorizer will add the correct `Authorization` headers
 // on the out-bound request.
-func NewClientWithURL(mu string, authorizer influx.Authorizer, tls bool, lg chronograf.Logger) (*Client, error) {
+func NewClientWithURL(mu string, authorizer influx.Authorizer, tls bool, insecure bool, lg chronograf.Logger) (*Client, error) {
 	metaURL, err := parseMetaURL(mu, tls)
 	if err != nil {
 		return nil, err
 	}
 
-	ctrl := NewMetaClient(metaURL, authorizer)
+	ctrl := NewMetaClient(metaURL, insecure, authorizer)
 	return &Client{
 		Ctrl: ctrl,
 		UsersStore: &UserStore{

--- a/enterprise/users.go
+++ b/enterprise/users.go
@@ -37,7 +37,7 @@ func (c *UserStore) Delete(ctx context.Context, u *chronograf.User) error {
 	return c.Ctrl.DeleteUser(ctx, u.Name)
 }
 
-// Number of users in Influx
+// Num of users in Influx
 func (c *UserStore) Num(ctx context.Context) (int, error) {
 	all, err := c.All(ctx)
 	if err != nil {

--- a/server/service.go
+++ b/server/service.go
@@ -48,7 +48,8 @@ func (c *InfluxClient) New(src chronograf.Source, logger chronograf.Logger) (chr
 	}
 	if src.Type == chronograf.InfluxEnterprise && src.MetaURL != "" {
 		tls := strings.Contains(src.MetaURL, "https")
-		return enterprise.NewClientWithTimeSeries(logger, src.MetaURL, influx.DefaultAuthorization(&src), tls, client)
+		insecure := src.InsecureSkipVerify
+		return enterprise.NewClientWithTimeSeries(logger, src.MetaURL, influx.DefaultAuthorization(&src), tls, insecure, client)
 	}
 	return client, nil
 }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Closes #2801 

### The problem
Meta nodes queries are not respecting `InsecureSkipVerify`.  `InsecureSkipVerify` allows sign-signed certs.
### The Solution
Wire `InsecureSkipVerfiy` into meta node queries

