### PR TITLE
Fix TICKscript Editor Overflow

### DIFF
--- a/ui/src/style/components/code-mirror-theme.scss
+++ b/ui/src/style/components/code-mirror-theme.scss
@@ -7,7 +7,7 @@
 
 */
 
-.ReactCodeMirror {
+.react-codemirror2 {
   position: relative;
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Closes #3257 

_Briefly describe your proposed changes:_
Update the codemirror theme styles to use the classname provided by the newest version of codemirror

_What was the problem?_

- TICKscript editor overflows, obscuring the console below it

_What was the solution?_

- TICKscript editor no longer overflows

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)