### PR TITLE
Remove logging for expected failure states

### DIFF
--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -310,7 +310,6 @@ export class TickscriptPage extends PureComponent<Props, State> {
             failStr,
           })
         } catch (err) {
-          console.warn(err, failStr) // tslint:disable-line
           this.setState({
             logs: [...logs, ...this.state.logs],
             failStr,


### PR DESCRIPTION
Closes #3224 


_What was the problem?_
We are logging warnings in an expected and needed catch.

_What was the solution?_
Stop throwing the warning and spamming the console.
