### PR TITLE
Add custom error handling for line graphs

### DIFF
--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -1,5 +1,4 @@
 import React, {PureComponent} from 'react'
-import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import {withRouter, InjectedRouter} from 'react-router'
@@ -52,15 +51,6 @@ interface State {
 
 @ErrorHandling
 export class DataExplorer extends PureComponent<Props, State> {
-  public static childContextTypes = {
-    source: PropTypes.shape({
-      links: PropTypes.shape({
-        proxy: PropTypes.string.isRequired,
-        self: PropTypes.string.isRequired,
-      }).isRequired,
-    }).isRequired,
-  }
-
   constructor(props) {
     super(props)
 

--- a/ui/src/shared/components/InvalidData.tsx
+++ b/ui/src/shared/components/InvalidData.tsx
@@ -1,0 +1,17 @@
+import React, {PureComponent} from 'react'
+
+class InvalidData extends PureComponent<{}> {
+  public render() {
+    return (
+      <p
+        className="data-error"
+        style={{textAlign: 'center', paddingTop: '10px'}}
+      >
+        The data returned from the query can't be visualized with this graph
+        type. Try updating the query or selecting a different graph type.
+      </p>
+    )
+  }
+}
+
+export default InvalidData

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -9,7 +9,7 @@ import {colorsStringSchema} from 'shared/schemas'
 import {ErrorHandlingWith} from 'src/shared/decorators/errors'
 import InvalidData from 'src/shared/components/InvalidData'
 
-@ErrorHandlingWith(InvalidData, true)
+@ErrorHandlingWith(InvalidData)
 class LineGraph extends Component {
   constructor(props) {
     super(props)

--- a/ui/src/shared/components/LineGraph.js
+++ b/ui/src/shared/components/LineGraph.js
@@ -6,9 +6,10 @@ import SingleStat from 'src/shared/components/SingleStat'
 import {timeSeriesToDygraph} from 'utils/timeSeriesTransformers'
 
 import {colorsStringSchema} from 'shared/schemas'
-import {ErrorHandling} from 'src/shared/decorators/errors'
+import {ErrorHandlingWith} from 'src/shared/decorators/errors'
+import InvalidData from 'src/shared/components/InvalidData'
 
-@ErrorHandling
+@ErrorHandlingWith(InvalidData, true)
 class LineGraph extends Component {
   constructor(props) {
     super(props)


### PR DESCRIPTION
Closes #3251

Special error handling for line graphs, specifically addressing when there is non numerical data returned from the query

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)