### PR TITLE
Prevent dygraph from continously updating

### DIFF
--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -185,11 +185,9 @@ export const testAlertOutput = async (kapacitor, outputName) => {
 
 export const getAllServices = async kapacitor => {
   try {
-    const {data: {services}} = await kapacitorProxy(
-      kapacitor,
-      'GET',
-      '/kapacitor/v1/service-tests'
-    )
+    const {
+      data: {services},
+    } = await kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/service-tests')
     return services
   } catch (error) {
     console.error(error)

--- a/ui/src/shared/components/AutoRefresh.js
+++ b/ui/src/shared/components/AutoRefresh.js
@@ -165,7 +165,9 @@ const AutoRefresh = ComposedComponent => {
     }
 
     setResolution = resolution => {
-      this.setState({resolution})
+      if (resolution !== this.state.resolution) {
+        this.setState({resolution})
+      }
     }
 
     render() {


### PR DESCRIPTION
Closes #3293

Dygraphs were calling a function on update that updated a grand parent component's state which tickles down to updating the dygraph and calling the function again

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)