### PR TITLE
Fix source maps to exactly reflect code instead of es5 transpilation

### DIFF
--- a/ui/webpack/dev.config.js
+++ b/ui/webpack/dev.config.js
@@ -45,7 +45,7 @@ module.exports = {
   },
   watch: true,
   cache: true,
-  devtool: 'cheap-eval-source-map',
+  devtool: 'eval-source-map',
   entry: {
     app: path.resolve(__dirname, '..', 'src', 'index.tsx'),
   },


### PR DESCRIPTION
_What was the problem?_
When using a devtool (verified in Chrome or Firefox), source maps were not mapping back to the actual code as-written. Instead, an ES5 transpilation was being shown. This made debugging using the devtools a huge headache, and effectively untenable.

_What was the solution?_
Change webpack's source map option to make the dev tools (verified in Chrome and Firefox) reflect exactly the code as-written. Specifically, the solution was to switch from `devtool: cheap-eval-source-map` to `devtool: eval-source-map` in `ui/webpack/dev.config.js`.

The only cost of this that I see is, as stated in the webpack docs, that initial build may take slightly longer. However, rebuilding should be quicker, and this is a minor cost in the scheme of the ability to debug effectively. See https://webpack.js.org/configuration/devtool/ for reference, where the following is taken from:

```
eval-source-map - Each module is executed with eval() and a SourceMap is added as a DataUrl to the eval(). Initially it is slow, but it provides fast rebuild speed and yields real files. Line numbers are correctly mapped since it gets mapped to the original code. It yields the best quality SourceMaps for development.

cheap-eval-source-map - Similar to eval-source-map, each module is executed with eval(). It is "cheap" because it doesn't have column mappings, it only maps line numbers. It ignores SourceMaps from Loaders and only display transpiled code similar to the eval devtool.
```

This post was also useful in this investigation: http://erikaybar.name/webpack-source-maps-in-chrome/.

### Broken/before:
![screen shot 2018-06-05 at 2 39 15 pm](https://user-images.githubusercontent.com/6403018/41004459-ce3cfca4-68ce-11e8-9317-db7f38342e1f.png)

### Fixed/after:
![screen shot 2018-06-05 at 2 43 51 pm](https://user-images.githubusercontent.com/6403018/41004487-e85253fa-68ce-11e8-9073-12d35753107f.png)
