### PR TITLE
Improve Flux Editor UX

### DIFF
--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -100,7 +100,7 @@ class ExpressionNode extends PureComponent<Props, State> {
                     onDelete={onDeleteFuncNode}
                     onToggleYield={onToggleYield}
                     isYieldable={isAfterFilter && isAfterRange}
-                    isYielding={this.isNextFuncYield(i)}
+                    isYielding={this.isBeforeFuncYield(i)}
                     declarationID={declarationID}
                     onGenerateScript={onGenerateScript}
                     declarationsFromBody={declarationsFromBody}
@@ -145,7 +145,7 @@ class ExpressionNode extends PureComponent<Props, State> {
                         onDelete={onDeleteFuncNode}
                         onToggleYield={this.handleHideImplicitYield}
                         isYieldable={isAfterFilter && isAfterRange}
-                        isYielding={this.isNextFuncYield(i)}
+                        isYielding={this.isBeforeFuncYield(i)}
                         declarationID={declarationID}
                         onGenerateScript={onGenerateScript}
                         declarationsFromBody={declarationsFromBody}
@@ -179,7 +179,7 @@ class ExpressionNode extends PureComponent<Props, State> {
     )
   }
 
-  private isNextFuncYield(funcIndex: number): boolean {
+  private isBeforeFuncYield(funcIndex: number): boolean {
     const {funcs, isLastBody} = this.props
     const {isImplicitYieldToggled} = this.state
 

--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -94,6 +94,7 @@ class ExpressionNode extends PureComponent<Props, State> {
                     key={i}
                     index={i}
                     func={func}
+                    funcs={funcs}
                     bodyID={bodyID}
                     service={service}
                     onChangeArg={onChangeArg}
@@ -139,6 +140,7 @@ class ExpressionNode extends PureComponent<Props, State> {
                         key={i}
                         index={i}
                         func={func}
+                        funcs={funcs}
                         bodyID={bodyID}
                         service={service}
                         onChangeArg={onChangeArg}

--- a/ui/src/flux/components/FuncArg.tsx
+++ b/ui/src/flux/components/FuncArg.tsx
@@ -1,4 +1,5 @@
 import React, {PureComponent} from 'react'
+import _ from 'lodash'
 
 import FuncArgInput from 'src/flux/components/FuncArgInput'
 import FuncArgTextArea from 'src/flux/components/FuncArgTextArea'
@@ -7,7 +8,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import FromDatabaseDropdown from 'src/flux/components/FromDatabaseDropdown'
 
 import {funcNames, argTypes} from 'src/flux/constants'
-import {OnChangeArg} from 'src/types/flux'
+import {OnChangeArg, Arg} from 'src/types/flux'
 import {Service} from 'src/types'
 
 interface Props {
@@ -15,6 +16,7 @@ interface Props {
   funcName: string
   funcID: string
   argKey: string
+  args: Arg[]
   value: string | boolean | {[x: string]: string}
   type: string
   bodyID: string
@@ -73,6 +75,7 @@ class FuncArg extends PureComponent<Props> {
             onChangeArg={onChangeArg}
             declarationID={declarationID}
             onGenerateScript={onGenerateScript}
+            autoFocus={this.isFirstArg}
           />
         )
       }
@@ -130,6 +133,14 @@ class FuncArg extends PureComponent<Props> {
 
   private get boolValue(): boolean {
     return this.props.value === true
+  }
+
+  private get isFirstArg(): boolean {
+    const {args, argKey} = this.props
+
+    const firstArg = _.first(args)
+
+    return firstArg.key === argKey
   }
 }
 

--- a/ui/src/flux/components/FuncArgInput.tsx
+++ b/ui/src/flux/components/FuncArgInput.tsx
@@ -11,12 +11,13 @@ interface Props {
   declarationID: string
   onChangeArg: OnChangeArg
   onGenerateScript: () => void
+  autoFocus?: boolean
 }
 
 @ErrorHandling
 class FuncArgInput extends PureComponent<Props> {
   public render() {
-    const {argKey, value, type} = this.props
+    const {argKey, value, type, autoFocus} = this.props
 
     return (
       <div className="func-arg">
@@ -34,6 +35,7 @@ class FuncArgInput extends PureComponent<Props> {
             className="form-control input-sm"
             spellCheck={false}
             autoComplete="off"
+            autoFocus={autoFocus}
           />
         </div>
       </div>

--- a/ui/src/flux/components/FuncArgs.tsx
+++ b/ui/src/flux/components/FuncArgs.tsx
@@ -16,7 +16,6 @@ interface Props {
   onChangeArg: OnChangeArg
   declarationID: string
   onGenerateScript: () => void
-  onDeleteFunc: (e: MouseEvent<HTMLElement>) => void
   declarationsFromBody: string[]
   onStopPropagation: (e: MouseEvent<HTMLElement>) => void
 }
@@ -24,20 +23,13 @@ interface Props {
 @ErrorHandling
 export default class FuncArgs extends PureComponent<Props> {
   public render() {
-    const {onDeleteFunc, onStopPropagation} = this.props
+    const {onStopPropagation} = this.props
 
     return (
-      <div className="func-node--tooltip" onClick={onStopPropagation}>
+      <div className="func-node--editor" onClick={onStopPropagation}>
+        <div className="func-node--connector" />
         <div className="func-args">{this.renderArguments}</div>
-        <div className="func-arg--buttons">
-          <div
-            className="btn btn-sm btn-danger btn-square"
-            onClick={onDeleteFunc}
-          >
-            <span className="icon trash" />
-          </div>
-          {this.build}
-        </div>
+        <div className="func-arg--buttons">{this.build}</div>
       </div>
     )
   }

--- a/ui/src/flux/components/FuncArgs.tsx
+++ b/ui/src/flux/components/FuncArgs.tsx
@@ -59,11 +59,12 @@ export default class FuncArgs extends PureComponent<Props> {
       onGenerateScript,
     } = this.props
 
-    const {name: funcName, id: funcID} = func
+    const {name: funcName, id: funcID, args} = func
 
-    return func.args.map(({key, value, type}) => (
+    return args.map(({key, value, type}) => (
       <FuncArg
         key={key}
+        args={args}
         type={type}
         argKey={key}
         value={value}

--- a/ui/src/style/components/time-machine/flux-builder.scss
+++ b/ui/src/style/components/time-machine/flux-builder.scss
@@ -248,35 +248,47 @@ $flux-invalid-hover: $c-dreamsicle;
   }
 }
 
-.func-node--tooltip {
+.func-node--menu {
+  display: flex;
+  align-items: center;
+  position: absolute;
+  top: 50%;
+  right: 0;
+  transform: translate(100%, -50%);
+  opacity: 0;
+  transition: opacity 0.25s ease;
+
+  > button.btn {
+    margin-left: 4px;
+  }
+}
+
+.func-node:hover .func-node--menu,
+.func-node.editing .func-node--menu,
+.func-node.active .func-node--menu {
+  opacity: 1;
+}
+
+.func-node--editor {
+  position: relative;
+  margin-left: $flux-node-gap;
+  margin-bottom: $flux-node-gap;
+  margin-top: $flux-node-tooltip-gap / 2;
   background-color: $g3-castle;
   border-radius: $radius;
-  padding: 10px;
+  padding: 6px;
   display: flex;
   align-items: stretch;
-  position: absolute;
-  top: 0;
-  left: calc(100% + #{$flux-node-tooltip-gap});
-  z-index: 9999;
-  box-shadow: 0 0 10px 2px $g2-kevlar; // Caret
+}
+
+.func-node--editor .func-node--connector {
+   // Vertical Line
   &:before {
-    content: '';
-    border-width: 9px;
-    border-style: solid;
-    border-color: transparent;
-    border-right-color: $g3-castle;
-    position: absolute;
-    top: $flux-node-height / 2;
-    left: 0;
-    transform: translate(-100%, -50%);
-  } // Invisible block to continue hovering
+    height: calc(100% + #{($flux-node-tooltip-gap / 2) + $flux-node-gap});
+  }
+   // Horizontal Line
   &:after {
-    content: '';
-    height: 50%;
-    width: $flux-node-tooltip-gap * 3;
-    position: absolute;
-    top: 0;
-    left: -$flux-node-tooltip-gap * 3;
+    content: none;
   }
 }
 
@@ -284,7 +296,6 @@ $flux-invalid-hover: $c-dreamsicle;
   display: flex;
   flex-direction: column;
   justify-content: center;
-  margin-left: 8px;
 }
 
 .func-node--build {
@@ -313,7 +324,7 @@ $flux-invalid-hover: $c-dreamsicle;
   font-size: 13px;
   font-weight: 600;
   color: $g10-wolf;
-  padding-right: 8px;
+  padding: 0 8px;
   @include no-user-select();
 }
 

--- a/ui/test/flux/components/FuncArg.test.tsx
+++ b/ui/test/flux/components/FuncArg.test.tsx
@@ -10,6 +10,7 @@ const setup = () => {
     funcName: '',
     declarationID: '',
     argKey: '',
+    args: [],
     value: '',
     type: '',
     service,


### PR DESCRIPTION
Closes #3679 
Closes #3675 
Closes #3674 

_Briefly describe your proposed changes:_
Hovering over a function node no longer triggers a tooltip, and instead reveals two buttons to the right of the node: `Toggle Yield` and `Delete`. Clicking the function node now toggles edit mode, which appears below the function. When a new function is created it is in edit mode by default (for discoverability purposes)

![new-func-edit](https://user-images.githubusercontent.com/2433762/41441799-0cf30b20-6fe9-11e8-998a-5f996adcd990.gif)

![flux-ux-improvements](https://user-images.githubusercontent.com/2433762/41441724-b2c63122-6fe8-11e8-905b-687a1a7c4dea.gif)


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass