### PR TITLE
Change clone cell notification to reflect cloned cell name

### DIFF
--- a/ui/src/shared/copy/notifications.js
+++ b/ui/src/shared/copy/notifications.js
@@ -428,7 +428,7 @@ export const notifyCellCloned = name => ({
   ...defaultSuccessNotification,
   icon: 'duplicate',
   duration: 1900,
-  message: `Added "${name}" to dashboard.`,
+  message: `Added "${name}" (Clone) to dashboard.`,
 })
 
 export const notifyCellDeleted = name => ({


### PR DESCRIPTION
Closes #3197 

_Briefly describe your proposed changes:_
_What was the problem?_
cloning a cell notified the user that a cell with _original_ cell's name was added to dasboard. 
_What was the solution?_
cloning a cell notifies the user that a cell with _cloned_ cell's name was added to dashboard. 


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)