### PR TITLE
Fix Data Explorer Status Reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 1.  [#3402](https://github.com/influxdata/chronograf/pull/3402): Fix missing icons when using basepath
 1.  [#3412](https://github.com/influxdata/chronograf/pull/3412): Limit max-width of TICKScript editor.
 1.  [#3166](https://github.com/influxdata/chronograf/pull/3166): Fixes naming of new TICKScripts
-
+1.  [#3449](https://github.com/influxdata/chronograf/pull/3449): Fixes data explorer query error reporting regression
 
 ## v1.4.4.1 [2018-04-16]
 

--- a/ui/src/data_explorer/components/Table.tsx
+++ b/ui/src/data_explorer/components/Table.tsx
@@ -225,7 +225,7 @@ class ChronoTable extends PureComponent<Props, State> {
     try {
       const {results} = await fetchTimeSeriesAsync({
         source: this.source,
-        query: query.text,
+        query,
         tempVars: TEMPLATES,
       })
 

--- a/ui/src/shared/actions/timeSeries.ts
+++ b/ui/src/shared/actions/timeSeries.ts
@@ -51,14 +51,24 @@ export const handleError = (error, query, editQueryStatus) => {
   })
 }
 
+interface Query {
+  host: string | string[]
+  text: string
+  id: string
+  database?: string
+  db?: string
+  rp?: string
+}
+
 interface Payload {
   source: string
-  query: string
+  query: Query
   tempVars: any[]
   db?: string
   rp?: string
   resolution?: number
 }
+
 export const fetchTimeSeriesAsync = async (
   {source, db, rp, query, tempVars, resolution}: Payload,
   editQueryStatus = noop
@@ -69,7 +79,7 @@ export const fetchTimeSeriesAsync = async (
       source,
       db,
       rp,
-      query,
+      query: query.text,
       tempVars,
       resolution,
     })

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -29,6 +29,7 @@ interface Query {
   database: string
   db: string
   rp: string
+  id: string
 }
 
 const parseSource = source => {
@@ -46,7 +47,7 @@ export const fetchTimeSeries = async (
   editQueryStatus: () => any
 ) => {
   const timeSeriesPromises = queries.map(query => {
-    const {host, database, rp, text} = query
+    const {host, database, rp} = query
     // the key `database` was used upstream in HostPage.js, and since as of this writing
     // the codebase has not been fully converted to TypeScript, it's not clear where else
     // it may be used, but this slight modification is intended to allow for the use of
@@ -72,7 +73,7 @@ export const fetchTimeSeries = async (
     const tempVars = removeUnselectedTemplateValues(templatesWithIntervalVals)
 
     const source = parseSource(host)
-    const payload = {source, db, rp, query: text, tempVars, resolution}
+    const payload = {source, db, rp, query, tempVars, resolution}
     return fetchTimeSeriesAsync(payload, editQueryStatus)
   })
 

--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -18,6 +18,7 @@ interface Query {
   database: string
   db: string
   rp: string
+  id: string
 }
 
 interface TemplateQuery {


### PR DESCRIPTION
Closes #3438

_Briefly describe your proposed changes:_

_What was the problem?_
Changes during TS conversion broke data explorer query status reporting. 
_What was the solution?_
Reverted the changes.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)