### PR TITLE
Refactor CellEditorOverlay State

### DIFF
--- a/ui/spec/dashboards/reducers/cellEditorOverlaySpec.js
+++ b/ui/spec/dashboards/reducers/cellEditorOverlaySpec.js
@@ -1,0 +1,119 @@
+import reducer, {initialState} from 'src/dashboards/reducers/cellEditorOverlay'
+
+import {
+  showCellEditorOverlay,
+  hideCellEditorOverlay,
+  changeCellType,
+  renameCell,
+  updateSingleStatColors,
+  updateSingleStatType,
+  updateGaugeColors,
+  updateAxes,
+} from 'src/dashboards/actions/cellEditorOverlay'
+
+import {
+  validateGaugeColors,
+  validateSingleStatColors,
+  getSingleStatType,
+} from 'src/dashboards/constants/gaugeColors'
+
+const defaultCellType = 'line'
+const defaultCellName = 'defaultCell'
+const defaultCellAxes = {
+  y: {
+    base: '10',
+    bounds: ['0', ''],
+    label: '',
+    prefix: '',
+    scale: 'linear',
+    suffix: '',
+  },
+}
+
+const defaultCell = {
+  axes: defaultCellAxes,
+  colors: [],
+  name: defaultCellName,
+  type: defaultCellType,
+}
+
+const defaultSingleStatType = getSingleStatType(defaultCell.colors)
+const defaultSingleStatColors = validateSingleStatColors(
+  defaultCell.colors,
+  defaultSingleStatType
+)
+const defaultGaugeColors = validateGaugeColors(defaultCell.colors)
+
+describe('Dashboards.Reducers.cellEditorOverlay', () => {
+  it('should show cell editor overlay', () => {
+    const actual = reducer(initialState, showCellEditorOverlay(defaultCell))
+    console.log('actual: ', actual)
+    const expected = {
+      cell: defaultCell,
+      gaugeColors: defaultGaugeColors,
+      singleStatColors: defaultSingleStatColors,
+      singleStatType: defaultSingleStatType,
+    }
+    console.log('expected: ', expected)
+
+    expect(actual.cell).to.equal(expected.cell)
+    expect(actual.gaugeColors).to.equal(expected.gaugeColors)
+    expect(actual.singleStatColors).to.equal(expected.singleStatColors)
+    expect(actual.singleStatType).to.equal(expected.singleStatType)
+  })
+
+  it('should hide cell editor overlay', () => {
+    const actual = reducer(initialState, hideCellEditorOverlay)
+    const expected = null
+
+    expect(actual.cell).to.equal(expected)
+  })
+
+  it('should change the cell editor visualization type', () => {
+    const actual = reducer(initialState, changeCellType(defaultCellType))
+    const expected = defaultCellType
+
+    expect(actual.cell.type).to.equal(expected)
+  })
+
+  it('should change the name of the cell', () => {
+    const actual = reducer(initialState, renameCell(defaultCellName))
+    const expected = defaultCellName
+
+    expect(actual.cell.name).to.equal(expected)
+  })
+
+  it('should update the cell single stat colors', () => {
+    const actual = reducer(
+      initialState,
+      updateSingleStatColors(defaultSingleStatColors)
+    )
+    const expected = defaultSingleStatColors
+
+    expect(actual.singleStatColors).to.equal(expected)
+  })
+
+  it('should toggle the single stat type', () => {
+    const actual = reducer(
+      initialState,
+      updateSingleStatType(defaultSingleStatType)
+    )
+    const expected = defaultSingleStatType
+
+    expect(actual.singleStatType).to.equal(expected)
+  })
+
+  it('should update the cell gauge colors', () => {
+    const actual = reducer(initialState, updateGaugeColors(defaultGaugeColors))
+    const expected = defaultGaugeColors
+
+    expect(actual.gaugeColors).to.equal(expected)
+  })
+
+  it('should update the cell axes', () => {
+    const actual = reducer(initialState, updateAxes(defaultCellAxes))
+    const expected = defaultCellAxes
+
+    expect(actual.cell.axes).to.equal(expected)
+  })
+})

