### PR TITLE
Upload Icon Appears even with basepath

### DIFF
--- a/server/url_prefixer.go
+++ b/server/url_prefixer.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"regexp"
 
 	"github.com/influxdata/chronograf"
 )
@@ -79,6 +80,12 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	if !ok {
 		up.Logger.Info(ErrNotFlusher)
+		up.Next.ServeHTTP(rw, r)
+		return
+	}
+
+	isSVG, _ := regexp.Match(".svg$", []byte(r.URL.String()))
+	if isSVG {
 		up.Next.ServeHTTP(rw, r)
 		return
 	}


### PR DESCRIPTION
Closes #3376

_Briefly describe your proposed changes:_
Make sure that SVGs dont have the basepath added to their url

_What was the problem?_
Basepath was getting added to the url of the svg

_What was the solution?_
Update url prefixer to ignore svgs

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)