### PR TITLE
Fix Jittery Template Variable Dropdowns

### DIFF
--- a/ui/src/dashboards/constants/templateControlBar.js
+++ b/ui/src/dashboards/constants/templateControlBar.js
@@ -8,9 +8,10 @@ export const dropdownPadding = 30
 const valueLength = a => _.size(a.value)
 
 export const calculateDropdownWidth = (values = []) => {
-  const longestValue = _.maxBy(values, valueLength)
+  const longest = _.maxBy(values, valueLength)
+
   const longestValuePixels =
-    calculateSize(longestValue, {
+    calculateSize(longest.value, {
       font: 'Monospace',
       fontSize: '12px',
     }).width + dropdownPadding

--- a/ui/src/dashboards/constants/templateControlBar.js
+++ b/ui/src/dashboards/constants/templateControlBar.js
@@ -1,8 +1,8 @@
 import _ from 'lodash'
 import calculateSize from 'calculate-size'
 
-export const minDropdownWidth = 146
-export const maxDropdownWidth = 300
+export const minDropdownWidth = 120
+export const maxDropdownWidth = 330
 export const dropdownPadding = 30
 
 const valueLength = a => _.size(a.value)

--- a/ui/src/dashboards/constants/templateControlBar.js
+++ b/ui/src/dashboards/constants/templateControlBar.js
@@ -7,7 +7,11 @@ export const dropdownPadding = 30
 
 const valueLength = a => _.size(a.value)
 
-export const calculateDropdownWidth = (values = []) => {
+export const calculateDropdownWidth = values => {
+  if (!values || !values.length) {
+    return minDropdownWidth
+  }
+
   const longest = _.maxBy(values, valueLength)
 
   const longestValuePixels =


### PR DESCRIPTION
Closes #3275 

_Briefly describe your proposed changes:_
Ensure template variable dropdowns are sized correctly

_What was the problem?_
![tempvar-dropdown-jitter](https://user-images.githubusercontent.com/2433762/39023289-89fe15a0-43ee-11e8-8bc3-5b6cc4244e93.gif)
The dropdown's size isn't getting calculated correctly

_What was the solution?_
Pass the `value` key into `calculateSize` instead of passing the whole object

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)