### PR TITLE
Prevent Multi-Select Dropdown in InfluxDB Admin Users and Roles tabs from losing selection state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### UI Improvements
 
-1. [#2910](https://github.com/influxdata/chronograf/pull/2910): Redesign system notifications
+1.  [#2910](https://github.com/influxdata/chronograf/pull/2910): Redesign system notifications
 
 ### Bug Fixes
 
@@ -17,6 +17,7 @@
 1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Automatically add graph type 'line' to any graph missing a type
 1.  [#2970](https://github.com/influxdata/chronograf/pull/2970): Fix hanging browser on docker host dashboard
 1.  [#3006](https://github.com/influxdata/chronograf/pull/3006): Fix Kapacitor Rules task enabled checkboxes to only toggle exactly as clicked
+1.  [#3048](https://github.com/influxdata/chronograf/pull/3048): Fix Multi-Select Dropdown bug
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 1.  [#2919](https://github.com/influxdata/chronograf/pull/2919): Automatically add graph type 'line' to any graph missing a type
 1.  [#2970](https://github.com/influxdata/chronograf/pull/2970): Fix hanging browser on docker host dashboard
 1.  [#3006](https://github.com/influxdata/chronograf/pull/3006): Fix Kapacitor Rules task enabled checkboxes to only toggle exactly as clicked
-1.  [#3048](https://github.com/influxdata/chronograf/pull/3048): Fix Multi-Select Dropdown bug
+1.  [#3048](https://github.com/influxdata/chronograf/pull/3048): Prevent Multi-Select Dropdown in InfluxDB Admin Users and Roles tabs from losing selection state
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/ui/src/admin/components/RoleRow.js
+++ b/ui/src/admin/components/RoleRow.js
@@ -77,6 +77,7 @@ const RoleRow = ({
             customClass={classnames(`dropdown-${ROLES_TABLE.colPermissions}`, {
               'admin-table--multi-select-empty': !permissions.length,
             })}
+            resetStateOnReceiveProps={false}
           />
         ) : null}
       </td>
@@ -92,6 +93,7 @@ const RoleRow = ({
             customClass={classnames(`dropdown-${ROLES_TABLE.colUsers}`, {
               'admin-table--multi-select-empty': !users.length,
             })}
+            resetStateOnReceiveProps={false}
           />
         ) : null}
       </td>

--- a/ui/src/admin/components/UserRow.js
+++ b/ui/src/admin/components/UserRow.js
@@ -96,6 +96,7 @@ const UserRow = ({
             customClass={classnames(`dropdown-${USERS_TABLE.colRoles}`, {
               'admin-table--multi-select-empty': !roles.length,
             })}
+            resetStateOnReceiveProps={false}
           />
         </td>
       ) : null}
@@ -113,6 +114,7 @@ const UserRow = ({
             customClass={classnames(`dropdown-${USERS_TABLE.colPermissions}`, {
               'admin-table--multi-select-empty': !permissions.length,
             })}
+            resetStateOnReceiveProps={false}
           />
         ) : null}
       </td>

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -39,6 +39,14 @@ class MultiSelectDropdown extends Component {
     this.setState({isOpen: false})
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (!_.isEqual(this.props.selectedItems, nextProps.selectedItems)) {
+      return
+    }
+
+    this.setState({localSelectedItems: nextProps.selectedItems})
+  }
+
   toggleMenu = e => {
     e.stopPropagation()
     this.setState({isOpen: !this.state.isOpen})

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -98,17 +98,16 @@ class MultiSelectDropdown extends Component {
 
   renderMenu() {
     const {items, isApplyShown} = this.props
-    const applyButton = isApplyShown ? (
-      <li className="multi-select--apply">
-        <button className="btn btn-xs btn-info" onClick={this.handleApply}>
-          Apply
-        </button>
-      </li>
-    ) : null
 
     return (
       <ul className="dropdown-menu">
-        {applyButton}
+        {isApplyShown && (
+          <li className="multi-select--apply">
+            <button className="btn btn-xs btn-info" onClick={this.handleApply}>
+              Apply
+            </button>
+          </li>
+        )}
         <FancyScrollbar
           autoHide={false}
           autoHeight={true}

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -39,14 +39,6 @@ class MultiSelectDropdown extends Component {
     this.setState({isOpen: false})
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!_.isEqual(this.props.selectedItems, nextProps.selectedItems)) {
-      return
-    }
-
-    this.setState({localSelectedItems: nextProps.selectedItems})
-  }
-
   toggleMenu = e => {
     e.stopPropagation()
     this.setState({isOpen: !this.state.isOpen})

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -40,7 +40,10 @@ class MultiSelectDropdown extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!_.isEqual(this.props.selectedItems, nextProps.selectedItems)) {
+    if (
+      !this.props.resetStateOnReceiveProps ||
+      !_.isEqual(this.props.selectedItems, nextProps.selectedItems)
+    ) {
       return
     }
 
@@ -161,6 +164,7 @@ MultiSelectDropdown.propTypes = {
   customClass: string,
   iconName: string,
   isApplyShown: bool,
+  resetStateOnReceiveProps: bool,
 }
 
 MultiSelectDropdown.defaultProps = {
@@ -169,6 +173,7 @@ MultiSelectDropdown.defaultProps = {
   customClass: 'dropdown-160',
   selectedItems: [],
   isApplyShown: true,
+  resetStateOnReceiveProps: true,
 }
 
 export default OnClickOutside(MultiSelectDropdown)


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #2980 

### The Problem
- If the Multi-Select Dropdown is open for more than brief moment the selected options appear to reset to previous values

### The Solution
- I removed `componentWillReceiveProps` from the component as it was setting state and forcing a re-render
- Somewhere higher up a re-render happens and the original props get passed down which causes the state change since the unsaved state is different
- Removing this shouldn't affect the functionality at all

