### PR TITLE
Fix template variables missing query bug

### DIFF
--- a/ui/src/tempVars/constants/index.ts
+++ b/ui/src/tempVars/constants/index.ts
@@ -97,6 +97,7 @@ export const DEFAULT_TEMPLATES: DefaultTemplates = {
       values: [],
       type: TemplateType.CSV,
       label: '',
+      query: {},
     }
   },
   [TemplateType.TagKeys]: () => {


### PR DESCRIPTION
_What was the problem?_

The default template for a CSV template was missing a `query` property (since it's not relevant to a CSV template variable). This caused the following error when attempting to rehydrate a CSV template variable:

```
TypeError: Cannot read property 'influxql' of undefined
    at eval (index.ts:722)
    at Array.filter (<anonymous>)
    at _callee13$ (index.ts:720)
    at tryCatch (runtime.js:62)
    at Generator.invoke [as _invoke] (runtime.js:296)
    at Generator.prototype.(:8080/sources/1/dashboards/anonymous function) [as next] (webpack-internal:///./node_modules/babel-runtime/node_modules/regenerator-runtime/runtime.js:114:21)
    at eval (tslib.es6.js:85)
    at new Promise (<anonymous>)
    at Module.__awaiter (tslib.es6.js:81)
    at eval (index.ts:710)
_callee13$ @ index.ts:754
```

_What was the solution?_

Add an empty `query` property to the default CSV template. 
