### PR TITLE
Rerender dygraph after ref is set to render crosshairs

### DIFF
--- a/ui/src/shared/components/Dygraph.js
+++ b/ui/src/shared/components/Dygraph.js
@@ -36,6 +36,7 @@ class Dygraph extends Component {
     super(props)
     this.state = {
       staticLegendHeight: null,
+      isMounted: false,
     }
   }
 
@@ -92,6 +93,7 @@ class Dygraph extends Component {
 
     const {w} = this.dygraph.getArea()
     this.props.setResolution(w)
+    this.setState({isMounted: true})
   }
 
   componentWillUnmount() {


### PR DESCRIPTION
Closes #3359 

_Briefly describe your proposed changes:_

_What was the problem?_
Crosshairs need refs to render, but refs are not set until componentDidMount, after which a re-render does not happen until user interaction. 

_What was the solution?_
force a single rerender at the end of componentDidMount, by setting state on an "isMounted" variable.


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)