### PR TITLE
Fix Single Stat & Gauge Cells

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.js
+++ b/ui/src/shared/components/RefreshingGraph.js
@@ -54,6 +54,7 @@ const RefreshingGraph = ({
         cellHeight={cellHeight}
         prefix={prefix}
         suffix={suffix}
+        inView={inView}
       />
     )
   }
@@ -72,6 +73,7 @@ const RefreshingGraph = ({
         cellID={cellID}
         prefix={prefix}
         suffix={suffix}
+        inView={inView}
       />
     )
   }


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The Problem
- Single Stat & Gauge cells were broken (always display 0, thresholds not working)

### The Solution
- Pass `inView` into Single Stat and Gauge cells (was previously only being passed to line graphs)

