### PR TITLE
Always return colors for single stat graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1.  [#2947](https://github.com/influxdata/chronograf/pull/2947): Fix Okta oauth2 provider support
 1.  [#2866](https://github.com/influxdata/chronograf/pull/2866): Change hover text on delete mappings confirmation button to 'Delete'
 1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Automatically add graph type 'line' to any graph missing a type
+1.  [#2970](https://github.com/influxdata/chronograf/pull/2970): Fix hanging browser on docker host dashboard
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/canned/docker.json
+++ b/canned/docker.json
@@ -56,6 +56,7 @@
           ]
         }
       ],
+      "colors": [],
       "type": "single-stat"
     },
     {
@@ -73,6 +74,7 @@
           ]
         }
       ],
+      "colors": [],
       "type": "single-stat"
     },
     {

--- a/canned/mesos.json
+++ b/canned/mesos.json
@@ -117,6 +117,7 @@
       "h": 4,
       "i": "0fa47984-825b-46f1-9ca5-0366e3220008",
       "name": "Mesos Master Uptime",
+      "colors": [],
       "type": "single-stat",
       "queries": [
         {

--- a/chronograf.go
+++ b/chronograf.go
@@ -572,15 +572,16 @@ type DashboardsStore interface {
 
 // Cell is a rectangle and multiple time series queries to visualize.
 type Cell struct {
-	X       int32           `json:"x"`
-	Y       int32           `json:"y"`
-	W       int32           `json:"w"`
-	H       int32           `json:"h"`
-	I       string          `json:"i"`
-	Name    string          `json:"name"`
-	Queries []Query         `json:"queries"`
-	Axes    map[string]Axis `json:"axes"`
-	Type    string          `json:"type"`
+	X          int32           `json:"x"`
+	Y          int32           `json:"y"`
+	W          int32           `json:"w"`
+	H          int32           `json:"h"`
+	I          string          `json:"i"`
+	Name       string          `json:"name"`
+	Queries    []Query         `json:"queries"`
+	Axes       map[string]Axis `json:"axes"`
+	Type       string          `json:"type"`
+	CellColors []CellColor     `json:"colors"`
 }
 
 // Layout is a collection of Cells for visualization

--- a/server/layout.go
+++ b/server/layout.go
@@ -30,6 +30,10 @@ func newLayoutResponse(layout chronograf.Layout) layoutResponse {
 			layout.Cells[idx].Axes = make(map[string]chronograf.Axis, len(axes))
 		}
 
+		if cell.CellColors == nil {
+			layout.Cells[idx].CellColors = []chronograf.CellColor{}
+		}
+
 		for _, axis := range axes {
 			if _, found := cell.Axes[axis]; !found {
 				layout.Cells[idx].Axes[axis] = chronograf.Axis{

--- a/server/layout_test.go
+++ b/server/layout_test.go
@@ -76,12 +76,13 @@ func Test_Layouts(t *testing.T) {
 				Measurement: "influxdb",
 				Cells: []chronograf.Cell{
 					{
-						X:    0,
-						Y:    0,
-						W:    4,
-						H:    4,
-						I:    "3b0e646b-2ca3-4df2-95a5-fd80915459dd",
-						Name: "A Graph",
+						X:          0,
+						Y:          0,
+						W:          4,
+						H:          4,
+						I:          "3b0e646b-2ca3-4df2-95a5-fd80915459dd",
+						Name:       "A Graph",
+						CellColors: []chronograf.CellColor{},
 						Axes: map[string]chronograf.Axis{
 							"x": chronograf.Axis{
 								Bounds: []string{},
@@ -103,12 +104,13 @@ func Test_Layouts(t *testing.T) {
 					Measurement: "influxdb",
 					Cells: []chronograf.Cell{
 						{
-							X:    0,
-							Y:    0,
-							W:    4,
-							H:    4,
-							I:    "3b0e646b-2ca3-4df2-95a5-fd80915459dd",
-							Name: "A Graph",
+							X:          0,
+							Y:          0,
+							W:          4,
+							H:          4,
+							I:          "3b0e646b-2ca3-4df2-95a5-fd80915459dd",
+							CellColors: []chronograf.CellColor{},
+							Name:       "A Graph",
 						},
 					},
 				},


### PR DESCRIPTION
Addresses a change that requires single stat graphs to have an array of
colors, specifically  in the case of canned dashboards. An empty array
is acceptable but an undefined value will break the page.

Closes #2862
Closes #2841 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### The problem

When a user attempts to open a docker dashboard for a host the browser locks up.

### The Solution

Ensure that we always return colors for a single stat graph in host dashboards.


