### PR TITLE
Ensure Cells show only data from TimeSelector Constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 ## v1.5.1.0 [unreleased]
 
 ### Features
+
 1.  [#3522](https://github.com/influxdata/chronograf/pull/3522): Add support for Template Variables in Cell Titles
 
 ### UI Improvements
 
 1.  [#3474](https://github.com/influxdata/chronograf/pull/3474): Sort task table on Manage Alert page alphabetically
+
 ### Bug Fixes
+
+1.  [#3527](https://github.com/influxdata/chronograf/pull/3527): Ensure cell queries use constraints from TimeSelector
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/ui/src/shared/data/timeRanges.ts
+++ b/ui/src/shared/data/timeRanges.ts
@@ -1,13 +1,12 @@
-interface TimeRange {
+import {TimeRange} from 'src/types/query'
+interface TimeRangeOption extends TimeRange {
   defaultGroupBy: string
   seconds: number
   inputValue: string
-  lower: string
-  upper: string | null
   menuOption: string
 }
 
-export const timeRanges: TimeRange[] = [
+export const timeRanges: TimeRangeOption[] = [
   {
     defaultGroupBy: '10s',
     seconds: 300,

--- a/ui/src/shared/data/timeRanges.ts
+++ b/ui/src/shared/data/timeRanges.ts
@@ -1,4 +1,13 @@
-export const timeRanges = [
+interface TimeRange {
+  defaultGroupBy: string
+  seconds: number
+  inputValue: string
+  lower: string
+  upper: string | null
+  menuOption: string
+}
+
+export const timeRanges: TimeRange[] = [
   {
     defaultGroupBy: '10s',
     seconds: 300,

--- a/ui/src/utils/buildQueriesForLayouts.ts
+++ b/ui/src/utils/buildQueriesForLayouts.ts
@@ -57,15 +57,25 @@ const addTimeBoundsToRawText = (rawText: string): string => {
     return
   }
 
+  const dashboardTimeRegex = new RegExp(
+    `time( )?>( )?${TEMP_VAR_DASHBOARD_TIME}`,
+    'g'
+  )
   const dashboardTimeText: string = `time > ${TEMP_VAR_DASHBOARD_TIME}`
-  if (rawText.indexOf(dashboardTimeText) !== -1) {
+  const isUsingTimeSelectorBounds: boolean = !_.isEmpty(
+    rawText.match(dashboardTimeRegex)
+  )
+
+  if (isUsingTimeSelectorBounds) {
+    const upperTimeBoundRegex = new RegExp('time( )?<', 'g')
+    const hasUpperTimeBound = !_.isEmpty(rawText.match(upperTimeBoundRegex))
     if (
       rawText.indexOf(TEMP_VAR_UPPER_DASHBOARD_TIME) === -1 &&
-      rawText.indexOf('time <') === -1
+      !hasUpperTimeBound
     ) {
       const upperDashboardTimeText = `time < ${TEMP_VAR_UPPER_DASHBOARD_TIME}`
       const fullTimeText = `${dashboardTimeText} AND ${upperDashboardTimeText}`
-      const boundedQueryText = rawText.replace(dashboardTimeText, fullTimeText)
+      const boundedQueryText = rawText.replace(dashboardTimeRegex, fullTimeText)
       return boundedQueryText
     }
   }

--- a/ui/src/utils/buildQueriesForLayouts.ts
+++ b/ui/src/utils/buildQueriesForLayouts.ts
@@ -21,7 +21,7 @@ const buildCannedDashboardQuery = (
 
   let text = query.query
   const wheres = _.get(query, 'wheres')
-  const groupbys = _.get(query, 'gropubys')
+  const groupbys = _.get(query, 'groupbys')
 
   if (upper) {
     text += ` where time > '${lower}' AND time < '${upper}'`


### PR DESCRIPTION
Closes #3517

_Briefly describe your proposed changes:_
Update the buildQueriesForLayouts function to add upper bounds to queries when necessary.

_What was the problem?_
Cells with queries that were not parseable into a query config were not getting an upper time bound like cells with query config parseable queries. Therefore, the upper time bound was defaulting to now().

_What was the solution?_
If a query was not able to be parsed into a query config, it was using 'time > :dasbhoardTime:' in the query, and it was not already using :upperDashboardTime", an upper bound of 'time < :upperDashboardTime:' is added to the WHERE clause of the query.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
