### PR TITLE
Fix rendering of template variables within regexes

### DIFF
--- a/influx/templates_test.go
+++ b/influx/templates_test.go
@@ -297,6 +297,32 @@ func TestTemplateReplace(t *testing.T) {
 			},
 			want: `SHOW DATABASES`,
 		},
+		{
+			name:  "query with some tagValue template variables inside a regex",
+			query: `SELECT "usage_active" FROM "cpu" WHERE host =~ /:host:/ AND time > :dashboardTime: FILL(null)`,
+			vars: []chronograf.TemplateVar{
+				{
+					Var: ":host:",
+					Values: []chronograf.TemplateValue{
+						{
+							Value: "my-host.local",
+							Type:  "tagValue",
+						},
+					},
+				},
+				{
+					Var: ":dashboardTime:",
+					Values: []chronograf.TemplateValue{
+						{
+							Value:    "now() - 1h",
+							Type:     "constant",
+							Selected: true,
+						},
+					},
+				},
+			},
+			want: `SELECT "usage_active" FROM "cpu" WHERE host =~ /my-host.local/ AND time > now() - 1h FILL(null)`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Closes #3317.

### What was the problem?

Template variables used within an InfluxQL regular expression would be improperly quoted in certain cases. For example, the query:
```
SELECT "usage_active" FROM "telegraf"."autogen"."cpu" WHERE host =~ /:host:/ AND time > :dashboardTime: FILL(null)
```
would render as
```
SELECT "usage_active" FROM "telegraf"."autogen"."cpu" WHERE host =~ /'my-host.local'/ AND time > now() - 15m FILL(null)
```
but it should have rendered as
```
SELECT "usage_active" FROM "telegraf"."autogen"."cpu" WHERE host =~ /my-host.local/ AND time > now() - 15m FILL(null)
```

### What was the solution?

Only certain kinds of template variables may used in an InfluxQL regular expression, according to the docs [here](https://docs.influxdata.com/influxdb/v1.5/query_language/spec/#regular-expressions). For these types of template variables, we now render the templated query in two steps:

1. First render all usages of the template variable within InfluxQL regular expressions.
2. Then render all other usages as before.

Which usages of a template variable appear within a regular expression is determined by... a regular expression :)