### PR TITLE
Polish Table Styles

### DIFF
--- a/ui/src/dashboards/components/GraphOptionsTimeFormat.tsx
+++ b/ui/src/dashboards/components/GraphOptionsTimeFormat.tsx
@@ -67,7 +67,7 @@ class GraphOptionsTimeFormat extends PureComponent<Props, State> {
           items={FORMAT_OPTIONS}
           selected={showCustom ? TIME_FORMAT_CUSTOM : format}
           buttonColor="btn-default"
-          buttonSize="btn-xs"
+          buttonSize="btn-sm"
           className="dropdown-stretch"
           onChoose={this.handleChooseFormat}
         />

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -148,16 +148,20 @@ class TableGraph extends Component {
     const columnName =
       foundColumn && (foundColumn.displayName || foundColumn.internalName)
 
+    const cellContents = isTimeData
+      ? `${moment(cellData).format(timeFormat)}`
+      : columnName || `${cellData}`
+
     return (
       <div
         key={key}
         style={cellStyle}
         className={cellClass}
         onMouseOver={this.handleHover(columnIndex, rowIndex)}
+        title={cellContents}
+        alt={cellContents}
       >
-        {isTimeData
-          ? `${moment(cellData).format(timeFormat)}`
-          : columnName || `${cellData}`}
+        {cellContents}
       </div>
     )
   }

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -107,14 +107,13 @@ class TableGraph extends Component {
       ? rowIndex > 0 && columnIndex === 0
       : isFixedRow
     const isFixedCorner = rowIndex === 0 && columnIndex === 0
-    const isLastRow = rowIndex === rowCount - 1
-    const isLastColumn = columnIndex === columnCount - 1
-    const isHighlighted =
-      rowIndex === parent.props.scrollToRow ||
-      columnIndex === parent.props.scrollToColumn ||
-      (rowIndex === hoveredRowIndex && hoveredRowIndex !== 0) ||
-      (columnIndex === hoveredColumnIndex && hoveredColumnIndex !== 0)
     const dataIsNumerical = _.isNumber(data[rowIndex][columnIndex])
+    const isHighlightedRow =
+      rowIndex === parent.props.scrollToRow ||
+      (rowIndex === hoveredRowIndex && hoveredRowIndex !== 0)
+    const isHighlightedColumn =
+      columnIndex === parent.props.scrollToColumn ||
+      (columnIndex === hoveredColumnIndex && hoveredColumnIndex !== 0)
 
     let cellStyle = style
 
@@ -135,9 +134,8 @@ class TableGraph extends Component {
       'table-graph-cell__fixed-row': isFixedRow,
       'table-graph-cell__fixed-column': isFixedColumn,
       'table-graph-cell__fixed-corner': isFixedCorner,
-      'table-graph-cell__last-row': isLastRow,
-      'table-graph-cell__last-column': isLastColumn,
-      'table-graph-cell__highlight': isHighlighted,
+      'table-graph-cell__highlight-row': isHighlightedRow,
+      'table-graph-cell__highlight-column': isHighlightedColumn,
       'table-graph-cell__numerical': dataIsNumerical,
     })
 

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -220,6 +220,7 @@ class TableGraph extends Component {
             hoveredRowIndex={hoveredRowIndex}
             hoverTime={hoverTime}
             colors={colors}
+            classNameBottomRightGrid="table-graph--scroll-window"
           />}
       </div>
     )

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -89,8 +89,6 @@ class TableGraph extends Component {
       ? this.state.data
       : this.state.unzippedData
 
-    const columnCount = _.get(data, ['0', 'length'], 0)
-    const rowCount = data.length
     const timeFormat = _.get(tableOptions, 'timeFormat', TIME_FORMAT_DEFAULT)
     const columnNames = _.get(tableOptions, 'columnNames', [
       TIME_COLUMN_DEFAULT,

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import classnames from 'classnames'
 import isEmpty from 'lodash/isEmpty'
 
-import {MultiGrid} from 'react-virtualized'
+import {MultiGrid, ColumnSizer} from 'react-virtualized'
 import moment from 'moment'
 
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesToDygraph'
@@ -194,34 +194,45 @@ class TableGraph extends Component {
         onMouseOut={this.handleMouseOut}
       >
         {!isEmpty(data) &&
-          <MultiGrid
+          <ColumnSizer
             columnCount={columnCount}
-            columnWidth={COLUMN_WIDTH}
-            rowCount={rowCount}
-            rowHeight={ROW_HEIGHT}
-            height={tableHeight}
+            columnMaxWidth={400}
+            columnMinWidth={40}
             width={tableWidth}
-            fixedColumnCount={fixedColumnCount}
-            fixedRowCount={1}
-            enableFixedColumnScroll={true}
-            enableFixedRowScroll={true}
-            timeFormat={
-              tableOptions ? tableOptions.timeFormat : TIME_FORMAT_DEFAULT
-            }
-            columnNames={
-              tableOptions ? tableOptions.columnNames : [TIME_COLUMN_DEFAULT]
-            }
-            scrollToRow={scrollToRow}
-            scrollToColumn={scrollToColumn}
-            verticalTimeAxis={verticalTimeAxis}
-            sortByColumnIndex={sortByColumnIndex}
-            cellRenderer={this.cellRenderer}
-            hoveredColumnIndex={hoveredColumnIndex}
-            hoveredRowIndex={hoveredRowIndex}
-            hoverTime={hoverTime}
-            colors={colors}
-            classNameBottomRightGrid="table-graph--scroll-window"
-          />}
+          >
+            {({getColumnWidth, registerChild}) =>
+              <MultiGrid
+                ref={registerChild}
+                columnCount={columnCount}
+                columnWidth={getColumnWidth}
+                rowCount={rowCount}
+                rowHeight={ROW_HEIGHT}
+                height={tableHeight}
+                width={tableWidth}
+                fixedColumnCount={fixedColumnCount}
+                fixedRowCount={1}
+                enableFixedColumnScroll={true}
+                enableFixedRowScroll={true}
+                timeFormat={
+                  tableOptions ? tableOptions.timeFormat : TIME_FORMAT_DEFAULT
+                }
+                columnNames={
+                  tableOptions
+                    ? tableOptions.columnNames
+                    : [TIME_COLUMN_DEFAULT]
+                }
+                scrollToRow={scrollToRow}
+                scrollToColumn={scrollToColumn}
+                verticalTimeAxis={verticalTimeAxis}
+                sortByColumnIndex={sortByColumnIndex}
+                cellRenderer={this.cellRenderer}
+                hoveredColumnIndex={hoveredColumnIndex}
+                hoveredRowIndex={hoveredRowIndex}
+                hoverTime={hoverTime}
+                colors={colors}
+                classNameBottomRightGrid="table-graph--scroll-window"
+              />}
+          </ColumnSizer>}
       </div>
     )
   }

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -172,7 +172,8 @@ class TableGraph extends Component {
 
     const columnCount = _.get(data, ['0', 'length'], 0)
     const rowCount = data.length
-    const COLUMN_WIDTH = 300
+    const COLUMN_MIN_WIDTH = 98
+    const COLUMN_MAX_WIDTH = 500
     const ROW_HEIGHT = 30
     const tableWidth = this.gridContainer ? this.gridContainer.clientWidth : 0
     const tableHeight = this.gridContainer ? this.gridContainer.clientHeight : 0
@@ -196,8 +197,8 @@ class TableGraph extends Component {
         {!isEmpty(data) &&
           <ColumnSizer
             columnCount={columnCount}
-            columnMaxWidth={400}
-            columnMinWidth={40}
+            columnMaxWidth={COLUMN_MAX_WIDTH}
+            columnMinWidth={COLUMN_MIN_WIDTH}
             width={tableWidth}
           >
             {({getColumnWidth, registerChild}) =>

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -223,7 +223,6 @@ class TableGraph extends Component {
         }
         onMouseOver={this.handleHover(columnIndex, rowIndex)}
         title={cellContents}
-        alt={cellContents}
       >
         {cellContents}
       </div>

--- a/ui/src/shared/components/ThresholdsList.js
+++ b/ui/src/shared/components/ThresholdsList.js
@@ -123,8 +123,9 @@ class ThresholdsList extends Component {
     const {thresholdsListColors, showListHeading} = this.props
     const disableAddThreshold = thresholdsListColors.length > MAX_THRESHOLDS
 
-    const thresholdsListClass = `thresholds-list${showListHeading &&
-      ' graph-options-group'}`
+    const thresholdsListClass = `thresholds-list${showListHeading
+      ? ' graph-options-group'
+      : ''}`
 
     return (
       <div className={thresholdsListClass}>

--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -21,7 +21,7 @@
   color: $g12-forge;
   border: 1px solid $g5-pepper;
 
-  // Blue Highlight
+  // Highlight
   &:after {
     content: '';
     position: absolute;
@@ -61,7 +61,7 @@
     border-bottom: 0;
   }
   &__last-column {
-    border-right: 0;
+    // border-right: 0;
   }
   &__highlight {
     background-color: $g6-smoke;
@@ -83,25 +83,36 @@
     outline: none;
   }
   &::-webkit-scrollbar {
-    width: 0;
-
-    &-button {
-      background-color: #f00;
-    }
-    &-track {
-      background-color: #f00;
-    }
-    &-track-piece {
-      background-color: #f00;
-    }
-    &-thumb {
-      background-color: #fff;
-    }
-    &-corner {
-      background-color: #f00;
-    }
+    width: 0px;
+    height: 0px;
   }
-  &::-webkit-resizer {
-    background-color: #f00;
+  &.table-graph--scroll-window {
+    &::-webkit-scrollbar {
+      width: 10px;
+      height: 10px;
+
+      &-button {
+        background-color: $g5-pepper;
+      }
+      &-track {
+        background-color: $g5-pepper;
+      }
+      &-track-piece {
+        background-color: $g5-pepper;
+        border: 2px solid $g5-pepper;
+        border-radius: 5px;
+      }
+      &-thumb {
+        background-color: $g11-sidewalk;
+        border: 2px solid $g5-pepper;
+        border-radius: 5px;
+      }
+      &-corner {
+        background-color: $g5-pepper;
+      }
+    }
+    &::-webkit-resizer {
+      background-color: $g5-pepper;
+    }
   }
 }

--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -28,13 +28,12 @@
   &:after {
     content: '';
     position: absolute;
-    top: -1px;
-    left: -1px;
-    width: calc(100% + 2px);
-    height: calc(100% + 2px);
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
     z-index: 5;
-    border: 2px solid $c-pool;
-    border-radius: 3px;
+    background-color: rgba(255,255,255,0.2);
     visibility: hidden;
     box-sizing: border-box;
   }
@@ -60,24 +59,13 @@
     color: $g18-cloud;
     background-color: $g5-pepper;
   }
-  &__last-row {
-    border-bottom: 0;
+  &__highlight-row:after,
+  &__highlight-column:after {
+    visibility: visible;
   }
-  &__last-column {
-    // border-right: 0;
-  }
-  &__highlight {
-    background-color: $g6-smoke;
-    color: $g16-pearl;
-  }
-  &__highlight:not(.table-graph-cell__fixed-row):not(.table-graph-cell__fixed-column):not(.table-graph-cell__fixed-corner) {
-    color: $g14-chromium;
-    background-color: $g6-smoke;
-  }
-  &:hover:not(.table-graph-cell__fixed-row):not(.table-graph-cell__fixed-column):not(.table-graph-cell__fixed-corner) {
-    color: $g20-white;
-    background-color: $g0-obsidian;
-    &:after {visibility: visible;}
+  &__highlight-row.table-graph-cell__highlight-column {
+    border-color: $g20-white;
+    &:after {visibility: hidden;}
   }
 }
 

--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -20,6 +20,9 @@
   font-size: 13px;
   color: $g12-forge;
   border: 1px solid $g5-pepper;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 
   // Highlight
   &:after {


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1686 

### The Problem
- Janky looking scrollbars
- Odd empty space on the right half of tables with only a few cells
- When using thresholds on a table the highlight styles conflict and do not appear
- Thresholds list sometimes has a tiny `+ Add` button
- Time format dropdown is tiny

### The Solution
- Polish scrollbar appearance
- Use the `ColumnSizer` HOC provided by `react-virtualized`
  - This accepts a min & max width for columns which I have arbitrarily set to `90 / 400`
  - Fills the available space with columns as much as possible
  - Looks much nicer than before
  - If cell contents get truncated, you can hover on the cell for a second or two to see the full contents
- Restyle column/row highlight styles
- Fix appearance of Thresholds list `+ Add` button
- Make Time Format dropdown the same size as other options
