### PR TITLE
Show kapacitor batch point info in log panel

### DIFF
--- a/ui/src/kapacitor/components/LogsTableRow.js
+++ b/ui/src/kapacitor/components/LogsTableRow.js
@@ -19,6 +19,9 @@ const LogsTableRow = ({logItem}) => {
   if (logItem.service === 'kapacitor' && logItem.msg === 'point') {
     return <LogItemKapacitorPoint logItem={logItem} />
   }
+  if (logItem.service === 'kapacitor' && logItem.msg === 'batch point') {
+    return <LogItemKapacitorPoint logItem={logItem} />
+  }
   if (logItem.service === 'httpd_server_errors' && logItem.lvl === 'error') {
     return <LogItemHTTPError logItem={logItem} />
   }


### PR DESCRIPTION
Closes https://stackoverflow.com/questions/50274447/how-to-debug-batch-query-in-kapacitor

_Briefly describe your proposed changes:_
_What was the problem?_

Previously only "msg" field was displayed for kapacitor "batch point" with `| log()` (https://docs.influxdata.com/kapacitor/v1.4/nodes/log_node/) which is inconvenient for debugging batch query

_What was the solution?_

Now we see all tags and values for "batch point" too and we don't need to run `kapaciot watch <task_id>` for debugging

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)