### PR TITLE
Fixes literal expression json serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1.  [#3111](https://github.com/influxdata/chronograf/pull/3111): Fix saving of new TICKscripts
 1.  [#3129](https://github.com/influxdata/chronograf/pull/3129): Only add stateChangesOnly to new rules
 1.  [#3131](https://github.com/influxdata/chronograf/pull/3131): Fix 500s when deleting organizations
+1.  [#3137](https://github.com/influxdata/chronograf/pull/3137): Fixes issues with providing regexp in query
 
 ## v1.4.3.1 [2018-04-02]
 

--- a/influx/queries/select.go
+++ b/influx/queries/select.go
@@ -13,6 +13,12 @@ import (
 	"github.com/influxdata/influxdb/influxql"
 )
 
+type literalJSON struct {
+	Expr string `json:"expr"`
+	Val  string `json:"val"`
+	Type string `json:"type"`
+}
+
 func ParseSelect(q string) (*SelectStatement, error) {
 	stmt, err := influxql.NewParser(strings.NewReader(q)).ParseStatement()
 	if err != nil {
@@ -115,8 +121,13 @@ func (p *ParenExpr) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`{"expr": "paren", "val": %s}`, expr)), nil
 }
 
-func LiteralJSON(lit string, litType string) []byte {
-	return []byte(fmt.Sprintf(`{"expr": "literal", "val": "%s", "type": "%s"}`, lit, litType))
+func LiteralJSON(lit string, litType string) ([]byte, error) {
+	result := literalJSON{
+		Expr: "literal",
+		Val:  lit,
+		Type: litType,
+	}
+	return json.Marshal(result)
 }
 
 type BooleanLiteral struct {
@@ -124,7 +135,7 @@ type BooleanLiteral struct {
 }
 
 func (b *BooleanLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(b.String(), "boolean"), nil
+	return LiteralJSON(b.String(), "boolean")
 }
 
 type DurationLiteral struct {
@@ -132,7 +143,7 @@ type DurationLiteral struct {
 }
 
 func (d *DurationLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(d.String(), "duration"), nil
+	return LiteralJSON(d.String(), "duration")
 }
 
 type IntegerLiteral struct {
@@ -140,7 +151,7 @@ type IntegerLiteral struct {
 }
 
 func (i *IntegerLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(i.String(), "integer"), nil
+	return LiteralJSON(i.String(), "integer")
 }
 
 type NumberLiteral struct {
@@ -148,7 +159,7 @@ type NumberLiteral struct {
 }
 
 func (n *NumberLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(n.String(), "number"), nil
+	return LiteralJSON(n.String(), "number")
 }
 
 type RegexLiteral struct {
@@ -156,7 +167,7 @@ type RegexLiteral struct {
 }
 
 func (r *RegexLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(r.String(), "regex"), nil
+	return LiteralJSON(r.String(), "regex")
 }
 
 // TODO: I don't think list is right
@@ -178,7 +189,7 @@ type StringLiteral struct {
 }
 
 func (s *StringLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(s.Val, "string"), nil
+	return LiteralJSON(s.Val, "string")
 }
 
 type TimeLiteral struct {
@@ -186,7 +197,7 @@ type TimeLiteral struct {
 }
 
 func (t *TimeLiteral) MarshalJSON() ([]byte, error) {
-	return LiteralJSON(t.Val.UTC().Format(time.RFC3339Nano), "time"), nil
+	return LiteralJSON(t.Val.UTC().Format(time.RFC3339Nano), "time")
 }
 
 type VarRef struct {

--- a/influx/queries/select_test.go
+++ b/influx/queries/select_test.go
@@ -16,6 +16,7 @@ func TestSelect(t *testing.T) {
 		{q: `SELECT derivative(field1, 1h) / derivative(field2, 1h) FROM myseries`},
 		{q: `SELECT mean("load1") FROM "system" WHERE "cluster_id" =~ /^$ClusterID$/ AND time > now() - 1h GROUP BY time(10m), "host" fill(null)`},
 		{q: "SELECT max(\"n_cpus\") AS \"max_cpus\", non_negative_derivative(median(\"n_users\"), 5m) FROM \"system\" WHERE \"cluster_id\" =~ /^23/ AND \"host\" = 'prod-2ccccc04-us-east-1-data-3' AND time > now() - 15m GROUP BY time(15m, 10s),host,tag_x fill(10)"},
+		{q: "SELECT mean(\"usage_user\") AS \"mean_usage_user\" FROM \"telegraf\".\"default\".\"cpu\" WHERE host =~ /\\./ AND time > now() - 1h"},
 		{q: `SELECT 1 + "A" FROM howdy`},
 	}
 


### PR DESCRIPTION
- \. was not being escaped properly

Closes #3115

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)