### PR TITLE
Fix Heroku OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Features
 ### UI Improvements
 ### Bug Fixes
+1. [#2911](https://github.com/influxdata/chronograf/pull/2911): Fix Heroku OAuth
 
 
 ## v1.4.2.1 [2018-02-28]

--- a/oauth2/heroku.go
+++ b/oauth2/heroku.go
@@ -61,7 +61,10 @@ func (h *Heroku) PrincipalID(provider *http.Client) (string, error) {
 		DefaultOrganization DefaultOrg `json:"default_organization"`
 	}
 
-	resp, err := provider.Get(HerokuAccountRoute)
+	req, err := http.NewRequest("GET", HerokuAccountRoute, nil)
+	// Requests fail to Heroku unless this Accept header is set.
+	req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
+	resp, err := provider.Do(req)
 	if err != nil {
 		h.Logger.Error("Unable to communicate with Heroku. err:", err)
 		return "", err

--- a/oauth2/heroku.go
+++ b/oauth2/heroku.go
@@ -2,6 +2,7 @@ package oauth2
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 
 	"github.com/influxdata/chronograf"
@@ -65,6 +66,15 @@ func (h *Heroku) PrincipalID(provider *http.Client) (string, error) {
 	// Requests fail to Heroku unless this Accept header is set.
 	req.Header.Set("Accept", "application/vnd.heroku+json; version=3")
 	resp, err := provider.Do(req)
+	if resp.StatusCode/100 != 2 {
+		err := fmt.Errorf(
+			"Unable to GET user data from %s. Status: %s",
+			HerokuAccountRoute,
+			resp.Status,
+		)
+		h.Logger.Error("", err)
+		return "", err
+	}
 	if err != nil {
 		h.Logger.Error("Unable to communicate with Heroku. err:", err)
 		return "", err


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #2511 

### The problem
- Heroku OAuth was broken. This is because a required Header when making a GET request to the api url was missing.
- We didn't have insight into the error because we weren't checking the response status code for that request.

### The Solution
- Fix Heroku OAuth by adding the required header.
- Add a simple status code checker and log any non-200-range HTTP responses.

### Further Thoughts
It may be useful to add status code checker logic for non-Heroku, such as GitHub, Google, Generic, etc. so that users (and we) can easily know what's failing, in case their APIs change or require headers in the future that they don't currently require. Created #2912 for this.