### PR TITLE
Fix templateVariables not loading properly.  Other variables were amazed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 1.  [#2950](https://github.com/influxdata/chronograf/pull/2094): Always save template variables on first edit
+1.  [#3101](https://github.com/influxdata/chronograf/pull/3101): Fix template variables not loading
 
 ## v1.4.3.0 [unreleased]
 

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -278,27 +278,37 @@ export default function ui(state = initialState, action) {
     case 'EDIT_TEMPLATE_VARIABLE_VALUES': {
       const {dashboardID, templateID, values} = action.payload
 
-      const dashboards = state.dashboards.map(
-        dashboard =>
-          dashboard.id === dashboardID
-            ? {
-                ...dashboard,
-                templates: dashboard.templates.map(
-                  template =>
-                    template.id === templateID && template.type !== 'csv'
-                      ? {
-                          ...template,
-                          values: values.map(value => ({
-                            selected: template.values[0].value === value,
-                            value,
-                            type: TEMPLATE_VARIABLE_TYPES[template.type],
-                          })),
-                        }
-                      : template
-                ),
-              }
-            : dashboard
-      )
+      const dashboards = state.dashboards.map(dashboard => {
+        if (dashboard.id !== dashboardID) {
+          return dashboard
+        }
+
+        const templates = dashboard.templates.map(template => {
+          if (template.id !== templateID && template.type !== 'csv') {
+            return template
+          }
+
+          const selectedValue = _.get(template, 'values', []).find(
+            v => v.selected
+          )
+
+          const v = values.map(value => ({
+            selected: _.get(selectedValue, 'value') === value,
+            value,
+            type: TEMPLATE_VARIABLE_TYPES[template.type],
+          }))
+
+          return {
+            ...template,
+            values: v,
+          }
+        })
+
+        return {
+          ...dashboard,
+          templates,
+        }
+      })
 
       return {...state, dashboards}
     }

--- a/ui/test/dashboards/reducers/ui.test.js
+++ b/ui/test/dashboards/reducers/ui.test.js
@@ -13,39 +13,42 @@ import {
   templateVariableSelected,
   templateVariablesSelectedByName,
   cancelEditCell,
+  editTemplateVariableValues,
 } from 'src/dashboards/actions'
 
 let state
-const templates = [
-  {
-    id: '1',
-    type: 'query',
-    label: 'test query',
-    tempVar: ':region:',
-    query: {
-      db: 'db1',
-      rp: 'rp1',
-      measurement: 'm1',
-      influxql: 'SHOW TAGS WHERE CHRONOGIRAFFE = "friend"',
-    },
-    values: [
-      {value: 'us-west', type: 'tagKey', selected: false},
-      {value: 'us-east', type: 'tagKey', selected: true},
-      {value: 'us-mount', type: 'tagKey', selected: false},
-    ],
+
+const t1 = {
+  id: '1',
+  type: 'tagKeys',
+  label: 'test query',
+  tempVar: ':region:',
+  query: {
+    db: 'db1',
+    rp: 'rp1',
+    measurement: 'm1',
+    influxql: 'SHOW TAGS WHERE CHRONOGIRAFFE = "friend"',
   },
-  {
-    id: '2',
-    type: 'csv',
-    label: 'test csv',
-    tempVar: ':temperature:',
-    values: [
-      {value: '98.7', type: 'measurement', selected: false},
-      {value: '99.1', type: 'measurement', selected: false},
-      {value: '101.3', type: 'measurement', selected: true},
-    ],
-  },
-]
+  values: [
+    {value: 'us-west', type: 'tagKey', selected: false},
+    {value: 'us-east', type: 'tagKey', selected: true},
+    {value: 'us-mount', type: 'tagKey', selected: false},
+  ],
+}
+
+const t2 = {
+  id: '2',
+  type: 'csv',
+  label: 'test csv',
+  tempVar: ':temperature:',
+  values: [
+    {value: '98.7', type: 'measurement', selected: false},
+    {value: '99.1', type: 'measurement', selected: false},
+    {value: '101.3', type: 'measurement', selected: true},
+  ],
+}
+
+const templates = [t1, t2]
 
 const d1 = {
   id: 1,
@@ -53,6 +56,7 @@ const d1 = {
   name: 'd1',
   templates,
 }
+
 const d2 = {id: 2, cells: [], name: 'd2', templates: []}
 const dashboards = [d1, d2]
 const c1 = {
@@ -211,5 +215,54 @@ describe('DataExplorer.Reducers.UI', () => {
 
     expect(actual.dashboards[0].cells[0].isEditing).toBe(false)
     expect(actual.dashboards[0].cells[0].name).toBe(editingCell.name)
+  })
+
+  describe('EDIT_TEMPLATE_VARIABLE_VALUES', () => {
+    it('can edit the tempvar values', () => {
+      const actual = reducer(
+        {dashboards},
+        editTemplateVariableValues(d1.id, t1.id, ['v1', 'v2'])
+      )
+
+      const expected = [
+        {
+          selected: false,
+          value: 'v1',
+          type: 'tagKey',
+        },
+        {
+          selected: false,
+          value: 'v2',
+          type: 'tagKey',
+        },
+      ]
+
+      expect(actual.dashboards[0].templates[0].values).toEqual(expected)
+    })
+
+    it('can handle an empty template.values', () => {
+      const ts = [{...t1, values: []}]
+      const ds = [{...d1, templates: ts}]
+
+      const actual = reducer(
+        {dashboards: ds},
+        editTemplateVariableValues(d1.id, t1.id, ['v1', 'v2'])
+      )
+
+      const expected = [
+        {
+          selected: false,
+          value: 'v1',
+          type: 'tagKey',
+        },
+        {
+          selected: false,
+          value: 'v2',
+          type: 'tagKey',
+        },
+      ]
+
+      expect(actual.dashboards[0].templates[0].values).toEqual(expected)
+    })
   })
 })


### PR DESCRIPTION
Runtime error in the 'EDIT_TEMPLATE_VARIABLE_VALUES' reducer
was causing the list not to populate

Co-authored-by: Andrew Watkins <andrew.watkinz@gmail.com>
Co-authored-by: Brandon Farmer <bthesorceror@gmail.com>


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Connect #1551 

### The problem
Was [this line](https://github.com/influxdata/chronograf/pull/3101/files#diff-1fa97645dc91f23845c492c6de56cf76L292) causing a runtime error if there were no template variable values to index upon.

### The Solution
- Add a test for this particular case
- Refactor [this line](https://github.com/influxdata/chronograf/pull/3101/files#diff-1fa97645dc91f23845c492c6de56cf76L292) to use `_.get`

### Notes
Most of the changes in the non-test code is a refactor to make the reducer a bit more readable.