### PR TITLE
Improved handling of large Flux query responses

### DIFF
--- a/ui/src/flux/constants/index.ts
+++ b/ui/src/flux/constants/index.ts
@@ -6,7 +6,7 @@ import * as builder from 'src/flux/constants/builder'
 import * as vis from 'src/flux/constants/vis'
 import * as explorer from 'src/flux/constants/explorer'
 
-const MAX_RESPONSE_BYTES = 2e6 // 2 MB
+const MAX_RESPONSE_BYTES = 1e7 // 10 MB
 
 export {
   ast,

--- a/ui/src/flux/constants/index.ts
+++ b/ui/src/flux/constants/index.ts
@@ -6,4 +6,15 @@ import * as builder from 'src/flux/constants/builder'
 import * as vis from 'src/flux/constants/vis'
 import * as explorer from 'src/flux/constants/explorer'
 
-export {ast, funcNames, argTypes, editor, builder, vis, explorer}
+const MAX_RESPONSE_BYTES = 2e6 // 2 MB
+
+export {
+  ast,
+  funcNames,
+  argTypes,
+  editor,
+  builder,
+  vis,
+  explorer,
+  MAX_RESPONSE_BYTES,
+}

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -9,6 +9,7 @@ import KeyboardShortcuts from 'src/shared/components/KeyboardShortcuts'
 import {
   analyzeSuccess,
   fluxTimeSeriesError,
+  fluxResponseTruncatedError,
 } from 'src/shared/copy/notifications'
 import {UpdateScript} from 'src/flux/actions'
 
@@ -439,8 +440,13 @@ export class FluxPage extends PureComponent<Props, State> {
     }
 
     try {
-      const data = await getTimeSeries(this.service, script)
-      this.setState({data})
+      const {tables, didTruncate} = await getTimeSeries(this.service, script)
+
+      this.setState({data: tables})
+
+      if (didTruncate) {
+        notify(fluxResponseTruncatedError())
+      }
     } catch (error) {
       this.setState({data: []})
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -2,6 +2,7 @@
 // and ensuring stylistic consistency
 
 import {FIVE_SECONDS, TEN_SECONDS, INFINITE} from 'src/shared/constants/index'
+import {MAX_RESPONSE_BYTES} from 'src/flux/constants'
 
 const defaultErrorNotification = {
   type: 'error',
@@ -680,3 +681,13 @@ export const fluxTimeSeriesError = (message: string) => ({
   ...defaultErrorNotification,
   message: `Could not get data: ${message}`,
 })
+
+export const fluxResponseTruncatedError = () => {
+  const BYTES_TO_MB = 1 / 1e6
+  const APPROX_MAX_RESPONSE_MB = +(MAX_RESPONSE_BYTES * BYTES_TO_MB).toFixed(2)
+
+  return {
+    ...defaultErrorNotification,
+    message: `Large response truncated to first ${APPROX_MAX_RESPONSE_MB} MB`,
+  }
+}

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -29,6 +29,12 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
     throw new Error('Unable to extract annotation data')
   }
 
+  if (_.isEmpty(nonAnnotationLines)) {
+    // A response may be truncated on an arbitrary line. This guards against
+    // the case where a response is truncated on annotation data
+    return []
+  }
+
   const nonAnnotationData = Papa.parse(nonAnnotationLines).data
   const annotationData = Papa.parse(annotationLines).data
   const headerRow = nonAnnotationData[0]

--- a/ui/test/shared/parsing/flux/constants.ts
+++ b/ui/test/shared/parsing/flux/constants.ts
@@ -134,3 +134,15 @@ export const CSV_TO_DYGRAPH_MISMATCHED = `
 ,,1,2018-06-04T17:12:21.025984999Z,2018-06-04T17:13:00Z,2018-06-05T17:12:25Z,10,available,mem,bertrand.local
 ,,1,2018-06-04T17:12:21.025984999Z,2018-06-04T17:13:00Z,2018-06-05T17:12:35Z,11,available,mem,bertrand.local
 `
+
+export const TRUNCATED_RESPONSE = `
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true
+#default,_result,,,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement,cpu,host
+,,0,1677-09-21T00:12:43.145224192Z,2018-05-22T22:39:17.042276772Z,2018-05-22T22:39:12.584Z,0,usage_guest,cpu,cpu-total,WattsInfluxDB
+,,1,1677-09-21T00:12:43.145224192Z,2018-05-22T22:39:17.042276772Z,2018-05-22T22:39:12.584Z,0,usage_guest_nice,cpu,cpu-total,WattsInfluxDB
+
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,string,string,string,string
+#partition,false,false,false,false,false,false,true,true,true,true,true,true,true
+#default,_result,,,,,,,,,,,,`

--- a/ui/test/shared/parsing/flux/results.test.ts
+++ b/ui/test/shared/parsing/flux/results.test.ts
@@ -4,6 +4,7 @@ import {
   RESPONSE_METADATA,
   MULTI_SCHEMA_RESPONSE,
   EXPECTED_COLUMNS,
+  TRUNCATED_RESPONSE,
 } from 'test/shared/parsing/flux/constants'
 
 describe('Flux results parser', () => {
@@ -35,6 +36,14 @@ describe('Flux results parser', () => {
         host: 'WattsInfluxDB',
       }
       expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('partial responses', () => {
+    it('should discard tables without any non-annotation rows', () => {
+      const actual = parseResponse(TRUNCATED_RESPONSE)
+
+      expect(actual).toHaveLength(2)
     })
   })
 })


### PR DESCRIPTION
#### What was the problem?

A user can enter a Flux query that returns a response too large to render. For example,
```
from(db: "telegraf") |> range(start: -24h)
```
will crash or lock up the browser. We would like to implement pagination in the table visualization as a way to limit the size of responses, but the necessary prerequisites aren't available from platform.

#### What was the solution?

This PR implements a stopgap solution—we only parse the first 10 MB of data returned by a Flux query, and drop the rest. When dropping data, we display a notification to the user:

![screen shot 2018-06-07 at 2 31 31 pm](https://user-images.githubusercontent.com/638955/41127647-73ee7956-6a60-11e8-91b7-3f85ecee0659.png)

This PR also includes a performance enhancement to the `TimeMachineTable`, so that it can render 10 MB of data smoothly. Previously, a bottleneck in the `TimeMachineTable` meant each scroll took several seconds:

![screen shot 2018-06-07 at 2 20 19 pm](https://user-images.githubusercontent.com/638955/41127772-d19624be-6a60-11e8-9c56-80435740dda7.png)

With these changes, a scroll event now takes about 20ms:

![screen shot 2018-06-07 at 2 26 18 pm](https://user-images.githubusercontent.com/638955/41127788-e153ea76-6a60-11e8-9d26-0837065664ea.png)






 