### PR TITLE
Limit max-width to TICKScript editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 1.  [#3357](https://github.com/influxdata/chronograf/pull/3357): Fix only the selected template variable value getting loaded
 1.  [#3389](https://github.com/influxdata/chronograf/pull/3389): Fix Generic OAuth bug for GitHub Enterprise where the principal was incorrectly being checked for email being Primary and Verified
 1.  [#3402](https://github.com/influxdata/chronograf/pull/3402): Fix missing icons when using basepath
+1.  [#3412](https://github.com/influxdata/chronograf/pull/3412): Limit max-width of TICKScript editor.
 
 ## v1.4.4.1 [2018-04-16]
 

--- a/ui/src/style/pages/tickscript-editor.scss
+++ b/ui/src/style/pages/tickscript-editor.scss
@@ -8,6 +8,7 @@ $tickscript-controls-height: 60px;
 .tickscript {
   flex: 1 0 0;
   position: relative;
+  max-width: 100%;
 }
 .tickscript-controls,
 .tickscript-console,


### PR DESCRIPTION
Closes #3324

_Briefly describe your proposed changes:_
_What was the problem?_

The editor of TICKScripts wasn't adjusted to window's width and it created scroll on all the UI instead of just in the editor.

_What was the solution?_

Adding a max-width in the container of the editor

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API) - **doesn't apply**
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)