### PR TITLE
Snip Snip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1.  [#3474](https://github.com/influxdata/chronograf/pull/3474): Sort task table on Manage Alert page alphabetically
 1.  [#3590](https://github.com/influxdata/chronograf/pull/3590): Redesign icons in side navigation
+1.  [#3671](https://github.com/influxdata/chronograf/pull/3671): Remove Snip functionality in hover legend
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/DygraphLegend.tsx
+++ b/ui/src/shared/components/DygraphLegend.tsx
@@ -10,7 +10,7 @@ import * as actions from 'src/dashboards/actions'
 import {SeriesLegendData} from 'src/types/dygraphs'
 import DygraphLegendSort from 'src/shared/components/DygraphLegendSort'
 
-import {makeLegendStyles, removeMeasurement} from 'src/shared/graphs/helpers'
+import {makeLegendStyles} from 'src/shared/graphs/helpers'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {NO_CELL} from 'src/shared/constants'
 
@@ -38,7 +38,6 @@ interface State {
   sortType: string
   isAscending: boolean
   filterText: string
-  isSnipped: boolean
   isFilterVisible: boolean
   legendStyles: object
   pageX: number | null
@@ -67,7 +66,6 @@ class DygraphLegend extends PureComponent<Props, State> {
       sortType: 'numeric',
       isAscending: false,
       filterText: '',
-      isSnipped: false,
       isFilterVisible: false,
       legendStyles: {},
       pageX: null,
@@ -85,13 +83,7 @@ class DygraphLegend extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {
-      legend,
-      filterText,
-      isSnipped,
-      isAscending,
-      isFilterVisible,
-    } = this.state
+    const {legend, filterText, isAscending, isFilterVisible} = this.state
 
     return (
       <div
@@ -117,7 +109,7 @@ class DygraphLegend extends PureComponent<Props, State> {
             onSort={this.handleSortLegend('numeric')}
           />
           <button
-            className={classnames('btn btn-square btn-sm', {
+            className={classnames('btn btn-square btn-xs', {
               'btn-default': !isFilterVisible,
               'btn-primary': isFilterVisible,
             })}
@@ -125,19 +117,10 @@ class DygraphLegend extends PureComponent<Props, State> {
           >
             <span className="icon search" />
           </button>
-          <button
-            className={classnames('btn btn-sm', {
-              'btn-default': !isSnipped,
-              'btn-primary': isSnipped,
-            })}
-            onClick={this.handleSnipLabel}
-          >
-            Snip
-          </button>
         </div>
         {isFilterVisible && (
           <input
-            className="dygraph-legend--filter form-control input-sm"
+            className="dygraph-legend--filter form-control input-xs"
             type="text"
             value={filterText}
             onChange={this.handleLegendInputChange}
@@ -145,7 +128,6 @@ class DygraphLegend extends PureComponent<Props, State> {
             autoFocus={true}
           />
         )}
-        <div className="dygraph-legend--divider" />
         <div className="dygraph-legend--contents">
           {this.filtered.map(({label, color, yHTML, isHighlighted}) => {
             const seriesClass = isHighlighted
@@ -153,9 +135,7 @@ class DygraphLegend extends PureComponent<Props, State> {
               : 'dygraph-legend--row'
             return (
               <div key={uuid.v4()} className={seriesClass}>
-                <span style={{color}}>
-                  {isSnipped ? removeMeasurement(label) : label}
-                </span>
+                <span style={{color}}>{label}</span>
                 <figure>{yHTML || 'no value'}</figure>
               </div>
             )
@@ -175,10 +155,6 @@ class DygraphLegend extends PureComponent<Props, State> {
       isFilterVisible: !this.state.isFilterVisible,
       filterText: '',
     })
-  }
-
-  private handleSnipLabel = (): void => {
-    this.setState({isSnipped: !this.state.isSnipped})
   }
 
   private handleLegendInputChange = (

--- a/ui/src/shared/components/DygraphLegendSort.tsx
+++ b/ui/src/shared/components/DygraphLegendSort.tsx
@@ -14,7 +14,7 @@ class DygraphLegendSort extends PureComponent<Props> {
     const {isAscending, top, bottom, onSort, isActive} = this.props
     return (
       <div
-        className={classnames('sort-btn btn btn-sm btn-square', {
+        className={classnames('sort-btn btn btn-xs btn-square', {
           'btn-primary': isActive,
           'btn-default': !isActive,
           'sort-btn--asc': isAscending && isActive,
@@ -22,9 +22,10 @@ class DygraphLegendSort extends PureComponent<Props> {
         })}
         onClick={onSort}
       >
-        <div className="sort-btn--arrow" />
-        <div className="sort-btn--top">{top}</div>
-        <div className="sort-btn--bottom">{bottom}</div>
+        <div className="sort-btn--rotator">
+          <div className="sort-btn--top">{top}</div>
+          <div className="sort-btn--bottom">{bottom}</div>
+        </div>
       </div>
     )
   }

--- a/ui/src/style/components/dygraphs.scss
+++ b/ui/src/style/components/dygraphs.scss
@@ -168,10 +168,9 @@
   background-color: $g0-obsidian;
   display: block !important;
   position: absolute;
-  padding: 11px;
+  padding: 8px;
   z-index: $dygraph-legend-z;
   border-radius: 3px;
-  min-width: 350px;
   user-select: text;
   transform: translateX(-50%);
   @extend %drop-shadow;
@@ -224,23 +223,15 @@
 }
 .dygraph-legend--timestamp {
   margin-right: 8px;
-  height: 30px;
-  font-size: 13px;
+  font-size: 12px;
   white-space: nowrap;
-  line-height: 30px;
   font-weight: 600;
   color: $g13-mist;
-  flex: 1 0 0%;
+  flex: 1 0 0;
 }
 .dygraph-legend--filter {
-  flex: 1 0 0%;
+  flex: 1 0 0;
   margin-top: 8px;
-}
-.dygraph-legend--divider {
-  width: 100%;
-  margin: 8px 0;
-  height: 2px;
-  background-color: $g5-pepper;
 }
 .dygraph-legend--contents {
   font-size: 13px;
@@ -248,6 +239,7 @@
   font-weight: 600;
   line-height: 13px;
   max-height: 123px;
+  margin-top: 8px;
   overflow-y: auto;
   @include custom-scrollbar-round($g0-obsidian, $g3-castle);
 }
@@ -285,34 +277,15 @@
   }
 }
 
-/* Sorting Buttons */
+// Sorting Buttons
 .sort-btn {
   position: relative;
 }
-.sort-btn--arrow {
+.sort-btn--rotator {
+  width: 100%;
+  height: 100%;
   position: absolute;
-  top: 8px;
-  right: 8px;
-  height: calc(100% - 16px);
-  width: 2px;
-  background-color: $g20-white;
-  transform: rotate(0deg);
-  transition: transform 0.25s ease;
-
-  &:after {
-    content: '';
-    position: absolute;
-    top: -8px;
-    left: 50%;
-    transform: translateX(-50%) scaleX(0.7);
-    border-style: solid;
-    border-width: 6px;
-    border-color: transparent;
-    border-bottom-color: $g20-white;
-  }
-}
-.sort-btn--asc .sort-btn--arrow {
-  transform: rotate(180deg);
+  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 .sort-btn--top,
 .sort-btn--bottom {
@@ -320,11 +293,23 @@
   font-size: 10px;
   font-weight: 900;
   color: $g20-white;
-  left: 6px;
+  transition: transform 0.25s cubic-bezier(0.175, 0.885, 0.32, 1.275);
 }
 .sort-btn--top {
-  top: -5px;
+  left: 3px;
+  top: -3px;
 }
 .sort-btn--bottom {
-  bottom: -6px;
+  bottom: -4px;
+  left: 12px;
+}
+// Toggled State
+.sort-btn.sort-btn--desc {
+  .sort-btn--rotator {
+    transform: rotate(180deg);
+  }
+  .sort-btn--top,
+  .sort-btn--bottom {
+    transform: rotate(-180deg);
+  }
 }


### PR DESCRIPTION
![spinny-sort](https://user-images.githubusercontent.com/2433762/41387957-8b6deb92-6f3e-11e8-8f8c-b1c24426320b.gif)

Floating legend is very large and often gets in the way. I have reduced the size of the legend using a variety of approaches including removing the `Snip` button, removing `min-width`, shrinking the padding, shrinking the size of the sort buttons and filter, and reducing the font size of the time stamp.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass