### PR TITLE
Remove redundant FieldName in favor of FieldOption interface

### DIFF
--- a/ui/src/dashboards/actions/cellEditorOverlay.ts
+++ b/ui/src/dashboards/actions/cellEditorOverlay.ts
@@ -1,7 +1,12 @@
 import {Cell} from 'src/types'
 import {CellType} from 'src/types/dashboard'
 import {ColorNumber, ColorString} from 'src/types/colors'
-import {Axes, DecimalPlaces, FieldName, TableOptions} from 'src/types/dashboard'
+import {
+  Axes,
+  DecimalPlaces,
+  FieldOption,
+  TableOptions,
+} from 'src/types/dashboard'
 
 interface ShowCellEditorOverlayAction {
   type: 'SHOW_CELL_EDITOR_OVERLAY'
@@ -172,11 +177,11 @@ export const changeDecimalPlaces = (
 interface UpdateFieldOptionsAction {
   type: 'UPDATE_FIELD_OPTIONS'
   payload: {
-    fieldOptions: FieldName[]
+    fieldOptions: FieldOption[]
   }
 }
 export const updateFieldOptions = (
-  fieldOptions: FieldName[]
+  fieldOptions: FieldOption[]
 ): UpdateFieldOptionsAction => ({
   type: 'UPDATE_FIELD_OPTIONS',
   payload: {

--- a/ui/src/dashboards/components/Visualization.tsx
+++ b/ui/src/dashboards/components/Visualization.tsx
@@ -13,7 +13,7 @@ import {TimeRange, QueryConfig, Axes, Template, Source} from 'src/types'
 import {
   TableOptions,
   DecimalPlaces,
-  FieldName,
+  FieldOption,
   CellType,
 } from 'src/types/dashboard'
 import {ColorString, ColorNumber} from 'src/types/colors'
@@ -29,7 +29,7 @@ interface Props {
   tableOptions: TableOptions
   timeFormat: string
   decimalPlaces: DecimalPlaces
-  fieldOptions: FieldName[]
+  fieldOptions: FieldOption[]
   resizerTopHeight: number
   thresholdsListColors: ColorNumber[]
   gaugeColors: ColorNumber[]

--- a/ui/src/types/dashboard.ts
+++ b/ui/src/types/dashboard.ts
@@ -18,15 +18,9 @@ export interface FieldOption {
   visible: boolean
 }
 
-export interface FieldName {
-  internalName: string
-  displayName: string
-  visible: boolean
-}
-
 export interface TableOptions {
   verticalTimeAxis: boolean
-  sortBy: FieldName
+  sortBy: FieldOption
   wrapping?: string
   fixFirstColumn: boolean
 }
@@ -76,7 +70,7 @@ export interface Cell {
   axes: Axes
   colors: ColorString[]
   tableOptions: TableOptions
-  fieldOptions: FieldName[]
+  fieldOptions: FieldOption[]
   timeFormat: string
   decimalPlaces: DecimalPlaces
   links: CellLinks


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
_What was the problem?_
There was a redundant interface defined. 
_What was the solution?_
Removed it.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)