### PR TITLE
Add Prefix & Suffix to Gauge & Single Stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.4.2.0 [unreleased]
 ### Features
 ### UI Improvements
+1. [#2848](https://github.com/influxdata/chronograf/pull/2848): Add ability to set a prefix and suffix on Single Stat and Gauge cell types
 ### Bug Fixes
 1. [#2821](https://github.com/influxdata/chronograf/pull/2821): Save only selected template variable values into dashboards for non csv template variables
 1. [#2842](https://github.com/influxdata/chronograf/pull/2842): Use Generic APIKey for Oauth2 group lookup

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -124,6 +124,7 @@ class AxesOptions extends Component {
               value={prefix}
               labelText="Y-Value's Prefix"
               onChange={this.handleSetPrefixSuffix}
+              maxLength="5"
             />
             <Input
               name="suffix"
@@ -131,6 +132,7 @@ class AxesOptions extends Component {
               value={suffix}
               labelText="Y-Value's Suffix"
               onChange={this.handleSetPrefixSuffix}
+              maxLength="5"
             />
             <Tabber
               labelText="Y-Value's Format"

--- a/ui/src/dashboards/components/GaugeOptions.js
+++ b/ui/src/dashboards/components/GaugeOptions.js
@@ -15,7 +15,10 @@ import {
   MIN_THRESHOLDS,
 } from 'src/dashboards/constants/gaugeColors'
 
-import {updateGaugeColors} from 'src/dashboards/actions/cellEditorOverlay'
+import {
+  updateGaugeColors,
+  updateAxes,
+} from 'src/dashboards/actions/cellEditorOverlay'
 
 class GaugeOptions extends Component {
   handleAddThreshold = () => {
@@ -118,8 +121,22 @@ class GaugeOptions extends Component {
     return allowedToUpdate
   }
 
+  handleUpdatePrefix = e => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, prefix: e.target.value}}
+
+    handleUpdateAxes(newAxes)
+  }
+
+  handleUpdateSuffix = e => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, suffix: e.target.value}}
+
+    handleUpdateAxes(newAxes)
+  }
+
   render() {
-    const {gaugeColors} = this.props
+    const {gaugeColors, axes: {y: {prefix, suffix}}} = this.props
 
     const disableMaxColor = gaugeColors.length > MIN_THRESHOLDS
     const disableAddThreshold = gaugeColors.length > MAX_THRESHOLDS
@@ -157,6 +174,28 @@ class GaugeOptions extends Component {
               />
             )}
           </div>
+          <div className="single-stat-controls">
+            <div className="form-group col-xs-6">
+              <label>Prefix</label>
+              <input
+                className="form-control input-sm"
+                placeholder="%, MPH, etc."
+                defaultValue={prefix}
+                onChange={this.handleUpdatePrefix}
+                maxLength="5"
+              />
+            </div>
+            <div className="form-group col-xs-6">
+              <label>Suffix</label>
+              <input
+                className="form-control input-sm"
+                placeholder="%, MPH, etc."
+                defaultValue={suffix}
+                onChange={this.handleUpdateSuffix}
+                maxLength="5"
+              />
+            </div>
+          </div>
         </div>
       </FancyScrollbar>
     )
@@ -176,13 +215,17 @@ GaugeOptions.propTypes = {
     }).isRequired
   ),
   handleUpdateGaugeColors: func.isRequired,
+  handleUpdateAxes: func.isRequired,
+  axes: shape({}).isRequired,
 }
 
