### PR TITLE
Fix type error when temp vars have no values

### DIFF
--- a/ui/src/dashboards/utils/tempVars.ts
+++ b/ui/src/dashboards/utils/tempVars.ts
@@ -32,7 +32,7 @@ export const generateURLQueryParamsFromTempVars = (
     const selected = values.find(value => value.selected === true)
     const strippedTempVar = stripTempVar(tempVar)
 
-    urlQueryParams[strippedTempVar] = selected.value
+    urlQueryParams[strippedTempVar] = _.get(selected, 'value', '')
   })
 
   return urlQueryParams


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_ 
Function assume template variables had a value. Now uses a getter to take into account of when it does not.

  - [x] Rebased/mergeable
  - [x] Tests pass