### PR TITLE
Fix saving of new TICKscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 ### Bug Fixes
 
 ## v1.4.3.0 [unreleased]
+
 1.  [#3080](https://github.com/influxdata/chronograf/pull/3080): Add tabular data visualization option with features
 1.  [#3103](https://github.com/influxdata/chronograf/pull/3103): Add ability to clone dashboards
+1.  [#3111](https://github.com/influxdata/chronograf/pull/3111): Fix saving of new TICKscripts
 
 ### UI Improvements
 

--- a/ui/src/kapacitor/components/TickscriptEditorControls.js
+++ b/ui/src/kapacitor/components/TickscriptEditorControls.js
@@ -19,7 +19,7 @@ const TickscriptEditorControls = ({
     {isNewTickscript ? (
       <TickscriptID onChangeID={onChangeID} id={task.id} />
     ) : (
-      <TickscriptStaticID id={task.name} />
+      <TickscriptStaticID id={task.id} />
     )}
     <div className="tickscript-controls--right">
       <TickscriptType type={task.type} onChangeType={onChangeType} />

--- a/ui/src/kapacitor/containers/TickscriptPage.js
+++ b/ui/src/kapacitor/containers/TickscriptPage.js
@@ -173,6 +173,7 @@ class TickscriptPage extends Component {
         response = await updateTask(kapacitor, task, ruleID, router, sourceID)
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
+        router.push(`/sources/${sourceID}/tickscript/${response.id}`)
       }
       if (response.code) {
         this.setState({unsavedChanges: true, consoleMessage: response.message})
@@ -227,6 +228,7 @@ class TickscriptPage extends Component {
       unsavedChanges,
       consoleMessage,
     } = this.state
+
     return (
       <Tickscript
         task={task}


### PR DESCRIPTION
Closes #3019 

_Briefly describe your proposed changes:_
Since new TICKscripts do not yet have IDs, the router uses `/new` as a placeholder. When the newly created TICKscript response comes back I use the ID and redirect to the editor

_What was the problem?_
When you create a new TICKscript you are stuck in the "New" mode and any changes don't affect the script you think it does

_What was the solution?_
Redirect user to the location of their new script

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Preview
![save-new-tickscript](https://user-images.githubusercontent.com/2433762/38222237-5df4a6e4-3698-11e8-9cbe-d43de8b3e948.gif)
