### PR TITLE
Fix line graph + single stat dygraphs

### DIFF
--- a/ui/src/shared/components/Dygraph.tsx
+++ b/ui/src/shared/components/Dygraph.tsx
@@ -1,9 +1,9 @@
 import React, {
   Component,
-  ReactNode,
   CSSProperties,
   MouseEvent,
   ReactElement,
+  Children,
 } from 'react'
 import {connect} from 'react-redux'
 import _ from 'lodash'
@@ -70,7 +70,6 @@ interface Props {
   dygraphRef?: (r: HTMLDivElement) => void
   onZoom?: (u: number | string, l: number | string) => void
   mode?: string
-  children?: ReactNode
 }
 
 interface State {
@@ -308,7 +307,7 @@ class Dygraph extends Component<Props, State> {
   private get isGraphNested(): boolean {
     const {children} = this.props
 
-    return _.get(children, '0', false)
+    return Children.count(children) > 0
   }
 
   private get dygraphStyle(): CSSProperties {


### PR DESCRIPTION
Closes #3632 

- Typescript has built in support for a React component's `children` prop.
- The `children` prop is [“opaque”](https://reactjs.org/docs/react-api.html#reactchildren), meaning in the most general case it is best accessed via the `React.Children` helpers.