### PR TITLE
Update PR template: Use GH Keyword; Reorganize/compact sections

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,13 +1,10 @@
+Closes #
+
+_Briefly describe your proposed changes:_
+_What was the problem?_
+_What was the solution?_
 
   - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
-
-Connect #
-
-### The problem
-
-### The Solution
-
-


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This is mainly to update `Connect` to `Closes` so that GH automatically closes issues when their corresponding PRs are merged. Second, I've moved the checklist to the bottom because I believe that they're less important than the description that the author puts forth. Third, I expanded the description prompts to something slightly more friendly.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)