### PR TITLE
Ensure correct basepath prefix in URL pathname when passing InfluxQL query param to Data Explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 1.  [#3129](https://github.com/influxdata/chronograf/pull/3129): Only add stateChangesOnly to new rules
 1.  [#3131](https://github.com/influxdata/chronograf/pull/3131): Fix 500s when deleting organizations
 1.  [#3137](https://github.com/influxdata/chronograf/pull/3137): Fixes issues with providing regexp in query
+1.  [#3144](https://github.com/influxdata/chronograf/pull/3144): Ensure correct basepath prefix in URL pathname when passing InfluxQL query param to Data Explorer
 
 ## v1.4.3.1 [2018-04-02]
 

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -8,6 +8,8 @@ import queryString from 'query-string'
 
 import _ from 'lodash'
 
+import {stripPrefix} from 'src/utils/basepath'
+
 import QueryMaker from 'src/data_explorer/components/QueryMaker'
 import Visualization from 'src/data_explorer/components/Visualization'
 import WriteDataForm from 'src/data_explorer/components/WriteDataForm'
@@ -87,7 +89,8 @@ export class DataExplorer extends PureComponent<Props, State> {
 
     if (query.length && qsCurrent.query !== query) {
       const qsNew = queryString.stringify({query})
-      router.push(`${location.pathname}?${qsNew}`)
+      const pathname = stripPrefix(location.pathname)
+      router.push(`${pathname}?${qsNew}`)
     }
   }
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -21,7 +21,7 @@ import {
 import CheckSources from 'src/CheckSources'
 import {StatusPage} from 'src/status'
 import {HostsPage, HostPage} from 'src/hosts'
-import DataExplorer from 'src/data_explorer'
+import DataExplorerPage from 'src/data_explorer'
 import {DashboardsPage, DashboardPage} from 'src/dashboards'
 import AlertsApp from 'src/alerts'
 import {
@@ -124,7 +124,10 @@ class Root extends PureComponent<{}, State> {
               <Route path="status" component={StatusPage} />
               <Route path="hosts" component={HostsPage} />
               <Route path="hosts/:hostID" component={HostPage} />
-              <Route path="chronograf/data-explorer" component={DataExplorer} />
+              <Route
+                path="chronograf/data-explorer"
+                component={DataExplorerPage}
+              />
               <Route path="dashboards" component={DashboardsPage} />
               <Route path="dashboards/:dashboardID" component={DashboardPage} />
               <Route path="alerts" component={AlertsApp} />

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -12,6 +12,7 @@ import configureStore from 'src/store/configureStore'
 import {loadLocalStorage} from 'src/localStorage'
 
 import {getRootNode} from 'src/utils/nodes'
+import {getBasepath} from 'src/utils/basepath'
 
 import App from 'src/App'
 import {
@@ -52,6 +53,8 @@ const errorsQueue = []
 
 const rootNode = getRootNode()
 
+const basepath = getBasepath()
+
 declare global {
   interface Window {
     basepath: string
@@ -59,7 +62,6 @@ declare global {
 }
 
 // Older method used for pre-IE 11 compatibility
-const basepath = rootNode.getAttribute('data-basepath') || ''
 window.basepath = basepath
 
 const browserHistory = useRouterHistory(createHistory)({

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -11,6 +11,8 @@ import {bindActionCreators} from 'redux'
 import configureStore from 'src/store/configureStore'
 import {loadLocalStorage} from 'src/localStorage'
 
+import {getRootNode} from 'src/utils/nodes'
+
 import App from 'src/App'
 import {
   Login,
@@ -48,7 +50,7 @@ import {HEARTBEAT_INTERVAL} from 'src/shared/constants'
 
 const errorsQueue = []
 
-const rootNode = document.getElementById('react-root')
+const rootNode = getRootNode()
 
 declare global {
   interface Window {

--- a/ui/src/utils/basepath.ts
+++ b/ui/src/utils/basepath.ts
@@ -5,9 +5,7 @@ export const getBasepath = () => {
   return rootNode.getAttribute('data-basepath') || ''
 }
 
-export const stripPrefix = pathname => {
-  const basepath = getBasepath()
-
+export const stripPrefix = (pathname, basepath = getBasepath()) => {
   if (basepath === '') {
     return pathname
   }

--- a/ui/src/utils/basepath.ts
+++ b/ui/src/utils/basepath.ts
@@ -4,3 +4,17 @@ export const getBasepath = () => {
   const rootNode = getRootNode()
   return rootNode.getAttribute('data-basepath') || ''
 }
+
+export const stripPrefix = pathname => {
+  const basepath = getBasepath()
+
+  if (basepath === '') {
+    return pathname
+  }
+
+  const expr = new RegExp(`^${basepath}`)
+  const matches = pathname.match(expr)
+  if (matches) {
+    return pathname.replace(expr, '')
+  }
+}

--- a/ui/src/utils/basepath.ts
+++ b/ui/src/utils/basepath.ts
@@ -1,0 +1,6 @@
+import {getRootNode} from 'src/utils/nodes'
+
+export const getBasepath = () => {
+  const rootNode = getRootNode()
+  return rootNode.getAttribute('data-basepath') || ''
+}

--- a/ui/src/utils/nodes.ts
+++ b/ui/src/utils/nodes.ts
@@ -1,0 +1,1 @@
+export const getRootNode = () => document.getElementById('react-root')

--- a/ui/test/utils/basepath.test.ts
+++ b/ui/test/utils/basepath.test.ts
@@ -1,0 +1,24 @@
+import {stripPrefix} from 'src/utils/basepath'
+
+describe('basepath.stripPrefix', () => {
+  it('returns unchanged pathname if basepath is empty', () => {
+    const basepath = ''
+    const pathname = '/sources/1/dashboards/1'
+
+    expect(stripPrefix(pathname, basepath)).toBe(pathname)
+  })
+
+  it('returns the stripped pathname when basepath is provided', () => {
+    const basepath = '/russ'
+    const pathname = '/russ/sources/1/dashboards/1'
+
+    expect(stripPrefix(pathname, basepath)).toBe('/sources/1/dashboards/1')
+  })
+
+  it('returns the stripped pathname when basepath is present twice', () => {
+    const basepath = '/russ'
+    const pathname = '/russ/russ/sources/1/dashboards/1'
+
+    expect(stripPrefix(pathname, basepath)).toBe('/russ/sources/1/dashboards/1')
+  })
+})


### PR DESCRIPTION
Closes #3141 

_Briefly describe your proposed changes:_
Factor out getting the root node and getting basepath into dedicated utils functions. Ensure that if basepath prefix is set, that it is properly stripped when using `router.push` in Data Explorer.

_What was the problem?_
Data Explorer couldn't be used when basepath prefix was set and on, when passing in an InfluxQL query via URL query param, because when the component would mount it would double the prefix accidentally.

_What was the solution?_
Strip the prefix so that it only appears once, as intended, when passing in a query to Data Explorer.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
