### PR TITLE
Fixes now() time parsing when requesting annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 1.  [#3182](https://github.com/influxdata/chronograf/pull/3182): Send notification when rp creation returns a failure
 1.  [#3181](https://github.com/influxdata/chronograf/pull/3181): Show valid time in custom time range when now is selected
 1.  [#3179](https://github.com/influxdata/chronograf/pull/3179): Default to zero for gauges
+1.  [#3237](https://github.com/influxdata/chronograf/pull/3237): Fixes now() time parsing when requesting annotations
 
 ## v1.4.3.1 [2018-04-02]
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -19,6 +19,7 @@ import TemplateControlBar from 'src/dashboards/components/TemplateControlBar'
 import {errorThrown as errorThrownAction} from 'shared/actions/errors'
 import {notify as notifyAction} from 'shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
+import {millisecondTimeRange} from 'src/dashboards/utils/time'
 
 import * as dashboardActionCreators from 'src/dashboards/actions'
 import * as annotationActions from 'shared/actions/annotations'
@@ -81,7 +82,7 @@ class DashboardPage extends Component {
       autoRefresh,
     } = this.props
 
-    const annotationRange = this.millisecondTimeRange(timeRange)
+    const annotationRange = millisecondTimeRange(timeRange)
     getAnnotationsAsync(source.links.annotations, annotationRange)
 
     if (autoRefresh) {
@@ -114,7 +115,7 @@ class DashboardPage extends Component {
     const {source, getAnnotationsAsync, timeRange} = this.props
     if (this.props.autoRefresh !== nextProps.autoRefresh) {
       clearInterval(this.intervalID)
-      const annotationRange = this.millisecondTimeRange(timeRange)
+      const annotationRange = millisecondTimeRange(timeRange)
       if (nextProps.autoRefresh) {
         this.intervalID = setInterval(() => {
           getAnnotationsAsync(source.links.annotations, annotationRange)
@@ -183,24 +184,8 @@ class DashboardPage extends Component {
       format: FORMAT_INFLUXQL,
     })
 
-    const annotationRange = this.millisecondTimeRange(timeRange)
+    const annotationRange = millisecondTimeRange(timeRange)
     getAnnotationsAsync(source.links.annotations, annotationRange)
-  }
-
-  millisecondTimeRange({seconds, lower, upper}) {
-    // Is this a relative time range?
-    if (seconds) {
-      return {
-        since: Date.now() - seconds * 1000,
-        until: null,
-      }
-    }
-
-    // No, this is an absolute (custom) time range
-    return {
-      since: Date.parse(lower),
-      until: Date.parse(upper),
-    }
   }
 
   handleUpdatePosition = cells => {

--- a/ui/src/dashboards/utils/time.ts
+++ b/ui/src/dashboards/utils/time.ts
@@ -1,0 +1,30 @@
+interface InputTimeRange {
+  seconds?: number
+  lower?: string
+  upper?: string
+}
+
+interface OutputTimeRange {
+  since: number
+  until: number | null
+}
+
+export const millisecondTimeRange = ({
+  seconds,
+  lower,
+  upper,
+}: InputTimeRange): OutputTimeRange => {
+  // Is this a relative time range?
+  if (seconds) {
+    return {since: Date.now() - seconds * 1000, until: null}
+  }
+
+  const since = Date.parse(lower)
+  let until
+  if (upper === 'now()') {
+    until = Date.now()
+  } else {
+    until = Date.parse(upper)
+  }
+  return {since, until}
+}

--- a/ui/test/dashboards/utils/time.test.ts
+++ b/ui/test/dashboards/utils/time.test.ts
@@ -1,0 +1,30 @@
+import moment from 'moment'
+import * as time from 'src/dashboards/utils/time'
+
+describe('dashboards.utils.time', () => {
+  describe('millisecondTimeRange', () => {
+    it('when upper is now() returns valid dates', () => {
+      const expectedNow = moment()
+        .subtract()
+        .seconds(1)
+        .unix()
+      const timeRange = {upper: 'now()', lower: moment().format()}
+      const result = time.millisecondTimeRange(timeRange)
+
+      expect(result.since).toBeGreaterThanOrEqual(expectedNow)
+      expect(result.until).toBeGreaterThanOrEqual(expectedNow)
+    })
+
+    it('when seconds is present returns valid dates', () => {
+      const timeRange = {seconds: 10}
+      const expectedSince = moment()
+        .subtract()
+        .seconds(10)
+        .unix()
+      const result = time.millisecondTimeRange(timeRange)
+
+      expect(result.since).toBeGreaterThanOrEqual(expectedSince)
+      expect(result.until).toBe(null)
+    })
+  })
+})


### PR DESCRIPTION
Closes #3218

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)