### PR TITLE
Feature Flag with this one weird trick

### DIFF
--- a/ui/src/shared/components/FeatureFlag.tsx
+++ b/ui/src/shared/components/FeatureFlag.tsx
@@ -1,0 +1,15 @@
+import {SFC} from 'react'
+
+interface Props {
+  children?: any
+}
+
+const FeatureFlag: SFC<Props> = props => {
+  if (process.env.NODE_ENV === 'development') {
+    return props.children
+  }
+
+  return null
+}
+
+export default FeatureFlag

--- a/ui/webpack/dev.config.js
+++ b/ui/webpack/dev.config.js
@@ -145,6 +145,9 @@ module.exports = {
     ],
   },
   plugins: [
+    new webpack.DefinePlugin({
+      'process.env.NODE_ENV': JSON.stringify('development'),
+    }),
     new webpack.DllReferencePlugin({
       context: process.cwd(),
       manifest: require('../build/vendor.dll.json'),


### PR DESCRIPTION
Closes #3072 

### The problem
We would like a way to hide features in production and show them in development

### The Solution
Create a component which will show its children only if the user is in development. 

### Usage
```
        <FeatureFlag name="ifql-builder">
          ...new sweet feature
        </FeatureFlag>
```
### Note
Name prop is optional and does nothing but convey which feature is flagged.