### PR TITLE
Ensure schema explorer copy button visible

### DIFF
--- a/ui/src/style/components/time-machine/flux-explorer.scss
+++ b/ui/src/style/components/time-machine/flux-explorer.scss
@@ -3,7 +3,7 @@
     ----------------------------------------------------------------------------
 */
 
-$flux-tree-min-width: 500px;
+$flux-tree-min-width: 250px;
 $flux-tree-indent: 26px;
 $flux-tree-line: 2px;
 $flux-tree-max-filter: 220px;


### PR DESCRIPTION
The “Copy” button in the Flux schema explorer was being hidden on small screens.

Before:

<img width="568" alt="screen shot 2018-06-08 at 3 31 17 pm" src="https://user-images.githubusercontent.com/638955/41183730-163ee22e-6b31-11e8-9f6c-fe59eef08766.png">

After:

<img width="531" alt="screen shot 2018-06-08 at 3 30 54 pm" src="https://user-images.githubusercontent.com/638955/41183738-1b05ea32-6b31-11e8-989b-a4bf5a7c6a37.png">

Closes #3610