### PR TITLE
Bugfix/tickscript log basepath

### DIFF
--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -107,7 +107,6 @@ const kapacitorLogHeaders = {
 }
 
 export const getLogStream = kapacitor =>
-  // fetch required for kapacitors log querying
   fetch(`${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs`, {
     method: 'GET',
     headers: kapacitorLogHeaders,
@@ -115,7 +114,6 @@ export const getLogStream = kapacitor =>
   })
 
 export const getLogStreamByRuleID = (kapacitor, ruleID) =>
-  // fetch required for kapacitors log querying
   fetch(
     `${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs?task=${ruleID}`,
     {

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -106,22 +106,33 @@ const kapacitorLogHeaders = {
   Accept: 'application/json',
 }
 
-export const getLogStream = kapacitor =>
-  fetch(`${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs`, {
+export const getLogStream = kapacitor => {
+  // axios doesn't support the chunked transfer encoding response kapacitor uses for logs
+  // AJAX adds basepath, but we need to supply it directly to fetch
+  const url = `${kapacitor.links.proxy}?pat=/kapacitor/v1preview/logs`
+  const basepath = window.basepath || ''
+
+  return fetch(`${basepath}${url}`, {
     method: 'GET',
     headers: kapacitorLogHeaders,
     credentials: 'include',
   })
+}
 
-export const getLogStreamByRuleID = (kapacitor, ruleID) =>
-  fetch(
-    `${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs?task=${ruleID}`,
-    {
-      method: 'GET',
-      headers: kapacitorLogHeaders,
-      credentials: 'include',
-    }
-  )
+export const getLogStreamByRuleID = (kapacitor, ruleID) => {
+  // axios doesn't support the chunked transfer encoding response kapacitor uses for logs
+  // AJAX adds basepath, but we need to supply it directly to fetch
+  const url = `${
+    kapacitor.links.proxy
+  }?path=/kapacitor/v1preview/logs?task=${ruleID}`
+  const basepath = window.basepath || ''
+
+  return fetch(`${basepath}${url}`, {
+    method: 'GET',
+    headers: kapacitorLogHeaders,
+    credentials: 'include',
+  })
+}
 
 export const pingKapacitorVersion = async kapacitor => {
   try {


### PR DESCRIPTION
Closes #3415

_Briefly describe your proposed changes:_
_What was the problem?_
Basepath string was added during call to AJAX, but was not added to direct call of fetch. 
_What was the solution?_
Add basepath string to request during call to fetch kapacitor logs

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)