### PR TITLE
Update PR template to include checkbox for Swagger docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -5,6 +5,7 @@ _What was the problem?_
 _What was the solution?_
 
   - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
-  - [ ] Rebased/mergable
+  - [ ] Rebased/mergeable
   - [ ] Tests pass
+  - [ ] swagger.json updated (if modified Go structs or API)
   - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


### PR DESCRIPTION
Our swagger docs are very out of date, defeating their purpose. We've discussed making this a requirement for any PR that modifies Go structs or the API. Now the PR Template will include a checkbox for doing so where relevant.