### PR TITLE
Improve Cell Renaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@
 1.  [#3088](https://github.com/influxdata/chronograf/pull/3088): New dashboard cells appear at bottom of layout and assume the size of the most common cell
 1.  [#3096](https://github.com/influxdata/chronograf/pull/3096): Standardize delete confirmation interactions
 1.  [#3096](https://github.com/influxdata/chronograf/pull/3096): Standardize save & cancel interactions
+1.  [#3116](https://github.com/influxdata/chronograf/pull/3116): Improve cell renaming
 
 ### Bug Fixes
 
 1.  [#3111](https://github.com/influxdata/chronograf/pull/3111): Fix saving of new TICKscripts
 
 ## v1.4.3.1 [2018-04-02]
+
 ### Bug Fixes
 
 1.  [#3107](https://github.com/influxdata/chronograf/pull/3107): Fixes template variable editing not allowing saving

--- a/ui/src/dashboards/components/VisualizationName.js
+++ b/ui/src/dashboards/components/VisualizationName.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 
-import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants/index'
 import {renameCell} from 'src/dashboards/actions/cellEditorOverlay'
 
 class VisualizationName extends Component {
@@ -11,33 +10,23 @@ class VisualizationName extends Component {
     super(props)
 
     this.state = {
-      isEditing: false,
+      workingName: props.name,
     }
   }
-
-  handleInputClick = () => {
-    this.setState({isEditing: true})
+  handleChange = e => {
+    this.setState({workingName: e.target.value})
   }
 
-  handleCancel = () => {
-    this.setState({
-      isEditing: false,
-    })
-  }
+  handleBlur = () => {
+    const {handleRenameCell} = this.props
+    const {workingName} = this.state
 
-  handleInputBlur = () => {
-    this.setState({isEditing: false})
+    handleRenameCell(workingName)
   }
 
   handleKeyDown = e => {
-    const {handleRenameCell} = this.props
-
-    if (e.key === 'Enter') {
-      handleRenameCell(e.target.value)
-      this.handleInputBlur(e)
-    }
-    if (e.key === 'Escape') {
-      this.handleInputBlur(e)
+    if (e.key === 'Enter' || e.key === 'Escape') {
+      e.target.blur()
     }
   }
 
@@ -46,32 +35,21 @@ class VisualizationName extends Component {
   }
 
   render() {
-    const {name} = this.props
-    const {isEditing} = this.state
-    const graphNameClass =
-      name === NEW_DEFAULT_DASHBOARD_CELL.name
-        ? 'graph-name graph-name__untitled'
-        : 'graph-name'
+    const {workingName} = this.state
 
     return (
       <div className="graph-heading">
-        {isEditing ? (
-          <input
-            type="text"
-            className="form-control input-sm"
-            defaultValue={name}
-            onBlur={this.handleInputBlur}
-            onKeyDown={this.handleKeyDown}
-            autoFocus={true}
-            onFocus={this.handleFocus}
-            placeholder="Name this Cell..."
-            spellCheck={false}
-          />
-        ) : (
-          <div className={graphNameClass} onClick={this.handleInputClick}>
-            {name}
-          </div>
-        )}
+        <input
+          type="text"
+          className="form-control input-sm"
+          value={workingName}
+          onChange={this.handleChange}
+          onFocus={this.handleFocus}
+          onBlur={this.handleBlur}
+          onKeyDown={this.handleKeyDown}
+          placeholder="Name this Cell..."
+          spellCheck={false}
+        />
       </div>
     )
   }


### PR DESCRIPTION
Closes #3065 

_Briefly describe your proposed changes:_
In the Cell Editor Overlay the cell's name is always an input. Confirming or cancelling changes can be handled by closing the overlay

_What was the problem?_
Users want more freedom when editing a cell's name. Having to hit enter to save was too restricting

_What was the solution?_
Replace the fancy input with a plain input

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)