### PR TITLE
Fix allowing hyphens in basepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1.  [#3527](https://github.com/influxdata/chronograf/pull/3527): Ensure cell queries use constraints from TimeSelector
 1.  [#3573](https://github.com/influxdata/chronograf/pull/3573): Fix Gauge color selection bug
 1.  [#3649](https://github.com/influxdata/chronograf/pull/3649): Fix erroneous icons in Date Picker widget
+1.  [#3697](https://github.com/influxdata/chronograf/pull/3697): Fix allowing hyphens in basepath
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/server/server.go
+++ b/server/server.go
@@ -540,6 +540,6 @@ func clientUsage(values client.Values) *client.Usage {
 }
 
 func validBasepath(basepath string) bool {
-	re := regexp.MustCompile(`(\/{1}\w+)+`)
+	re := regexp.MustCompile(`(\/{1}[\w-]+)+`)
 	return re.ReplaceAllLiteralString(basepath, "") == ""
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,6 +44,13 @@ func Test_validBasepath(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "Basepath can include numbers, hyphens, and underscores",
+			args: args{
+				basepath: "/3shishka-bob/-rus4s_rus-1_s-",
+			},
+			want: true,
+		},
+		{
 			name: "Basepath is not empty and invalid - no slashes",
 			args: args{
 				basepath: "russ",


### PR DESCRIPTION
Closes #3687

_What was the problem?_
A user reported that removing `-` as a valid char in basepath broke their basepath configuration. This PR is a stopgap until we implement all valid URL paths, which is in flight. I've opened up https://github.com/influxdata/chronograf/issues/3699 for the full fix.

_What was the solution?_
Update the basepath validator regex to include hyphens, and test for numbers, hyphens, and underscores.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass