### PR TITLE
Truncate Alert Rule Message Preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1.  [#3474](https://github.com/influxdata/chronograf/pull/3474): Sort task table on Manage Alert page alphabetically
 1.  [#3590](https://github.com/influxdata/chronograf/pull/3590): Redesign icons in side navigation
+1.  [#3663](https://github.com/influxdata/chronograf/pull/3663): Truncate message preview in Alert Rules table
 
 ### Bug Fixes
 

--- a/ui/src/kapacitor/components/KapacitorRulesTable.tsx
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.tsx
@@ -102,7 +102,11 @@ export class RuleRow extends PureComponent<RuleRowProps> {
         <td style={{width: colTrigger, textTransform: 'capitalize'}}>
           {rule.trigger}
         </td>
-        <td style={{width: colMessage}}>{rule.message}</td>
+        <td style={{width: colMessage}}>
+          <span className="text-ellipsis" style={{maxWidth: colMessage}}>
+            {rule.message}
+          </span>
+        </td>
         <td style={{width: colAlerts}}>{parseAlertNodeList(rule)}</td>
         <td style={{width: colEnabled}} className="text-center">
           <div className="dark-checkbox">

--- a/ui/src/style/theme/_tables.scss
+++ b/ui/src/style/theme/_tables.scss
@@ -22,7 +22,6 @@ $table--highlight-color: $g4-onyx;
       font-family: $code-font;
       letter-spacing: 0;
     }
-
     &.text-left {
       text-align: left;
     }
@@ -31,6 +30,13 @@ $table--highlight-color: $g4-onyx;
     }
     &.text-right {
       text-align: right;
+    }
+    & > .text-ellipsis {
+      display: inline-block;
+      width: 100%;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
   }
 


### PR DESCRIPTION
Closes #3641 

_What was the problem?_
When an alerts have long message contents the index table becomes difficult to use

_What was the solution?_
Create a CSS helper class for truncating text in tables and implement on the alert rules table

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass


## Before
![screen shot 2018-06-13 at 2 38 36 pm](https://user-images.githubusercontent.com/2433762/41380121-df452864-6f18-11e8-822a-befacfe91d93.png)

## After
![screen shot 2018-06-13 at 2 48 48 pm](https://user-images.githubusercontent.com/2433762/41380132-e865ed52-6f18-11e8-9cd1-a1488f198876.png)
