### PR TITLE
Order tickscript names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### UI Improvements
 
+1.  [#3474](https://github.com/influxdata/chronograf/pull/3474): Sort task table on Manage Alert page alphabetically
 ### Bug Fixes
 
 ## v1.5.0.0 [2018-05-15-RC]

--- a/ui/src/kapacitor/components/TasksTable.tsx
+++ b/ui/src/kapacitor/components/TasksTable.tsx
@@ -40,7 +40,7 @@ const TasksTable: SFC<TasksTableProps> = ({
       </tr>
     </thead>
     <tbody>
-      {_.sortBy(tasks, t => t.id.toLowerCase()).map(task => {
+      {_.sortBy(tasks, t => t.name.toLowerCase()).map(task => {
         return (
           <TaskRow
             key={task.id}

--- a/ui/test/kapacitor/components/TasksTable.test.tsx
+++ b/ui/test/kapacitor/components/TasksTable.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
+import _ from 'lodash'
 
 import TasksTable from 'src/kapacitor/components/TasksTable'
 import {TaskRow} from 'src/kapacitor/components/TasksTable'
@@ -19,6 +20,21 @@ describe('Kapacitor.Components.TasksTable', () => {
       const wrapper = shallow(<TasksTable {...props} />)
 
       expect(wrapper.exists()).toBe(true)
+    })
+
+    it('renders TaskRows alphabetically sorted by task name', () => {
+      const wrapper = shallow(<TasksTable {...props} />)
+      const taskRows = wrapper.find(TaskRow)
+      const actualNamesOrder = taskRows.map(taskRow => {
+        const {name} = taskRow.prop('task')
+        return name
+      })
+
+      const expectedNamesOrder = _.sortBy(kapacitorRules, r =>
+        r.name.toLowerCase()
+      ).map(r => r.name)
+
+      expect(actualNamesOrder).toEqual(expectedNamesOrder)
     })
   })
 


### PR DESCRIPTION
Closes #3455

_What was the problem?_
Rows were being sorted by task id instead of by name
_What was the solution?_
Sort rows by task id

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
