### PR TITLE
Fix Single Stat Line Graph Appearance

### DIFF
--- a/ui/src/shared/components/AnnotationSpan.js
+++ b/ui/src/shared/components/AnnotationSpan.js
@@ -222,14 +222,14 @@ AnnotationSpan.propTypes = {
   annotation: schema.annotation.isRequired,
   mode: string.isRequired,
   dygraph: shape({}).isRequired,
-  staticLegendHeight: number.isRequired,
+  staticLegendHeight: number,
   updateAnnotationAsync: func.isRequired,
   updateAnnotation: func.isRequired,
 }
 
-const mdtp = {
+const mapDispatchToProps = {
   updateAnnotationAsync: actions.updateAnnotationAsync,
   updateAnnotation: actions.updateAnnotation,
 }
 
-export default connect(null, mdtp)(AnnotationSpan)
+export default connect(null, mapDispatchToProps)(AnnotationSpan)

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -301,8 +301,9 @@ class Dygraph extends Component {
 
   render() {
     const {isHidden, staticLegendHeight} = this.state
-    const {staticLegend} = this.props
+    const {staticLegend, children} = this.props
 
+    const nestedGraph = (children && children.length && children[0]) || children
     let dygraphStyle = {...this.props.containerStyle, zIndex: '2'}
     if (staticLegend) {
       const cellVerticalPadding = 16
@@ -344,12 +345,13 @@ class Dygraph extends Component {
               this.handleReceiveStaticLegendHeight
             }
           />}
+        {nestedGraph && React.cloneElement(nestedGraph, {staticLegendHeight})}
       </div>
     )
   }
 }
 
-const {array, arrayOf, bool, func, shape, string} = PropTypes
+const {array, arrayOf, bool, func, node, shape, string} = PropTypes
 
 Dygraph.defaultProps = {
   axes: {
@@ -408,6 +410,7 @@ Dygraph.propTypes = {
   dygraphRef: func,
   onZoom: func,
   mode: string,
+  children: node,
 }
 
 const mapStateToProps = ({annotations: {mode}}) => ({

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -93,13 +93,8 @@ class LineGraph extends Component {
       top: '8px',
     }
 
-    let prefix
-    let suffix
-
-    if (axes) {
-      prefix = axes.y.prefix
-      suffix = axes.y.suffix
-    }
+    const prefix = (axes && axes.y.prefix) || ''
+    const suffix = (axes && axes.y.suffix) || ''
 
     return (
       <div className="dygraph graph--hasYLabel" style={{height: '100%'}}>

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -119,16 +119,15 @@ class LineGraph extends Component {
           staticLegend={staticLegend}
           isGraphFilled={showSingleStat ? false : isGraphFilled}
         >
-          {showSingleStat
-            ? <SingleStat
-                prefix={prefix}
-                suffix={suffix}
-                data={data}
-                lineGraph={true}
-                colors={colors}
-                cellHeight={cellHeight}
-              />
-            : null}
+          {showSingleStat &&
+            <SingleStat
+              prefix={prefix}
+              suffix={suffix}
+              data={data}
+              lineGraph={true}
+              colors={colors}
+              cellHeight={cellHeight}
+            />}
         </Dygraph>
       </div>
     )

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -93,8 +93,8 @@ class LineGraph extends Component {
       top: '8px',
     }
 
-    const prefix = (axes && axes.y.prefix) || ''
-    const suffix = (axes && axes.y.suffix) || ''
+    const prefix = axes ? axes.y.prefix : ''
+    const suffix = axes ? axes.y.suffix : ''
 
     return (
       <div className="dygraph graph--hasYLabel" style={{height: '100%'}}>

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -118,17 +118,18 @@ class LineGraph extends Component {
           containerStyle={containerStyle}
           staticLegend={staticLegend}
           isGraphFilled={showSingleStat ? false : isGraphFilled}
-        />
-        {showSingleStat
-          ? <SingleStat
-              prefix={prefix}
-              suffix={suffix}
-              data={data}
-              lineGraph={true}
-              colors={colors}
-              cellHeight={cellHeight}
-            />
-          : null}
+        >
+          {showSingleStat
+            ? <SingleStat
+                prefix={prefix}
+                suffix={suffix}
+                data={data}
+                lineGraph={true}
+                colors={colors}
+                cellHeight={cellHeight}
+              />
+            : null}
+        </Dygraph>
       </div>
     )
   }

--- a/ui/src/shared/components/SingleStat.js
+++ b/ui/src/shared/components/SingleStat.js
@@ -3,6 +3,7 @@ import classnames from 'classnames'
 import lastValues from 'shared/parsing/lastValues'
 
 import {SMALL_CELL_HEIGHT} from 'shared/graphs/helpers'
+import {DYGRAPH_CONTAINER_V_MARGIN} from 'shared/constants'
 import {SINGLE_STAT_TEXT} from 'src/dashboards/constants/gaugeColors'
 import {generateSingleStatHexs} from 'shared/constants/colorOperations'
 
@@ -16,6 +17,7 @@ class SingleStat extends PureComponent {
       prefix,
       suffix,
       lineGraph,
+      staticLegendHeight,
     } = this.props
 
     // If data for this graph is being fetched for the first time, show a graph-wide spinner.
@@ -39,11 +41,24 @@ class SingleStat extends PureComponent {
       lastValue
     )
 
+    const backgroundColor = bgColor
+    const color = textColor
+    const height = `calc(100% - ${staticLegendHeight +
+      DYGRAPH_CONTAINER_V_MARGIN * 2}px)`
+
+    const singleStatStyles = staticLegendHeight
+      ? {
+          backgroundColor,
+          color,
+          height,
+        }
+      : {
+          backgroundColor,
+          color,
+        }
+
     return (
-      <div
-        className="single-stat"
-        style={{backgroundColor: bgColor, color: textColor}}
-      >
+      <div className="single-stat" style={singleStatStyles}>
         <span
           className={classnames('single-stat--value', {
             'single-stat--small': cellHeight === SMALL_CELL_HEIGHT,
@@ -77,6 +92,7 @@ SingleStat.propTypes = {
   prefix: string,
   suffix: string,
   lineGraph: bool,
+  staticLegendHeight: number,
 }
 
 export default SingleStat

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -93,6 +93,9 @@
     height: 100% !important;
   }
 }
+.dygraph > .single-stat {
+  z-index: 3;
+}
 .single-stat--value {
   position: absolute;
   top: 50%;

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -93,7 +93,7 @@
     height: 100% !important;
   }
 }
-.dygraph > .single-stat {
+.dygraph-child > .single-stat {
   z-index: 3;
 }
 .single-stat--value {


### PR DESCRIPTION
  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The Problem
- in `single-stat-plus-line` graphs the single stat text is obscured by the graph axes & lines

### The Solution
- Clone `SingleStat` inside `Dygraphs` to place it in the same stacking context
- `SingleStat` z-indexed above graph, annotations, and static legend
- Pass `staticLegendHeight` into `SingleStat` so it doesn't obscure the static legend

## Preview
![screen shot 2018-02-28 at 3 00 58 pm](https://user-images.githubusercontent.com/2433762/36818239-04ec1064-1c99-11e8-98ac-ebbd343afe8d.png)



