### PR TITLE
Fix Deprecation to say PagerDuty v1 instead of v2

### DIFF
--- a/ui/src/kapacitor/components/AlertTabs.js
+++ b/ui/src/kapacitor/components/AlertTabs.js
@@ -170,7 +170,7 @@ class AlertTabs extends Component {
     const showDeprecation = pagerDutyV1Enabled
     const pagerDutyDeprecationMessage = (
       <div>
-        PagerDuty v2 is being{' '}
+        PagerDuty v1 is being{' '}
         {
           <a
             href="https://v2.developer.pagerduty.com/docs/v1-rest-api-decommissioning-faq"

--- a/ui/src/shared/apis/index.js
+++ b/ui/src/shared/apis/index.js
@@ -185,11 +185,9 @@ export const testAlertOutput = async (kapacitor, outputName) => {
 
 export const getAllServices = async kapacitor => {
   try {
-    const {data: {services}} = await kapacitorProxy(
-      kapacitor,
-      'GET',
-      '/kapacitor/v1/service-tests'
-    )
+    const {
+      data: {services},
+    } = await kapacitorProxy(kapacitor, 'GET', '/kapacitor/v1/service-tests')
     return services
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Fix deprecation typo
Ran prettier

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)