### PR TITLE
Flux Page Error Robustness

### DIFF
--- a/ui/src/flux/components/TagListItem.tsx
+++ b/ui/src/flux/components/TagListItem.tsx
@@ -34,6 +34,8 @@ interface State {
 }
 
 export default class TagListItem extends PureComponent<Props, State> {
+  private debouncedOnSearch: () => void
+
   constructor(props) {
     super(props)
 
@@ -132,8 +134,6 @@ export default class TagListItem extends PureComponent<Props, State> {
       this.debouncedOnSearch()
     )
   }
-
-  private debouncedOnSearch() {} // See constructor
 
   private handleInputClick = (e: MouseEvent<HTMLDivElement>): void => {
     e.stopPropagation()

--- a/ui/src/flux/components/TimeMachineEditor.tsx
+++ b/ui/src/flux/components/TimeMachineEditor.tsx
@@ -73,13 +73,13 @@ class TimeMachineEditor extends PureComponent<Props, State> {
     const {script} = this.props
 
     const options = {
-      lineNumbers: true,
-      theme: 'time-machine',
       tabIndex: 1,
-      readonly: false,
-      completeSingle: false,
-      autoRefresh: true,
       mode: 'flux',
+      readonly: false,
+      lineNumbers: true,
+      autoRefresh: true,
+      theme: 'time-machine',
+      completeSingle: false,
       gutters: ['error-gutter'],
     }
 
@@ -135,7 +135,6 @@ class TimeMachineEditor extends PureComponent<Props, State> {
     }
 
     const errorDiv = document.createElement('div')
-    errorDiv.id = text
     errorDiv.className = 'inline-error-message'
     errorDiv.innerText = text
     widget = this.editor.addLineWidget(line, errorDiv) as Widget

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -76,8 +76,8 @@ export class FluxPage extends PureComponent<Props, State> {
     }
 
     this.debouncedASTResponse = _.debounce(script => {
-      this.getASTResponse(script)
-    }, 500)
+      this.getASTResponse(script, false)
+    }, 250)
   }
 
   public async componentDidMount() {
@@ -414,7 +414,7 @@ export class FluxPage extends PureComponent<Props, State> {
     }
   }
 
-  private getASTResponse = async (script: string) => {
+  private getASTResponse = async (script: string, update: boolean = true) => {
     const {links} = this.props
 
     if (!script) {
@@ -423,6 +423,11 @@ export class FluxPage extends PureComponent<Props, State> {
 
     try {
       const ast = await getAST({url: links.ast, body: script})
+
+      if (update) {
+        this.props.updateScript(script)
+      }
+
       const body = bodyNodes(ast, this.state.suggestions)
       const status = {type: 'success', text: ''}
       this.setState({ast, body, status})

--- a/ui/src/style/components/time-machine/flux-editor.scss
+++ b/ui/src/style/components/time-machine/flux-editor.scss
@@ -24,3 +24,8 @@
   color: $c-dreamsicle;
   cursor: pointer;
 }
+
+.inline-error-message {
+  color: white;
+  background-color: red;
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_
- Updates the AST as the user types.  This provides almost instantaneous feedback to the user for syntax error reporting.  Additionally, this 'builds' the builder as the user types.
- Adds more robust error reporting:
![kapture 2018-06-07 at 13 40 16](https://user-images.githubusercontent.com/7582765/41124958-57b0a9f6-6a58-11e8-849f-5a7e8a45aaf3.gif)


