### PR TITLE
Add Ability to Clone Dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1.  [#2526](https://github.com/influxdata/chronograf/pull/2526): Add support for RS256/JWKS verification, support for id_token parsing (as in ADFS)
+1.  [#3103](https://github.com/influxdata/chronograf/pull/3103): Add ability to clone dashboards
 
 ### UI Improvements
 

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -73,7 +73,6 @@ export const deleteDashboard = dashboard => ({
   type: 'DELETE_DASHBOARD',
   payload: {
     dashboard,
-    dashboardID: dashboard.id,
   },
 })
 

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -73,6 +73,7 @@ export const deleteDashboard = dashboard => ({
   type: 'DELETE_DASHBOARD',
   payload: {
     dashboard,
+    dashboardID: dashboard.id,
   },
 })
 

--- a/ui/src/dashboards/components/DashboardsPageContents.js
+++ b/ui/src/dashboards/components/DashboardsPageContents.js
@@ -25,6 +25,7 @@ class DashboardsPageContents extends Component {
       dashboards,
       onDeleteDashboard,
       onCreateDashboard,
+      onCloneDashboard,
       dashboardLink,
     } = this.props
     const {searchTerm} = this.state
@@ -69,6 +70,7 @@ class DashboardsPageContents extends Component {
                     dashboards={filteredDashboards}
                     onDeleteDashboard={onDeleteDashboard}
                     onCreateDashboard={onCreateDashboard}
+                    onCloneDashboard={onCloneDashboard}
                     dashboardLink={dashboardLink}
                   />
                 </div>
@@ -87,6 +89,7 @@ DashboardsPageContents.propTypes = {
   dashboards: arrayOf(shape()),
   onDeleteDashboard: func.isRequired,
   onCreateDashboard: func.isRequired,
+  onCloneDashboard: func.isRequired,
   dashboardLink: string.isRequired,
 }
 

--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -70,7 +70,7 @@ const DashboardsTable = ({
             >
               <td className="text-right">
                 <button
-                  className="btn btn-xs btn-default"
+                  className="btn btn-xs btn-default table--show-on-row-hover"
                   onClick={onCloneDashboard(dashboard)}
                 >
                   <span className="icon duplicate" />

--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -33,6 +33,7 @@ const DashboardsTable = ({
   dashboards,
   onDeleteDashboard,
   onCreateDashboard,
+  onCloneDashboard,
   dashboardLink,
 }) => {
   const wrappedDelete = dashboard => () => {
@@ -71,6 +72,13 @@ const DashboardsTable = ({
               replaceWithIfNotAuthorized={<td />}
             >
               <td className="text-right">
+                <button
+                  className="btn btn-xs btn-default"
+                  onClick={onCloneDashboard(dashboard)}
+                >
+                  <span className="icon duplicate" />
+                  Clone
+                </button>
                 <ConfirmButton
                   confirmAction={wrappedDelete}
                   size="btn-xs"
@@ -100,6 +108,7 @@ DashboardsTable.propTypes = {
   dashboards: arrayOf(shape()),
   onDeleteDashboard: func.isRequired,
   onCreateDashboard: func.isRequired,
+  onCloneDashboard: func.isRequired,
   dashboardLink: string.isRequired,
 }
 

--- a/ui/src/dashboards/components/DashboardsTable.js
+++ b/ui/src/dashboards/components/DashboardsTable.js
@@ -36,9 +36,6 @@ const DashboardsTable = ({
   onCloneDashboard,
   dashboardLink,
 }) => {
-  const wrappedDelete = dashboard => () => {
-    onDeleteDashboard(dashboard)
-  }
   return dashboards && dashboards.length ? (
     <table className="table v-center admin-table table-highlight">
       <thead>
@@ -80,7 +77,7 @@ const DashboardsTable = ({
                   Clone
                 </button>
                 <ConfirmButton
-                  confirmAction={wrappedDelete}
+                  confirmAction={onDeleteDashboard(dashboard)}
                   size="btn-xs"
                   type="btn-danger"
                   text="Delete"

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -28,7 +28,7 @@ class DashboardsPage extends Component {
     createDashboard({...dashboard, name: `${dashboard.name} (Clone)`})
   }
 
-  handleDeleteDashboard = dashboard => {
+  handleDeleteDashboard = dashboard => () => {
     this.props.handleDeleteDashboard(dashboard)
   }
 

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -23,6 +23,11 @@ class DashboardsPage extends Component {
     push(`/sources/${id}/dashboards/${data.id}`)
   }
 
+  handleCloneDashboard = dashboard => () => {
+    console.log(dashboard)
+    createDashboard({...dashboard, name: `${dashboard.name} (Clone)`})
+  }
+
   handleDeleteDashboard = dashboard => {
     this.props.handleDeleteDashboard(dashboard)
   }
@@ -39,6 +44,7 @@ class DashboardsPage extends Component {
           dashboards={dashboards}
           onDeleteDashboard={this.handleDeleteDashboard}
           onCreateDashboard={this.handleCreateDashbord}
+          onCloneDashboard={this.handleCloneDashboard}
         />
       </div>
     )

--- a/ui/src/dashboards/containers/DashboardsPage.js
+++ b/ui/src/dashboards/containers/DashboardsPage.js
@@ -23,9 +23,13 @@ class DashboardsPage extends Component {
     push(`/sources/${id}/dashboards/${data.id}`)
   }
 
-  handleCloneDashboard = dashboard => () => {
-    console.log(dashboard)
-    createDashboard({...dashboard, name: `${dashboard.name} (Clone)`})
+  handleCloneDashboard = dashboard => async () => {
+    const {source: {id}, router: {push}} = this.props
+    const {data} = await createDashboard({
+      ...dashboard,
+      name: `${dashboard.name} (clone)`,
+    })
+    push(`/sources/${id}/dashboards/${data.id}`)
   }
 
   handleDeleteDashboard = dashboard => () => {

--- a/ui/test/dashboards/reducers/ui.test.js
+++ b/ui/test/dashboards/reducers/ui.test.js
@@ -4,6 +4,7 @@ import reducer from 'src/dashboards/reducers/ui'
 
 import {
   loadDashboards,
+  deleteDashboard,
   deleteDashboardFailed,
   setTimeRange,
   updateDashboardCells,
@@ -82,6 +83,16 @@ describe('DataExplorer.Reducers.UI', () => {
     }
 
     expect(actual.dashboards).toEqual(expected.dashboards)
+  })
+
+  it('can delete a dashboard', () => {
+    const initialState = {...state, dashboards}
+    const actual = reducer(initialState, deleteDashboard(d1))
+    const expected = initialState.dashboards.filter(
+      dashboard => dashboard.id !== d1.id
+    )
+
+    expect(actual.dashboards).toEqual(expected)
   })
 
   it('can handle a failed dashboard deletion', () => {


### PR DESCRIPTION
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

Closes #3102 

### The Problem
- Creating dashboards from scratch every time is time consuming and frustrating

### The Solution
- User can "Clone" dashboards from the dashboards index view

### Preview
![clone-dashboard](https://user-images.githubusercontent.com/2433762/38156686-b835b4f6-3434-11e8-95f3-1306b41eede1.gif)


