### PR TITLE
Fix: Close main template body only once

### DIFF
--- a/ui/src/index.template.html
+++ b/ui/src/index.template.html
@@ -10,6 +10,4 @@
   <div id='react-root' data-basepath=""></div>
 </body>
 
-</body>
-
 </html>


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

_Briefly describe your proposed changes:_
_What was the problem?_
The body template was closed twice
_What was the solution?_
Close the body template only once

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] Rebased/mergeable
  - [X] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)