### PR TITLE
Set redux field options at table mount

### DIFF
--- a/ui/src/shared/components/TableGraph.js
+++ b/ui/src/shared/components/TableGraph.js
@@ -71,6 +71,11 @@ class TableGraph extends Component {
     const sortedLabels = result.sortedLabels
 
     const computedFieldOptions = computeFieldOptions(fieldOptions, sortedLabels)
+
+    if (!_.isEqual(computedFieldOptions, fieldOptions)) {
+      this.handleUpdateFieldOptions(computedFieldOptions)
+    }
+
     const {
       transformedData,
       sortedTimeVals,


### PR DESCRIPTION
Closes #3364

_Briefly describe your proposed changes:_
_What was the problem?_
fieldOptions were not getting set at mount
_What was the solution?_
set fieldOptions at mount. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)