### PR TITLE
Preserve schema tree children open state

### DIFF
--- a/ui/src/flux/components/DatabaseListItem.tsx
+++ b/ui/src/flux/components/DatabaseListItem.tsx
@@ -87,7 +87,7 @@ class DatabaseListItem extends PureComponent<Props, State> {
 
     if (isOpen) {
       return (
-        <>
+        <div className="flux-schema--children">
           <div className="flux-schema--filter">
             <input
               className="form-control input-xs"
@@ -101,7 +101,7 @@ class DatabaseListItem extends PureComponent<Props, State> {
             />
           </div>
           <TagList db={db} service={service} tags={this.tags} filter={[]} />
-        </>
+        </div>
       )
     }
   }

--- a/ui/src/flux/components/DatabaseListItem.tsx
+++ b/ui/src/flux/components/DatabaseListItem.tsx
@@ -85,25 +85,23 @@ class DatabaseListItem extends PureComponent<Props, State> {
     const {db, service} = this.props
     const {isOpen, searchTerm} = this.state
 
-    if (isOpen) {
-      return (
-        <div className="flux-schema--children">
-          <div className="flux-schema--filter">
-            <input
-              className="form-control input-xs"
-              placeholder={`Filter within ${db}`}
-              type="text"
-              spellCheck={false}
-              autoComplete="off"
-              value={searchTerm}
-              onClick={this.handleInputClick}
-              onChange={this.onSearch}
-            />
-          </div>
-          <TagList db={db} service={service} tags={this.tags} filter={[]} />
+    return (
+      <div className={`flux-schema--children ${isOpen ? '' : 'hidden'}`}>
+        <div className="flux-schema--filter">
+          <input
+            className="form-control input-xs"
+            placeholder={`Filter within ${db}`}
+            type="text"
+            spellCheck={false}
+            autoComplete="off"
+            value={searchTerm}
+            onClick={this.handleInputClick}
+            onChange={this.onSearch}
+          />
         </div>
-      )
-    }
+        <TagList db={db} service={service} tags={this.tags} filter={[]} />
+      </div>
+    )
   }
 
   private handleClickCopy = e => {

--- a/ui/src/flux/components/TagList.tsx
+++ b/ui/src/flux/components/TagList.tsx
@@ -12,17 +12,7 @@ interface Props {
   filter: SchemaFilter[]
 }
 
-interface State {
-  isOpen: boolean
-}
-
-export default class TagList extends PureComponent<Props, State> {
-  constructor(props) {
-    super(props)
-
-    this.state = {isOpen: false}
-  }
-
+export default class TagList extends PureComponent<Props> {
   public render() {
     const {db, service, tags, filter} = this.props
 

--- a/ui/src/flux/components/TagListItem.tsx
+++ b/ui/src/flux/components/TagListItem.tsx
@@ -84,7 +84,7 @@ export default class TagListItem extends PureComponent<Props, State> {
           </CopyToClipboard>
         </div>
         {this.state.isOpen && (
-          <>
+          <div className="flux-schema--children">
             <div
               className="flux-schema--header"
               onClick={this.handleInputClick}
@@ -107,21 +107,19 @@ export default class TagListItem extends PureComponent<Props, State> {
             </div>
             {this.isLoading && <LoaderSkeleton />}
             {!this.isLoading && (
-              <>
-                <TagValueList
-                  db={db}
-                  service={service}
-                  values={tagValues}
-                  tagKey={tagKey}
-                  filter={filter}
-                  onLoadMoreValues={this.handleLoadMoreValues}
-                  isLoadingMoreValues={loadingMore === RemoteDataState.Loading}
-                  shouldShowMoreValues={limit < count}
-                  loadMoreCount={this.loadMoreCount}
-                />
-              </>
+              <TagValueList
+                db={db}
+                service={service}
+                values={tagValues}
+                tagKey={tagKey}
+                filter={filter}
+                onLoadMoreValues={this.handleLoadMoreValues}
+                isLoadingMoreValues={loadingMore === RemoteDataState.Loading}
+                shouldShowMoreValues={limit < count}
+                loadMoreCount={this.loadMoreCount}
+              />
             )}
-          </>
+          </div>
         )}
       </div>
     )

--- a/ui/src/flux/components/TagListItem.tsx
+++ b/ui/src/flux/components/TagListItem.tsx
@@ -66,7 +66,14 @@ export default class TagListItem extends PureComponent<Props, State> {
 
   public render() {
     const {tagKey, db, service, filter} = this.props
-    const {tagValues, searchTerm, loadingMore, count, limit} = this.state
+    const {
+      tagValues,
+      searchTerm,
+      loadingMore,
+      count,
+      limit,
+      isOpen,
+    } = this.state
 
     return (
       <div className={this.className}>
@@ -83,44 +90,37 @@ export default class TagListItem extends PureComponent<Props, State> {
             </div>
           </CopyToClipboard>
         </div>
-        {this.state.isOpen && (
-          <div className="flux-schema--children">
-            <div
-              className="flux-schema--header"
-              onClick={this.handleInputClick}
-            >
-              <div className="flux-schema--filter">
-                <input
-                  className="form-control input-xs"
-                  placeholder={`Filter within ${tagKey}`}
-                  type="text"
-                  spellCheck={false}
-                  autoComplete="off"
-                  value={searchTerm}
-                  onChange={this.onSearch}
-                />
-                {this.isSearching && (
-                  <LoadingSpinner style={this.spinnerStyle} />
-                )}
-              </div>
-              {this.count}
-            </div>
-            {this.isLoading && <LoaderSkeleton />}
-            {!this.isLoading && (
-              <TagValueList
-                db={db}
-                service={service}
-                values={tagValues}
-                tagKey={tagKey}
-                filter={filter}
-                onLoadMoreValues={this.handleLoadMoreValues}
-                isLoadingMoreValues={loadingMore === RemoteDataState.Loading}
-                shouldShowMoreValues={limit < count}
-                loadMoreCount={this.loadMoreCount}
+        <div className={`flux-schema--children ${isOpen ? '' : 'hidden'}`}>
+          <div className="flux-schema--header" onClick={this.handleInputClick}>
+            <div className="flux-schema--filter">
+              <input
+                className="form-control input-xs"
+                placeholder={`Filter within ${tagKey}`}
+                type="text"
+                spellCheck={false}
+                autoComplete="off"
+                value={searchTerm}
+                onChange={this.onSearch}
               />
-            )}
+              {this.isSearching && <LoadingSpinner style={this.spinnerStyle} />}
+            </div>
+            {this.count}
           </div>
-        )}
+          {this.isLoading && <LoaderSkeleton />}
+          {!this.isLoading && (
+            <TagValueList
+              db={db}
+              service={service}
+              values={tagValues}
+              tagKey={tagKey}
+              filter={filter}
+              onLoadMoreValues={this.handleLoadMoreValues}
+              isLoadingMoreValues={loadingMore === RemoteDataState.Loading}
+              shouldShowMoreValues={limit < count}
+              loadMoreCount={this.loadMoreCount}
+            />
+          )}
+        </div>
       </div>
     )
   }
@@ -313,7 +313,7 @@ export default class TagListItem extends PureComponent<Props, State> {
     return (
       !isOpen &&
       (loadingAll === RemoteDataState.NotStarted ||
-        loadingAll !== RemoteDataState.Error)
+        loadingAll === RemoteDataState.Error)
     )
   }
 

--- a/ui/src/flux/components/TagValueListItem.tsx
+++ b/ui/src/flux/components/TagValueListItem.tsx
@@ -48,7 +48,7 @@ class TagValueListItem extends PureComponent<Props, State> {
 
   public render() {
     const {db, service, value} = this.props
-    const {searchTerm} = this.state
+    const {searchTerm, isOpen} = this.state
 
     return (
       <div className={this.className} onClick={this.handleClick}>
@@ -65,35 +65,33 @@ class TagValueListItem extends PureComponent<Props, State> {
             </div>
           </CopyToClipboard>
         </div>
-        {this.state.isOpen && (
-          <div className="flux-schema--children">
-            {this.isLoading && <LoaderSkeleton />}
-            {!this.isLoading && (
-              <>
-                {!!this.tags.length && (
-                  <div className="flux-schema--filter">
-                    <input
-                      className="form-control input-xs"
-                      placeholder={`Filter within ${value}`}
-                      type="text"
-                      spellCheck={false}
-                      autoComplete="off"
-                      value={searchTerm}
-                      onClick={this.handleInputClick}
-                      onChange={this.onSearch}
-                    />
-                  </div>
-                )}
-                <TagList
-                  db={db}
-                  service={service}
-                  tags={this.tags}
-                  filter={this.filter}
-                />
-              </>
-            )}
-          </div>
-        )}
+        <div className={`flux-schema--children ${isOpen ? '' : 'hidden'}`}>
+          {this.isLoading && <LoaderSkeleton />}
+          {!this.isLoading && (
+            <>
+              {!!this.tags.length && (
+                <div className="flux-schema--filter">
+                  <input
+                    className="form-control input-xs"
+                    placeholder={`Filter within ${value}`}
+                    type="text"
+                    spellCheck={false}
+                    autoComplete="off"
+                    value={searchTerm}
+                    onClick={this.handleInputClick}
+                    onChange={this.onSearch}
+                  />
+                </div>
+              )}
+              <TagList
+                db={db}
+                service={service}
+                tags={this.tags}
+                filter={this.filter}
+              />
+            </>
+          )}
+        </div>
       </div>
     )
   }
@@ -177,7 +175,7 @@ class TagValueListItem extends PureComponent<Props, State> {
     return (
       !isOpen &&
       (loading === RemoteDataState.NotStarted ||
-        loading !== RemoteDataState.Error)
+        loading === RemoteDataState.Error)
     )
   }
 }

--- a/ui/src/flux/components/TagValueListItem.tsx
+++ b/ui/src/flux/components/TagValueListItem.tsx
@@ -66,7 +66,7 @@ class TagValueListItem extends PureComponent<Props, State> {
           </CopyToClipboard>
         </div>
         {this.state.isOpen && (
-          <>
+          <div className="flux-schema--children">
             {this.isLoading && <LoaderSkeleton />}
             {!this.isLoading && (
               <>
@@ -92,7 +92,7 @@ class TagValueListItem extends PureComponent<Props, State> {
                 />
               </>
             )}
-          </>
+          </div>
         )}
       </div>
     )

--- a/ui/src/style/components/time-machine/flux-explorer.scss
+++ b/ui/src/style/components/time-machine/flux-explorer.scss
@@ -22,7 +22,7 @@ $flux-tree-gutter: 11px;
   flex-direction: column;
   align-items: stretch;
   padding-left: 0;
-  > .flux-schema-tree {
+  > .flux-schema--children > .flux-schema-tree {
     padding-left: $flux-tree-indent;
   }
 }

--- a/ui/src/style/components/time-machine/flux-explorer.scss
+++ b/ui/src/style/components/time-machine/flux-explorer.scss
@@ -27,6 +27,10 @@ $flux-tree-gutter: 11px;
   }
 }
 
+.flux-schema--children.hidden {
+  display: none;
+}
+
 .flux-schema-tree__empty {
   height: $flux-tree-indent;
   display: flex;


### PR DESCRIPTION
Every list item in the Flux schema explorer is either open or closed, and each list item can contain as children many other list items. Previously, closing a list item would close all of it's children. Reopening a child that had been closed because one of its ancestors had been closed would still trigger a meta-query request and subsequent loading state, even though that necessary data had been previously fetched.

This PR changes the schema explorer so that the open state of a child item is persisted even its ancestors are opened and closed. This is best explained in pictures:

Before:

![before](https://user-images.githubusercontent.com/638955/41180844-84f4669c-6b24-11e8-8de5-62a8bd5c58bc.gif)

After:

![after](https://user-images.githubusercontent.com/638955/41180851-8a485694-6b24-11e8-99d8-99a2a43e3b9e.gif)

These changes eliminate duplicate meta-query requests and result in a better UX.
