### PR TITLE
New tables have a populated customized fields

### DIFF
--- a/ui/src/dashboards/components/TableOptions.tsx
+++ b/ui/src/dashboards/components/TableOptions.tsx
@@ -62,10 +62,14 @@ export class TableOptions extends PureComponent<Props, {}> {
   get computedFieldNames() {
     const {dataLabels} = this.props
 
-    return dataLabels.map(label => {
-      const existing = this.fieldNames.find(f => f.internalName === label)
-      return existing || {internalName: label, displayName: '', visible: true}
-    })
+    return dataLabels.length
+      ? dataLabels.map(label => {
+          const existing = this.fieldNames.find(f => f.internalName === label)
+          return (
+            existing || {internalName: label, displayName: '', visible: true}
+          )
+        })
+      : [this.timeColumn]
   }
 
   public handleChooseSortBy = (option: Option) => {
@@ -96,9 +100,13 @@ export class TableOptions extends PureComponent<Props, {}> {
   }
 
   public handleFieldUpdate = field => {
-    const {handleUpdateTableOptions, tableOptions} = this.props
-    const {fieldNames, sortBy} = tableOptions
-    const updatedFields = fieldNames.map(
+    const {handleUpdateTableOptions, tableOptions, dataLabels} = this.props
+    const {sortBy, fieldNames} = tableOptions
+    const fields =
+      fieldNames.length >= dataLabels.length
+        ? fieldNames
+        : this.computedFieldNames
+    const updatedFields = fields.map(
       f => (f.internalName === field.internalName ? field : f)
     )
     const updatedSortBy =
@@ -146,6 +154,8 @@ export class TableOptions extends PureComponent<Props, {}> {
       text: field.displayName || field.internalName,
     }))
 
+    const fields = fieldNames.length > 1 ? fieldNames : this.computedFieldNames
+
     return (
       <FancyScrollbar
         className="display-options--cell y-axis-controls"
@@ -173,7 +183,7 @@ export class TableOptions extends PureComponent<Props, {}> {
             />
           </div>
           <GraphOptionsCustomizeFields
-            fields={fieldNames}
+            fields={fields}
             onFieldUpdate={this.handleFieldUpdate}
           />
           <ThresholdsList showListHeading={true} onResetFocus={onResetFocus} />

--- a/ui/src/dashboards/components/TableOptions.tsx
+++ b/ui/src/dashboards/components/TableOptions.tsx
@@ -140,8 +140,6 @@ export class TableOptions extends PureComponent<Props, {}> {
     return tableOptionsDifferent || dataLabelsDifferent
   }
 
-  public handleToggleTextWrapping = () => {}
-
   public render() {
     const {
       tableOptions: {timeFormat, fieldNames, verticalTimeAxis, fixFirstColumn},

--- a/ui/src/dashboards/components/TableOptions.tsx
+++ b/ui/src/dashboards/components/TableOptions.tsx
@@ -62,14 +62,14 @@ export class TableOptions extends PureComponent<Props, {}> {
   get computedFieldNames() {
     const {dataLabels} = this.props
 
-    return dataLabels.length
-      ? dataLabels.map(label => {
+    return _.isEmpty(dataLabels)
+      ? [this.timeColumn]
+      : dataLabels.map(label => {
           const existing = this.fieldNames.find(f => f.internalName === label)
           return (
             existing || {internalName: label, displayName: '', visible: true}
           )
         })
-      : [this.timeColumn]
   }
 
   public handleChooseSortBy = (option: Option) => {

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -122,7 +122,7 @@ class LineGraph extends Component {
           staticLegend={staticLegend}
           isGraphFilled={showSingleStat ? false : isGraphFilled}
         >
-          {showSingleStat &&
+          {showSingleStat && (
             <SingleStat
               prefix={prefix}
               suffix={suffix}
@@ -130,24 +130,27 @@ class LineGraph extends Component {
               lineGraph={true}
               colors={colors}
               cellHeight={cellHeight}
-            />}
+            />
+          )}
         </Dygraph>
       </div>
     )
   }
 }
 
-const GraphLoadingDots = () =>
+const GraphLoadingDots = () => (
   <div className="graph-panel__refreshing">
     <div />
     <div />
     <div />
   </div>
+)
 
-const GraphSpinner = () =>
+const GraphSpinner = () => (
   <div className="graph-fetching">
     <div className="graph-spinner" />
   </div>
+)
 
 const {array, arrayOf, bool, func, number, shape, string} = PropTypes
 

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -122,7 +122,7 @@ class LineGraph extends Component {
           staticLegend={staticLegend}
           isGraphFilled={showSingleStat ? false : isGraphFilled}
         >
-          {showSingleStat && (
+          {showSingleStat &&
             <SingleStat
               prefix={prefix}
               suffix={suffix}
@@ -130,27 +130,24 @@ class LineGraph extends Component {
               lineGraph={true}
               colors={colors}
               cellHeight={cellHeight}
-            />
-          )}
+            />}
         </Dygraph>
       </div>
     )
   }
 }
 
-const GraphLoadingDots = () => (
+const GraphLoadingDots = () =>
   <div className="graph-panel__refreshing">
     <div />
     <div />
     <div />
   </div>
-)
 
-const GraphSpinner = () => (
+const GraphSpinner = () =>
   <div className="graph-fetching">
     <div className="graph-spinner" />
   </div>
-)
 
 const {array, arrayOf, bool, func, number, shape, string} = PropTypes
 

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -346,14 +346,14 @@ class TableGraph extends Component {
         ref={gridContainer => (this.gridContainer = gridContainer)}
         onMouseOut={this.handleMouseOut}
       >
-        {rowCount > 0 &&
+        {rowCount > 0 && (
           <ColumnSizer
             columnCount={columnCount}
             columnMaxWidth={COLUMN_MAX_WIDTH}
             columnMinWidth={COLUMN_MIN_WIDTH}
             width={tableWidth}
           >
-            {({getColumnWidth, registerChild}) =>
+            {({getColumnWidth, registerChild}) => (
               <MultiGrid
                 ref={registerChild}
                 columnCount={columnCount}
@@ -377,8 +377,10 @@ class TableGraph extends Component {
                 colors={colors}
                 tableOptions={tableOptions}
                 classNameBottomRightGrid="table-graph--scroll-window"
-              />}
-          </ColumnSizer>}
+              />
+            )}
+          </ColumnSizer>
+        )}
       </div>
     )
   }

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -195,10 +195,14 @@ class TableGraph extends Component {
   calculateColumnWidth = columnSizerWidth => column => {
     const {index} = column
     const {tableOptions: {verticalTimeAxis, fieldNames}} = this.props
-    const {timeColumnWidth} = this.state
+    const {timeColumnWidth, processedData} = this.state
 
-    if (fieldNames.length > 0) {
-      return verticalTimeAxis && fieldNames[index].internalName === 'time'
+    const labels = verticalTimeAxis
+      ? _.unzip(processedData)[0]
+      : processedData[0]
+
+    if (labels.length > 0) {
+      return verticalTimeAxis && labels[index] === 'time'
         ? timeColumnWidth
         : columnSizerWidth
     }
@@ -342,14 +346,14 @@ class TableGraph extends Component {
         ref={gridContainer => (this.gridContainer = gridContainer)}
         onMouseOut={this.handleMouseOut}
       >
-        {rowCount > 0 && (
+        {rowCount > 0 &&
           <ColumnSizer
             columnCount={columnCount}
             columnMaxWidth={COLUMN_MAX_WIDTH}
             columnMinWidth={COLUMN_MIN_WIDTH}
             width={tableWidth}
           >
-            {({getColumnWidth, registerChild}) => (
+            {({getColumnWidth, registerChild}) =>
               <MultiGrid
                 ref={registerChild}
                 columnCount={columnCount}
@@ -373,10 +377,8 @@ class TableGraph extends Component {
                 colors={colors}
                 tableOptions={tableOptions}
                 classNameBottomRightGrid="table-graph--scroll-window"
-              />
-            )}
-          </ColumnSizer>
-        )}
+              />}
+          </ColumnSizer>}
       </div>
     )
   }

--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -194,7 +194,7 @@ class TableGraph extends Component {
 
   calculateColumnWidth = columnSizerWidth => column => {
     const {index} = column
-    const {tableOptions: {verticalTimeAxis, fieldNames}} = this.props
+    const {tableOptions: {verticalTimeAxis}} = this.props
     const {timeColumnWidth, processedData} = this.state
 
     const labels = verticalTimeAxis


### PR DESCRIPTION
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #1686 

### The problem
When switching from a non table to a table or creating a new cell and after creating a query, there were no fields available to hide or rename.


