### PR TITLE
Fix Gauge Color Selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 1.  [#3527](https://github.com/influxdata/chronograf/pull/3527): Ensure cell queries use constraints from TimeSelector
+1.  [#3573](https://github.com/influxdata/chronograf/pull/3573): Fix Gauge color selection bug
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/ui/src/dashboards/components/GaugeOptions.js
+++ b/ui/src/dashboards/components/GaugeOptions.js
@@ -72,12 +72,12 @@ class GaugeOptions extends Component {
     onResetFocus()
   }
 
-  handleChooseColor = threshold => chosenColor => {
+  handleChooseColor = threshold => {
     const {handleUpdateGaugeColors} = this.props
     const gaugeColors = this.props.gaugeColors.map(
       color =>
         color.id === threshold.id
-          ? {...color, hex: chosenColor.hex, name: chosenColor.name}
+          ? {...color, hex: threshold.hex, name: threshold.name}
           : color
     )
 


### PR DESCRIPTION
Closes #3569 

_What was the problem?_
User cannot change colors in Gauge thresholds. Color Dropdown was working fine but the handler function passed into it had an extra closure which prevented the update from firing.

_What was the solution?_
Remove the extra closure

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass