### PR TITLE
Fix graph fill bug: Other graphs hate him

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1.  [#2970](https://github.com/influxdata/chronograf/pull/2970): Fix hanging browser on docker host dashboard
 1.  [#3006](https://github.com/influxdata/chronograf/pull/3006): Fix Kapacitor Rules task enabled checkboxes to only toggle exactly as clicked
 1.  [#3048](https://github.com/influxdata/chronograf/pull/3048): Prevent Multi-Select Dropdown in InfluxDB Admin Users and Roles tabs from losing selection state
+1.  [#3068](https://github.com/influxdata/chronograf/pull/3068): Fix intermittent missing fill from graphs
 
 ## v1.4.2.3 [2018-03-08]
 

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -76,6 +76,7 @@ class LineGraph extends Component {
       rightGap: 0,
       yRangePad: 10,
       labelsKMB: true,
+      fillGraph: true,
       underlayCallback,
       axisLabelWidth: 60,
       drawAxesAtZero: true,


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #3026 

### The problem
LineGraph was not passing the proper prop '`fillGraph: true`' to Dygraph.  

### The Solution
Add it


