### PR TITLE
Fix test warning spam

### DIFF
--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -8,7 +8,7 @@ module.exports = {
       ],
       modulePaths: ['<rootDir>', '<rootDir>/node_modules/'],
       moduleDirectories: ['src'],
-      setupFiles: ['<rootDir>/test/setupTests.js'],
+      setupFiles: ['<rootDir>/test/setup.js'],
       transform: {
         '^.+\\.tsx?$': 'ts-jest',
         '^.+\\.js$': 'babel-jest',

--- a/ui/test/setup.js
+++ b/ui/test/setup.js
@@ -1,0 +1,22 @@
+import {configure} from 'enzyme'
+import React from 'react'
+
+import Adapter from 'enzyme-adapter-react-15'
+
+configure({adapter: new Adapter()})
+
+/**
+ * Since React v15.5, there's a warning printed if you access `React.createClass` or `React.PropTypes`
+ * https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings
+ *
+ * `import * as React from 'react'` is required by Flowtype https://flow.org/en/docs/react/types/ ,
+ * but the * causes both those deprecated getters to be called.
+ * This is particularly annoying in Jest since every test prints two useless warnings.
+ *
+ * This file can be used as a Jest setup file to simply delete those features of the `react` package.
+ * You don't need the deprecation warning. Your tests will simply fail if you're still using the old ways.
+ * https://facebook.github.io/jest/docs/en/configuration.html#setupfiles-array
+ */
+
+delete React.createClass
+delete React.PropTypes

--- a/ui/test/setupTests.js
+++ b/ui/test/setupTests.js
@@ -1,4 +1,0 @@
-import {configure} from 'enzyme'
-import Adapter from 'enzyme-adapter-react-15'
-
-configure({adapter: new Adapter()})


### PR DESCRIPTION
### The problem
React virtualized imported react with `*` this causes deprecation warnings.  Please see [this](https://github.com/facebook/flow/issues/4673) issue for more info.  

### The Solution
Hack that I found [here](https://github.com/bvaughn/react-virtualized/issues/1037#issuecomment-371615531).  Basically, before tests run, remove `createClass` and `PropTypes` from the React API.  

### Note
This only effects tests, will still get warnings in dev / prod builds.  


