### PR TITLE
Add linting fix scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,9 @@ gotestrace:
 jstest:
 	cd ui && yarn test --runInBand
 
+jslint:
+	cd ui && yarn run lint:fix
+
 run: ${BINARY}
 	./chronograf
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -20,7 +20,10 @@
     "test:lint": "yarn run lint; yarn run test",
     "test:watch": "jest --watch",
     "clean": "rm -rf ./build/*",
-    "prettier": "prettier --single-quote --trailing-comma es5 --bracket-spacing false --semi false --write \"{src,spec}/**/*.js\"; eslint src --fix",
+    "eslint:fix": "eslint src --fix",
+    "tslint:fix": "tslint --fix -c ./tslint.json '{src,test}/**/*.ts?(x)'",
+    "prettier": "prettier --single-quote --trailing-comma es5 --bracket-spacing false --semi false --write \"{src,spec}/**/*.js\"",
+    "lint:fix": "yarn run prettier && yarn run eslint:fix && yarn run tslint:fix",
     "eslint-check": "eslint --print-config .eslintrc | eslint-config-prettier-check"
   },
   "author": "",


### PR DESCRIPTION
### The problem
People don't want to think about how to fix linter / formatting errors

### The Solution
Provide scripts for `eslint`, `tslint`, `prettier`, and all three together. 

- fix all things: `yarn run lint:fix`
- fix eslint: `yarn run eslint:fix`
- fix tslint: `yarn run tslint:fix`
- fix prettier: `yarn run prettier`

