### PR TITLE
Prevent legend text from wrapping

### DIFF
--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -226,6 +226,8 @@
 .dygraph-legend--timestamp {
   margin-right: 8px;
   height: 30px;
+  font-size: 14px;
+  white-space: nowrap;
   line-height: 30px;
   font-weight: 600;
   color: $g13-mist;


### PR DESCRIPTION
Closes #3171 

_What was the problem?_
Legend timestamp occasionally wraps, is large font size

_What was the solution?_
Prevent timestamp from wrapping, make font size slightly smaller

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)