### PR TITLE
Improve box packing for New and Cloned cells

### DIFF
--- a/ui/src/dashboards/utils/cellGetters.js
+++ b/ui/src/dashboards/utils/cellGetters.js
@@ -20,14 +20,37 @@ const getMostCommonValue = values => {
   return results.mostCommonValue
 }
 
+const numColumns = 12
+
+const getNextAvailablePosition = (dashboard, newCell) => {
+  const farthestY = dashboard.cells
+    .map(cell => cell.y)
+    .reduce((a, b) => (a > b ? a : b))
+
+  const bottomCells = dashboard.cells.filter(cell => cell.y === farthestY)
+  const farthestX = bottomCells
+    .map(cell => cell.x)
+    .reduce((a, b) => (a > b ? a : b))
+  const lastCell = bottomCells.find(cell => cell.x === farthestX)
+
+  const availableSpace = numColumns - (lastCell.x + lastCell.w)
+  const newCellFits = availableSpace >= newCell.w
+
+  return newCellFits
+    ? {
+        x: lastCell.x + lastCell.w,
+        y: farthestY,
+      }
+    : {
+        x: 0,
+        y: lastCell.y + lastCell.h,
+      }
+}
+
 export const getNewDashboardCell = dashboard => {
   if (dashboard.cells.length === 0) {
     return NEW_DEFAULT_DASHBOARD_CELL
   }
-
-  const newCellY = dashboard.cells
-    .map(cell => cell.y + cell.h)
-    .reduce((a, b) => (a > b ? a : b))
 
   const existingCellWidths = dashboard.cells.map(cell => cell.w)
   const existingCellHeights = dashboard.cells.map(cell => cell.h)
@@ -35,20 +58,25 @@ export const getNewDashboardCell = dashboard => {
   const mostCommonCellWidth = getMostCommonValue(existingCellWidths)
   const mostCommonCellHeight = getMostCommonValue(existingCellHeights)
 
-  return {
+  const newCell = {
     ...NEW_DEFAULT_DASHBOARD_CELL,
-    y: newCellY,
     w: mostCommonCellWidth,
     h: mostCommonCellHeight,
+  }
+
+  const {x, y} = getNextAvailablePosition(dashboard, newCell)
+
+  return {
+    ...newCell,
+    x,
+    y,
   }
 }
 
 export const getClonedDashboardCell = (dashboard, cloneCell) => {
-  const newCellY = dashboard.cells
-    .map(cell => cell.y + cell.h)
-    .reduce((a, b) => (a > b ? a : b))
+  const {x, y} = getNextAvailablePosition(dashboard, cloneCell)
 
   const name = `${cloneCell.name} (Clone)`
 
-  return {...cloneCell, y: newCellY, name}
+  return {...cloneCell, x, y, name}
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Add new/cloned cells to the next available space in the dashboard, instead of always forcing it to the bottom

_What was the problem?_
New/cloned cells appear to stack along the left side when there is plenty of space available to the right

_What was the solution?_
Locate the bottom-right cell and depending on the new cell's size and available space to the right, add it there or to the bottom

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)