### PR TITLE
Legacy dashboard cells default to type 'line'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1.  [#2953](https://github.com/influxdata/chronograf/pull/2953): Fix error reporting in DataExplorer
 1.  [#2947](https://github.com/influxdata/chronograf/pull/2947): Fix Okta oauth2 provider support
 1.  [#2866](https://github.com/influxdata/chronograf/pull/2866): Change hover text on delete mappings confirmation button to 'Delete'
+1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Legacy Graph is missing type, default to line graph
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 1.  [#2953](https://github.com/influxdata/chronograf/pull/2953): Fix error reporting in DataExplorer
 1.  [#2947](https://github.com/influxdata/chronograf/pull/2947): Fix Okta oauth2 provider support
 1.  [#2866](https://github.com/influxdata/chronograf/pull/2866): Change hover text on delete mappings confirmation button to 'Delete'
-1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Legacy Graph is missing type, default to line graph
+1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Automatically add graph type 'line' to any graph missing a type
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/bolt/internal/internal.go
+++ b/bolt/internal/internal.go
@@ -404,6 +404,13 @@ func UnmarshalDashboard(data []byte, d *chronograf.Dashboard) error {
 			legend.Orientation = c.Legend.Orientation
 		}
 
+		// FIXME: this is merely for legacy cells and
+		//        should be removed as soon as possible
+		cellType := c.Type
+		if cellType == "" {
+			cellType = "line"
+		}
+
 		cells[i] = chronograf.DashboardCell{
 			ID:         c.ID,
 			X:          c.X,
@@ -412,7 +419,7 @@ func UnmarshalDashboard(data []byte, d *chronograf.Dashboard) error {
 			H:          c.H,
 			Name:       c.Name,
 			Queries:    queries,
-			Type:       c.Type,
+			Type:       cellType,
 			Axes:       axes,
 			CellColors: colors,
 			Legend:     legend,

--- a/bolt/internal/internal_test.go
+++ b/bolt/internal/internal_test.go
@@ -368,7 +368,46 @@ func Test_MarshalDashboard_WithEmptyLegacyBounds(t *testing.T) {
 						Value: "100",
 					},
 				},
-				Type: "line",
+				Type: "bar",
+			},
+			{
+				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235d",
+				X:    0,
+				Y:    0,
+				W:    4,
+				H:    4,
+				Name: "Super awesome query",
+				Queries: []chronograf.DashboardQuery{
+					{
+						Command: "select * from cpu",
+						Label:   "CPU Utilization",
+						Range: &chronograf.Range{
+							Upper: int64(100),
+						},
+						Shifts: []chronograf.TimeShift{},
+					},
+				},
+				Axes: map[string]chronograf.Axis{
+					"y": chronograf.Axis{
+						LegacyBounds: [2]int64{},
+					},
+				},
+				CellColors: []chronograf.CellColor{
+					{
+						ID:    "myid",
+						Type:  "min",
+						Hex:   "#234567",
+						Name:  "Laser",
+						Value: "0",
+					},
+					{
+						ID:    "id2",
+						Type:  "max",
+						Hex:   "#876543",
+						Name:  "Solitude",
+						Value: "100",
+					},
+				},
 			},
 		},
 		Templates: []chronograf.Template{},
@@ -380,6 +419,48 @@ func Test_MarshalDashboard_WithEmptyLegacyBounds(t *testing.T) {
 		Cells: []chronograf.DashboardCell{
 			{
 				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235c",
+				X:    0,
+				Y:    0,
+				W:    4,
+				H:    4,
+				Name: "Super awesome query",
+				Queries: []chronograf.DashboardQuery{
+					{
+						Command: "select * from cpu",
+						Label:   "CPU Utilization",
+						Range: &chronograf.Range{
+							Upper: int64(100),
+						},
+						Shifts: []chronograf.TimeShift{},
+					},
+				},
+				Axes: map[string]chronograf.Axis{
+					"y": chronograf.Axis{
+						Bounds: []string{},
+						Base:   "10",
+						Scale:  "linear",
+					},
+				},
+				CellColors: []chronograf.CellColor{
+					{
+						ID:    "myid",
+						Type:  "min",
+						Hex:   "#234567",
+						Name:  "Laser",
+						Value: "0",
+					},
+					{
+						ID:    "id2",
+						Type:  "max",
+						Hex:   "#876543",
+						Name:  "Solitude",
+						Value: "100",
+					},
+				},
+				Type: "bar",
+			},
+			{
+				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235d",
 				X:    0,
 				Y:    0,
 				W:    4,

--- a/bolt/internal/internal_test.go
+++ b/bolt/internal/internal_test.go
@@ -368,46 +368,7 @@ func Test_MarshalDashboard_WithEmptyLegacyBounds(t *testing.T) {
 						Value: "100",
 					},
 				},
-				Type: "bar",
-			},
-			{
-				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235d",
-				X:    0,
-				Y:    0,
-				W:    4,
-				H:    4,
-				Name: "Super awesome query",
-				Queries: []chronograf.DashboardQuery{
-					{
-						Command: "select * from cpu",
-						Label:   "CPU Utilization",
-						Range: &chronograf.Range{
-							Upper: int64(100),
-						},
-						Shifts: []chronograf.TimeShift{},
-					},
-				},
-				Axes: map[string]chronograf.Axis{
-					"y": chronograf.Axis{
-						LegacyBounds: [2]int64{},
-					},
-				},
-				CellColors: []chronograf.CellColor{
-					{
-						ID:    "myid",
-						Type:  "min",
-						Hex:   "#234567",
-						Name:  "Laser",
-						Value: "0",
-					},
-					{
-						ID:    "id2",
-						Type:  "max",
-						Hex:   "#876543",
-						Name:  "Solitude",
-						Value: "100",
-					},
-				},
+				Type: "line",
 			},
 		},
 		Templates: []chronograf.Template{},
@@ -457,10 +418,76 @@ func Test_MarshalDashboard_WithEmptyLegacyBounds(t *testing.T) {
 						Value: "100",
 					},
 				},
-				Type: "bar",
+				Type: "line",
 			},
+		},
+		Templates: []chronograf.Template{},
+		Name:      "Dashboard",
+	}
+
+	var actual chronograf.Dashboard
+	if buf, err := internal.MarshalDashboard(dashboard); err != nil {
+		t.Fatal("Error marshaling dashboard: err", err)
+	} else if err := internal.UnmarshalDashboard(buf, &actual); err != nil {
+		t.Fatal("Error unmarshaling dashboard: err:", err)
+	} else if !cmp.Equal(expected, actual) {
+		t.Fatalf("Dashboard protobuf copy error: diff follows:\n%s", cmp.Diff(expected, actual))
+	}
+}
+
+func Test_MarshalDashboard_WithEmptyCellType(t *testing.T) {
+	dashboard := chronograf.Dashboard{
+		ID: 1,
+		Cells: []chronograf.DashboardCell{
 			{
-				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235d",
+				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235c",
+				X:    0,
+				Y:    0,
+				W:    4,
+				H:    4,
+				Name: "Super awesome query",
+				Queries: []chronograf.DashboardQuery{
+					{
+						Command: "select * from cpu",
+						Label:   "CPU Utilization",
+						Range: &chronograf.Range{
+							Upper: int64(100),
+						},
+						Shifts: []chronograf.TimeShift{},
+					},
+				},
+				Axes: map[string]chronograf.Axis{
+					"y": chronograf.Axis{
+						LegacyBounds: [2]int64{},
+					},
+				},
+				CellColors: []chronograf.CellColor{
+					{
+						ID:    "myid",
+						Type:  "min",
+						Hex:   "#234567",
+						Name:  "Laser",
+						Value: "0",
+					},
+					{
+						ID:    "id2",
+						Type:  "max",
+						Hex:   "#876543",
+						Name:  "Solitude",
+						Value: "100",
+					},
+				},
+			},
+		},
+		Templates: []chronograf.Template{},
+		Name:      "Dashboard",
+	}
+
+	expected := chronograf.Dashboard{
+		ID: 1,
+		Cells: []chronograf.DashboardCell{
+			{
+				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235c",
 				X:    0,
 				Y:    0,
 				W:    4,

--- a/bolt/internal/internal_test.go
+++ b/bolt/internal/internal_test.go
@@ -440,97 +440,23 @@ func Test_MarshalDashboard_WithEmptyCellType(t *testing.T) {
 		ID: 1,
 		Cells: []chronograf.DashboardCell{
 			{
-				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235c",
-				X:    0,
-				Y:    0,
-				W:    4,
-				H:    4,
-				Name: "Super awesome query",
-				Queries: []chronograf.DashboardQuery{
-					{
-						Command: "select * from cpu",
-						Label:   "CPU Utilization",
-						Range: &chronograf.Range{
-							Upper: int64(100),
-						},
-						Shifts: []chronograf.TimeShift{},
-					},
-				},
-				Axes: map[string]chronograf.Axis{
-					"y": chronograf.Axis{
-						LegacyBounds: [2]int64{},
-					},
-				},
-				CellColors: []chronograf.CellColor{
-					{
-						ID:    "myid",
-						Type:  "min",
-						Hex:   "#234567",
-						Name:  "Laser",
-						Value: "0",
-					},
-					{
-						ID:    "id2",
-						Type:  "max",
-						Hex:   "#876543",
-						Name:  "Solitude",
-						Value: "100",
-					},
-				},
+				ID: "9b5367de-c552-4322-a9e8-7f384cbd235c",
 			},
 		},
-		Templates: []chronograf.Template{},
-		Name:      "Dashboard",
 	}
 
 	expected := chronograf.Dashboard{
 		ID: 1,
 		Cells: []chronograf.DashboardCell{
 			{
-				ID:   "9b5367de-c552-4322-a9e8-7f384cbd235c",
-				X:    0,
-				Y:    0,
-				W:    4,
-				H:    4,
-				Name: "Super awesome query",
-				Queries: []chronograf.DashboardQuery{
-					{
-						Command: "select * from cpu",
-						Label:   "CPU Utilization",
-						Range: &chronograf.Range{
-							Upper: int64(100),
-						},
-						Shifts: []chronograf.TimeShift{},
-					},
-				},
-				Axes: map[string]chronograf.Axis{
-					"y": chronograf.Axis{
-						Bounds: []string{},
-						Base:   "10",
-						Scale:  "linear",
-					},
-				},
-				CellColors: []chronograf.CellColor{
-					{
-						ID:    "myid",
-						Type:  "min",
-						Hex:   "#234567",
-						Name:  "Laser",
-						Value: "0",
-					},
-					{
-						ID:    "id2",
-						Type:  "max",
-						Hex:   "#876543",
-						Name:  "Solitude",
-						Value: "100",
-					},
-				},
-				Type: "line",
+				ID:         "9b5367de-c552-4322-a9e8-7f384cbd235c",
+				Type:       "line",
+				Queries:    []chronograf.DashboardQuery{},
+				Axes:       map[string]chronograf.Axis{},
+				CellColors: []chronograf.CellColor{},
 			},
 		},
 		Templates: []chronograf.Template{},
-		Name:      "Dashboard",
 	}
 
 	var actual chronograf.Dashboard


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Closes #2920, #2919

### The problem

Legacy dashboard cells have no type assigned to them, which prevents annotation

### The Solution

If dashboard cell type is empty then fallback to line type


