### PR TITLE
bugfix/TICKscript name instead of ID

### DIFF
--- a/ui/src/kapacitor/components/TickscriptEditorControls.js
+++ b/ui/src/kapacitor/components/TickscriptEditorControls.js
@@ -19,7 +19,7 @@ const TickscriptEditorControls = ({
     {isNewTickscript ? (
       <TickscriptID onChangeID={onChangeID} id={task.id} />
     ) : (
-      <TickscriptStaticID id={task.id} />
+      <TickscriptStaticID id={task.name ? task.name : task.id} />
     )}
     <div className="tickscript-controls--right">
       <TickscriptType type={task.type} onChangeType={onChangeType} />


### PR DESCRIPTION
Render TICKscript name instead of ID, but render ID if there is no name

Closes #3166

_Briefly describe your proposed changes:_
Render the TICKscript name instead of ID in the editor

_What was the problem?_
Editor controls were rendering the `id` of the script, which in the case of editing an Alert Rule is a long unfriendly string

_What was the solution?_
Render the TICKscript name instead of ID in the editor

  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)