### PR TITLE
Load all template variable values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 1.  [#3354](https://github.com/influxdata/chronograf/pull/3354): Disable template variables for non editing users
 1.  [#3353](https://github.com/influxdata/chronograf/pull/3353): YAxisLabels in Dashboard Graph Builder not showing until graph is redrawn
 
-
 ### Bug Fixes
 
 1.  [#3252](https://github.com/influxdata/chronograf/pull/3252): Allows users to select tickscript editor with mouse
@@ -27,6 +26,7 @@
 1.  [#3345](https://github.com/influxdata/chronograf/pull/3345): Fix auto not showing in the group by dropdown and explorer getting disconnected
 1.  [#3353](https://github.com/influxdata/chronograf/pull/3353): Display y-axis label on initial graph load
 1.  [#3352](https://github.com/influxdata/chronograf/pull/3352): Fix not being able to change the source in the CEO display
+1.  [#3357](https://github.com/influxdata/chronograf/pull/3357): Fix only the selected template variable value getting loaded
 
 ## v1.4.4.1 [2018-04-16]
 

--- a/ui/src/dashboards/containers/DashboardPage.js
+++ b/ui/src/dashboards/containers/DashboardPage.js
@@ -111,8 +111,8 @@ class DashboardPage extends Component {
     // If using auth and role is Viewer, temp vars will be stale until dashboard
     // is refactored so as not to require a write operation (a PUT in this case)
     if (!isUsingAuth || isUserAuthorized(meRole, EDITOR_ROLE)) {
-      await updateTempVarValues(source, dashboard)
       await putDashboardByID(dashboardID)
+      await updateTempVarValues(source, dashboard)
     }
   }
 


### PR DESCRIPTION
Closes #3332

_Briefly describe your proposed changes:_
Populate the template variable values as the last thing that happens after DashboardPage mounts so that the values do not get overwritten.

_What was the problem?_
The dashboard was getting saved to the server and updated in redux after the template variable values were getting populated. During that save to the server, all but the selected template variable values were getting removed, and since that was also getting saved into redux, the dashboard that was rendered had only the selected values in the template variables.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)