### PR TITLE
Fix Generic OAuth bug for GitHub Enterprise where the principal was incorrectly being checked for email being Primary and Verified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 1.  [#3353](https://github.com/influxdata/chronograf/pull/3353): Display y-axis label on initial graph load
 1.  [#3352](https://github.com/influxdata/chronograf/pull/3352): Fix not being able to change the source in the CEO display
 1.  [#3357](https://github.com/influxdata/chronograf/pull/3357): Fix only the selected template variable value getting loaded
+1.  [#3389](https://github.com/influxdata/chronograf/pull/3389): Fix Generic OAuth bug for GitHub Enterprise where the principal was incorrectly being checked for email being Primary and Verified
 
 ## v1.4.4.1 [2018-04-16]
 

--- a/oauth2/generic.go
+++ b/oauth2/generic.go
@@ -165,28 +165,6 @@ type UserEmail struct {
 	Verified *bool   `json:"verified,omitempty"`
 }
 
-// GetPrimary returns if the email is the primary email.
-// If primary is not present, all emails are considered the primary.
-func (u *UserEmail) GetPrimary() bool {
-	if u == nil {
-		return false
-	} else if u.Primary == nil {
-		return true
-	}
-	return *u.Primary
-}
-
-// GetVerified returns if the email has been verified.
-// If verified is not present, all emails are considered verified.
-func (u *UserEmail) GetVerified() bool {
-	if u == nil {
-		return false
-	} else if u.Verified == nil {
-		return true
-	}
-	return *u.Verified
-}
-
 // getPrimaryEmail gets the private email account for the authenticated user.
 func (g *Generic) getPrimaryEmail(client *http.Client) (string, error) {
 	emailsEndpoint := g.APIURL + "/emails"
@@ -211,7 +189,7 @@ func (g *Generic) getPrimaryEmail(client *http.Client) (string, error) {
 
 func (g *Generic) primaryEmail(emails []*UserEmail) (string, error) {
 	for _, m := range emails {
-		if m != nil && m.GetPrimary() && m.GetVerified() && m.Email != nil {
+		if m != nil && m.Primary != nil && m.Verified != nil && m.Email != nil {
 			return *m.Email, nil
 		}
 	}

--- a/oauth2/generic_test.go
+++ b/oauth2/generic_test.go
@@ -155,9 +155,7 @@ func TestGenericPrincipalIDDomain(t *testing.T) {
 		Primary  bool   `json:"primary"`
 		Verified bool   `json:"verified"`
 	}{
-		{"mcfly@example.com", false, true},
-		{"martymcspelledwrong@example.com", false, false},
-		{"martymcfly@pinheads.rok", true, true},
+		{"martymcfly@pinheads.rok", true, false},
 	}
 	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/" {


### PR DESCRIPTION
In #3168, 43c5afe7 introduced the same change to GitHub-specific OAuth as it did for Generic OAuth based on assumption that Generic Oauth would benefit from the same `.Primary` and `.Verified` checks, but it ended up breaking GitHub Enterprise via Generic OAuth. The change should only have been applied to GitHub-specific OAuth. This PR reverts the changes made only to Generic OAuth, which was confirmed to fix the issue for the user.

Closes #3388 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass