### PR TITLE
Add server flag to grant SuperAdmin status to users authenticating from a specific Auth0 Organization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ### Features
 
 1.  [#2973](https://github.com/influxdata/chronograf/pull/2973): Add unsafe SSL to Kapacitor UI configuration
+1.  [#3047](https://github.com/influxdata/chronograf/pull/3047): Add server flag to grant SuperAdmin status to users authenticating from a specific Auth0 Organization
 
 ### UI Improvements
 
-1. [#2910](https://github.com/influxdata/chronograf/pull/2910): Redesign system notifications
+1.  [#2910](https://github.com/influxdata/chronograf/pull/2910): Redesign system notifications
 
 ### Bug Fixes
 

--- a/server/mapping.go
+++ b/server/mapping.go
@@ -13,6 +13,22 @@ import (
 	"github.com/influxdata/chronograf/oauth2"
 )
 
+func (s *Service) mapPrincipalToSuperAdmin(p oauth2.Principal) bool {
+	if p.Issuer != "auth0" {
+		return false
+	}
+
+	groups := strings.Split(p.Group, ",")
+	superAdmin := false
+	for _, group := range groups {
+		if group != "" && group == s.SuperAdminProviderGroups.auth0 {
+			superAdmin = true
+			break
+		}
+	}
+	return superAdmin
+}
+
 func (s *Service) mapPrincipalToRoles(ctx context.Context, p oauth2.Principal) ([]chronograf.Role, error) {
 	mappings, err := s.Store.Mappings(ctx).All(ctx)
 	if err != nil {

--- a/server/mapping.go
+++ b/server/mapping.go
@@ -147,8 +147,6 @@ func (s *Service) Mappings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	fmt.Printf("mappings: %#v\n", mappings)
-
 	res := newMappingsResponse(mappings)
 
 	encodeJSON(w, http.StatusOK, res, s.Logger)

--- a/server/me.go
+++ b/server/me.go
@@ -271,16 +271,26 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 		SuperAdmin: s.newUsersAreSuperAdmin(),
 	}
 
+	superAdmin, err := s.mapPrincipalToSuperAdmin(serverCtx, p)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, err.Error(), s.Logger)
+		return
+	}
+
+	user.SuperAdmin = superAdmin
+
 	roles, err := s.mapPrincipalToRoles(serverCtx, p)
 	if err != nil {
 		Error(w, http.StatusInternalServerError, err.Error(), s.Logger)
 		return
 	}
 
-	if len(roles) == 0 {
+	if !superAdmin && len(roles) == 0 {
 		Error(w, http.StatusForbidden, "This Chronograf is private. To gain access, you must be explicitly added by an administrator.", s.Logger)
 		return
 	}
+
+	// TODO: possibly add user to Default org
 
 	user.Roles = roles
 

--- a/server/me.go
+++ b/server/me.go
@@ -235,6 +235,16 @@ func (s *Service) Me(w http.ResponseWriter, r *http.Request) {
 
 	// user exists
 	if usr != nil {
+		superAdmin := s.mapPrincipalToSuperAdmin(p)
+		if superAdmin && !usr.SuperAdmin {
+			usr.SuperAdmin = superAdmin
+			err := s.Store.Users(serverCtx).Update(serverCtx, usr)
+			if err != nil {
+				unknownErrorWithMessage(w, err, s.Logger)
+				return
+			}
+		}
+
 		currentOrg, err := s.Store.Organizations(serverCtx).Get(serverCtx, chronograf.OrganizationQuery{ID: &p.Organization})
 		if err == chronograf.ErrOrganizationNotFound {
 			// The intent is to force a the user to go through another auth flow

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -21,12 +21,13 @@ type MockUsers struct{}
 
 func TestService_Me(t *testing.T) {
 	type fields struct {
-		UsersStore         chronograf.UsersStore
-		OrganizationsStore chronograf.OrganizationsStore
-		MappingsStore      chronograf.MappingsStore
-		ConfigStore        chronograf.ConfigStore
-		Logger             chronograf.Logger
-		UseAuth            bool
+		UsersStore               chronograf.UsersStore
+		OrganizationsStore       chronograf.OrganizationsStore
+		MappingsStore            chronograf.MappingsStore
+		ConfigStore              chronograf.ConfigStore
+		SuperAdminProviderGroups superAdminProviderGroups
+		Logger                   chronograf.Logger
+		UseAuth                  bool
 	}
 	type args struct {
 		w *httptest.ResponseRecorder
@@ -658,6 +659,214 @@ func TestService_Me(t *testing.T) {
 			wantContentType: "application/json",
 			wantBody:        `{"code":403,"message":"This Chronograf is private. To gain access, you must be explicitly added by an administrator."}`,
 		},
+		{
+			name: "new user - default org is private, user is in auth0 superadmin group",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				SuperAdminProviderGroups: superAdminProviderGroups{
+					auth0: "example",
+				},
+				Logger: log.New(log.DebugLevel),
+				ConfigStore: mocks.ConfigStore{
+					Config: &chronograf.Config{
+						Auth: chronograf.AuthConfig{
+							SuperAdminNewUsers: false,
+						},
+					},
+				},
+				MappingsStore: &mocks.MappingsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
+						return []chronograf.Mapping{}, nil
+					},
+				},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   "0",
+							Name: "The Bad Place",
+						}, nil
+					},
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return nil, chronograf.ErrUserNotFound
+					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+				Group:   "example",
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}`,
+		},
+		{
+			name: "new user - default org is private, user is not in auth0 superadmin group",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				SuperAdminProviderGroups: superAdminProviderGroups{
+					auth0: "example",
+				},
+				Logger: log.New(log.DebugLevel),
+				ConfigStore: mocks.ConfigStore{
+					Config: &chronograf.Config{
+						Auth: chronograf.AuthConfig{
+							SuperAdminNewUsers: false,
+						},
+					},
+				},
+				MappingsStore: &mocks.MappingsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
+						return []chronograf.Mapping{}, nil
+					},
+				},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   "0",
+							Name: "The Bad Place",
+						}, nil
+					},
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return nil, chronograf.ErrUserNotFound
+					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+				Group:   "not_example",
+			},
+			wantStatus:      http.StatusForbidden,
+			wantContentType: "application/json",
+			wantBody:        `{"code":403,"message":"This Chronograf is private. To gain access, you must be explicitly added by an administrator."}`,
+		},
+		{
+			name: "new user - default org is private, user is not in auth0 superadmin group, but has role in default org",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				SuperAdminProviderGroups: superAdminProviderGroups{
+					auth0: "example",
+				},
+				Logger: log.New(log.DebugLevel),
+				ConfigStore: mocks.ConfigStore{
+					Config: &chronograf.Config{
+						Auth: chronograf.AuthConfig{
+							SuperAdminNewUsers: false,
+						},
+					},
+				},
+				MappingsStore: &mocks.MappingsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
+						return []chronograf.Mapping{
+							{
+								Organization:         "0",
+								Provider:             chronograf.MappingWildcard,
+								Scheme:               chronograf.MappingWildcard,
+								ProviderOrganization: chronograf.MappingWildcard,
+							},
+						}, nil
+					},
+				},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:   "0",
+							Name: "The Bad Place",
+						}, nil
+					},
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return nil, chronograf.ErrUserNotFound
+					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+				Group:   "not_example",
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody:        `{"name":"secret","roles":[{"name":"","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}`,
+		},
 	}
 	for _, tt := range tests {
 		tt.args.r = tt.args.r.WithContext(context.WithValue(context.Background(), oauth2.PrincipalKey, tt.principal))
@@ -668,8 +877,9 @@ func TestService_Me(t *testing.T) {
 				MappingsStore:      tt.fields.MappingsStore,
 				ConfigStore:        tt.fields.ConfigStore,
 			},
-			Logger:  tt.fields.Logger,
-			UseAuth: tt.fields.UseAuth,
+			Logger:                   tt.fields.Logger,
+			UseAuth:                  tt.fields.UseAuth,
+			SuperAdminProviderGroups: tt.fields.SuperAdminProviderGroups,
 		}
 
 		fmt.Println(tt.name)

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -686,8 +686,9 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   "0",
-							Name: "The Bad Place",
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
 						}, nil
 					},
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
@@ -724,7 +725,7 @@ func TestService_Me(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}`,
+			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
 		},
 		{
 			name: "new user - Chronograf is private, user is not in auth0 superadmin group",
@@ -753,8 +754,9 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   "0",
-							Name: "The Bad Place",
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
 						}, nil
 					},
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
@@ -794,7 +796,7 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"code":403,"message":"This Chronograf is private. To gain access, you must be explicitly added by an administrator."}`,
 		},
 		{
-			name: "new user - Chronograf is private, user is not in auth0 superadmin group, but has role in default org",
+			name: "new user - Chronograf is not private (has a fully open wildcard mapping to an org), user is not in auth0 superadmin group",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -827,8 +829,9 @@ func TestService_Me(t *testing.T) {
 				OrganizationsStore: &mocks.OrganizationsStore{
 					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
 						return &chronograf.Organization{
-							ID:   "0",
-							Name: "The Bad Place",
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
 						}, nil
 					},
 					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
@@ -865,7 +868,7 @@ func TestService_Me(t *testing.T) {
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
-			wantBody:        `{"name":"secret","roles":[{"name":"","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}`,
+			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
 		},
 	}
 	for _, tt := range tests {

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -945,6 +945,91 @@ func TestService_Me(t *testing.T) {
 			wantContentType: "application/json",
 			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
 		},
+		{
+			name: "Existing user - Chronograf is not private, user is not SuperAdmin, user is in auth0 superadmin group",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				SuperAdminProviderGroups: superAdminProviderGroups{
+					auth0: "example",
+				},
+				Logger: log.New(log.DebugLevel),
+				ConfigStore: mocks.ConfigStore{
+					Config: &chronograf.Config{
+						Auth: chronograf.AuthConfig{
+							SuperAdminNewUsers: false,
+						},
+					},
+				},
+				MappingsStore: &mocks.MappingsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
+						return []chronograf.Mapping{
+							{
+								Organization:         "0",
+								Provider:             chronograf.MappingWildcard,
+								Scheme:               chronograf.MappingWildcard,
+								ProviderOrganization: chronograf.MappingWildcard,
+							},
+						}, nil
+					},
+				},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return &chronograf.User{
+							Name:     "secret",
+							Provider: "auth0",
+							Scheme:   "oauth2",
+							Roles: []chronograf.Role{
+								{
+									Name:         roles.MemberRoleName,
+									Organization: "0",
+								},
+							},
+						}, nil
+					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+				Group:   "example",
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
+		},
 	}
 	for _, tt := range tests {
 		tt.args.r = tt.args.r.WithContext(context.WithValue(context.Background(), oauth2.PrincipalKey, tt.principal))

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -720,7 +720,7 @@ func TestService_Me(t *testing.T) {
 			principal: oauth2.Principal{
 				Subject: "secret",
 				Issuer:  "auth0",
-				Group:   "example",
+				Group:   "not_example,example",
 			},
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -882,7 +882,6 @@ func TestService_Me(t *testing.T) {
 			SuperAdminProviderGroups: tt.fields.SuperAdminProviderGroups,
 		}
 
-		fmt.Println(tt.name)
 		s.Me(tt.args.w, tt.args.r)
 
 		resp := tt.args.w.Result()

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -946,7 +946,7 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
 		},
 		{
-			name: "Existing user - Chronograf is not private, user is not SuperAdmin, user is in auth0 superadmin group",
+			name: "Existing user - Chronograf is not private, user doesn't have SuperAdmin status, user is in auth0 superadmin group",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -958,11 +958,7 @@ func TestService_Me(t *testing.T) {
 				},
 				Logger: log.New(log.DebugLevel),
 				ConfigStore: mocks.ConfigStore{
-					Config: &chronograf.Config{
-						Auth: chronograf.AuthConfig{
-							SuperAdminNewUsers: false,
-						},
-					},
+					Config: &chronograf.Config{},
 				},
 				MappingsStore: &mocks.MappingsStore{
 					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
@@ -1011,6 +1007,88 @@ func TestService_Me(t *testing.T) {
 									Organization: "0",
 								},
 							},
+						}, nil
+					},
+					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {
+						return u, nil
+					},
+					UpdateF: func(ctx context.Context, u *chronograf.User) error {
+						return nil
+					},
+				},
+			},
+			principal: oauth2.Principal{
+				Subject: "secret",
+				Issuer:  "auth0",
+				Group:   "example",
+			},
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place","defaultRole":"member"}],"currentOrganization":{"id":"0","name":"The Bad Place","defaultRole":"member"}}`,
+		},
+		{
+			name: "Existing user - Chronograf is not private, user has SuperAdmin status, user is in auth0 superadmin group",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
+			},
+			fields: fields{
+				UseAuth: true,
+				SuperAdminProviderGroups: superAdminProviderGroups{
+					auth0: "example",
+				},
+				Logger: log.New(log.DebugLevel),
+				ConfigStore: mocks.ConfigStore{
+					Config: &chronograf.Config{},
+				},
+				MappingsStore: &mocks.MappingsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Mapping, error) {
+						return []chronograf.Mapping{
+							{
+								Organization:         "0",
+								Provider:             chronograf.MappingWildcard,
+								Scheme:               chronograf.MappingWildcard,
+								ProviderOrganization: chronograf.MappingWildcard,
+							},
+						}, nil
+					},
+				},
+				OrganizationsStore: &mocks.OrganizationsStore{
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+					DefaultOrganizationF: func(ctx context.Context) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "0",
+							Name:        "The Bad Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+				UsersStore: &mocks.UsersStore{
+					NumF: func(ctx context.Context) (int, error) {
+						// This function gets to verify that there is at least one first user
+						return 1, nil
+					},
+					GetF: func(ctx context.Context, q chronograf.UserQuery) (*chronograf.User, error) {
+						if q.Name == nil || q.Provider == nil || q.Scheme == nil {
+							return nil, fmt.Errorf("Invalid user query: missing Name, Provider, and/or Scheme")
+						}
+						return &chronograf.User{
+							Name:     "secret",
+							Provider: "auth0",
+							Scheme:   "oauth2",
+							Roles: []chronograf.Role{
+								{
+									Name:         roles.MemberRoleName,
+									Organization: "0",
+								},
+							},
+							SuperAdmin: true,
 						}, nil
 					},
 					AddF: func(ctx context.Context, u *chronograf.User) (*chronograf.User, error) {

--- a/server/me_test.go
+++ b/server/me_test.go
@@ -603,7 +603,7 @@ func TestService_Me(t *testing.T) {
 			},
 		},
 		{
-			name: "new user - default org is private",
+			name: "new user - Chronograf is private",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -660,7 +660,7 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"code":403,"message":"This Chronograf is private. To gain access, you must be explicitly added by an administrator."}`,
 		},
 		{
-			name: "new user - default org is private, user is in auth0 superadmin group",
+			name: "new user - Chronograf is private, user is in auth0 superadmin group",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -727,7 +727,7 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"name":"secret","roles":[{"name":"member","organization":"0"}],"provider":"auth0","scheme":"oauth2","superAdmin":true,"links":{"self":"/chronograf/v1/organizations/0/users/0"},"organizations":[{"id":"0","name":"The Bad Place"}],"currentOrganization":{"id":"0","name":"The Bad Place"}}`,
 		},
 		{
-			name: "new user - default org is private, user is not in auth0 superadmin group",
+			name: "new user - Chronograf is private, user is not in auth0 superadmin group",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),
@@ -794,7 +794,7 @@ func TestService_Me(t *testing.T) {
 			wantBody:        `{"code":403,"message":"This Chronograf is private. To gain access, you must be explicitly added by an administrator."}`,
 		},
 		{
-			name: "new user - default org is private, user is not in auth0 superadmin group, but has role in default org",
+			name: "new user - Chronograf is private, user is not in auth0 superadmin group, but has role in default org",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest("GET", "http://example.com/foo", nil),

--- a/server/server.go
+++ b/server/server.go
@@ -328,6 +328,9 @@ func (s *Server) Serve(ctx context.Context) error {
 		return err
 	}
 	service := openService(ctx, s.BuildInfo, s.BoltPath, s.newBuilders(logger), logger, s.useAuth())
+	service.SuperAdminProviderGroups = superAdminProviderGroups{
+		auth0: s.Auth0SuperAdminOrg,
+	}
 	service.Env = chronograf.Environment{
 		TelegrafSystemInterval: s.TelegrafSystemInterval,
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -86,6 +86,7 @@ type Server struct {
 	Auth0ClientID      string   `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
 	Auth0ClientSecret  string   `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
 	Auth0Organizations []string `long:"auth0-organizations" description:"Auth0 organizations permitted to access Chronograf (comma separated)" env:"AUTH0_ORGS" env-delim:","`
+	Auth0SuperAdminOrg string   `long:"auth0-superadmin-org" description:"Auth0 organizations from which users are automatically granted SuperAdmin status" env:"AUTH0_SUPERADMIN_ORG"`
 
 	StatusFeedURL          string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
 	CustomLinks            map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`

--- a/server/server.go
+++ b/server/server.go
@@ -86,7 +86,7 @@ type Server struct {
 	Auth0ClientID      string   `long:"auth0-client-id" description:"Auth0 Client ID for OAuth2 support" env:"AUTH0_CLIENT_ID"`
 	Auth0ClientSecret  string   `long:"auth0-client-secret" description:"Auth0 Client Secret for OAuth2 support" env:"AUTH0_CLIENT_SECRET"`
 	Auth0Organizations []string `long:"auth0-organizations" description:"Auth0 organizations permitted to access Chronograf (comma separated)" env:"AUTH0_ORGS" env-delim:","`
-	Auth0SuperAdminOrg string   `long:"auth0-superadmin-org" description:"Auth0 organizations from which users are automatically granted SuperAdmin status" env:"AUTH0_SUPERADMIN_ORG"`
+	Auth0SuperAdminOrg string   `long:"auth0-superadmin-org" description:"Auth0 organization from which users are automatically granted SuperAdmin status" env:"AUTH0_SUPERADMIN_ORG"`
 
 	StatusFeedURL          string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
 	CustomLinks            map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`

--- a/server/service.go
+++ b/server/service.go
@@ -11,12 +11,17 @@ import (
 
 // Service handles REST calls to the persistence
 type Service struct {
-	Store            DataStore
-	TimeSeriesClient TimeSeriesClient
-	Logger           chronograf.Logger
-	UseAuth          bool
-	Env              chronograf.Environment
-	Databases        chronograf.Databases
+	Store                    DataStore
+	TimeSeriesClient         TimeSeriesClient
+	Logger                   chronograf.Logger
+	UseAuth                  bool
+	SuperAdminProviderGroups superAdminProviderGroups
+	Env                      chronograf.Environment
+	Databases                chronograf.Databases
+}
+
+type superAdminProviderGroups struct {
+	auth0 string
 }
 
 // TimeSeriesClient returns the correct client for a time series database.


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass

Connect #2963

### The problem

Currently there isn't a way to have a general class of user that can be granted superadmin status.

### The Solution
Allow users from specific Auth0 organizations to be granted superadmin status. This feature is added a CLI option where users could specify specific Auth0 organizations that would grant users superadmin status.


