### PR TITLE
feat(influx/annotations): add type parameter to search for annonations

### DIFF
--- a/chronograf.go
+++ b/chronograf.go
@@ -518,11 +518,11 @@ type Annotation struct {
 
 // AnnotationStore represents storage and retrieval of annotations
 type AnnotationStore interface {
-	All(ctx context.Context, start, stop time.Time) ([]Annotation, error) // All lists all Annotations between start and stop
-	Add(context.Context, *Annotation) (*Annotation, error)                // Add creates a new annotation in the store
-	Delete(ctx context.Context, id string) error                          // Delete removes the annotation from the store
-	Get(ctx context.Context, id string) (*Annotation, error)              // Get retrieves an annotation
-	Update(context.Context, *Annotation) error                            // Update replaces annotation
+	All(ctx context.Context, annotationType string, start, stop time.Time) ([]Annotation, error) // All lists all Annotations between start and stop with an optional type.
+	Add(context.Context, *Annotation) (*Annotation, error)                                       // Add creates a new annotation in the store
+	Delete(ctx context.Context, id string) error                                                 // Delete removes the annotation from the store
+	Get(ctx context.Context, id string) (*Annotation, error)                                     // Get retrieves an annotation
+	Update(context.Context, *Annotation) error                                                   // Update replaces annotation
 }
 
 // DashboardID is the dashboard ID

--- a/influx/annotations.go
+++ b/influx/annotations.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// AllAnnotations returns all annotations from the chronograf database
-	AllAnnotations = `SELECT "start_time", "modified_time_ns", "text", "type", "id" FROM "annotations" WHERE "deleted"=false AND time >= %dns and "start_time" <= %d ORDER BY time DESC`
+	AllAnnotations = `SELECT "start_time", "modified_time_ns", "text", "type", "id" FROM "annotations" WHERE "type"='%s' AND deleted"=false AND time >= %dns and "start_time" <= %d ORDER BY time DESC`
 	// GetAnnotationID returns all annotations from the chronograf database where id is %s
 	GetAnnotationID = `SELECT "start_time", "modified_time_ns", "text", "type", "id" FROM "annotations" WHERE "id"='%s' AND "deleted"=false ORDER BY time DESC`
 	// AnnotationsDB is chronograf.  Perhaps later we allow this to be changed
@@ -45,8 +45,8 @@ func NewAnnotationStore(client chronograf.TimeSeries) *AnnotationStore {
 }
 
 // All lists all Annotations
-func (a *AnnotationStore) All(ctx context.Context, start, stop time.Time) ([]chronograf.Annotation, error) {
-	return a.queryAnnotations(ctx, fmt.Sprintf(AllAnnotations, start.UnixNano(), stop.UnixNano()))
+func (a *AnnotationStore) All(ctx context.Context, annotationType string, start, stop time.Time) ([]chronograf.Annotation, error) {
+	return a.queryAnnotations(ctx, fmt.Sprintf(AllAnnotations, annotationType, start.UnixNano(), stop.UnixNano()))
 }
 
 // Get retrieves an annotation

--- a/influx/templates.go
+++ b/influx/templates.go
@@ -98,6 +98,7 @@ func RenderTemplate(query string, t chronograf.TemplateVar, now time.Time) (stri
 	return query, nil
 }
 
+// AutoInterval uses the number of points and duration to define the group by time.
 func AutoInterval(points int64, duration time.Duration) string {
 	// The function is: ((total_seconds * millisecond_converstion) / group_by) = pixels / 3
 	// Number of points given the pixels


### PR DESCRIPTION
Closes #3650 

_Briefly describe your proposed changes:_

/chronograf/v1/annotations takes an optional `type` parameter.  This parameter
can be used to filter through all annotations for a certain type.

_What was the problem?_
Annotations need scoping.  

_What was the solution?_

The type parameter provides scoping for annotations. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)