-const mapStateToProps = ({cellEditorOverlay: {gaugeColors}}) => ({
+const mapStateToProps = ({cellEditorOverlay: {gaugeColors, cell: {axes}}}) => ({
   gaugeColors,
+  axes,
 })
 
 const mapDispatchToProps = dispatch => ({
   handleUpdateGaugeColors: bindActionCreators(updateGaugeColors, dispatch),
+  handleUpdateAxes: bindActionCreators(updateAxes, dispatch),
 })
 export default connect(mapStateToProps, mapDispatchToProps)(GaugeOptions)

--- a/ui/src/dashboards/components/SingleStatOptions.js
+++ b/ui/src/dashboards/components/SingleStatOptions.js
@@ -109,6 +109,13 @@ class SingleStatOptions extends Component {
     return !sortedColors.some(color => color.value === targetValue)
   }
 
+  handleUpdatePrefix = e => {
+    const {handleUpdateAxes, axes} = this.props
+    const newAxes = {...axes, y: {...axes.y, prefix: e.target.value}}
+
+    handleUpdateAxes(newAxes)
+  }
+
   handleUpdateSuffix = e => {
     const {handleUpdateAxes, axes} = this.props
     const newAxes = {...axes, y: {...axes.y, suffix: e.target.value}}
@@ -117,7 +124,11 @@ class SingleStatOptions extends Component {
   }
 
   render() {
-    const {singleStatColors, singleStatType, axes: {y: {suffix}}} = this.props
+    const {
+      singleStatColors,
+      singleStatType,
+      axes: {y: {prefix, suffix}},
+    } = this.props
 
     const disableAddThreshold = singleStatColors.length > MAX_THRESHOLDS
 
@@ -163,6 +174,26 @@ class SingleStatOptions extends Component {
           </div>
           <div className="single-stat-controls">
             <div className="form-group col-xs-6">
+              <label>Prefix</label>
+              <input
+                className="form-control input-sm"
+                placeholder="%, MPH, etc."
+                defaultValue={prefix}
+                onChange={this.handleUpdatePrefix}
+                maxLength="5"
+              />
+            </div>
+            <div className="form-group col-xs-6">
+              <label>Suffix</label>
+              <input
+                className="form-control input-sm"
+                placeholder="%, MPH, etc."
+                defaultValue={suffix}
+                onChange={this.handleUpdateSuffix}
+                maxLength="5"
+              />
+            </div>
+            <div className="form-group col-xs-6">
               <label>Coloring</label>
               <ul className="nav nav-tablist nav-tablist-sm">
                 <li
@@ -182,16 +213,6 @@ class SingleStatOptions extends Component {
                   Text
                 </li>
               </ul>
-            </div>
-            <div className="form-group col-xs-6">
-              <label>Suffix</label>
-              <input
-                className="form-control input-sm"
-                placeholder="%, MPH, etc."
-                defaultValue={suffix}
-                onChange={this.handleUpdateSuffix}
-                maxLength="5"
-              />
             </div>
           </div>
         </div>

--- a/ui/src/shared/components/Gauge.js
+++ b/ui/src/shared/components/Gauge.js
@@ -226,6 +226,7 @@ class Gauge extends Component {
     minValue,
     maxValue
   ) => {
+    const {prefix, suffix} = this.props
     const {degree, lineCount, labelColor, labelFontSize} = GAUGE_SPECS
 
     const incrementValue = (maxValue - minValue) / lineCount
@@ -258,12 +259,14 @@ class Gauge extends Component {
       if (i > 3) {
         ctx.textAlign = 'left'
       }
+      const labelText = `${prefix}${gaugeValues[i]}${suffix}`
+
       ctx.rotate(startDegree)
       ctx.rotate(i * arcIncrement)
       ctx.translate(labelRadius, 0)
       ctx.rotate(i * -arcIncrement)
       ctx.rotate(-startDegree)
-      ctx.fillText(gaugeValues[i], 0, 0)
+      ctx.fillText(labelText, 0, 0)
       ctx.rotate(startDegree)
       ctx.rotate(i * arcIncrement)
       ctx.translate(-labelRadius, 0)
@@ -273,7 +276,7 @@ class Gauge extends Component {
   }
 
   drawGaugeValue = (ctx, radius, labelValueFontSize) => {
-    const {gaugePosition} = this.props
+    const {gaugePosition, prefix, suffix} = this.props
     const {valueColor} = GAUGE_SPECS
 
     ctx.font = `${labelValueFontSize}px Roboto`
@@ -282,7 +285,8 @@ class Gauge extends Component {
     ctx.textAlign = 'center'
 
     const textY = radius
-    ctx.fillText(gaugePosition.toString(), 0, textY)
+    const textContent = `${prefix}${gaugePosition.toString()}${suffix}`
+    ctx.fillText(textContent, 0, textY)
   }
 
   drawNeedle = (ctx, radius, minValue, maxValue) => {
@@ -335,6 +339,8 @@ Gauge.propTypes = {
       value: string.isRequired,
     }).isRequired
   ).isRequired,
+  prefix: string.isRequired,
+  suffix: string.isRequired,
 }
 
 export default Gauge

--- a/ui/src/shared/components/GaugeChart.js
+++ b/ui/src/shared/components/GaugeChart.js
@@ -17,6 +17,8 @@ class GaugeChart extends PureComponent {
       colors,
       resizeCoords,
       resizerTopHeight,
+      prefix,
+      suffix,
     } = this.props
 
     // If data for this graph is being fetched for the first time, show a graph-wide spinner.
@@ -54,6 +56,8 @@ class GaugeChart extends PureComponent {
           height={height}
           colors={colors}
           gaugePosition={roundedValue}
+          prefix={prefix}
+          suffix={suffix}
         />
       </div>
     )
@@ -81,6 +85,8 @@ GaugeChart.propTypes = {
       value: string.isRequired,
     }).isRequired
   ),
+  prefix: string.isRequired,
+  suffix: string.isRequired,
 }
 
 export default GaugeChart

--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -39,8 +39,6 @@ const RefreshingGraph = ({
   }
 
   if (type === 'single-stat') {
-    const suffix = axes.y.suffix || ''
-
     return (
       <RefreshingSingleStat
         colors={colors}
@@ -49,7 +47,8 @@ const RefreshingGraph = ({
         templates={templates}
         autoRefresh={autoRefresh}
         cellHeight={cellHeight}
-        suffix={suffix}
+        prefix={axes.y.prefix || ''}
+        suffix={axes.y.suffix || ''}
       />
     )
   }

--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -28,6 +28,9 @@ const RefreshingGraph = ({
   editQueryStatus,
   grabDataForDownload,
 }) => {
+  const prefix = axes.y.prefix || ''
+  const suffix = axes.y.suffix || ''
+
   if (!queries.length) {
     return (
       <div className="graph-empty">
@@ -47,8 +50,8 @@ const RefreshingGraph = ({
         templates={templates}
         autoRefresh={autoRefresh}
         cellHeight={cellHeight}
-        prefix={axes.y.prefix || ''}
-        suffix={axes.y.suffix || ''}
+        prefix={prefix}
+        suffix={suffix}
       />
     )
   }
@@ -64,6 +67,8 @@ const RefreshingGraph = ({
         cellHeight={cellHeight}
         resizerTopHeight={resizerTopHeight}
         resizeCoords={resizeCoords}
+        prefix={prefix}
+        suffix={suffix}
       />
     )
   }


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2779 

### The Problem
- Unable to set a Prefix or Suffix on Gauge cells
- Unable to set a Prefix on Single Stat cells 

### The Solution
- User can set a Prefix & Suffix on both Gauge & Single Stat cell types

### Preview
![screen shot 2018-02-23 at 10 40 47 am](https://user-images.githubusercontent.com/2433762/36610991-df3d04ba-1886-11e8-9c92-34ae84d0d8bb.png)
![screen shot 2018-02-23 at 10 47 04 am](https://user-images.githubusercontent.com/2433762/36611009-ebaba8c8-1886-11e8-9e3d-25fd84d227af.png)
![screen shot 2018-02-23 at 10 47 09 am](https://user-images.githubusercontent.com/2433762/36611011-ee353a64-1886-11e8-9eb0-d22ec52bc5b7.png)

