### PR TITLE
Make query configs available in table options on visualization tab

### DIFF
--- a/ui/src/dashboards/components/DisplayOptions.js
+++ b/ui/src/dashboards/components/DisplayOptions.js
@@ -42,6 +42,7 @@ class DisplayOptions extends Component {
       staticLegend,
       onToggleStaticLegend,
       onResetFocus,
+      queryConfigs,
     } = this.props
     switch (type) {
       case 'gauge':
@@ -49,7 +50,7 @@ class DisplayOptions extends Component {
       case 'single-stat':
         return <SingleStatOptions onResetFocus={onResetFocus} />
       case 'table':
-        return <TableOptions />
+        return <TableOptions queryConfigs={queryConfigs} />
       default:
         return (
           <AxesOptions

--- a/ui/src/dashboards/components/TableOptions.tsx
+++ b/ui/src/dashboards/components/TableOptions.tsx
@@ -45,9 +45,18 @@ type Options = {
   columnNames: TableColumn[]
 }
 
+type QueryConfig = {
+  measurement: string
+  fields: [{
+    alias: string
+    value: string
+  }]
+}
+
 interface Props {
   singleStatType: string
   singleStatColors: Color[]
+  queryConfigs: QueryConfig[]
   handleUpdateSingleStatType: () => void
   handleUpdateSingleStatColors: () => void
   handleUpdateTableOptions: (options: Options) => void

--- a/ui/src/dashboards/graphics/graph.js
+++ b/ui/src/dashboards/graphics/graph.js
@@ -546,9 +546,9 @@ export const GRAPH_TYPES = [
     graphic: GRAPH_SVGS.gauge,
   },
   // FEATURE FLAG for Table-Graph
-  // {
-  //   type: 'table',
-  //   menuOption: 'Table',
-  //   graphic: GRAPH_SVGS.table,
-  // },
+  {
+    type: 'table',
+    menuOption: 'Table',
+    graphic: GRAPH_SVGS.table,
+  },
 ]

--- a/ui/src/dashboards/graphics/graph.js
+++ b/ui/src/dashboards/graphics/graph.js
@@ -546,9 +546,9 @@ export const GRAPH_TYPES = [
     graphic: GRAPH_SVGS.gauge,
   },
   // FEATURE FLAG for Table-Graph
-  {
-    type: 'table',
-    menuOption: 'Table',
-    graphic: GRAPH_SVGS.table,
-  },
+  // {
+  //   type: 'table',
+  //   menuOption: 'Table',
+  //   graphic: GRAPH_SVGS.table,
+  // },
 ]

--- a/ui/test/dashboards/components/TableOptions.test.tsx
+++ b/ui/test/dashboards/components/TableOptions.test.tsx
@@ -17,6 +17,7 @@ const setup = (override = {}) => {
   const props = {
     singleStatType: '',
     singleStatColors: [],
+    queryConfigs: [],
     handleUpdateSingleStatType: () => {},
     handleUpdateSingleStatColors: () => {},
     handleUpdateTableOptions: () => {},


### PR DESCRIPTION
Makes query configs available for work on table graphs


