### PR TITLE
Fix consuming source from context in FieldList

### DIFF
--- a/ui/src/kapacitor/components/DataSection.js
+++ b/ui/src/kapacitor/components/DataSection.js
@@ -7,6 +7,8 @@ import FieldList from 'src/shared/components/FieldList'
 
 import {defaultEveryFrequency} from 'src/kapacitor/constants'
 
+import {SourceContext} from 'src/CheckSources'
+
 const makeQueryHandlers = (actions, query) => ({
   handleChooseNamespace: namespace => {
     actions.chooseNamespace(query.id, namespace)
@@ -66,28 +68,36 @@ const DataSection = ({
   } = makeQueryHandlers(actions, query)
 
   return (
-    <div className="rule-section">
-      <div className="query-builder">
-        <DatabaseList query={query} onChooseNamespace={handleChooseNamespace} />
-        <MeasurementList
-          query={query}
-          onChooseMeasurement={handleChooseMeasurement}
-          onChooseTag={handleChooseTag}
-          onGroupByTag={handleGroupByTag}
-          onToggleTagAcceptance={handleToggleTagAcceptance}
-        />
-        {isDeadman ? null : (
-          <FieldList
-            query={query}
-            onToggleField={handleToggleField}
-            isKapacitorRule={isKapacitorRule}
-            onGroupByTime={handleGroupByTime}
-            removeFuncs={handleRemoveFuncs}
-            applyFuncsToField={handleApplyFuncsToField(onAddEvery)}
-          />
-        )}
-      </div>
-    </div>
+    <SourceContext.Consumer>
+      {source => (
+        <div className="rule-section">
+          <div className="query-builder">
+            <DatabaseList
+              query={query}
+              onChooseNamespace={handleChooseNamespace}
+            />
+            <MeasurementList
+              query={query}
+              onChooseMeasurement={handleChooseMeasurement}
+              onChooseTag={handleChooseTag}
+              onGroupByTag={handleGroupByTag}
+              onToggleTagAcceptance={handleToggleTagAcceptance}
+            />
+            {isDeadman ? null : (
+              <FieldList
+                query={query}
+                onToggleField={handleToggleField}
+                isKapacitorRule={isKapacitorRule}
+                onGroupByTime={handleGroupByTime}
+                removeFuncs={handleRemoveFuncs}
+                applyFuncsToField={handleApplyFuncsToField(onAddEvery)}
+                source={source}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </SourceContext.Consumer>
   )
 }
 

--- a/ui/src/shared/components/FieldList.tsx
+++ b/ui/src/shared/components/FieldList.tsx
@@ -61,18 +61,15 @@ interface Props {
   addInitialField: (field: Field, groupBy: GroupBy) => void
   initialGroupByTime: string | null
   isQuerySupportedByExplorer: boolean
+  source: Source
 }
 
 interface State {
   fields: Field[]
 }
 
-interface Context {
-  source: Source
-}
 @ErrorHandling
 class FieldList extends PureComponent<Props, State> {
-  public static context: Context
   public static defaultProps: Partial<Props> = {
     isKapacitorRule: false,
     initialGroupByTime: null,
@@ -249,8 +246,7 @@ class FieldList extends PureComponent<Props, State> {
 
   private getFields = (): void => {
     const {database, measurement, retentionPolicy} = this.props.query
-    const {source} = this.context
-    const {querySource} = this.props
+    const {querySource, source} = this.props
 
     const proxy =
       _.get(querySource, ['links', 'proxy'], null) || source.links.proxy


### PR DESCRIPTION
Closes #3355 

_What was the problem?_
- The FieldList component was broken, and the Kapa rule builder page would thus go blank, due to a change in React 16 context API.

_What was the solution?_
- Update the `DataSection` & `FieldList` components to use React 16's context API.

  - [ ] Rebased/mergeable
  - [ ] Tests pass