### PR TITLE
Notify when User adds, deletes, or clones a cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 1.  [#3096](https://github.com/influxdata/chronograf/pull/3096): Standardize delete confirmation interactions
 1.  [#3096](https://github.com/influxdata/chronograf/pull/3096): Standardize save & cancel interactions
 1.  [#3116](https://github.com/influxdata/chronograf/pull/3116): Improve cell renaming
+1.  [#3204](https://github.com/influxdata/chronograf/pull/3204): Notify user when a dashboard cell is added, removed, or cloned
 
 ### Bug Fixes
 

--- a/ui/src/dashboards/actions/index.js
+++ b/ui/src/dashboards/actions/index.js
@@ -18,6 +18,9 @@ import {
 import {
   notifyDashboardDeleted,
   notifyDashboardDeleteFailed,
+  notifyCellAdded,
+  notifyCellCloned,
+  notifyCellDeleted,
 } from 'shared/copy/notifications'
 
 import {
@@ -293,6 +296,7 @@ export const addDashboardCellAsync = dashboard => async dispatch => {
       getNewDashboardCell(dashboard)
     )
     dispatch(addDashboardCell(dashboard, data))
+    dispatch(notify(notifyCellAdded()))
   } catch (error) {
     console.error(error)
     dispatch(errorThrown(error))
@@ -306,6 +310,7 @@ export const cloneDashboardCellAsync = (dashboard, cell) => async dispatch => {
       getClonedDashboardCell(dashboard, cell)
     )
     dispatch(addDashboardCell(dashboard, data))
+    dispatch(notify(notifyCellCloned(cell.name)))
   } catch (error) {
     console.error(error)
     dispatch(errorThrown(error))
@@ -316,6 +321,7 @@ export const deleteDashboardCellAsync = (dashboard, cell) => async dispatch => {
   try {
     await deleteDashboardCellAJAX(cell)
     dispatch(deleteDashboardCell(dashboard, cell))
+    dispatch(notify(notifyCellDeleted(cell.name)))
   } catch (error) {
     console.error(error)
     dispatch(errorThrown(error))

--- a/ui/src/shared/copy/notifications.js
+++ b/ui/src/shared/copy/notifications.js
@@ -412,6 +412,27 @@ export const notifyDashboardDeleted = name => ({
 export const notifyDashboardDeleteFailed = (name, errorMessage) =>
   `Failed to delete Dashboard ${name}: ${errorMessage}.`
 
+export const notifyCellAdded = () => ({
+  ...defaultSuccessNotification,
+  icon: 'dash-h',
+  duration: 2200,
+  message: 'Added "Untitled Cell" to dashboard.',
+})
+
+export const notifyCellCloned = name => ({
+  ...defaultSuccessNotification,
+  icon: 'duplicate',
+  duration: 2200,
+  message: `Added "${name}" to dashboard.`,
+})
+
+export const notifyCellDeleted = name => ({
+  ...defaultDeletionNotification,
+  icon: 'dash-h',
+  duration: 2200,
+  message: `Deleted "${name}" from dashboard.`,
+})
+
 //  Rule Builder Notifications
 //  ----------------------------------------------------------------------------
 export const notifyAlertRuleCreated = () => ({

--- a/ui/src/shared/copy/notifications.js
+++ b/ui/src/shared/copy/notifications.js
@@ -15,6 +15,12 @@ const defaultSuccessNotification = {
   duration: FIVE_SECONDS,
 }
 
+const defaultDeletionNotification = {
+  type: 'primary',
+  icon: 'trash',
+  duration: FIVE_SECONDS,
+}
+
 //  Misc Notifications
 //  ----------------------------------------------------------------------------
 export const notifyGenericFail = () => 'Could not communicate with server.'


### PR DESCRIPTION
Closes #3197 

_Briefly describe your proposed changes:_
Display notification when user adds, deletes, or clones a cell.

_What was the problem?_
In some cases the location for a new or cloned cell is below the visible area and it is unclear if the action succeeded

_What was the solution?_
Display a notification for cell actions (add/delete/clone) so there is more consistent system feedback

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)