### PR TITLE
Polish Alerts Page Design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.4.2.0 [unreleased]
 ### Features
 ### UI Improvements
+1. [#2831](https://github.com/influxdata/chronograf/pull/2831): Rename 'Create Alerts' page to 'Manage Tasks'; Redesign page to improve clarity of purpose
 ### Bug Fixes
 1. [#2821](https://github.com/influxdata/chronograf/pull/2821): Save only selected template variable values into dashboards for non csv template variables
 1. [#2842](https://github.com/influxdata/chronograf/pull/2842): Use Generic APIKey for Oauth2 group lookup

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -105,9 +105,7 @@ const PageContents = ({children}) =>
     <div className="page-header">
       <div className="page-header__container">
         <div className="page-header__left">
-          <h1 className="page-header__title">
-            Build Alert Rules or Write TICKscripts
-          </h1>
+          <h1 className="page-header__title">Manage Alerts</h1>
         </div>
         <div className="page-header__right">
           <SourceIndicator />

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -41,17 +41,21 @@ const KapacitorRules = ({
     )
   }
 
-  const rulez = rules.filter(r => r.query)
-  const tasks = rules.filter(r => !r.query)
+  const builderRules = rules.filter(r => r.query)
 
-  const rHeader = `${rulez.length} Alert Rule${rulez.length === 1 ? '' : 's'}`
-  const tHeader = `${tasks.length} TICKscript${tasks.length === 1 ? '' : 's'}`
+  const builderHeader = `${builderRules.length} Alert Rule${builderRules.length ===
+  1
+    ? ''
+    : 's'}`
+  const scriptsHeader = `${rules.length} TICKscript${rules.length === 1
+    ? ''
+    : 's'}`
 
   return (
     <PageContents source={source}>
       <div className="panel-heading u-flex u-ai-center u-jc-space-between">
         <h2 className="panel-title">
-          {rHeader}
+          {builderHeader}
         </h2>
         <div className="u-flex u-ai-center u-jc-space-between">
           <Link
@@ -65,7 +69,7 @@ const KapacitorRules = ({
       </div>
       <KapacitorRulesTable
         source={source}
-        rules={rulez}
+        rules={builderRules}
         onDelete={onDelete}
         onChangeRuleStatus={onChangeRuleStatus}
       />
@@ -75,12 +79,12 @@ const KapacitorRules = ({
           <div className="panel panel-minimal">
             <div className="panel-heading u-flex u-ai-center u-jc-space-between">
               <h2 className="panel-title">
-                {tHeader}
+                {scriptsHeader}
               </h2>
               <div className="u-flex u-ai-center u-jc-space-between">
                 <Link
                   to={`/sources/${source.id}/tickscript/new`}
-                  className="btn btn-sm btn-primary"
+                  className="btn btn-sm btn-success"
                   style={{marginRight: '4px'}}
                 >
                   <span className="icon plus" /> Write TICKscript
@@ -89,7 +93,7 @@ const KapacitorRules = ({
             </div>
             <TasksTable
               source={source}
-              tasks={tasks}
+              tasks={rules}
               onDelete={onDelete}
               onChangeRuleStatus={onChangeRuleStatus}
             />

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -6,6 +6,7 @@ import SourceIndicator from 'shared/components/SourceIndicator'
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import TasksTable from 'src/kapacitor/components/TasksTable'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
+import QuestionMarkTooltip from 'shared/components/QuestionMarkTooltip'
 
 const KapacitorRules = ({
   source,
@@ -112,6 +113,10 @@ const PageContents = ({children}) =>
           <h1 className="page-header__title">Manage Tasks</h1>
         </div>
         <div className="page-header__right">
+          <QuestionMarkTooltip
+            tipID="manage-tasks--tooltip"
+            tipContent="<b>Alert Rules</b> generate a TICKscript for<br/>you using our Builder UI.<br/><br/>Not all TICKscripts can be edited<br/>using the Builder."
+          />
           <SourceIndicator />
         </div>
       </div>

--- a/ui/src/kapacitor/components/KapacitorRules.js
+++ b/ui/src/kapacitor/components/KapacitorRules.js
@@ -109,7 +109,7 @@ const PageContents = ({children}) =>
     <div className="page-header">
       <div className="page-header__container">
         <div className="page-header__left">
-          <h1 className="page-header__title">Manage Alerts</h1>
+          <h1 className="page-header__title">Manage Tasks</h1>
         </div>
         <div className="page-header__right">
           <SourceIndicator />

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -48,8 +48,10 @@ const handleDelete = (rule, onDelete) => onDelete(rule)
 
 const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
   <tr key={rule.id}>
-    <td style={{width: colName}} className="monotype">
-      <RuleTitle rule={rule} source={source} />
+    <td style={{minWidth: colName}}>
+      <Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>
+        {rule.name}
+      </Link>
     </td>
     <td style={{width: colTrigger}} className="monotype">
       {rule.trigger}
@@ -78,12 +80,6 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
       </div>
     </td>
     <td style={{width: colActions}} className="text-right table-cell-nowrap">
-      <Link
-        className="btn btn-info btn-xs"
-        to={`/sources/${source.id}/tickscript/${rule.id}`}
-      >
-        Edit TICKscript
-      </Link>
       <button
         className="btn btn-danger btn-xs"
         onClick={handleDelete(rule, onDelete)}
@@ -92,23 +88,6 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
       </button>
     </td>
   </tr>
-
-const RuleTitle = ({rule: {id, name, query}, source}) => {
-  // no queryConfig means the rule was manually created outside of Chronograf
-  if (!query) {
-    return (
-      <i>
-        {name}
-      </i>
-    )
-  }
-
-  return (
-    <Link to={`/sources/${source.id}/alert-rules/${id}`}>
-      {name}
-    </Link>
-  )
-}
 
 const {arrayOf, func, shape, string} = PropTypes
 
@@ -126,19 +105,6 @@ RuleRow.propTypes = {
   source: shape(),
   onChangeRuleStatus: func,
   onDelete: func,
-}
-
-RuleTitle.propTypes = {
-  rule: shape({
-    name: string.isRequired,
-    query: shape(),
-    links: shape({
-      self: string.isRequired,
-    }),
-  }),
-  source: shape({
-    id: string.isRequired,
-  }).isRequired,
 }
 
 export default KapacitorRulesTable

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -2,6 +2,7 @@ import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
 
+import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {parseAlertNodeList} from 'src/shared/parsing/parseHandlersFromRule'
 import {KAPACITOR_RULES_TABLE} from 'src/kapacitor/constants/tableSizing'
 const {
@@ -15,10 +16,10 @@ const {
 
 const KapacitorRulesTable = ({rules, source, onDelete, onChangeRuleStatus}) =>
   <div className="panel-body">
-    <table className="table v-center">
+    <table className="table v-center table-highlight">
       <thead>
         <tr>
-          <th style={{width: colName}}>Name</th>
+          <th style={{minWidth: colName}}>Name</th>
           <th style={{width: colTrigger}}>Rule Trigger</th>
           <th style={{width: colMessage}}>Message</th>
           <th style={{width: colAlerts}}>Alerts</th>
@@ -53,21 +54,16 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
         {rule.name}
       </Link>
     </td>
-    <td style={{width: colTrigger}} className="monotype">
+    <td style={{width: colTrigger, textTransform: 'capitalize'}}>
       {rule.trigger}
     </td>
-    <td className="monotype">
-      <span
-        className="table-cell-nowrap"
-        style={{display: 'inline-block', maxWidth: colMessage}}
-      >
-        {rule.message}
-      </span>
+    <td style={{wdith: colMessage}}>
+      {rule.message}
     </td>
-    <td style={{width: colAlerts}} className="monotype">
+    <td style={{width: colAlerts}}>
       {parseAlertNodeList(rule)}
     </td>
-    <td style={{width: colEnabled}} className="monotype text-center">
+    <td style={{width: colEnabled}} className="text-center">
       <div className="dark-checkbox">
         <input
           id={`kapacitor-enabled ${rule.id}`}
@@ -79,13 +75,14 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
         <label htmlFor={`kapacitor-enabled ${rule.id}`} />
       </div>
     </td>
-    <td style={{width: colActions}} className="text-right table-cell-nowrap">
-      <button
-        className="btn btn-danger btn-xs"
-        onClick={handleDelete(rule, onDelete)}
-      >
-        Delete
-      </button>
+    <td style={{width: colActions}} className="text-right">
+      <ConfirmButton
+        text="Delete"
+        type="btn-danger"
+        size="btn-xs"
+        customClass="table--show-on-row-hover"
+        confirmAction={handleDelete(rule, onDelete)}
+      />
     </td>
   </tr>
 

--- a/ui/src/kapacitor/components/KapacitorRulesTable.js
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {parseAlertNodeList} from 'src/shared/parsing/parseHandlersFromRule'
-import {KAPACITOR_RULES_TABLE} from 'src/kapacitor/constants/tableSizing'
+import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
 const {
   colName,
   colTrigger,
@@ -12,7 +12,7 @@ const {
   colAlerts,
   colEnabled,
   colActions,
-} = KAPACITOR_RULES_TABLE
+} = TASKS_TABLE
 
 const KapacitorRulesTable = ({rules, source, onDelete, onChangeRuleStatus}) =>
   <div className="panel-body">
@@ -20,11 +20,11 @@ const KapacitorRulesTable = ({rules, source, onDelete, onChangeRuleStatus}) =>
       <thead>
         <tr>
           <th style={{minWidth: colName}}>Name</th>
-          <th style={{width: colTrigger}}>Rule Trigger</th>
+          <th style={{width: colTrigger}}>Rule Type</th>
           <th style={{width: colMessage}}>Message</th>
-          <th style={{width: colAlerts}}>Alerts</th>
+          <th style={{width: colAlerts}}>Alert Handlers</th>
           <th style={{width: colEnabled}} className="text-center">
-            Enabled
+            Task Enabled
           </th>
           <th style={{width: colActions}} />
         </tr>
@@ -57,7 +57,7 @@ const RuleRow = ({rule, source, onDelete, onChangeRuleStatus}) =>
     <td style={{width: colTrigger, textTransform: 'capitalize'}}>
       {rule.trigger}
     </td>
-    <td style={{wdith: colMessage}}>
+    <td style={{width: colMessage}}>
       {rule.message}
     </td>
     <td style={{width: colAlerts}}>

--- a/ui/src/kapacitor/components/TasksTable.js
+++ b/ui/src/kapacitor/components/TasksTable.js
@@ -2,16 +2,21 @@ import React, {PropTypes} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
 
+import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
 
 const {colID, colType, colEnabled, colActions} = TASKS_TABLE
 
+const checkForName = task => {
+  return task.id.slice(0, 10) === 'chronograf' ? task.name : task.id
+}
+
 const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
   <div className="panel-body">
-    <table className="table v-center">
+    <table className="table v-center table-highlight">
       <thead>
         <tr>
-          <th style={{width: colID}}>ID</th>
+          <th style={{minWidth: colID}}>ID</th>
           <th style={{width: colType}}>Type</th>
           <th style={{width: colEnabled}} className="text-center">
             Enabled
@@ -39,7 +44,6 @@ const handleDelete = (task, onDelete) => onDelete(task)
 
 const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
   <tr key={task.id}>
-    <td style={{width: colID}} className="monotype">
     <td style={{minWidth: colID}}>
       <Link
         className="link-success"
@@ -48,10 +52,10 @@ const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
         {checkForName(task)}
       </Link>
     </td>
-    <td style={{width: colType}} className="monotype">
+    <td style={{width: colType, textTransform: 'capitalize'}}>
       {task.type}
     </td>
-    <td style={{width: colEnabled}} className="monotype text-center">
+    <td style={{width: colEnabled}} className="text-center">
       <div className="dark-checkbox">
         <input
           id={`kapacitor-enabled ${task.id}`}
@@ -63,13 +67,14 @@ const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
         <label htmlFor={`kapacitor-enabled ${task.id}`} />
       </div>
     </td>
-    <td style={{width: colActions}} className="text-right table-cell-nowrap">
-      <button
-        className="btn btn-danger btn-xs"
-        onClick={handleDelete(task, onDelete)}
-      >
-        Delete
-      </button>
+    <td style={{width: colActions}} className="text-right">
+      <ConfirmButton
+        text="Delete"
+        type="btn-danger"
+        size="btn-xs"
+        customClass="table--show-on-row-hover"
+        confirmAction={handleDelete(task, onDelete)}
+      />
     </td>
   </tr>
 

--- a/ui/src/kapacitor/components/TasksTable.js
+++ b/ui/src/kapacitor/components/TasksTable.js
@@ -40,9 +40,13 @@ const handleDelete = (task, onDelete) => onDelete(task)
 const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
   <tr key={task.id}>
     <td style={{width: colID}} className="monotype">
-      <i>
-        {task.id}
-      </i>
+    <td style={{minWidth: colID}}>
+      <Link
+        className="link-success"
+        to={`/sources/${source.id}/tickscript/${task.id}`}
+      >
+        {checkForName(task)}
+      </Link>
     </td>
     <td style={{width: colType}} className="monotype">
       {task.type}
@@ -60,12 +64,6 @@ const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
       </div>
     </td>
     <td style={{width: colActions}} className="text-right table-cell-nowrap">
-      <Link
-        className="btn btn-info btn-xs"
-        to={`/sources/${source.id}/tickscript/${task.id}`}
-      >
-        Edit TICKscript
-      </Link>
       <button
         className="btn btn-danger btn-xs"
         onClick={handleDelete(task, onDelete)}

--- a/ui/src/kapacitor/components/TasksTable.js
+++ b/ui/src/kapacitor/components/TasksTable.js
@@ -5,14 +5,13 @@ import _ from 'lodash'
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
 
-const {colID, colName, colType, colEnabled, colActions} = TASKS_TABLE
+const {colName, colType, colEnabled, colActions} = TASKS_TABLE
 
 const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
   <div className="panel-body">
     <table className="table v-center table-highlight">
       <thead>
         <tr>
-          <th style={{minWidth: colID}}>ID</th>
           <th style={{minWidth: colName}}>Name</th>
           <th style={{width: colType}}>Type</th>
           <th style={{width: colEnabled}} className="text-center">
@@ -41,16 +40,13 @@ const handleDelete = (task, onDelete) => onDelete(task)
 
 const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
   <tr key={task.id}>
-    <td style={{minWidth: colID}}>
+    <td style={{minWidth: colName}}>
       <Link
         className="link-success"
         to={`/sources/${source.id}/tickscript/${task.id}`}
       >
-        {task.id}
+        {task.name}
       </Link>
-    </td>
-    <td style={{width: colName}}>
-      {task.name || ''}
     </td>
     <td style={{width: colType, textTransform: 'capitalize'}}>
       {task.type}

--- a/ui/src/kapacitor/components/TasksTable.js
+++ b/ui/src/kapacitor/components/TasksTable.js
@@ -15,7 +15,7 @@ const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
           <th style={{minWidth: colName}}>Name</th>
           <th style={{width: colType}}>Type</th>
           <th style={{width: colEnabled}} className="text-center">
-            Enabled
+            Task Enabled
           </th>
           <th style={{width: colActions}} />
         </tr>

--- a/ui/src/kapacitor/components/TasksTable.js
+++ b/ui/src/kapacitor/components/TasksTable.js
@@ -5,11 +5,7 @@ import _ from 'lodash'
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
 
-const {colID, colType, colEnabled, colActions} = TASKS_TABLE
-
-const checkForName = task => {
-  return task.id.slice(0, 10) === 'chronograf' ? task.name : task.id
-}
+const {colID, colName, colType, colEnabled, colActions} = TASKS_TABLE
 
 const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
   <div className="panel-body">
@@ -17,6 +13,7 @@ const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
       <thead>
         <tr>
           <th style={{minWidth: colID}}>ID</th>
+          <th style={{minWidth: colName}}>Name</th>
           <th style={{width: colType}}>Type</th>
           <th style={{width: colEnabled}} className="text-center">
             Enabled
@@ -25,7 +22,7 @@ const TasksTable = ({tasks, source, onDelete, onChangeRuleStatus}) =>
         </tr>
       </thead>
       <tbody>
-        {_.sortBy(tasks, t => t.name.toLowerCase()).map(task => {
+        {_.sortBy(tasks, t => t.id.toLowerCase()).map(task => {
           return (
             <TaskRow
               key={task.id}
@@ -49,8 +46,11 @@ const TaskRow = ({task, source, onDelete, onChangeRuleStatus}) =>
         className="link-success"
         to={`/sources/${source.id}/tickscript/${task.id}`}
       >
-        {checkForName(task)}
+        {task.id}
       </Link>
+    </td>
+    <td style={{width: colName}}>
+      {task.name || ''}
     </td>
     <td style={{width: colType, textTransform: 'capitalize'}}>
       {task.type}

--- a/ui/src/kapacitor/constants/tableSizing.js
+++ b/ui/src/kapacitor/constants/tableSizing.js
@@ -1,15 +1,15 @@
 export const KAPACITOR_RULES_TABLE = {
   colName: '200px',
   colTrigger: '90px',
-  colMessage: '460px',
+  colMessage: '200px',
   colAlerts: '120px',
   colEnabled: '64px',
-  colActions: '176px',
+  colActions: '68px',
 }
 
 export const TASKS_TABLE = {
   colID: '200px',
   colType: '90px',
   colEnabled: '64px',
-  colActions: '176px',
+  colActions: '68px',
 }

--- a/ui/src/kapacitor/constants/tableSizing.js
+++ b/ui/src/kapacitor/constants/tableSizing.js
@@ -8,7 +8,6 @@ export const KAPACITOR_RULES_TABLE = {
 }
 
 export const TASKS_TABLE = {
-  colID: '200px',
   colName: '200px',
   colType: '90px',
   colEnabled: '64px',

--- a/ui/src/kapacitor/constants/tableSizing.js
+++ b/ui/src/kapacitor/constants/tableSizing.js
@@ -1,15 +1,9 @@
-export const KAPACITOR_RULES_TABLE = {
+export const TASKS_TABLE = {
   colName: '200px',
   colTrigger: '90px',
   colMessage: '200px',
   colAlerts: '120px',
-  colEnabled: '64px',
+  colEnabled: '95px',
   colActions: '68px',
-}
-
-export const TASKS_TABLE = {
-  colName: '200px',
   colType: '90px',
-  colEnabled: '64px',
-  colActions: '68px',
 }

--- a/ui/src/kapacitor/constants/tableSizing.js
+++ b/ui/src/kapacitor/constants/tableSizing.js
@@ -9,6 +9,7 @@ export const KAPACITOR_RULES_TABLE = {
 
 export const TASKS_TABLE = {
   colID: '200px',
+  colName: '200px',
   colType: '90px',
   colEnabled: '64px',
   colActions: '68px',

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -121,7 +121,7 @@ const SideNav = React.createClass({
             <NavHeader link={`${sourcePrefix}/alerts`} title="Alerting" />
             <NavListItem link={`${sourcePrefix}/alerts`}>History</NavListItem>
             <NavListItem link={`${sourcePrefix}/alert-rules`}>
-              Create
+              Manage Alerts
             </NavListItem>
           </NavBlock>
 

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -115,13 +115,15 @@ const SideNav = React.createClass({
           <NavBlock
             matcher="alerts"
             icon="alert-triangle"
-            link={`${sourcePrefix}/alerts`}
+            link={`${sourcePrefix}/alert-rules`}
             location={location}
           >
-            <NavHeader link={`${sourcePrefix}/alerts`} title="Alerting" />
-            <NavListItem link={`${sourcePrefix}/alerts`}>History</NavListItem>
+            <NavHeader link={`${sourcePrefix}/alert-rules`} title="Alerting" />
             <NavListItem link={`${sourcePrefix}/alert-rules`}>
               Manage Tasks
+            </NavListItem>
+            <NavListItem link={`${sourcePrefix}/alerts`}>
+              Alert History
             </NavListItem>
           </NavBlock>
 

--- a/ui/src/side_nav/containers/SideNav.js
+++ b/ui/src/side_nav/containers/SideNav.js
@@ -121,7 +121,7 @@ const SideNav = React.createClass({
             <NavHeader link={`${sourcePrefix}/alerts`} title="Alerting" />
             <NavListItem link={`${sourcePrefix}/alerts`}>History</NavListItem>
             <NavListItem link={`${sourcePrefix}/alert-rules`}>
-              Manage Alerts
+              Manage Tasks
             </NavListItem>
           </NavBlock>
 

--- a/ui/src/style/theme/bootstrap-theme.scss
+++ b/ui/src/style/theme/bootstrap-theme.scss
@@ -4807,7 +4807,8 @@ p .label {
 .table .table--show-on-row-hover {
   visibility: hidden;
 }
-.table > tbody > tr:hover .table--show-on-row-hover {
+.table > tbody > tr:hover .table--show-on-row-hover,
+.table > tbody > tr .active.table--show-on-row-hover {
   visibility: visible;
 }
 .table-responsive {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2749 

### The Problem
- Delete / Edit buttons do not follow the *appear on hover* pattern seen in other tables
- TICKscripts do not follow the *click name to edit* pattern seen in the rules table
- Alert Rules do not show in TICKscripts table even though they are technically TICKscripts beneath the surface
- Delete buttons do not require confirmation
- The name of the page in the page header does not match the side nav
- Unclear what the difference between TICKscripts and Alert Rules is

### The Solution
- Delete buttons only appear on row hover and require confirmation
- Removed the `Edit TICKscript` button from both tables
- TICKscript names are links that take you to the editor (matches pattern found in Alert Rules table)
- TICkscripts table shows both Alert Rules and TICKscripts (although it shows the `name` instead of `id` for Alert Rules
  - This modifies the UX such that if the user wants to edit an Alert Rule as a TICKscript they must locate it in the TICKscripts list and click the name there
- TICKscripts are color coded green because all things Kapacitor are usually green
- Changed the name of the page to `Manage Alerts` in both the page header and sidenav
- Should be more clear that all Alert Rules are TICKscripts but not all TICKscripts are Alert Rules
- Will be more straightforward to selectively show each table based on permissions
- Improved the column widths and removed monotype text

### Preview
![screen shot 2018-02-20 at 2 04 08 pm](https://user-images.githubusercontent.com/2433762/36452375-1678d480-1649-11e8-9859-0a8ffaf35f7c.png)

![screen shot 2018-02-20 at 2 05 36 pm](https://user-images.githubusercontent.com/2433762/36452378-18f01908-1649-11e8-8ae9-819986db4644.png)

![screen shot 2018-02-20 at 2 19 48 pm](https://user-images.githubusercontent.com/2433762/36453420-c18735e4-164c-11e8-937f-8c3693d9e332.png)
