### PR TITLE
Fix CONTRIBUTING to cite 'dep' for Go dependency management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ We really like to receive feature requests, as it helps us prioritize our work. 
 
 Contributing to the source code
 -------------------------------
-Chronograf is built using Go for its API backend and serving the front-end assets. The front-end visualization is built with React and uses Yarn for package management. The assumption is that all your Go development are done in `$GOPATH/src`. `GOPATH` can be any directory under which Chronograf and all its dependencies will be cloned. For full details on the project structure, follow along below.
+Chronograf is built using Go for its API backend and serving the front-end assets, and uses Dep for dependency management. The front-end visualization is built with React (JavaScript) and uses Yarn for dependency management. The assumption is that all your Go development are done in `$GOPATH/src`. `GOPATH` can be any directory under which Chronograf and all its dependencies will be cloned. For full details on the project structure, follow along below.
 
 Submitting a pull request
 -------------------------
@@ -43,9 +43,13 @@ Signing the CLA
 If you are going to be contributing back to Chronograf please take a second to sign our CLA, which can be found
 [on our website](https://influxdata.com/community/cla/).
 
-Installing Yarn
+Installing & Using Yarn
 --------------
-You'll need to install Yarn to manage the JavaScript modules that the front-end uses. This varies depending on what platform you're developing on, but you should be able to find an installer on [the Yarn installation page](https://yarnpkg.com/en/docs/install).
+You'll need to install Yarn to manage the frontend (JavaScript) dependencies.
+
+* [Install Yarn](https://yarnpkg.com/en/docs/install)
+
+To add a dependency via Yarn, for example, run `yarn add <dependency>` from within the `/chronograf/ui` directory.
 
 Installing Go
 -------------
@@ -62,13 +66,13 @@ running the following:
   gvm use go1.7.5 --default
 ```
 
-Installing GDM
+Installing & Using Dep
 --------------
-Chronograf uses [gdm](https://github.com/sparrc/gdm) to manage dependencies.  Install it by running the following:
+You'll need to install Dep to manage the backend (Go) dependencies.
 
-```bash
-  go get github.com/sparrc/gdm
-```
+* [Install Dep](https://github.com/golang/dep)
+
+To add a dependency via Dep, for example, run `dep ensure -add <dependency>` from within the `/chronograf` directory. _Note that as of this writing, `dep ensure` will modify many extraneous vendor files, so you'll need to run `dep prune` to clean this up before committing your changes. Apparently, the next version of `dep` will take care of this step for you._
 
 Revision Control Systems
 ------------------------


### PR DESCRIPTION
Clarify and make consistent the difference & usage of
frontend vs backend dependency management.


Connect #2676 

### The problem
- Our Contributing guide cited the obsolete use of `gdm` for Go dependency management.
- The language around frontend vs backend dependencies was inconsistent.
- A note about a known issue with `dep` was missing.

### The Solution
Fix and clarify the above.

