### PR TITLE
Fixes errors caused by switching query tabs in CEO

### DIFF
--- a/ui/src/data_explorer/components/QueryMakerTab.tsx
+++ b/ui/src/data_explorer/components/QueryMakerTab.tsx
@@ -33,11 +33,11 @@ class QueryMakerTab extends PureComponent<Props> {
     )
   }
 
-  private handleSelect() {
+  private handleSelect = () => {
     this.props.onSelect(this.props.queryIndex)
   }
 
-  private handleDelete(e) {
+  private handleDelete = e => {
     e.stopPropagation()
     this.props.onDelete(this.props.queryIndex)
   }


### PR DESCRIPTION
Closes #3147

_Briefly describe your proposed changes:_
_What was the problem?
Switching tabs in CEO causing errors because this is undefined.
_What was the solution?_
Event handlers in QueryMakerTabs are now bound to the component.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)