### PR TITLE
TagKeyDropdown uses source provided by props instead of context

### DIFF
--- a/ui/src/dashboards/components/TagKeyDropdown.js
+++ b/ui/src/dashboards/components/TagKeyDropdown.js
@@ -53,12 +53,10 @@ class TagKeyDropdown extends Component {
       tagKey,
       onSelectTagKey,
       onErrorThrown,
-    } = this.props
-    const {
       source: {
         links: {proxy},
       },
-    } = this.context
+    } = this.props
 
     try {
       const {data} = await showTagKeys({source: proxy, database, measurement})
@@ -78,15 +76,12 @@ class TagKeyDropdown extends Component {
 
 const {func, shape, string} = PropTypes
 
-TagKeyDropdown.contextTypes = {
+TagKeyDropdown.propTypes = {
   source: shape({
     links: shape({
       proxy: string.isRequired,
     }).isRequired,
   }).isRequired,
-}
-
-TagKeyDropdown.propTypes = {
   database: string.isRequired,
   measurement: string.isRequired,
   tagKey: string,

--- a/ui/src/dashboards/components/template_variables/TemplateQueryBuilder.js
+++ b/ui/src/dashboards/components/template_variables/TemplateQueryBuilder.js
@@ -90,6 +90,7 @@ const TemplateQueryBuilder = ({
           <span className="tvm-query-builder--text">WITH KEY =</span>
           {selectedMeasurement ? (
             <TagKeyDropdown
+              source={source}
               database={selectedDatabase}
               measurement={selectedMeasurement}
               tagKey={selectedTagKey}


### PR DESCRIPTION
Closes #3365

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)