### PR TITLE
Use predefined TimeSeriesServerResponse type in LayoutCell

### DIFF
--- a/ui/src/shared/components/LayoutCell.tsx
+++ b/ui/src/shared/components/LayoutCell.tsx
@@ -12,25 +12,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import {dataToCSV} from 'src/shared/parsing/dataToCSV'
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
 import {Cell, CellQuery} from 'src/types/dashboard'
-
-interface Series {
-  columns: string[]
-  name: string
-  values: number[][]
-}
-
-interface Result {
-  statement_id: number
-  series: Series[]
-}
-
-interface Response {
-  results: Result[]
-}
-
-interface Data {
-  response: Response[]
-}
+import {TimeSeriesServerResponse} from 'src/types/series'
 
 interface Props {
   cell: Cell
@@ -40,7 +22,7 @@ interface Props {
   onSummonOverlayTechnologies: (cell: Cell) => void
   isEditable: boolean
   onCancelEditCell: () => void
-  cellData: Data[]
+  cellData: TimeSeriesServerResponse[]
 }
 
 @ErrorHandling


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
_What was the problem?_
TS error following merge of tables to TS PR. 
_What was the solution?_
Use common type definitions for same data. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)