### PR TITLE
Bugfix/tickscript save

### DIFF
--- a/ui/mocks/kapacitor/apis/index.ts
+++ b/ui/mocks/kapacitor/apis/index.ts
@@ -1,2 +1,8 @@
 export const pingKapacitorVersion = jest.fn(() => Promise.resolve('2.0'))
-export const getLogStreamByRuleID = jest.fn(() => Promise.resolve())
+export const getLogStreamByRuleID = jest.fn(() =>
+  Promise.resolve({
+    body: {
+      getReader: () => {},
+    },
+  })
+)

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -180,13 +180,19 @@ export class TickscriptPage extends PureComponent<Props, State> {
         response = await updateTask(kapacitor, task, ruleID, router, sourceID)
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
-        router.push(`/sources/${sourceID}/tickscript/${response.id}`)
       }
-      if (response.code) {
+
+      if (response.code === 422) {
+        router.push(`/sources/${sourceID}/tickscript/new`)
+        this.setState({unsavedChanges: true, consoleMessage: response.message})
+        return
+      } else if (response.code) {
         this.setState({unsavedChanges: true, consoleMessage: response.message})
       } else {
         this.setState({unsavedChanges: false, consoleMessage: ''})
       }
+
+      router.push(`/sources/${sourceID}/tickscript/${response.id}`)
     } catch (error) {
       console.error(error)
       throw error

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -114,7 +114,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
       errorActions.errorThrown(notifyKapacitorNotFound())
     }
 
-    if (this._isEditing()) {
+    if (this.isEditing) {
       await kapacitorActions.getRule(kapacitor, ruleID)
       const {id, name, tickscript, status, dbrps, type} = this.props.rules.find(
         r => r.id === ruleID
@@ -156,7 +156,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
         consoleMessage={consoleMessage}
         onChangeID={this.handleChangeID}
         onChangeType={this.handleChangeType}
-        isNewTickscript={!this._isEditing()}
+        isNewTickscript={!this.isEditing}
         onSelectDbrps={this.handleSelectDbrps}
         onChangeScript={this.handleChangeScript}
         onToggleLogsVisibility={this.handleToggleLogsVisibility}
@@ -176,7 +176,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
     let response
 
     try {
-      if (this._isEditing()) {
+      if (this.isEditing) {
         response = await updateTask(kapacitor, task, ruleID, router, sourceID)
       } else {
         response = await createTask(kapacitor, task, router, sourceID)
@@ -225,7 +225,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
     this.setState({areLogsVisible: !this.state.areLogsVisible})
   }
 
-  private _isEditing() {
+  private get isEditing() {
     const {params} = this.props
     return params.ruleID && params.ruleID !== 'new'
   }

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -183,7 +183,6 @@ export class TickscriptPage extends PureComponent<Props, State> {
       }
 
       if (response.code === 422) {
-        router.push(`/sources/${sourceID}/tickscript/new`)
         this.setState({unsavedChanges: true, consoleMessage: response.message})
         return
       } else if (response.code) {

--- a/ui/test/kapacitor/containers/TickscriptPage.test.tsx
+++ b/ui/test/kapacitor/containers/TickscriptPage.test.tsx
@@ -83,7 +83,7 @@ describe('Kapacitor.Containers.TickscriptPage', () => {
         })
       })
 
-      it('routes the user to Tickscript /new page if save fails', done => {
+      it('keeps the user on /new if save fails', done => {
         const push = jest.fn()
         const createTask = jest.fn(() =>
           Promise.resolve({code: 422, message: 'invalid tickscript'})
@@ -106,8 +106,7 @@ describe('Kapacitor.Containers.TickscriptPage', () => {
         save.dive().simulate('click')
 
         process.nextTick(() => {
-          expect(push).toHaveBeenCalledTimes(1)
-          expect(push.mock.calls[0][0]).toMatch('new')
+          expect(push).not.toHaveBeenCalled()
           done()
         })
       })

--- a/ui/test/kapacitor/containers/TickscriptPage.test.tsx
+++ b/ui/test/kapacitor/containers/TickscriptPage.test.tsx
@@ -1,22 +1,26 @@
 import React from 'react'
 import {shallow} from 'enzyme'
 import {TickscriptPage} from 'src/kapacitor/containers/TickscriptPage'
+import TickscriptHeader from 'src/kapacitor/components/TickscriptHeader'
+import TickscriptSave from 'src/kapacitor/components/TickscriptSave'
 import {source, kapacitorRules} from 'test/resources'
 
 jest.mock('src/shared/apis', () => require('mocks/shared/apis'))
 jest.mock('src/kapacitor/apis', () => require('mocks/kapacitor/apis'))
 
-const setup = () => {
+const kapacitorActions = {
+  updateTask: () => {},
+  createTask: () => {},
+  getRule: () => {},
+}
+
+const setup = (override?) => {
   const props = {
     source,
     errorActions: {
       errorThrown: () => {},
     },
-    kapacitorActions: {
-      updateTask: () => {},
-      createTask: () => {},
-      getRule: () => {},
-    },
+    kapacitorActions,
     router: {
       push: () => {},
     },
@@ -25,7 +29,9 @@ const setup = () => {
     },
     rules: kapacitorRules,
     notify: () => {},
+    ...override,
   }
+
   const wrapper = shallow(<TickscriptPage {...props} />)
 
   return {
@@ -34,10 +40,77 @@ const setup = () => {
 }
 
 describe('Kapacitor.Containers.TickscriptPage', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('rendering', () => {
     it('renders without errors', () => {
       const {wrapper} = setup()
       expect(wrapper.exists()).toBe(true)
+    })
+  })
+
+  describe('user interractions', () => {
+    describe('saving a new Tickscript', () => {
+      it('routes the user Tickscript edit page if save succeeds', done => {
+        const id = 'newly-create-tickscript'
+        const push = jest.fn()
+        const createTask = jest.fn(() =>
+          Promise.resolve({code: 200, message: 'nice tickscript', id})
+        )
+
+        const actions = {
+          ...kapacitorActions,
+          createTask,
+        }
+
+        const {wrapper} = setup({
+          kapacitorActions: actions,
+          router: {push},
+          params: {ruleID: 'new'},
+        })
+
+        const header = wrapper.dive().find(TickscriptHeader)
+        const save = header.dive().find(TickscriptSave)
+
+        save.dive().simulate('click')
+
+        process.nextTick(() => {
+          expect(push).toHaveBeenCalledTimes(1)
+          expect(push.mock.calls[0][0]).toMatch(id)
+          done()
+        })
+      })
+
+      it('routes the user to Tickscript /new page if save fails', done => {
+        const push = jest.fn()
+        const createTask = jest.fn(() =>
+          Promise.resolve({code: 422, message: 'invalid tickscript'})
+        )
+
+        const actions = {
+          ...kapacitorActions,
+          createTask,
+        }
+
+        const {wrapper} = setup({
+          kapacitorActions: actions,
+          router: {push},
+          params: {ruleID: 'new'},
+        })
+
+        const header = wrapper.dive().find(TickscriptHeader)
+        const save = header.dive().find(TickscriptSave)
+
+        save.dive().simulate('click')
+
+        process.nextTick(() => {
+          expect(push).toHaveBeenCalledTimes(1)
+          expect(push.mock.calls[0][0]).toMatch('new')
+          done()
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Closes #3019


_What was the problem?_

We were optimistically routing the user to the 'edit' page on save

_What was the solution?_

Only route the user to 'edit' is save is successful

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)