--- a/ui/spec/dashboards/reducers/cellEditorOverlaySpec.js
+++ b/ui/spec/dashboards/reducers/cellEditorOverlaySpec.js
@@ -47,14 +47,12 @@ const defaultGaugeColors = validateGaugeColors(defaultCell.colors)
 describe('Dashboards.Reducers.cellEditorOverlay', () => {
   it('should show cell editor overlay', () => {
     const actual = reducer(initialState, showCellEditorOverlay(defaultCell))
-    console.log('actual: ', actual)
     const expected = {
       cell: defaultCell,
       gaugeColors: defaultGaugeColors,
       singleStatColors: defaultSingleStatColors,
       singleStatType: defaultSingleStatType,
     }
-    console.log('expected: ', expected)
 
     expect(actual.cell).to.equal(expected.cell)
     expect(actual.gaugeColors).to.equal(expected.gaugeColors)

--- a/ui/src/dashboards/actions/cellEditorOverlay.js
+++ b/ui/src/dashboards/actions/cellEditorOverlay.js
@@ -43,3 +43,10 @@ export const updateGaugeColors = gaugeColors => ({
     gaugeColors,
   },
 })
+
+export const updateAxes = axes => ({
+  type: 'UPDATE_AXES',
+  payload: {
+    axes,
+  },
+})

--- a/ui/src/dashboards/actions/cellEditorOverlay.js
+++ b/ui/src/dashboards/actions/cellEditorOverlay.js
@@ -36,3 +36,10 @@ export const updateSingleStatType = singleStatType => ({
     singleStatType,
   },
 })
+
+export const updateGaugeColors = gaugeColors => ({
+  type: 'UPDATE_GAUGE_COLORS',
+  payload: {
+    gaugeColors,
+  },
+})

--- a/ui/src/dashboards/actions/cellEditorOverlay.js
+++ b/ui/src/dashboards/actions/cellEditorOverlay.js
@@ -1,10 +1,3 @@
-export const changeCellType = cellType => ({
-  type: 'CHANGE_CELL_TYPE',
-  payload: {
-    cellType,
-  },
-})
-
 export const showCellEditorOverlay = cell => ({
   type: 'SHOW_CELL_EDITOR_OVERLAY',
   payload: {
@@ -14,4 +7,18 @@ export const showCellEditorOverlay = cell => ({
 
 export const hideCellEditorOverlay = () => ({
   type: 'HIDE_CELL_EDITOR_OVERLAY',
+})
+
+export const changeCellType = cellType => ({
+  type: 'CHANGE_CELL_TYPE',
+  payload: {
+    cellType,
+  },
+})
+
+export const renameCell = cellName => ({
+  type: 'RENAME_CELL',
+  payload: {
+    cellName,
+  },
 })

--- a/ui/src/dashboards/actions/cellEditorOverlay.js
+++ b/ui/src/dashboards/actions/cellEditorOverlay.js
@@ -22,3 +22,17 @@ export const renameCell = cellName => ({
     cellName,
   },
 })
+
+export const updateSingleStatColors = singleStatColors => ({
+  type: 'UPDATE_SINGLE_STAT_COLORS',
+  payload: {
+    singleStatColors,
+  },
+})
+
+export const updateSingleStatType = singleStatType => ({
+  type: 'UPDATE_SINGLE_STAT_TYPE',
+  payload: {
+    singleStatType,
+  },
+})

--- a/ui/src/dashboards/actions/cellEditorOverlay.js
+++ b/ui/src/dashboards/actions/cellEditorOverlay.js
@@ -1,0 +1,17 @@
+export const changeCellType = cellType => ({
+  type: 'CHANGE_CELL_TYPE',
+  payload: {
+    cellType,
+  },
+})
+
+export const showCellEditorOverlay = cell => ({
+  type: 'SHOW_CELL_EDITOR_OVERLAY',
+  payload: {
+    cell,
+  },
+})
+
+export const hideCellEditorOverlay = () => ({
+  type: 'HIDE_CELL_EDITOR_OVERLAY',
+})

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -1,4 +1,6 @@
-import React, {PropTypes} from 'react'
+import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
 
 import OptIn from 'shared/components/OptIn'
 import Input from 'src/dashboards/components/DisplayOptionsInput'
@@ -11,105 +13,158 @@ import {GRAPH_TYPES} from 'src/dashboards/graphics/graph'
 const {LINEAR, LOG, BASE_2, BASE_10} = DISPLAY_OPTIONS
 const getInputMin = scale => (scale === LOG ? '0' : null)
 
-const AxesOptions = ({
-  axes: {y: {bounds, label, prefix, suffix, base, scale, defaultYLabel}},
-  onSetBase,
-  onSetScale,
-  onSetLabel,
-  onSetPrefixSuffix,
-  onSetYAxisBoundMin,
-  onSetYAxisBoundMax,
-  cellType,
-}) => {
-  const [min, max] = bounds
+import {updateAxes} from 'src/dashboards/actions/cellEditorOverlay'
 
-  const {menuOption} = GRAPH_TYPES.find(graph => graph.type === cellType)
+class AxesOptions extends Component {
+  handleSetPrefixSuffix = e => {
+    const {handleUpdateAxes, axes} = this.props
+    const {prefix, suffix} = e.target.form
 
-  return (
-    <FancyScrollbar
-      className="display-options--cell y-axis-controls"
-      autoHide={false}
-    >
-      <div className="display-options--cell-wrapper">
-        <h5 className="display-options--header">
-          {menuOption} Controls
-        </h5>
-        <form autoComplete="off" style={{margin: '0 -6px'}}>
-          <div className="form-group col-sm-12">
-            <label htmlFor="prefix">Title</label>
-            <OptIn
-              customPlaceholder={defaultYLabel || 'y-axis title'}
-              customValue={label}
-              onSetValue={onSetLabel}
-              type="text"
+    const newAxes = {
+      ...axes,
+      y: {
+        ...axes.y,
+        prefix: prefix.value,
+        suffix: suffix.value,
+      },
+    }
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleSetYAxisBoundMin = min => {
+    const {handleUpdateAxes, axes} = this.props
+    const {y: {bounds: [, max]}} = this.props.axes
+    const newAxes = {...axes, y: {...axes.y, bounds: [min, max]}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleSetYAxisBoundMax = max => {
+    const {handleUpdateAxes, axes} = this.props
+    const {y: {bounds: [min]}} = axes
+    const newAxes = {...axes, y: {...axes.y, bounds: [min, max]}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleSetLabel = label => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, label}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleSetScale = scale => () => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, scale}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleSetBase = base => () => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, base}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  render() {
+    const {
+      axes: {y: {bounds, label, prefix, suffix, base, scale, defaultYLabel}},
+      type,
+    } = this.props
+
+    const [min, max] = bounds
+
+    const {menuOption} = GRAPH_TYPES.find(graph => graph.type === type)
+
+    return (
+      <FancyScrollbar
+        className="display-options--cell y-axis-controls"
+        autoHide={false}
+      >
+        <div className="display-options--cell-wrapper">
+          <h5 className="display-options--header">
+            {menuOption} Controls
+          </h5>
+          <form autoComplete="off" style={{margin: '0 -6px'}}>
+            <div className="form-group col-sm-12">
+              <label htmlFor="prefix">Title</label>
+              <OptIn
+                customPlaceholder={defaultYLabel || 'y-axis title'}
+                customValue={label}
+                onSetValue={this.handleSetLabel}
+                type="text"
+              />
+            </div>
+            <div className="form-group col-sm-6">
+              <label htmlFor="min">Min</label>
+              <OptIn
+                customPlaceholder={'min'}
+                customValue={min}
+                onSetValue={this.handleSetYAxisBoundMin}
+                type="number"
+                min={getInputMin(scale)}
+              />
+            </div>
+            <div className="form-group col-sm-6">
+              <label htmlFor="max">Max</label>
+              <OptIn
+                customPlaceholder={'max'}
+                customValue={max}
+                onSetValue={this.handleSetYAxisBoundMax}
+                type="number"
+                min={getInputMin(scale)}
+              />
+            </div>
+            <Input
+              name="prefix"
+              id="prefix"
+              value={prefix}
+              labelText="Y-Value's Prefix"
+              onChange={this.handleSetPrefixSuffix}
             />
-          </div>
-          <div className="form-group col-sm-6">
-            <label htmlFor="min">Min</label>
-            <OptIn
-              customPlaceholder={'min'}
-              customValue={min}
-              onSetValue={onSetYAxisBoundMin}
-              type="number"
-              min={getInputMin(scale)}
+            <Input
+              name="suffix"
+              id="suffix"
+              value={suffix}
+              labelText="Y-Value's Suffix"
+              onChange={this.handleSetPrefixSuffix}
             />
-          </div>
-          <div className="form-group col-sm-6">
-            <label htmlFor="max">Max</label>
-            <OptIn
-              customPlaceholder={'max'}
-              customValue={max}
-              onSetValue={onSetYAxisBoundMax}
-              type="number"
-              min={getInputMin(scale)}
-            />
-          </div>
-          <Input
-            name="prefix"
-            id="prefix"
-            value={prefix}
-            labelText="Y-Value's Prefix"
-            onChange={onSetPrefixSuffix}
-          />
-          <Input
-            name="suffix"
-            id="suffix"
-            value={suffix}
-            labelText="Y-Value's Suffix"
-            onChange={onSetPrefixSuffix}
-          />
-          <Tabber
-            labelText="Y-Value's Format"
-            tipID="Y-Values's Format"
-            tipContent={TOOLTIP_CONTENT.FORMAT}
-          >
-            <Tab
-              text="K/M/B"
-              isActive={base === BASE_10}
-              onClickTab={onSetBase(BASE_10)}
-            />
-            <Tab
-              text="K/M/G"
-              isActive={base === BASE_2}
-              onClickTab={onSetBase(BASE_2)}
-            />
-          </Tabber>
-          <Tabber labelText="Scale">
-            <Tab
-              text="Linear"
-              isActive={scale === LINEAR}
-              onClickTab={onSetScale(LINEAR)}
-            />
-            <Tab
-              text="Logarithmic"
-              isActive={scale === LOG}
-              onClickTab={onSetScale(LOG)}
-            />
-          </Tabber>
-        </form>
-      </div>
-    </FancyScrollbar>
-  )
+            <Tabber
+              labelText="Y-Value's Format"
+              tipID="Y-Values's Format"
+              tipContent={TOOLTIP_CONTENT.FORMAT}
+            >
+              <Tab
+                text="K/M/B"
+                isActive={base === BASE_10}
+                onClickTab={this.handleSetBase(BASE_10)}
+              />
+              <Tab
+                text="K/M/G"
+                isActive={base === BASE_2}
+                onClickTab={this.handleSetBase(BASE_2)}
+              />
+            </Tabber>
+            <Tabber labelText="Scale">
+              <Tab
+                text="Linear"
+                isActive={scale === LINEAR}
+                onClickTab={this.handleSetScale(LINEAR)}
+              />
+              <Tab
+                text="Logarithmic"
+                isActive={scale === LOG}
+                onClickTab={this.handleSetScale(LOG)}
+              />
+            </Tabber>
+          </form>
+        </div>
+      </FancyScrollbar>
+    )
+  }
 }
 
 const {arrayOf, func, shape, string} = PropTypes
@@ -128,13 +183,7 @@ AxesOptions.defaultProps = {
 }
 
 AxesOptions.propTypes = {
-  cellType: string.isRequired,
-  onSetPrefixSuffix: func.isRequired,
-  onSetYAxisBoundMin: func.isRequired,
-  onSetYAxisBoundMax: func.isRequired,
-  onSetLabel: func.isRequired,
-  onSetScale: func.isRequired,
-  onSetBase: func.isRequired,
+  type: string.isRequired,
   axes: shape({
     y: shape({
       bounds: arrayOf(string),
@@ -142,6 +191,16 @@ AxesOptions.propTypes = {
       defaultYLabel: string,
     }),
   }).isRequired,
+  handleUpdateAxes: func.isRequired,
 }
 
-export default AxesOptions
+const mapStateToProps = ({cellEditorOverlay: {cell: {axes, type}}}) => ({
+  axes,
+  type,
+})
+
+const mapDispatchToProps = dispatch => ({
+  handleUpdateAxes: bindActionCreators(updateAxes, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(AxesOptions)

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -19,13 +19,11 @@ const AxesOptions = ({
   onSetPrefixSuffix,
   onSetYAxisBoundMin,
   onSetYAxisBoundMax,
-  selectedGraphType,
+  cellType,
 }) => {
   const [min, max] = bounds
 
-  const {menuOption} = GRAPH_TYPES.find(
-    graph => graph.type === selectedGraphType
-  )
+  const {menuOption} = GRAPH_TYPES.find(graph => graph.type === cellType)
 
   return (
     <FancyScrollbar
@@ -130,7 +128,7 @@ AxesOptions.defaultProps = {
 }
 
 AxesOptions.propTypes = {
-  selectedGraphType: string.isRequired,
+  cellType: string.isRequired,
   onSetPrefixSuffix: func.isRequired,
   onSetYAxisBoundMin: func.isRequired,
   onSetYAxisBoundMax: func.isRequired,

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -345,6 +345,7 @@ CellEditorOverlay.propTypes = {
   }).isRequired,
   dashboardID: string.isRequired,
   sources: arrayOf(shape()),
+  singleStatType: string.isRequired,
   singleStatColors: arrayOf(shape({}).isRequired).isRequired,
   gaugeColors: arrayOf(shape({}).isRequired).isRequired,
 }

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -28,7 +28,7 @@ class CellEditorOverlay extends Component {
   constructor(props) {
     super(props)
 
-    const {cell: {queries, axes}, sources} = props
+    const {cell: {queries}, sources} = props
 
     let source = _.get(queries, ['0', 'source'], null)
     source = sources.find(s => s.links.self === source) || props.source
@@ -45,7 +45,6 @@ class CellEditorOverlay extends Component {
       queriesWorkingDraft,
       activeQueryIndex: 0,
       isDisplayOptionsTabActive: false,
-      axes,
     }
   }
 
@@ -67,7 +66,7 @@ class CellEditorOverlay extends Component {
   }
 
   handleSetSuffix = e => {
-    const {axes} = this.state
+    const {axes} = this.props.cell
 
     this.setState({
       axes: {
@@ -96,46 +95,6 @@ class CellEditorOverlay extends Component {
     this.setState({queriesWorkingDraft: nextQueries})
   }
 
-  handleSetYAxisBoundMin = min => {
-    const {axes} = this.state
-    const {y: {bounds: [, max]}} = axes
-
-    this.setState({
-      axes: {...axes, y: {...axes.y, bounds: [min, max]}},
-    })
-  }
-
-  handleSetYAxisBoundMax = max => {
-    const {axes} = this.state
-    const {y: {bounds: [min]}} = axes
-
-    this.setState({
-      axes: {...axes, y: {...axes.y, bounds: [min, max]}},
-    })
-  }
-
-  handleSetLabel = label => {
-    const {axes} = this.state
-
-    this.setState({axes: {...axes, y: {...axes.y, label}}})
-  }
-
-  handleSetPrefixSuffix = e => {
-    const {axes} = this.state
-    const {prefix, suffix} = e.target.form
-
-    this.setState({
-      axes: {
-        ...axes,
-        y: {
-          ...axes.y,
-          prefix: prefix.value,
-          suffix: suffix.value,
-        },
-      },
-    })
-  }
-
   handleAddQuery = () => {
     const {queriesWorkingDraft} = this.state
     const newIndex = queriesWorkingDraft.length
@@ -157,7 +116,7 @@ class CellEditorOverlay extends Component {
   }
 
   handleSaveCell = () => {
-    const {queriesWorkingDraft, axes} = this.state
+    const {queriesWorkingDraft} = this.state
 
     const {cell, singleStatColors, gaugeColors} = this.props
 
@@ -185,7 +144,6 @@ class CellEditorOverlay extends Component {
     this.props.onSave({
       ...cell,
       queries,
-      axes,
       colors,
     })
   }
@@ -196,34 +154,6 @@ class CellEditorOverlay extends Component {
 
   handleSetActiveQueryIndex = activeQueryIndex => {
     this.setState({activeQueryIndex})
-  }
-
-  handleSetBase = base => () => {
-    const {axes} = this.state
-
-    this.setState({
-      axes: {
-        ...axes,
-        y: {
-          ...axes.y,
-          base,
-        },
-      },
-    })
-  }
-
-  handleSetScale = scale => () => {
-    const {axes} = this.state
-
-    this.setState({
-      axes: {
-        ...axes,
-        y: {
-          ...axes.y,
-          scale,
-        },
-      },
-    })
   }
 
   handleSetQuerySource = source => {
@@ -325,7 +255,6 @@ class CellEditorOverlay extends Component {
     } = this.props
 
     const {
-      axes,
       activeQueryIndex,
       isDisplayOptionsTabActive,
       queriesWorkingDraft,
@@ -355,7 +284,6 @@ class CellEditorOverlay extends Component {
           initialBottomHeight={INITIAL_HEIGHTS.queryMaker}
         >
           <Visualization
-            axes={axes}
             timeRange={timeRange}
             templates={templates}
             autoRefresh={autoRefresh}
@@ -376,20 +304,8 @@ class CellEditorOverlay extends Component {
             />
             {isDisplayOptionsTabActive
               ? <DisplayOptions
-                  axes={axes}
-                  onChooseColor={this.handleChooseColor}
-                  onValidateColorValue={this.handleValidateColorValue}
-                  onUpdateColorValue={this.handleUpdateColorValue}
-                  onAddGaugeThreshold={this.handleAddGaugeThreshold}
-                  onDeleteThreshold={this.handleDeleteThreshold}
-                  onSetBase={this.handleSetBase}
-                  onSetLabel={this.handleSetLabel}
-                  onSetScale={this.handleSetScale}
                   queryConfigs={queriesWorkingDraft}
-                  onSetPrefixSuffix={this.handleSetPrefixSuffix}
                   onSetSuffix={this.handleSetSuffix}
-                  onSetYAxisBoundMin={this.handleSetYAxisBoundMin}
-                  onSetYAxisBoundMax={this.handleSetYAxisBoundMax}
                 />
               : <QueryMaker
                   source={this.getSource()}

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -65,20 +65,6 @@ class CellEditorOverlay extends Component {
     this.overlayRef.focus()
   }
 
-  handleSetSuffix = e => {
-    const {axes} = this.props.cell
-
-    this.setState({
-      axes: {
-        ...axes,
-        y: {
-          ...axes.y,
-          suffix: e.target.value,
-        },
-      },
-    })
-  }
-
   queryStateReducer = queryModifier => (queryID, ...payload) => {
     const {queriesWorkingDraft} = this.state
     const query = queriesWorkingDraft.find(q => q.id === queryID)
@@ -303,10 +289,7 @@ class CellEditorOverlay extends Component {
               onClickDisplayOptions={this.handleClickDisplayOptionsTab}
             />
             {isDisplayOptionsTabActive
-              ? <DisplayOptions
-                  queryConfigs={queriesWorkingDraft}
-                  onSetSuffix={this.handleSetSuffix}
-                />
+              ? <DisplayOptions queryConfigs={queriesWorkingDraft} />
               : <QueryMaker
                   source={this.getSource()}
                   templates={templates}

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -38,7 +38,7 @@ class CellEditorOverlay extends Component {
   constructor(props) {
     super(props)
 
-    const {cell: {name, queries, axes, colors}, sources} = props
+    const {cell: {queries, axes, colors}, sources} = props
 
     let source = _.get(queries, ['0', 'source'], null)
     source = sources.find(s => s.links.self === source) || props.source
@@ -54,7 +54,6 @@ class CellEditorOverlay extends Component {
     const singleStatType = getSingleStatType(colors)
 
     this.state = {
-      cellWorkingName: name,
       queriesWorkingDraft,
       activeQueryIndex: 0,
       isDisplayOptionsTabActive: false,
@@ -358,7 +357,6 @@ class CellEditorOverlay extends Component {
   handleSaveCell = () => {
     const {
       queriesWorkingDraft,
-      cellWorkingName: name,
       axes,
       gaugeColors,
       singleStatColors,
@@ -389,7 +387,6 @@ class CellEditorOverlay extends Component {
 
     this.props.onSave({
       ...cell,
-      name,
       queries,
       axes,
       colors,
@@ -416,10 +413,6 @@ class CellEditorOverlay extends Component {
         },
       },
     })
-  }
-
-  handleCellRename = newName => {
-    this.setState({cellWorkingName: newName})
   }
 
   handleSetScale = scale => () => {
@@ -540,7 +533,6 @@ class CellEditorOverlay extends Component {
       gaugeColors,
       singleStatColors,
       activeQueryIndex,
-      cellWorkingName,
       isDisplayOptionsTabActive,
       queriesWorkingDraft,
       singleStatType,
@@ -576,13 +568,11 @@ class CellEditorOverlay extends Component {
             axes={axes}
             colors={visualizationColors}
             type={cell.type}
-            name={cellWorkingName}
             timeRange={timeRange}
             templates={templates}
             autoRefresh={autoRefresh}
             queryConfigs={queriesWorkingDraft}
             editQueryStatus={editQueryStatus}
-            onCellRename={this.handleCellRename}
           />
           <CEOBottom>
             <OverlayControls

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -345,7 +345,6 @@ CellEditorOverlay.propTypes = {
   }).isRequired,
   dashboardID: string.isRequired,
   sources: arrayOf(shape()),
-  singleStatType: string.isRequired,
   singleStatColors: arrayOf(shape({}).isRequired).isRequired,
   gaugeColors: arrayOf(shape({}).isRequired).isRequired,
 }

--- a/ui/src/dashboards/components/CellEditorOverlay.js
+++ b/ui/src/dashboards/components/CellEditorOverlay.js
@@ -38,7 +38,7 @@ class CellEditorOverlay extends Component {
   constructor(props) {
     super(props)
 
-    const {cell: {name, type, queries, axes, colors}, sources} = props
+    const {cell: {name, queries, axes, colors}, sources} = props
 
     let source = _.get(queries, ['0', 'source'], null)
     source = sources.find(s => s.links.self === source) || props.source
@@ -55,7 +55,6 @@ class CellEditorOverlay extends Component {
 
     this.state = {
       cellWorkingName: name,
-      cellWorkingType: type,
       queriesWorkingDraft,
       activeQueryIndex: 0,
       isDisplayOptionsTabActive: false,
@@ -141,9 +140,9 @@ class CellEditorOverlay extends Component {
   }
 
   handleDeleteThreshold = threshold => () => {
-    const {cellWorkingType} = this.state
+    const {type} = this.props.cell
 
-    if (cellWorkingType === 'gauge') {
+    if (type === 'gauge') {
       const gaugeColors = this.state.gaugeColors.filter(
         color => color.id !== threshold.id
       )
@@ -151,7 +150,7 @@ class CellEditorOverlay extends Component {
       this.setState({gaugeColors})
     }
 
-    if (cellWorkingType === 'single-stat') {
+    if (type === 'single-stat') {
       const singleStatColors = this.state.singleStatColors.filter(
         color => color.id !== threshold.id
       )
@@ -161,9 +160,9 @@ class CellEditorOverlay extends Component {
   }
 
   handleChooseColor = threshold => chosenColor => {
-    const {cellWorkingType} = this.state
+    const {type} = this.props.cell
 
-    if (cellWorkingType === 'gauge') {
+    if (type === 'gauge') {
       const gaugeColors = this.state.gaugeColors.map(
         color =>
           color.id === threshold.id
@@ -174,7 +173,7 @@ class CellEditorOverlay extends Component {
       this.setState({gaugeColors})
     }
 
-    if (cellWorkingType === 'single-stat') {
+    if (type === 'single-stat') {
       const singleStatColors = this.state.singleStatColors.map(
         color =>
           color.id === threshold.id
@@ -187,9 +186,9 @@ class CellEditorOverlay extends Component {
   }
 
   handleUpdateColorValue = (threshold, value) => {
-    const {cellWorkingType} = this.state
+    const {type} = this.props.cell
 
-    if (cellWorkingType === 'gauge') {
+    if (type === 'gauge') {
       const gaugeColors = this.state.gaugeColors.map(
         color => (color.id === threshold.id ? {...color, value} : color)
       )
@@ -197,7 +196,7 @@ class CellEditorOverlay extends Component {
       this.setState({gaugeColors})
     }
 
-    if (cellWorkingType === 'single-stat') {
+    if (type === 'single-stat') {
       const singleStatColors = this.state.singleStatColors.map(
         color => (color.id === threshold.id ? {...color, value} : color)
       )
@@ -207,11 +206,13 @@ class CellEditorOverlay extends Component {
   }
 
   handleValidateColorValue = (threshold, targetValue) => {
-    const {gaugeColors, singleStatColors, cellWorkingType} = this.state
+    const {gaugeColors, singleStatColors} = this.state
+    const {type} = this.props.cell
+
     const thresholdValue = threshold.value
     let allowedToUpdate = false
 
-    if (cellWorkingType === 'single-stat') {
+    if (type === 'single-stat') {
       // If type is single-stat then value only has to be unique
       const sortedColors = _.sortBy(singleStatColors, color => color.value)
       return !sortedColors.some(color => color.value === targetValue)
@@ -357,7 +358,6 @@ class CellEditorOverlay extends Component {
   handleSaveCell = () => {
     const {
       queriesWorkingDraft,
-      cellWorkingType: type,
       cellWorkingName: name,
       axes,
       gaugeColors,
@@ -378,24 +378,22 @@ class CellEditorOverlay extends Component {
     })
 
     let colors = []
-    if (type === 'gauge') {
+    if (cell.type === 'gauge') {
       colors = stringifyColorValues(gaugeColors)
-    } else if (type === 'single-stat' || type === 'line-plus-single-stat') {
+    } else if (
+      cell.type === 'single-stat' ||
+      cell.type === 'line-plus-single-stat'
+    ) {
       colors = stringifyColorValues(singleStatColors)
     }
 
     this.props.onSave({
       ...cell,
       name,
-      type,
       queries,
       axes,
       colors,
     })
-  }
-
-  handleSelectGraphType = cellWorkingType => () => {
-    this.setState({cellWorkingType})
   }
 
   handleClickDisplayOptionsTab = isDisplayOptionsTabActive => () => {
@@ -529,6 +527,7 @@ class CellEditorOverlay extends Component {
 
   render() {
     const {
+      cell,
       onCancel,
       templates,
       timeRange,
@@ -542,7 +541,6 @@ class CellEditorOverlay extends Component {
       singleStatColors,
       activeQueryIndex,
       cellWorkingName,
-      cellWorkingType,
       isDisplayOptionsTabActive,
       queriesWorkingDraft,
       singleStatType,
@@ -558,7 +556,7 @@ class CellEditorOverlay extends Component {
       !!query.rawText
 
     const visualizationColors =
-      cellWorkingType === 'gauge' ? gaugeColors : singleStatColors
+      cell.type === 'gauge' ? gaugeColors : singleStatColors
 
     return (
       <div
@@ -577,7 +575,7 @@ class CellEditorOverlay extends Component {
           <Visualization
             axes={axes}
             colors={visualizationColors}
-            type={cellWorkingType}
+            type={cell.type}
             name={cellWorkingName}
             timeRange={timeRange}
             templates={templates}
@@ -615,10 +613,8 @@ class CellEditorOverlay extends Component {
                   onSetLabel={this.handleSetLabel}
                   onSetScale={this.handleSetScale}
                   queryConfigs={queriesWorkingDraft}
-                  selectedGraphType={cellWorkingType}
                   onSetPrefixSuffix={this.handleSetPrefixSuffix}
                   onSetSuffix={this.handleSetSuffix}
-                  onSelectGraphType={this.handleSelectGraphType}
                   onSetYAxisBoundMin={this.handleSetYAxisBoundMin}
                   onSetYAxisBoundMax={this.handleSetYAxisBoundMax}
                 />

--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -35,17 +35,7 @@ class DisplayOptions extends Component {
   }
 
   renderOptions = () => {
-    const {
-      cell,
-      onSetBase,
-      onSetScale,
-      onSetLabel,
-      onSetPrefixSuffix,
-      onSetYAxisBoundMin,
-      onSetYAxisBoundMax,
-      onSetSuffix,
-    } = this.props
-    const {axes, axes: {y: {suffix}}} = this.state
+    const {cell, cell: {axes: {y: {suffix}}}, onSetSuffix} = this.props
 
     switch (cell.type) {
       case 'gauge':
@@ -53,18 +43,7 @@ class DisplayOptions extends Component {
       case 'single-stat':
         return <SingleStatOptions suffix={suffix} onSetSuffix={onSetSuffix} />
       default:
-        return (
-          <AxesOptions
-            cellType={cell.type}
-            axes={axes}
-            onSetBase={onSetBase}
-            onSetLabel={onSetLabel}
-            onSetScale={onSetScale}
-            onSetPrefixSuffix={onSetPrefixSuffix}
-            onSetYAxisBoundMin={onSetYAxisBoundMin}
-            onSetYAxisBoundMax={onSetYAxisBoundMax}
-          />
-        )
+        return <AxesOptions />
     }
   }
 
@@ -83,19 +62,20 @@ DisplayOptions.propTypes = {
   cell: shape({
     type: string.isRequired,
   }).isRequired,
-  onSetPrefixSuffix: func.isRequired,
+  axes: shape({
+    y: shape({
+      bounds: arrayOf(string),
+      label: string,
+      defaultYLabel: string,
+    }),
+  }).isRequired,
   onSetSuffix: func.isRequired,
-  onSetYAxisBoundMin: func.isRequired,
-  onSetYAxisBoundMax: func.isRequired,
-  onSetScale: func.isRequired,
-  onSetLabel: func.isRequired,
-  onSetBase: func.isRequired,
-  axes: shape({}).isRequired,
   queryConfigs: arrayOf(shape()).isRequired,
 }
 
-const mapStateToProps = ({cellEditorOverlay: {cell}}) => ({
+const mapStateToProps = ({cellEditorOverlay: {cell, cell: {axes}}}) => ({
   cell,
+  axes,
 })
 
 export default connect(mapStateToProps, null)(DisplayOptions)

--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -37,34 +37,19 @@ class DisplayOptions extends Component {
   renderOptions = () => {
     const {
       cell,
-      gaugeColors,
       onSetBase,
       onSetScale,
       onSetLabel,
       onSetPrefixSuffix,
       onSetYAxisBoundMin,
       onSetYAxisBoundMax,
-      onAddGaugeThreshold,
-      onDeleteThreshold,
-      onChooseColor,
-      onValidateColorValue,
-      onUpdateColorValue,
       onSetSuffix,
     } = this.props
     const {axes, axes: {y: {suffix}}} = this.state
 
     switch (cell.type) {
       case 'gauge':
-        return (
-          <GaugeOptions
-            colors={gaugeColors}
-            onChooseColor={onChooseColor}
-            onValidateColorValue={onValidateColorValue}
-            onUpdateColorValue={onUpdateColorValue}
-            onAddThreshold={onAddGaugeThreshold}
-            onDeleteThreshold={onDeleteThreshold}
-          />
-        )
+        return <GaugeOptions />
       case 'single-stat':
         return <SingleStatOptions suffix={suffix} onSetSuffix={onSetSuffix} />
       default:
@@ -92,14 +77,9 @@ class DisplayOptions extends Component {
     )
   }
 }
-const {arrayOf, func, number, shape, string} = PropTypes
+const {arrayOf, func, shape, string} = PropTypes
 
 DisplayOptions.propTypes = {
-  onAddGaugeThreshold: func.isRequired,
-  onDeleteThreshold: func.isRequired,
-  onChooseColor: func.isRequired,
-  onValidateColorValue: func.isRequired,
-  onUpdateColorValue: func.isRequired,
   cell: shape({
     type: string.isRequired,
   }).isRequired,
@@ -111,15 +91,6 @@ DisplayOptions.propTypes = {
   onSetLabel: func.isRequired,
   onSetBase: func.isRequired,
   axes: shape({}).isRequired,
-  gaugeColors: arrayOf(
-    shape({
-      type: string.isRequired,
-      hex: string.isRequired,
-      id: string.isRequired,
-      name: string.isRequired,
-      value: number.isRequired,
-    }).isRequired
-  ),
   queryConfigs: arrayOf(shape()).isRequired,
 }
 

--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -1,4 +1,5 @@
 import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
 
 import GraphTypeSelector from 'src/dashboards/components/GraphTypeSelector'
 import GaugeOptions from 'src/dashboards/components/GaugeOptions'
@@ -35,12 +36,12 @@ class DisplayOptions extends Component {
 
   renderOptions = () => {
     const {
+      cell,
       gaugeColors,
       singleStatColors,
       onSetBase,
       onSetScale,
       onSetLabel,
-      selectedGraphType,
       onSetPrefixSuffix,
       onSetYAxisBoundMin,
       onSetYAxisBoundMax,
@@ -56,7 +57,7 @@ class DisplayOptions extends Component {
     } = this.props
     const {axes, axes: {y: {suffix}}} = this.state
 
-    switch (selectedGraphType) {
+    switch (cell.type) {
       case 'gauge':
         return (
           <GaugeOptions
@@ -86,7 +87,7 @@ class DisplayOptions extends Component {
       default:
         return (
           <AxesOptions
-            selectedGraphType={selectedGraphType}
+            cellType={cell.type}
             axes={axes}
             onSetBase={onSetBase}
             onSetLabel={onSetLabel}
@@ -100,14 +101,9 @@ class DisplayOptions extends Component {
   }
 
   render() {
-    const {selectedGraphType, onSelectGraphType} = this.props
-
     return (
       <div className="display-options">
-        <GraphTypeSelector
-          selectedGraphType={selectedGraphType}
-          onSelectGraphType={onSelectGraphType}
-        />
+        <GraphTypeSelector />
         {this.renderOptions()}
       </div>
     )
@@ -122,8 +118,9 @@ DisplayOptions.propTypes = {
   onChooseColor: func.isRequired,
   onValidateColorValue: func.isRequired,
   onUpdateColorValue: func.isRequired,
-  selectedGraphType: string.isRequired,
-  onSelectGraphType: func.isRequired,
+  cell: shape({
+    type: string.isRequired,
+  }).isRequired,
   onSetPrefixSuffix: func.isRequired,
   onSetSuffix: func.isRequired,
   onSetYAxisBoundMin: func.isRequired,
@@ -155,4 +152,8 @@ DisplayOptions.propTypes = {
   onToggleSingleStatType: func.isRequired,
 }
 
-export default DisplayOptions
+const mapStateToProps = ({cellEditorOverlay: {cell}}) => ({
+  cell,
+})
+
+export default connect(mapStateToProps, null)(DisplayOptions)

--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -35,13 +35,13 @@ class DisplayOptions extends Component {
   }
 
   renderOptions = () => {
-    const {cell, cell: {axes: {y: {suffix}}}, onSetSuffix} = this.props
+    const {cell: {type}} = this.props
 
-    switch (cell.type) {
+    switch (type) {
       case 'gauge':
         return <GaugeOptions />
       case 'single-stat':
-        return <SingleStatOptions suffix={suffix} onSetSuffix={onSetSuffix} />
+        return <SingleStatOptions />
       default:
         return <AxesOptions />
     }
@@ -56,7 +56,7 @@ class DisplayOptions extends Component {
     )
   }
 }
-const {arrayOf, func, shape, string} = PropTypes
+const {arrayOf, shape, string} = PropTypes
 
 DisplayOptions.propTypes = {
   cell: shape({
@@ -69,7 +69,6 @@ DisplayOptions.propTypes = {
       defaultYLabel: string,
     }),
   }).isRequired,
-  onSetSuffix: func.isRequired,
   queryConfigs: arrayOf(shape()).isRequired,
 }
 

--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -38,7 +38,6 @@ class DisplayOptions extends Component {
     const {
       cell,
       gaugeColors,
-      singleStatColors,
       onSetBase,
       onSetScale,
       onSetLabel,
@@ -46,13 +45,10 @@ class DisplayOptions extends Component {
       onSetYAxisBoundMin,
       onSetYAxisBoundMax,
       onAddGaugeThreshold,
-      onAddSingleStatThreshold,
       onDeleteThreshold,
       onChooseColor,
       onValidateColorValue,
       onUpdateColorValue,
-      singleStatType,
-      onToggleSingleStatType,
       onSetSuffix,
     } = this.props
     const {axes, axes: {y: {suffix}}} = this.state
@@ -70,20 +66,7 @@ class DisplayOptions extends Component {
           />
         )
       case 'single-stat':
-        return (
-          <SingleStatOptions
-            colors={singleStatColors}
-            suffix={suffix}
-            onSetSuffix={onSetSuffix}
-            onChooseColor={onChooseColor}
-            onValidateColorValue={onValidateColorValue}
-            onUpdateColorValue={onUpdateColorValue}
-            onAddThreshold={onAddSingleStatThreshold}
-            onDeleteThreshold={onDeleteThreshold}
-            singleStatType={singleStatType}
-            onToggleSingleStatType={onToggleSingleStatType}
-          />
-        )
+        return <SingleStatOptions suffix={suffix} onSetSuffix={onSetSuffix} />
       default:
         return (
           <AxesOptions
@@ -113,7 +96,6 @@ const {arrayOf, func, number, shape, string} = PropTypes
 
 DisplayOptions.propTypes = {
   onAddGaugeThreshold: func.isRequired,
-  onAddSingleStatThreshold: func.isRequired,
   onDeleteThreshold: func.isRequired,
   onChooseColor: func.isRequired,
   onValidateColorValue: func.isRequired,
@@ -138,18 +120,7 @@ DisplayOptions.propTypes = {
       value: number.isRequired,
     }).isRequired
   ),
-  singleStatColors: arrayOf(
-    shape({
-      type: string.isRequired,
-      hex: string.isRequired,
-      id: string.isRequired,
-      name: string.isRequired,
-      value: number.isRequired,
-    }).isRequired
-  ),
   queryConfigs: arrayOf(shape()).isRequired,
-  singleStatType: string.isRequired,
-  onToggleSingleStatType: func.isRequired,
 }
 
 const mapStateToProps = ({cellEditorOverlay: {cell}}) => ({

--- a/ui/src/dashboards/components/GaugeOptions.js
+++ b/ui/src/dashboards/components/GaugeOptions.js
@@ -1,67 +1,172 @@
-import React, {PropTypes} from 'react'
+import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+
 import _ from 'lodash'
+import uuid from 'node-uuid'
 
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 import Threshold from 'src/dashboards/components/Threshold'
 
 import {
+  COLOR_TYPE_THRESHOLD,
+  GAUGE_COLORS,
   MAX_THRESHOLDS,
   MIN_THRESHOLDS,
 } from 'src/dashboards/constants/gaugeColors'
 
-const GaugeOptions = ({
-  colors,
-  onAddThreshold,
-  onDeleteThreshold,
-  onChooseColor,
-  onValidateColorValue,
-  onUpdateColorValue,
-}) => {
-  const disableMaxColor = colors.length > MIN_THRESHOLDS
-  const disableAddThreshold = colors.length > MAX_THRESHOLDS
-  const sortedColors = _.sortBy(colors, color => color.value)
+import {updateGaugeColors} from 'src/dashboards/actions/cellEditorOverlay'
 
-  return (
-    <FancyScrollbar
-      className="display-options--cell y-axis-controls"
-      autoHide={false}
-    >
-      <div className="display-options--cell-wrapper">
-        <h5 className="display-options--header">Gauge Controls</h5>
-        <div className="gauge-controls">
-          <button
-            className="btn btn-sm btn-primary gauge-controls--add-threshold"
-            onClick={onAddThreshold}
-            disabled={disableAddThreshold}
-          >
-            <span className="icon plus" /> Add Threshold
-          </button>
-          {sortedColors.map(color =>
-            <Threshold
-              isMin={color.value === sortedColors[0].value}
-              isMax={
-                color.value === sortedColors[sortedColors.length - 1].value
-              }
-              visualizationType="gauge"
-              threshold={color}
-              key={color.id}
-              disableMaxColor={disableMaxColor}
-              onChooseColor={onChooseColor}
-              onValidateColorValue={onValidateColorValue}
-              onUpdateColorValue={onUpdateColorValue}
-              onDeleteThreshold={onDeleteThreshold}
-            />
-          )}
+class GaugeOptions extends Component {
+  handleAddThreshold = () => {
+    const {gaugeColors, handleUpdateGaugeColors} = this.props
+    const sortedColors = _.sortBy(gaugeColors, color => color.value)
+
+    if (sortedColors.length <= MAX_THRESHOLDS) {
+      const randomColor = _.random(0, GAUGE_COLORS.length - 1)
+
+      const maxValue = sortedColors[sortedColors.length - 1].value
+      const minValue = sortedColors[0].value
+
+      const colorsValues = _.mapValues(gaugeColors, 'value')
+      let randomValue
+
+      do {
+        randomValue = _.round(_.random(minValue, maxValue, true), 2)
+      } while (_.includes(colorsValues, randomValue))
+
+      const newThreshold = {
+        type: COLOR_TYPE_THRESHOLD,
+        id: uuid.v4(),
+        value: randomValue,
+        hex: GAUGE_COLORS[randomColor].hex,
+        name: GAUGE_COLORS[randomColor].name,
+      }
+
+      handleUpdateGaugeColors([...gaugeColors, newThreshold])
+    }
+  }
+
+  handleDeleteThreshold = threshold => () => {
+    const {handleUpdateGaugeColors} = this.props
+    const gaugeColors = this.props.gaugeColors.filter(
+      color => color.id !== threshold.id
+    )
+
+    handleUpdateGaugeColors(gaugeColors)
+  }
+
+  handleChooseColor = threshold => chosenColor => {
+    const {handleUpdateGaugeColors} = this.props
+    const gaugeColors = this.props.gaugeColors.map(
+      color =>
+        color.id === threshold.id
+          ? {...color, hex: chosenColor.hex, name: chosenColor.name}
+          : color
+    )
+
+    handleUpdateGaugeColors(gaugeColors)
+  }
+
+  handleUpdateColorValue = (threshold, value) => {
+    const {handleUpdateGaugeColors} = this.props
+    const gaugeColors = this.props.gaugeColors.map(
+      color => (color.id === threshold.id ? {...color, value} : color)
+    )
+
+    handleUpdateGaugeColors(gaugeColors)
+  }
+
+  handleValidateColorValue = (threshold, targetValue) => {
+    const {gaugeColors} = this.props
+
+    const thresholdValue = threshold.value
+    let allowedToUpdate = false
+
+    const sortedColors = _.sortBy(gaugeColors, color => color.value)
+
+    const minValue = sortedColors[0].value
+    const maxValue = sortedColors[sortedColors.length - 1].value
+
+    // If lowest value, make sure it is less than the next threshold
+    if (thresholdValue === minValue) {
+      const nextValue = sortedColors[1].value
+      allowedToUpdate = targetValue < nextValue
+    }
+    // If highest value, make sure it is greater than the previous threshold
+    if (thresholdValue === maxValue) {
+      const previousValue = sortedColors[sortedColors.length - 2].value
+      allowedToUpdate = previousValue < targetValue
+    }
+    // If not min or max, make sure new value is greater than min, less than max, and unique
+    if (thresholdValue !== minValue && thresholdValue !== maxValue) {
+      const greaterThanMin = targetValue > minValue
+      const lessThanMax = targetValue < maxValue
+
+      const colorsWithoutMinOrMax = sortedColors.slice(
+        1,
+        sortedColors.length - 1
+      )
+
+      const isUnique = !colorsWithoutMinOrMax.some(
+        color => color.value === targetValue
+      )
+
+      allowedToUpdate = greaterThanMin && lessThanMax && isUnique
+    }
+
+    return allowedToUpdate
+  }
+
+  render() {
+    const {gaugeColors} = this.props
+
+    const disableMaxColor = gaugeColors.length > MIN_THRESHOLDS
+    const disableAddThreshold = gaugeColors.length > MAX_THRESHOLDS
+    const sortedColors = _.sortBy(gaugeColors, color => color.value)
+
+    return (
+      <FancyScrollbar
+        className="display-options--cell y-axis-controls"
+        autoHide={false}
+      >
+        <div className="display-options--cell-wrapper">
+          <h5 className="display-options--header">Gauge Controls</h5>
+          <div className="gauge-controls">
+            <button
+              className="btn btn-sm btn-primary gauge-controls--add-threshold"
+              onClick={this.handleAddThreshold}
+              disabled={disableAddThreshold}
+            >
+              <span className="icon plus" /> Add Threshold
+            </button>
+            {sortedColors.map(color =>
+              <Threshold
+                isMin={color.value === sortedColors[0].value}
+                isMax={
+                  color.value === sortedColors[sortedColors.length - 1].value
+                }
+                visualizationType="gauge"
+                threshold={color}
+                key={color.id}
+                disableMaxColor={disableMaxColor}
+                onChooseColor={this.handleChooseColor}
+                onValidateColorValue={this.handleValidateColorValue}
+                onUpdateColorValue={this.handleUpdateColorValue}
+                onDeleteThreshold={this.handleDeleteThreshold}
+              />
+            )}
+          </div>
         </div>
-      </div>
-    </FancyScrollbar>
-  )
+      </FancyScrollbar>
+    )
+  }
 }
 
 const {arrayOf, func, number, shape, string} = PropTypes
 
 GaugeOptions.propTypes = {
-  colors: arrayOf(
+  gaugeColors: arrayOf(
     shape({
       type: string.isRequired,
       hex: string.isRequired,
@@ -70,11 +175,14 @@ GaugeOptions.propTypes = {
       value: number.isRequired,
     }).isRequired
   ),
-  onAddThreshold: func.isRequired,
-  onDeleteThreshold: func.isRequired,
-  onChooseColor: func.isRequired,
-  onValidateColorValue: func.isRequired,
-  onUpdateColorValue: func.isRequired,
+  handleUpdateGaugeColors: func.isRequired,
 }
 
-export default GaugeOptions
+const mapStateToProps = ({cellEditorOverlay: {gaugeColors}}) => ({
+  gaugeColors,
+})
+
+const mapDispatchToProps = dispatch => ({
+  handleUpdateGaugeColors: bindActionCreators(updateGaugeColors, dispatch),
+})
+export default connect(mapStateToProps, mapDispatchToProps)(GaugeOptions)

--- a/ui/src/dashboards/components/GraphTypeSelector.js
+++ b/ui/src/dashboards/components/GraphTypeSelector.js
@@ -1,41 +1,61 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
 import classnames from 'classnames'
+
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 
 import {GRAPH_TYPES} from 'src/dashboards/graphics/graph'
 
-const GraphTypeSelector = ({selectedGraphType, onSelectGraphType}) =>
-  <FancyScrollbar
-    className="display-options--cell display-options--cellx2"
-    autoHide={false}
-  >
-    <div className="display-options--cell-wrapper">
-      <h5 className="display-options--header">Visualization Type</h5>
-      <div className="viz-type-selector">
-        {GRAPH_TYPES.map(graphType =>
-          <div
-            key={graphType.type}
-            className={classnames('viz-type-selector--option', {
-              active: graphType.type === selectedGraphType,
-            })}
-          >
-            <div onClick={onSelectGraphType(graphType.type)}>
-              {graphType.graphic}
-              <p>
-                {graphType.menuOption}
-              </p>
+import {changeCellType} from 'src/dashboards/actions/cellEditorOverlay'
+
+const GraphTypeSelector = ({type, handleChangeCellType}) => {
+  const onChangeCellType = newType => () => {
+    handleChangeCellType(newType)
+  }
+
+  return (
+    <FancyScrollbar
+      className="display-options--cell display-options--cellx2"
+      autoHide={false}
+    >
+      <div className="display-options--cell-wrapper">
+        <h5 className="display-options--header">Visualization Type</h5>
+        <div className="viz-type-selector">
+          {GRAPH_TYPES.map(graphType =>
+            <div
+              key={graphType.type}
+              className={classnames('viz-type-selector--option', {
+                active: graphType.type === type,
+              })}
+            >
+              <div onClick={onChangeCellType(graphType.type)}>
+                {graphType.graphic}
+                <p>
+                  {graphType.menuOption}
+                </p>
+              </div>
             </div>
-          </div>
-        )}
+          )}
+        </div>
       </div>
-    </div>
-  </FancyScrollbar>
+    </FancyScrollbar>
+  )
+}
 
 const {func, string} = PropTypes
 
 GraphTypeSelector.propTypes = {
-  selectedGraphType: string.isRequired,
-  onSelectGraphType: func.isRequired,
+  type: string.isRequired,
+  handleChangeCellType: func.isRequired,
 }
 
-export default GraphTypeSelector
+const mapStateToProps = ({cellEditorOverlay: {cell: {type}}}) => ({
+  type,
+})
+
+const mapDispatchToProps = dispatch => ({
+  handleChangeCellType: bindActionCreators(changeCellType, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(GraphTypeSelector)

--- a/ui/src/dashboards/components/SingleStatOptions.js
+++ b/ui/src/dashboards/components/SingleStatOptions.js
@@ -1,5 +1,9 @@
-import React, {PropTypes} from 'react'
+import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
+
 import _ from 'lodash'
+import uuid from 'node-uuid'
 
 import FancyScrollbar from 'shared/components/FancyScrollbar'
 import Threshold from 'src/dashboards/components/Threshold'
@@ -7,106 +11,185 @@ import ColorDropdown from 'shared/components/ColorDropdown'
 
 import {
   GAUGE_COLORS,
+  DEFAULT_VALUE_MIN,
+  DEFAULT_VALUE_MAX,
   MAX_THRESHOLDS,
   SINGLE_STAT_BASE,
   SINGLE_STAT_TEXT,
   SINGLE_STAT_BG,
 } from 'src/dashboards/constants/gaugeColors'
 
+import {
+  updateSingleStatType,
+  updateSingleStatColors,
+} from 'src/dashboards/actions/cellEditorOverlay'
+
 const formatColor = color => {
   const {hex, name} = color
   return {hex, name}
 }
-const SingleStatOptions = ({
-  suffix,
-  onSetSuffix,
-  colors,
-  onAddThreshold,
-  onDeleteThreshold,
-  onChooseColor,
-  onValidateColorValue,
-  onUpdateColorValue,
-  singleStatType,
-  onToggleSingleStatType,
-}) => {
-  const disableAddThreshold = colors.length > MAX_THRESHOLDS
 
-  const sortedColors = _.sortBy(colors, color => color.value)
+class SingleStatOptions extends Component {
+  handleToggleSingleStatType = newType => () => {
+    const {handleUpdateSingleStatType} = this.props
 
-  return (
-    <FancyScrollbar
-      className="display-options--cell y-axis-controls"
-      autoHide={false}
-    >
-      <div className="display-options--cell-wrapper">
-        <h5 className="display-options--header">Single Stat Controls</h5>
-        <div className="gauge-controls">
-          <button
-            className="btn btn-sm btn-primary gauge-controls--add-threshold"
-            onClick={onAddThreshold}
-            disabled={disableAddThreshold}
-          >
-            <span className="icon plus" /> Add Threshold
-          </button>
-          {sortedColors.map(
-            color =>
-              color.id === SINGLE_STAT_BASE
-                ? <div className="gauge-controls--section" key={color.id}>
-                    <div className="gauge-controls--label">Base Color</div>
-                    <ColorDropdown
-                      colors={GAUGE_COLORS}
-                      selected={formatColor(color)}
-                      onChoose={onChooseColor(color)}
-                      stretchToFit={true}
+    handleUpdateSingleStatType(newType)
+  }
+
+  handleAddThreshold = () => {
+    const {
+      singleStatColors,
+      singleStatType,
+      handleUpdateSingleStatColors,
+    } = this.props
+
+    const randomColor = _.random(0, GAUGE_COLORS.length - 1)
+
+    const maxValue = DEFAULT_VALUE_MIN
+    const minValue = DEFAULT_VALUE_MAX
+
+    let randomValue = _.round(_.random(minValue, maxValue, true), 2)
+
+    if (singleStatColors.length > 0) {
+      const colorsValues = _.mapValues(singleStatColors, 'value')
+      do {
+        randomValue = _.round(_.random(minValue, maxValue, true), 2)
+      } while (_.includes(colorsValues, randomValue))
+    }
+
+    const newThreshold = {
+      type: singleStatType,
+      id: uuid.v4(),
+      value: randomValue,
+      hex: GAUGE_COLORS[randomColor].hex,
+      name: GAUGE_COLORS[randomColor].name,
+    }
+
+    handleUpdateSingleStatColors([...singleStatColors, newThreshold])
+  }
+
+  handleDeleteThreshold = threshold => () => {
+    const {handleUpdateSingleStatColors} = this.props
+
+    const singleStatColors = this.props.singleStatColors.filter(
+      color => color.id !== threshold.id
+    )
+
+    handleUpdateSingleStatColors(singleStatColors)
+  }
+
+  handleChooseColor = threshold => chosenColor => {
+    const {handleUpdateSingleStatColors} = this.props
+
+    const singleStatColors = this.props.singleStatColors.map(
+      color =>
+        color.id === threshold.id
+          ? {...color, hex: chosenColor.hex, name: chosenColor.name}
+          : color
+    )
+
+    handleUpdateSingleStatColors(singleStatColors)
+  }
+
+  handleUpdateColorValue = (threshold, value) => {
+    const {handleUpdateSingleStatColors} = this.props
+
+    const singleStatColors = this.props.singleStatColors.map(
+      color => (color.id === threshold.id ? {...color, value} : color)
+    )
+
+    handleUpdateSingleStatColors(singleStatColors)
+  }
+
+  handleValidateColorValue = (threshold, targetValue) => {
+    const {singleStatColors} = this.props
+    const sortedColors = _.sortBy(singleStatColors, color => color.value)
+
+    return !sortedColors.some(color => color.value === targetValue)
+  }
+
+  render() {
+    const {suffix, onSetSuffix, singleStatColors, singleStatType} = this.props
+
+    const disableAddThreshold = singleStatColors.length > MAX_THRESHOLDS
+
+    const sortedColors = _.sortBy(singleStatColors, color => color.value)
+
+    return (
+      <FancyScrollbar
+        className="display-options--cell y-axis-controls"
+        autoHide={false}
+      >
+        <div className="display-options--cell-wrapper">
+          <h5 className="display-options--header">Single Stat Controls</h5>
+          <div className="gauge-controls">
+            <button
+              className="btn btn-sm btn-primary gauge-controls--add-threshold"
+              onClick={this.handleAddThreshold}
+              disabled={disableAddThreshold}
+            >
+              <span className="icon plus" /> Add Threshold
+            </button>
+            {sortedColors.map(
+              color =>
+                color.id === SINGLE_STAT_BASE
+                  ? <div className="gauge-controls--section" key={color.id}>
+                      <div className="gauge-controls--label">Base Color</div>
+                      <ColorDropdown
+                        colors={GAUGE_COLORS}
+                        selected={formatColor(color)}
+                        onChoose={this.handleChooseColor(color)}
+                        stretchToFit={true}
+                      />
+                    </div>
+                  : <Threshold
+                      visualizationType="single-stat"
+                      threshold={color}
+                      key={color.id}
+                      onChooseColor={this.handleChooseColor}
+                      onValidateColorValue={this.handleValidateColorValue}
+                      onUpdateColorValue={this.handleUpdateColorValue}
+                      onDeleteThreshold={this.handleDeleteThreshold}
                     />
-                  </div>
-                : <Threshold
-                    visualizationType="single-stat"
-                    threshold={color}
-                    key={color.id}
-                    onChooseColor={onChooseColor}
-                    onValidateColorValue={onValidateColorValue}
-                    onUpdateColorValue={onUpdateColorValue}
-                    onDeleteThreshold={onDeleteThreshold}
-                  />
-          )}
-        </div>
-        <div className="single-stat-controls">
-          <div className="form-group col-xs-6">
-            <label>Coloring</label>
-            <ul className="nav nav-tablist nav-tablist-sm">
-              <li
-                className={`${singleStatType === SINGLE_STAT_BG
-                  ? 'active'
-                  : ''}`}
-                onClick={onToggleSingleStatType(SINGLE_STAT_BG)}
-              >
-                Background
-              </li>
-              <li
-                className={`${singleStatType === SINGLE_STAT_TEXT
-                  ? 'active'
-                  : ''}`}
-                onClick={onToggleSingleStatType(SINGLE_STAT_TEXT)}
-              >
-                Text
-              </li>
-            </ul>
+            )}
           </div>
-          <div className="form-group col-xs-6">
-            <label>Suffix</label>
-            <input
-              className="form-control input-sm"
-              placeholder="%, MPH, etc."
-              defaultValue={suffix}
-              onChange={onSetSuffix}
-              maxLength="5"
-            />
+          <div className="single-stat-controls">
+            <div className="form-group col-xs-6">
+              <label>Coloring</label>
+              <ul className="nav nav-tablist nav-tablist-sm">
+                <li
+                  className={`${singleStatType === SINGLE_STAT_BG
+                    ? 'active'
+                    : ''}`}
+                  onClick={this.handleToggleSingleStatType(SINGLE_STAT_BG)}
+                >
+                  Background
+                </li>
+                <li
+                  className={`${singleStatType === SINGLE_STAT_TEXT
+                    ? 'active'
+                    : ''}`}
+                  onClick={this.handleToggleSingleStatType(SINGLE_STAT_TEXT)}
+                >
+                  Text
+                </li>
+              </ul>
+            </div>
+            <div className="form-group col-xs-6">
+              <label>Suffix</label>
+              <input
+                className="form-control input-sm"
+                placeholder="%, MPH, etc."
+                defaultValue={suffix}
+                onChange={onSetSuffix}
+                maxLength="5"
+              />
+            </div>
           </div>
         </div>
-      </div>
-    </FancyScrollbar>
-  )
+      </FancyScrollbar>
+    )
+  }
 }
 
 const {arrayOf, func, number, shape, string} = PropTypes
@@ -116,7 +199,8 @@ SingleStatOptions.defaultProps = {
 }
 
 SingleStatOptions.propTypes = {
-  colors: arrayOf(
+  singleStatType: string.isRequired,
+  singleStatColors: arrayOf(
     shape({
       type: string.isRequired,
       hex: string.isRequired,
@@ -125,15 +209,28 @@ SingleStatOptions.propTypes = {
       value: number.isRequired,
     }).isRequired
   ),
-  onAddThreshold: func.isRequired,
-  onDeleteThreshold: func.isRequired,
-  onChooseColor: func.isRequired,
-  onValidateColorValue: func.isRequired,
-  onUpdateColorValue: func.isRequired,
-  singleStatType: string.isRequired,
-  onToggleSingleStatType: func.isRequired,
   onSetSuffix: func.isRequired,
   suffix: string.isRequired,
+  handleUpdateSingleStatType: func.isRequired,
+  handleUpdateSingleStatColors: func.isRequired,
 }
 
-export default SingleStatOptions
+const mapStateToProps = ({
+  cellEditorOverlay: {singleStatType, singleStatColors},
+}) => ({
+  singleStatType,
+  singleStatColors,
+})
+
+const mapDispatchToProps = dispatch => ({
+  handleUpdateSingleStatType: bindActionCreators(
+    updateSingleStatType,
+    dispatch
+  ),
+  handleUpdateSingleStatColors: bindActionCreators(
+    updateSingleStatColors,
+    dispatch
+  ),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(SingleStatOptions)

--- a/ui/src/dashboards/components/SingleStatOptions.js
+++ b/ui/src/dashboards/components/SingleStatOptions.js
@@ -22,6 +22,7 @@ import {
 import {
   updateSingleStatType,
   updateSingleStatColors,
+  updateAxes,
 } from 'src/dashboards/actions/cellEditorOverlay'
 
 const formatColor = color => {
@@ -108,8 +109,15 @@ class SingleStatOptions extends Component {
     return !sortedColors.some(color => color.value === targetValue)
   }
 
+  handleUpdateSuffix = e => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, suffix: e.target.value}}
+
+    handleUpdateAxes(newAxes)
+  }
+
   render() {
-    const {suffix, onSetSuffix, singleStatColors, singleStatType} = this.props
+    const {singleStatColors, singleStatType, axes: {y: {suffix}}} = this.props
 
     const disableAddThreshold = singleStatColors.length > MAX_THRESHOLDS
 
@@ -181,7 +189,7 @@ class SingleStatOptions extends Component {
                 className="form-control input-sm"
                 placeholder="%, MPH, etc."
                 defaultValue={suffix}
-                onChange={onSetSuffix}
+                onChange={this.handleUpdateSuffix}
                 maxLength="5"
               />
             </div>
@@ -209,17 +217,18 @@ SingleStatOptions.propTypes = {
       value: number.isRequired,
     }).isRequired
   ),
-  onSetSuffix: func.isRequired,
-  suffix: string.isRequired,
   handleUpdateSingleStatType: func.isRequired,
   handleUpdateSingleStatColors: func.isRequired,
+  handleUpdateAxes: func.isRequired,
+  axes: shape({}).isRequired,
 }
 
 const mapStateToProps = ({
-  cellEditorOverlay: {singleStatType, singleStatColors},
+  cellEditorOverlay: {singleStatType, singleStatColors, cell: {axes}},
 }) => ({
   singleStatType,
   singleStatColors,
+  axes,
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -231,6 +240,7 @@ const mapDispatchToProps = dispatch => ({
     updateSingleStatColors,
     dispatch
   ),
+  handleUpdateAxes: bindActionCreators(updateAxes, dispatch),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SingleStatOptions)

--- a/ui/src/dashboards/components/Visualization.js
+++ b/ui/src/dashboards/components/Visualization.js
@@ -14,6 +14,7 @@ const DashVisualization = (
     templates,
     timeRange,
     autoRefresh,
+    gaugeColors,
     queryConfigs,
     editQueryStatus,
     resizerTopHeight,
@@ -21,14 +22,14 @@ const DashVisualization = (
   },
   {source: {links: {proxy}}}
 ) => {
-  // const colors = type === 'gauge' ? gaugeColors : singleStatColors
+  const colors = type === 'gauge' ? gaugeColors : singleStatColors
 
   return (
     <div className="graph">
       <VisualizationName />
       <div className="graph-container">
         <RefreshingGraph
-          colors={stringifyColorValues(singleStatColors)}
+          colors={stringifyColorValues(colors)}
           axes={axes}
           type={type}
           queries={buildQueries(proxy, queryConfigs, timeRange)}
@@ -63,8 +64,21 @@ DashVisualization.propTypes = {
   singleStatColors: arrayOf(
     shape({
       type: string.isRequired,
+      hex: string.isRequired,
+      id: string.isRequired,
+      name: string.isRequired,
+      value: number.isRequired,
     }).isRequired
-  ).isRequired,
+  ),
+  gaugeColors: arrayOf(
+    shape({
+      type: string.isRequired,
+      hex: string.isRequired,
+      id: string.isRequired,
+      name: string.isRequired,
+      value: number.isRequired,
+    }).isRequired
+  ),
 }
 
 DashVisualization.contextTypes = {
@@ -76,8 +90,9 @@ DashVisualization.contextTypes = {
 }
 
 const mapStateToProps = ({
-  cellEditorOverlay: {singleStatColors, cell: {type}},
+  cellEditorOverlay: {singleStatColors, gaugeColors, cell: {type}},
 }) => ({
+  gaugeColors,
   singleStatColors,
   type,
 })

--- a/ui/src/dashboards/components/Visualization.js
+++ b/ui/src/dashboards/components/Visualization.js
@@ -9,12 +9,10 @@ const DashVisualization = (
   {
     axes,
     type,
-    name,
     colors,
     templates,
     timeRange,
     autoRefresh,
-    onCellRename,
     queryConfigs,
     editQueryStatus,
     resizerTopHeight,
@@ -22,7 +20,7 @@ const DashVisualization = (
   {source: {links: {proxy}}}
 ) =>
   <div className="graph">
-    <VisualizationName defaultName={name} onCellRename={onCellRename} />
+    <VisualizationName />
     <div className="graph-container">
       <RefreshingGraph
         colors={stringifyColorValues(colors)}
@@ -40,12 +38,10 @@ const DashVisualization = (
 const {arrayOf, func, number, shape, string} = PropTypes
 
 DashVisualization.defaultProps = {
-  name: '',
   type: '',
 }
 
 DashVisualization.propTypes = {
-  name: string,
   type: string,
   autoRefresh: number.isRequired,
   templates: arrayOf(shape()),
@@ -60,7 +56,6 @@ DashVisualization.propTypes = {
       bounds: arrayOf(string),
     }),
   }),
-  onCellRename: func,
   resizerTopHeight: number,
   colors: arrayOf(
     shape({

--- a/ui/src/dashboards/components/Visualization.js
+++ b/ui/src/dashboards/components/Visualization.js
@@ -1,4 +1,6 @@
 import React, {PropTypes} from 'react'
+import {connect} from 'react-redux'
+
 import RefreshingGraph from 'shared/components/RefreshingGraph'
 import buildQueries from 'utils/buildQueriesForGraphs'
 import VisualizationName from 'src/dashboards/components/VisualizationName'
@@ -9,40 +11,41 @@ const DashVisualization = (
   {
     axes,
     type,
-    colors,
     templates,
     timeRange,
     autoRefresh,
     queryConfigs,
     editQueryStatus,
     resizerTopHeight,
+    singleStatColors,
   },
   {source: {links: {proxy}}}
-) =>
-  <div className="graph">
-    <VisualizationName />
-    <div className="graph-container">
-      <RefreshingGraph
-        colors={stringifyColorValues(colors)}
-        axes={axes}
-        type={type}
-        queries={buildQueries(proxy, queryConfigs, timeRange)}
-        templates={templates}
-        autoRefresh={autoRefresh}
-        editQueryStatus={editQueryStatus}
-        resizerTopHeight={resizerTopHeight}
-      />
+) => {
+  // const colors = type === 'gauge' ? gaugeColors : singleStatColors
+
+  return (
+    <div className="graph">
+      <VisualizationName />
+      <div className="graph-container">
+        <RefreshingGraph
+          colors={stringifyColorValues(singleStatColors)}
+          axes={axes}
+          type={type}
+          queries={buildQueries(proxy, queryConfigs, timeRange)}
+          templates={templates}
+          autoRefresh={autoRefresh}
+          editQueryStatus={editQueryStatus}
+          resizerTopHeight={resizerTopHeight}
+        />
+      </div>
     </div>
-  </div>
+  )
+}
 
 const {arrayOf, func, number, shape, string} = PropTypes
 
-DashVisualization.defaultProps = {
-  type: '',
-}
-
 DashVisualization.propTypes = {
-  type: string,
+  type: string.isRequired,
   autoRefresh: number.isRequired,
   templates: arrayOf(shape()),
   timeRange: shape({
@@ -57,15 +60,11 @@ DashVisualization.propTypes = {
     }),
   }),
   resizerTopHeight: number,
-  colors: arrayOf(
+  singleStatColors: arrayOf(
     shape({
       type: string.isRequired,
-      hex: string.isRequired,
-      id: string.isRequired,
-      name: string.isRequired,
-      value: number.isRequired,
-    })
-  ),
+    }).isRequired
+  ).isRequired,
 }
 
 DashVisualization.contextTypes = {
@@ -76,4 +75,11 @@ DashVisualization.contextTypes = {
   }).isRequired,
 }
 
-export default DashVisualization
+const mapStateToProps = ({
+  cellEditorOverlay: {singleStatColors, cell: {type}},
+}) => ({
+  singleStatColors,
+  type,
+})
+
+export default connect(mapStateToProps, null)(DashVisualization)

--- a/ui/src/dashboards/components/Visualization.js
+++ b/ui/src/dashboards/components/Visualization.js
@@ -90,11 +90,12 @@ DashVisualization.contextTypes = {
 }
 
 const mapStateToProps = ({
-  cellEditorOverlay: {singleStatColors, gaugeColors, cell: {type}},
+  cellEditorOverlay: {singleStatColors, gaugeColors, cell: {type, axes}},
 }) => ({
   gaugeColors,
   singleStatColors,
   type,
+  axes,
 })
 
 export default connect(mapStateToProps, null)(DashVisualization)

--- a/ui/src/dashboards/components/VisualizationName.js
+++ b/ui/src/dashboards/components/VisualizationName.js
@@ -1,34 +1,43 @@
 import React, {Component, PropTypes} from 'react'
+import {connect} from 'react-redux'
+import {bindActionCreators} from 'redux'
 
 import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants/index'
+import {renameCell} from 'src/dashboards/actions/cellEditorOverlay'
 
 class VisualizationName extends Component {
   constructor(props) {
     super(props)
 
     this.state = {
-      reset: false,
       isEditing: false,
     }
   }
 
-  handleInputBlur = reset => e => {
-    this.props.onCellRename(reset ? this.props.defaultName : e.target.value)
-    this.setState({reset: false, isEditing: false})
+  handleInputClick = () => {
+    this.setState({isEditing: true})
+  }
+
+  handleCancel = () => {
+    this.setState({
+      isEditing: false,
+    })
+  }
+
+  handleInputBlur = () => {
+    this.setState({isEditing: false})
   }
 
   handleKeyDown = e => {
+    const {handleRenameCell} = this.props
+
     if (e.key === 'Enter') {
-      this.inputRef.blur()
+      handleRenameCell(e.target.value)
+      this.handleInputBlur(e)
     }
     if (e.key === 'Escape') {
-      this.inputRef.value = this.props.defaultName
-      this.setState({reset: true}, () => this.inputRef.blur())
+      this.handleInputBlur(e)
     }
-  }
-
-  handleEditMode = () => {
-    this.setState({isEditing: true})
   }
 
   handleFocus = e => {
@@ -36,10 +45,10 @@ class VisualizationName extends Component {
   }
 
   render() {
-    const {defaultName} = this.props
-    const {reset, isEditing} = this.state
+    const {name} = this.props
+    const {isEditing} = this.state
     const graphNameClass =
-      defaultName === NEW_DEFAULT_DASHBOARD_CELL.name
+      name === NEW_DEFAULT_DASHBOARD_CELL.name
         ? 'graph-name graph-name__untitled'
         : 'graph-name'
 
@@ -49,16 +58,15 @@ class VisualizationName extends Component {
           ? <input
               type="text"
               className="form-control input-sm"
-              defaultValue={defaultName}
-              onBlur={this.handleInputBlur(reset)}
+              defaultValue={name}
+              onBlur={this.handleInputBlur}
               onKeyDown={this.handleKeyDown}
-              placeholder="Name this Cell..."
               autoFocus={true}
               onFocus={this.handleFocus}
-              ref={r => (this.inputRef = r)}
+              placeholder="Name this Cell..."
             />
-          : <div className={graphNameClass} onClick={this.handleEditMode}>
-              {defaultName}
+          : <div className={graphNameClass} onClick={this.handleInputClick}>
+              {name}
             </div>}
       </div>
     )
@@ -68,8 +76,16 @@ class VisualizationName extends Component {
 const {string, func} = PropTypes
 
 VisualizationName.propTypes = {
-  defaultName: string.isRequired,
-  onCellRename: func,
+  name: string.isRequired,
+  handleRenameCell: func,
 }
 
-export default VisualizationName
+const mapStateToProps = ({cellEditorOverlay: {cell: {name}}}) => ({
+  name,
+})
+
+const mapDispatchToProps = dispatch => ({
+  handleRenameCell: bindActionCreators(renameCell, dispatch),
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(VisualizationName)

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -239,6 +239,7 @@ class DashboardPage extends Component {
       showTemplateControlBar,
       dashboard,
       dashboards,
+      gaugeColors,
       autoRefresh,
       selectedCell,
       manualRefresh,
@@ -352,6 +353,7 @@ class DashboardPage extends Component {
               editQueryStatus={dashboardActions.editCellQueryStatus}
               singleStatType={singleStatType}
               singleStatColors={singleStatColors}
+              gaugeColors={gaugeColors}
             />
           : null}
         <DashboardHeader
@@ -479,6 +481,7 @@ DashboardPage.propTypes = {
   selectedCell: shape({}),
   singleStatType: string.isRequired,
   singleStatColors: arrayOf(shape({}).isRequired).isRequired,
+  gaugeColors: arrayOf(shape({}).isRequired).isRequired,
 }
 
 const mapStateToProps = (state, {params: {dashboardID}}) => {
@@ -491,7 +494,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     sources,
     dashTimeV1,
     auth: {me, isUsingAuth},
-    cellEditorOverlay: {cell, singleStatType, singleStatColors},
+    cellEditorOverlay: {cell, singleStatType, singleStatColors, gaugeColors},
   } = state
   const meRole = _.get(me, 'role', null)
 
@@ -519,6 +522,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     selectedCell,
     singleStatType,
     singleStatColors,
+    gaugeColors,
   }
 }
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -244,6 +244,8 @@ class DashboardPage extends Component {
       manualRefresh,
       onManualRefresh,
       cellQueryStatus,
+      singleStatType,
+      singleStatColors,
       dashboardActions,
       inPresentationMode,
       handleChooseAutoRefresh,
@@ -348,6 +350,8 @@ class DashboardPage extends Component {
               onCancel={handleHideCellEditorOverlay}
               templates={templatesIncludingDashTime}
               editQueryStatus={dashboardActions.editCellQueryStatus}
+              singleStatType={singleStatType}
+              singleStatColors={singleStatColors}
             />
           : null}
         <DashboardHeader
@@ -473,6 +477,8 @@ DashboardPage.propTypes = {
   handleShowCellEditorOverlay: func.isRequired,
   handleHideCellEditorOverlay: func.isRequired,
   selectedCell: shape({}),
+  singleStatType: string.isRequired,
+  singleStatColors: arrayOf(shape({}).isRequired).isRequired,
 }
 
 const mapStateToProps = (state, {params: {dashboardID}}) => {
@@ -485,7 +491,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     sources,
     dashTimeV1,
     auth: {me, isUsingAuth},
-    cellEditorOverlay: {cell},
+    cellEditorOverlay: {cell, singleStatType, singleStatColors},
   } = state
   const meRole = _.get(me, 'role', null)
 
@@ -511,6 +517,8 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     meRole,
     isUsingAuth,
     selectedCell,
+    singleStatType,
+    singleStatColors,
   }
 }
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -20,6 +20,10 @@ import {publishNotification} from 'shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 
 import * as dashboardActionCreators from 'src/dashboards/actions'
+import {
+  showCellEditorOverlay,
+  hideCellEditorOverlay,
+} from 'src/dashboards/actions/cellEditorOverlay'
 
 import {
   setAutoRefresh,
@@ -95,19 +99,15 @@ class DashboardPage extends Component {
     }
   }
 
-  handleDismissOverlay = () => {
-    this.setState({selectedCell: null})
-  }
-
   handleSaveEditedCell = newCell => {
-    const {dashboardActions, dashboard} = this.props
+    const {
+      dashboardActions,
+      dashboard,
+      handleHideCellEditorOverlay,
+    } = this.props
     dashboardActions
       .updateDashboardCell(dashboard, newCell)
-      .then(this.handleDismissOverlay)
-  }
-
-  handleSummonOverlayTechnologies = cell => {
-    this.setState({selectedCell: cell})
+      .then(handleHideCellEditorOverlay)
   }
 
   handleChooseTimeRange = ({upper, lower}) => {
@@ -240,12 +240,15 @@ class DashboardPage extends Component {
       dashboard,
       dashboards,
       autoRefresh,
+      selectedCell,
       manualRefresh,
       onManualRefresh,
       cellQueryStatus,
       dashboardActions,
       inPresentationMode,
       handleChooseAutoRefresh,
+      handleShowCellEditorOverlay,
+      handleHideCellEditorOverlay,
       handleClickPresentationButton,
       params: {sourceID, dashboardID},
     } = this.props
@@ -313,7 +316,7 @@ class DashboardPage extends Component {
       templatesIncludingDashTime = []
     }
 
-    const {selectedCell, isEditMode, isTemplating} = this.state
+    const {isEditMode, isTemplating} = this.state
     const names = dashboards.map(d => ({
       name: d.name,
       link: `/sources/${sourceID}/dashboards/${d.id}`,
@@ -342,7 +345,7 @@ class DashboardPage extends Component {
               dashboardID={dashboardID}
               queryStatus={cellQueryStatus}
               onSave={this.handleSaveEditedCell}
-              onCancel={this.handleDismissOverlay}
+              onCancel={handleHideCellEditorOverlay}
               templates={templatesIncludingDashTime}
               editQueryStatus={dashboardActions.editCellQueryStatus}
             />
@@ -387,7 +390,7 @@ class DashboardPage extends Component {
               showTemplateControlBar={showTemplateControlBar}
               onOpenTemplateManager={this.handleOpenTemplateManager}
               templatesIncludingDashTime={templatesIncludingDashTime}
-              onSummonOverlayTechnologies={this.handleSummonOverlayTechnologies}
+              onSummonOverlayTechnologies={handleShowCellEditorOverlay}
             />
           : null}
       </div>
@@ -467,6 +470,9 @@ DashboardPage.propTypes = {
   isUsingAuth: bool.isRequired,
   router: shape().isRequired,
   notify: func.isRequired,
+  handleShowCellEditorOverlay: func.isRequired,
+  handleHideCellEditorOverlay: func.isRequired,
+  selectedCell: shape({}),
 }
 
 const mapStateToProps = (state, {params: {dashboardID}}) => {
@@ -479,6 +485,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     sources,
     dashTimeV1,
     auth: {me, isUsingAuth},
+    cellEditorOverlay: {cell},
   } = state
   const meRole = _.get(me, 'role', null)
 
@@ -490,6 +497,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
   const dashboard = dashboards.find(
     d => d.id === idNormalizer(TYPE_ID, dashboardID)
   )
+  const selectedCell = cell
 
   return {
     dashboards,
@@ -502,6 +510,7 @@ const mapStateToProps = (state, {params: {dashboardID}}) => {
     sources,
     meRole,
     isUsingAuth,
+    selectedCell,
   }
 }
 
@@ -515,6 +524,14 @@ const mapDispatchToProps = dispatch => ({
   dashboardActions: bindActionCreators(dashboardActionCreators, dispatch),
   errorThrown: bindActionCreators(errorThrownAction, dispatch),
   notify: bindActionCreators(publishNotification, dispatch),
+  handleShowCellEditorOverlay: bindActionCreators(
+    showCellEditorOverlay,
+    dispatch
+  ),
+  handleHideCellEditorOverlay: bindActionCreators(
+    hideCellEditorOverlay,
+    dispatch
+  ),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -1,0 +1,28 @@
+const initialState = {
+  cell: null,
+}
+
+export default function cellEditorOverlay(state = initialState, action) {
+  switch (action.type) {
+    case 'SHOW_CELL_EDITOR_OVERLAY': {
+      const {cell} = action.payload
+
+      return {...state, cell}
+    }
+
+    case 'HIDE_CELL_EDITOR_OVERLAY': {
+      const cell = null
+
+      return {...state, cell}
+    }
+
+    case 'CHANGE_CELL_TYPE': {
+      const {cellType} = action.payload
+      const cell = {...state.cell, type: cellType}
+
+      return {...state, cell}
+    }
+  }
+
+  return state
+}

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -68,6 +68,13 @@ export default function cellEditorOverlay(state = initialState, action) {
 
       return {...state, gaugeColors}
     }
+
+    case 'UPDATE_AXES': {
+      const {axes} = action.payload
+      const cell = {...state.cell, axes}
+
+      return {...state, cell}
+    }
   }
 
   return state

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -7,7 +7,7 @@ import {
   getSingleStatType,
 } from 'src/dashboards/constants/gaugeColors'
 
-const initialState = {
+export const initialState = {
   cell: null,
   singleStatType: SINGLE_STAT_TEXT,
   singleStatColors: DEFAULT_SINGLESTAT_COLORS,

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -22,6 +22,13 @@ export default function cellEditorOverlay(state = initialState, action) {
 
       return {...state, cell}
     }
+
+    case 'RENAME_CELL': {
+      const {cellName} = action.payload
+      const cell = {...state.cell, name: cellName}
+
+      return {...state, cell}
+    }
   }
 
   return state

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -1,13 +1,25 @@
+import {
+  SINGLE_STAT_TEXT,
+  DEFAULT_SINGLESTAT_COLORS,
+  validateSingleStatColors,
+  getSingleStatType,
+} from 'src/dashboards/constants/gaugeColors'
+
 const initialState = {
   cell: null,
+  singleStatType: SINGLE_STAT_TEXT,
+  singleStatColors: DEFAULT_SINGLESTAT_COLORS,
 }
 
 export default function cellEditorOverlay(state = initialState, action) {
   switch (action.type) {
     case 'SHOW_CELL_EDITOR_OVERLAY': {
-      const {cell} = action.payload
+      const {cell, cell: {colors}} = action.payload
 
-      return {...state, cell}
+      const singleStatType = getSingleStatType(colors)
+      const singleStatColors = validateSingleStatColors(colors, singleStatType)
+
+      return {...state, cell, singleStatType, singleStatColors}
     }
 
     case 'HIDE_CELL_EDITOR_OVERLAY': {
@@ -28,6 +40,23 @@ export default function cellEditorOverlay(state = initialState, action) {
       const cell = {...state.cell, name: cellName}
 
       return {...state, cell}
+    }
+
+    case 'UPDATE_SINGLE_STAT_COLORS': {
+      const {singleStatColors} = action.payload
+
+      return {...state, singleStatColors}
+    }
+
+    case 'UPDATE_SINGLE_STAT_TYPE': {
+      const {singleStatType} = action.payload
+
+      const singleStatColors = state.singleStatColors.map(color => ({
+        ...color,
+        type: singleStatType,
+      }))
+
+      return {...state, singleStatType, singleStatColors}
     }
   }
 

--- a/ui/src/dashboards/reducers/cellEditorOverlay.js
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.js
@@ -1,6 +1,8 @@
 import {
   SINGLE_STAT_TEXT,
   DEFAULT_SINGLESTAT_COLORS,
+  DEFAULT_GAUGE_COLORS,
+  validateGaugeColors,
   validateSingleStatColors,
   getSingleStatType,
 } from 'src/dashboards/constants/gaugeColors'
@@ -9,6 +11,7 @@ const initialState = {
   cell: null,
   singleStatType: SINGLE_STAT_TEXT,
   singleStatColors: DEFAULT_SINGLESTAT_COLORS,
+  gaugeColors: DEFAULT_GAUGE_COLORS,
 }
 
 export default function cellEditorOverlay(state = initialState, action) {
@@ -18,8 +21,9 @@ export default function cellEditorOverlay(state = initialState, action) {
 
       const singleStatType = getSingleStatType(colors)
       const singleStatColors = validateSingleStatColors(colors, singleStatType)
+      const gaugeColors = validateGaugeColors(colors)
 
-      return {...state, cell, singleStatType, singleStatColors}
+      return {...state, cell, singleStatType, singleStatColors, gaugeColors}
     }
 
     case 'HIDE_CELL_EDITOR_OVERLAY': {
@@ -57,6 +61,12 @@ export default function cellEditorOverlay(state = initialState, action) {
       }))
 
       return {...state, singleStatType, singleStatColors}
+    }
+
+    case 'UPDATE_GAUGE_COLORS': {
+      const {gaugeColors} = action.payload
+
+      return {...state, gaugeColors}
     }
   }
 

--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -40,6 +40,7 @@ const RefreshingGraph = ({
 
   if (type === 'single-stat') {
     const suffix = axes.y.suffix || ''
+
     return (
       <RefreshingSingleStat
         colors={colors}

--- a/ui/src/store/configureStore.js
+++ b/ui/src/store/configureStore.js
@@ -12,6 +12,7 @@ import dataExplorerReducers from 'src/data_explorer/reducers'
 import adminReducers from 'src/admin/reducers'
 import kapacitorReducers from 'src/kapacitor/reducers'
 import dashboardUI from 'src/dashboards/reducers/ui'
+import cellEditorOverlay from 'src/dashboards/reducers/cellEditorOverlay'
 import dashTimeV1 from 'src/dashboards/reducers/dashTimeV1'
 import persistStateEnhancer from './persistStateEnhancer'
 
@@ -22,6 +23,7 @@ const rootReducer = combineReducers({
   ...kapacitorReducers,
   ...adminReducers,
   dashboardUI,
+  cellEditorOverlay,
   dashTimeV1,
   routing: routerReducer,
 })


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2802 

This was making me crazy so even though it's not on the roadmap I put in some extra-curricular time to tackle it. Should be much better to work with now.

### The Problem
- The CellEditorOverlay has become a monster sized component that is really hard to reason about
- Ran into a lot of unnecessary friction when extending single-stat functionality
- Concerned that as we add more cell types it will become even more unweildy

### The Solution
- Moved most of the state in `CellEditorOverlay` into redux and the handlers into their associated child components
```
cellEditorOverlay: {
  cell: {}, // selected cell to edit -  name, axes, and type are stored in here
  singleStatType: '',
  singleStatColors: [],
  gaugeColors: [],
}
```
- Child components only grab the state they care about
- CEO is much cleaner and nicer to work with
- `AxesOptions`, `SingleStatOptions`, and `GaugeOptions` are much more modular
- Adding new cell types should be more straightforward with this pattern
- Only remaining handlers in CEO concern query editing, might be possible to move those down as well

### Feedback
- Can the query editing handlers be moved into a child component and out of CEO?
- Can the `handleSaveCell` function be moved up into `DashboardPage`? Does that make sense?