### PR TITLE
Cancel FilterArgs response on unmount

### DIFF
--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -113,52 +113,6 @@ const tagsetFilter = (filter: SchemaFilter[]): string => {
   return `|> filter(fn: (r) => ${predicates.join(' and ')} )`
 }
 
-type CancelablePromiseResult<T> = T | CanceledPromiseError | Error
-
-interface WrappedCancelablePromise<T> {
-  promise: Promise<CancelablePromiseResult<T>>
-  cancel: () => void
-}
-
-class CanceledPromiseError extends Error {
-  constructor() {
-    super('Canceled Promise')
-  }
-}
-
-export const makeCancelable = <T>(
-  promise: Promise<T>
-): WrappedCancelablePromise<T> => {
-  let isCanceled = false
-
-  const wrappedPromise = new Promise<CancelablePromiseResult<T>>(
-    async (resolve, reject) => {
-      try {
-        const value = await promise
-
-        if (isCanceled) {
-          reject(new CanceledPromiseError())
-        } else {
-          resolve(value)
-        }
-      } catch (error) {
-        if (isCanceled) {
-          reject(new CanceledPromiseError())
-        } else {
-          reject(error)
-        }
-      }
-    }
-  )
-
-  return {
-    promise: wrappedPromise,
-    cancel() {
-      isCanceled = true
-    },
-  }
-}
-
 const proxy = async (service: Service, script: string) => {
   const and = encodeURIComponent('&')
   const mark = encodeURIComponent('?')

--- a/ui/src/types/promises.ts
+++ b/ui/src/types/promises.ts
@@ -1,0 +1,4 @@
+export interface WrappedCancelablePromise<T> {
+  promise: Promise<T>
+  cancel: () => void
+}

--- a/ui/src/utils/promises.ts
+++ b/ui/src/utils/promises.ts
@@ -1,0 +1,32 @@
+import {WrappedCancelablePromise} from 'src/types/promises'
+
+export const makeCancelable = <T>(
+  promise: Promise<T>
+): WrappedCancelablePromise<T> => {
+  let isCanceled = false
+
+  const wrappedPromise = new Promise<T>(async (resolve, reject) => {
+    try {
+      const value = await promise
+
+      if (isCanceled) {
+        reject({isCanceled})
+      } else {
+        resolve(value)
+      }
+    } catch (error) {
+      if (isCanceled) {
+        reject({isCanceled})
+      } else {
+        reject(error)
+      }
+    }
+  })
+
+  return {
+    promise: wrappedPromise,
+    cancel() {
+      isCanceled = true
+    },
+  }
+}


### PR DESCRIPTION
Closes #3638 

_What was the problem?_
A handler for an AJAX request made by the `FilterArgs` was creating errors in the console because it was attempting to update state on an unmounted component.

_What was the solution?_
Introduce a `makeCancelable` utility for promises and use this to wrap the AJAX request and reject the AJAX response promise when the component is unmounted.

  - [x] Rebased/mergeable
  - [x] Tests pass
