### PR TITLE
Fixes template variable editing not allowing saving

### DIFF
--- a/ui/src/dashboards/components/template_variables/Row.js
+++ b/ui/src/dashboards/components/template_variables/Row.js
@@ -70,7 +70,7 @@ const TemplateVariableRow = ({
       <Dropdown
         items={TEMPLATE_TYPES}
         onChoose={onSelectType}
-        onClick={onStartEdit}
+        onClick={onStartEdit('tempVar')}
         selected={TEMPLATE_TYPES.find(t => t.type === selectedType).text}
         className="dropdown-140"
       />
@@ -84,7 +84,7 @@ const TemplateVariableRow = ({
         selectedMeasurement={selectedMeasurement}
         selectedTagKey={selectedTagKey}
         onSelectTagKey={onSelectTagKey}
-        onStartEdit={onStartEdit}
+        onStartEdit={onStartEdit('tempVar')}
         onErrorThrown={onErrorThrown}
       />
       <RowValues


### PR DESCRIPTION
- Dropdown and TemplateQueryBuilder components require that a function
  is passed to them, where as TableInput requires that a function builder
  is passed to them for starting editing

  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)