### PR TITLE
fix(alert): alert creation detailed response

### DIFF
--- a/ui/src/kapacitor/components/KapacitorRule.js
+++ b/ui/src/kapacitor/components/KapacitorRule.js
@@ -52,10 +52,10 @@ class KapacitorRule extends Component {
     createRule(kapacitor, newRule)
       .then(() => {
         router.push(pathname || `/sources/${source.id}/alert-rules`)
-        notify(notifyAlertRuleCreated())
+        notify(notifyAlertRuleCreated(newRule.name))
       })
-      .catch(() => {
-        notify(notifyAlertRuleCreateFailed())
+      .catch(e => {
+        notify(notifyAlertRuleCreateFailed(newRule.name, e.data.message))
       })
   }
 

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -490,14 +490,14 @@ export const notifyViewerUnauthorizedToSetTempVars = () => ({
 
 //  Rule Builder Notifications
 //  ----------------------------------------------------------------------------
-export const notifyAlertRuleCreated = () => ({
+export const notifyAlertRuleCreated = ruleName => ({
   ...defaultSuccessNotification,
-  message: 'Alert Rule created successfully.',
+  message: `${ruleName} created successfully.`,
 })
 
-export const notifyAlertRuleCreateFailed = () => ({
+export const notifyAlertRuleCreateFailed = (ruleName, errorMessage) => ({
   ...defaultErrorNotification,
-  message: 'Alert Rule could not be created.',
+  message: `There was a problem creating ${ruleName}: ${errorMessage}`,
 })
 
 export const notifyAlertRuleUpdated = ruleName => ({


### PR DESCRIPTION

_What was the problem?_
Kapacitor Rule creation fails without clear message to the user ("_Alert could not be created_").   for example, create a rule with an invalid template (no dot), e.g. `{{TaskName}}`.       No way for the user to know what happened unless one looks at the dev-tools.
<img width="397" alt="screen shot 2018-06-13 at 10 44 36" src="https://user-images.githubusercontent.com/200688/41337077-dcccabf6-6ef6-11e8-9eee-0af6a59affc3.png">


_What was the solution?_
Proper response, like rule edit.
<img width="433" alt="screen shot 2018-06-13 at 10 29 54" src="https://user-images.githubusercontent.com/200688/41337022-b014e380-6ef6-11e8-9efc-dff56bcd9432.png">
<img width="380" alt="screen shot 2018-06-13 at 10 30 11" src="https://user-images.githubusercontent.com/200688/41337020-afe39dca-6ef6-11e8-92d2-a07c7306d563.png">



  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)