### PR TITLE
Polish/Line+SingleStat Colors

### DIFF
--- a/ui/src/dashboards/constants/cellEditor.js
+++ b/ui/src/dashboards/constants/cellEditor.js
@@ -34,13 +34,13 @@ export const getCellTypeColors = ({
       break
     }
     case 'single-stat':
-    case 'line-plus-single-stat':
     case 'table': {
       colors = stringifyColorValues(thresholdsListColors)
       break
     }
     case 'bar':
     case 'line':
+    case 'line-plus-single-stat':
     case 'line-stacked':
     case 'line-stepplot': {
       colors = stringifyColorValues(lineColors)

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -26,10 +26,7 @@ import {
   highlightSeriesOpts,
 } from 'src/shared/graphs/helpers'
 
-import {
-  DEFAULT_LINE_COLORS,
-  getLineColorsHexes,
-} from 'src/shared/constants/graphColorPalettes'
+import {getLineColorsHexes} from 'src/shared/constants/graphColorPalettes'
 const {LINEAR, LOG, BASE_10, BASE_2} = AXES_SCALE_OPTIONS
 
 import {colorsStringSchema} from 'shared/schemas'
@@ -196,15 +193,10 @@ class Dygraph extends Component {
   }
 
   colorDygraphSeries = () => {
-    const {dygraphSeries, children, colors, overrideLineColors} = this.props
+    const {dygraphSeries, colors, overrideLineColors} = this.props
     const numSeries = Object.keys(dygraphSeries).length
 
     let lineColors = getLineColorsHexes(colors, numSeries)
-
-    if (React.children && React.children.count(children)) {
-      // If graph is line-plus-single-stat then reserve colors for single stat
-      lineColors = getLineColorsHexes(DEFAULT_LINE_COLORS, numSeries)
-    }
 
     if (overrideLineColors) {
       lineColors = getLineColorsHexes(overrideLineColors, numSeries)

--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -195,7 +195,7 @@ class Dygraph extends Component {
   colorDygraphSeries = () => {
     const {dygraphSeries, colors, overrideLineColors} = this.props
     const numSeries = Object.keys(dygraphSeries).length
-
+    const dygraphSeriesKeys = Object.keys(dygraphSeries).sort()
     let lineColors = getLineColorsHexes(colors, numSeries)
 
     if (overrideLineColors) {
@@ -203,14 +203,12 @@ class Dygraph extends Component {
     }
 
     const coloredDygraphSeries = {}
-
     for (const seriesName in dygraphSeries) {
       const series = dygraphSeries[seriesName]
-      const color = lineColors[Object.keys(dygraphSeries).indexOf(seriesName)]
+      const color = lineColors[dygraphSeriesKeys.indexOf(seriesName)]
 
       coloredDygraphSeries[seriesName] = {...series, color}
     }
-
     return coloredDygraphSeries
   }
 

--- a/ui/src/shared/components/SingleStat.js
+++ b/ui/src/shared/components/SingleStat.js
@@ -1,7 +1,8 @@
 import React, {PureComponent} from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
-import lastValues from 'shared/parsing/lastValues'
+import getLastValues from 'shared/parsing/lastValues'
+import _ from 'lodash'
 
 import {SMALL_CELL_HEIGHT} from 'shared/graphs/helpers'
 import {DYGRAPH_CONTAINER_V_MARGIN} from 'shared/constants'
@@ -29,8 +30,14 @@ class SingleStat extends PureComponent {
         </div>
       )
     }
+    const {lastValues, series} = getLastValues(data)
+    const firstAlphabeticalSeriesName = _.sortBy(series)[0]
 
-    const lastValue = lastValues(data)[1]
+    const firstAlphabeticalindex = _.indexOf(
+      series,
+      firstAlphabeticalSeriesName
+    )
+    const lastValue = lastValues[firstAlphabeticalindex]
     const precision = 100.0
     const roundedValue = Math.round(+lastValue * precision) / precision
 
@@ -39,9 +46,9 @@ class SingleStat extends PureComponent {
       lastValue,
       cellType: lineGraph ? 'line-plus-single-stat' : 'single-stat',
     })
-
     const backgroundColor = bgColor
     const color = textColor
+
     const height = `calc(100% - ${staticLegendHeight +
       DYGRAPH_CONTAINER_V_MARGIN * 2}px)`
 

--- a/ui/src/shared/constants/colorOperations.js
+++ b/ui/src/shared/constants/colorOperations.js
@@ -42,13 +42,17 @@ export const generateThresholdsListHexs = ({
   }
   const lastValueNumber = Number(lastValue) || 0
 
-  if (!colors.length || !lastValue) {
+  if (!colors.length) {
     return defaultColoring
   }
 
   // baseColor is expected in all cases
   const baseColor = colors.find(color => (color.id = THRESHOLD_TYPE_BASE)) || {
     hex: defaultColoring.textColor,
+  }
+
+  if (!lastValue) {
+    return {...defaultColoring, textColor: baseColor}
   }
 
   // If the single stat is above a line graph never have a background color

--- a/ui/src/shared/constants/colorOperations.js
+++ b/ui/src/shared/constants/colorOperations.js
@@ -7,15 +7,15 @@ import {
   THRESHOLD_TYPE_TEXT,
 } from 'shared/constants/thresholds'
 
-const luminanceThreshold = 0.5
-
 const getLegibleTextColor = bgColorHex => {
   const darkText = '#292933'
   const lightText = '#ffffff'
 
-  return chroma(bgColorHex).luminance() < luminanceThreshold
-    ? darkText
-    : lightText
+  const [red, green, blue] = chroma(bgColorHex).rgb()
+  const average = (red + green + blue) / 3
+  const mediumGrey = 128
+
+  return average > mediumGrey ? darkText : lightText
 }
 
 const findNearestCrossedThreshold = (colors, lastValue) => {

--- a/ui/src/shared/parsing/lastValues.js
+++ b/ui/src/shared/parsing/lastValues.js
@@ -6,7 +6,14 @@ export default function(timeSeriesResponse) {
     ['0', 'response', 'results', '0', 'series', '0', 'values'],
     [['', '']]
   )
-  const lastValues = values[values.length - 1]
 
-  return lastValues
+  const series = _.get(
+    timeSeriesResponse,
+    ['0', 'response', 'results', '0', 'series', '0', 'columns'],
+    ['', '']
+  ).slice(1)
+
+  const lastValues = values[values.length - 1].slice(1) // remove time with slice 1
+
+  return {lastValues, series}
 }


### PR DESCRIPTION
Closes #2738 

_Briefly describe your proposed changes:_
![sync-colors-between-line-and-singlestat](https://user-images.githubusercontent.com/2433762/38526201-2bd6b392-3c0a-11e8-994c-e184744e8b00.gif)

_What was the problem?_
When the user chooses a `line-plus-single-stat` cell type there is some unexpected behavior. This is partially because the behavior is not accurately reflected in the UI. Choosing a color set from the dropdown has to apparent effect.

_What was the solution?_
`line-plus-single-stat` cells now use line colors instead of single stat colors. Additionally, the single stat inside gets its coloration from the first color in the selected line colors set.

  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)