### PR TITLE
Use Generic APIKey for Oauth2 group lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### UI Improvements
 ### Bug Fixes
 1. [#2821](https://github.com/influxdata/chronograf/pull/2821): Save only selected template variable values into dashboards for non csv template variables
+1. [#2842](https://github.com/influxdata/chronograf/pull/2842): Use Generic APIKey for Oauth2 group lookup
 
 ## v1.4.1.3 [2018-02-14]
 ### Bug Fixes

--- a/oauth2/generic_test.go
+++ b/oauth2/generic_test.go
@@ -10,6 +10,98 @@ import (
 	"github.com/influxdata/chronograf/oauth2"
 )
 
+func TestGenericGroup_withNotEmail(t *testing.T) {
+	t.Parallel()
+
+	response := struct {
+		Email string `json:"not-email"`
+	}{
+		"martymcfly@pinheads.rok",
+	}
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+		enc := json.NewEncoder(rw)
+
+		rw.WriteHeader(http.StatusOK)
+		_ = enc.Encode(response)
+	}))
+	defer mockAPI.Close()
+
+	logger := clog.New(clog.ParseLevel("debug"))
+	prov := oauth2.Generic{
+		Logger: logger,
+		APIURL: mockAPI.URL,
+		APIKey: "not-email",
+	}
+	tt, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
+	if err != nil {
+		t.Fatal("Error initializing TestTripper: err:", err)
+	}
+
+	tc := &http.Client{
+		Transport: tt,
+	}
+
+	got, err := prov.Group(tc)
+	if err != nil {
+		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+	}
+
+	want := "pinheads.rok"
+	if got != want {
+		t.Fatal("Retrieved group was not as expected. Want:", want, "Got:", got)
+	}
+}
+
+func TestGenericGroup_withEmail(t *testing.T) {
+	t.Parallel()
+
+	response := struct {
+		Email string `json:"email"`
+	}{
+		"martymcfly@pinheads.rok",
+	}
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			rw.WriteHeader(http.StatusNotFound)
+			return
+		}
+		enc := json.NewEncoder(rw)
+
+		rw.WriteHeader(http.StatusOK)
+		_ = enc.Encode(response)
+	}))
+	defer mockAPI.Close()
+
+	logger := clog.New(clog.ParseLevel("debug"))
+	prov := oauth2.Generic{
+		Logger: logger,
+		APIURL: mockAPI.URL,
+		APIKey: "email",
+	}
+	tt, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
+	if err != nil {
+		t.Fatal("Error initializing TestTripper: err:", err)
+	}
+
+	tc := &http.Client{
+		Transport: tt,
+	}
+
+	got, err := prov.Group(tc)
+	if err != nil {
+		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+	}
+
+	want := "pinheads.rok"
+	if got != want {
+		t.Fatal("Retrieved group was not as expected. Want:", want, "Got:", got)
+	}
+}
+
 func TestGenericPrincipalID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #2827

### The problem

The `Group` method did was not updated to use the `APIKey` to look up the authorizing users email. It instead used to old standard `email` key.

### The Solution

Use the `APIKey` instead of `email`.

