### PR TITLE
Fix unable to toggle yields

### DIFF
--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -38,6 +38,17 @@ class ExpressionNode extends PureComponent<Props, State> {
     }
   }
 
+  public componentDidUpdate(prevProps) {
+    const {funcs: prevFuncs} = prevProps
+    const {funcs} = this.props
+
+    if (!_.isEqual(prevFuncs, funcs)) {
+      this.setState({
+        nonYieldableIndexesToggled: this.nonYieldableNodesFromScript,
+      })
+    }
+  }
+
   public render() {
     const {
       declarationID,
@@ -121,6 +132,10 @@ class ExpressionNode extends PureComponent<Props, State> {
                     i,
                     false
                   )
+
+                  if (this.isBeforeFuncYield(i)) {
+                    return funcNode
+                  }
 
                   return (
                     <Fragment key={`${i}-notInScript`}>

--- a/ui/src/flux/components/FuncArg.tsx
+++ b/ui/src/flux/components/FuncArg.tsx
@@ -8,7 +8,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import FromDatabaseDropdown from 'src/flux/components/FromDatabaseDropdown'
 
 import {funcNames, argTypes} from 'src/flux/constants'
-import {OnChangeArg, Arg} from 'src/types/flux'
+import {OnChangeArg, Arg, OnGenerateScript} from 'src/types/flux'
 import {Service} from 'src/types'
 
 interface Props {
@@ -22,7 +22,7 @@ interface Props {
   bodyID: string
   declarationID: string
   onChangeArg: OnChangeArg
-  onGenerateScript: () => void
+  onGenerateScript: OnGenerateScript
 }
 
 @ErrorHandling

--- a/ui/src/flux/components/FuncArgInput.tsx
+++ b/ui/src/flux/components/FuncArgInput.tsx
@@ -1,6 +1,6 @@
 import React, {PureComponent, ChangeEvent, KeyboardEvent} from 'react'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {OnChangeArg} from 'src/types/flux'
+import {OnChangeArg, OnGenerateScript} from 'src/types/flux'
 
 interface Props {
   funcID: string
@@ -10,7 +10,7 @@ interface Props {
   bodyID: string
   declarationID: string
   onChangeArg: OnChangeArg
-  onGenerateScript: () => void
+  onGenerateScript: OnGenerateScript
   autoFocus?: boolean
 }
 

--- a/ui/src/flux/components/FuncArgs.tsx
+++ b/ui/src/flux/components/FuncArgs.tsx
@@ -2,7 +2,7 @@ import React, {PureComponent, ReactElement, MouseEvent} from 'react'
 import FuncArg from 'src/flux/components/FuncArg'
 import {OnChangeArg} from 'src/types/flux'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Func} from 'src/types/flux'
+import {Func, OnGenerateScript} from 'src/types/flux'
 import {funcNames} from 'src/flux/constants'
 import JoinArgs from 'src/flux/components/JoinArgs'
 import FilterArgs from 'src/flux/components/FilterArgs'
@@ -15,7 +15,7 @@ interface Props {
   bodyID: string
   onChangeArg: OnChangeArg
   declarationID: string
-  onGenerateScript: () => void
+  onGenerateScript: OnGenerateScript
   declarationsFromBody: string[]
   onStopPropagation: (e: MouseEvent<HTMLElement>) => void
 }

--- a/ui/src/flux/components/FuncNode.tsx
+++ b/ui/src/flux/components/FuncNode.tsx
@@ -6,6 +6,7 @@ import BodyDelete from 'src/flux/components/BodyDelete'
 import FuncArgs from 'src/flux/components/FuncArgs'
 import FuncArgsPreview from 'src/flux/components/FuncArgsPreview'
 import {
+  OnGenerateScript,
   OnDeleteFuncNode,
   OnChangeArg,
   OnToggleYield,
@@ -24,7 +25,7 @@ interface Props {
   onDelete: OnDeleteFuncNode
   onToggleYield: OnToggleYield
   onChangeArg: OnChangeArg
-  onGenerateScript: () => void
+  onGenerateScript: OnGenerateScript
   onToggleYieldWithLast: (funcNodeIndex: number) => void
   declarationsFromBody: string[]
   isYielding: boolean
@@ -184,10 +185,11 @@ export default class FuncNode extends PureComponent<Props, State> {
       bodyID,
       declarationID,
       onToggleYieldWithLast,
+      isYieldable,
       isYieldedInScript,
     } = this.props
 
-    if (isYieldedInScript) {
+    if (isYieldedInScript || isYieldable) {
       onToggleYield(bodyID, declarationID, index)
     } else {
       onToggleYieldWithLast(index)

--- a/ui/src/flux/components/FuncNode.tsx
+++ b/ui/src/flux/components/FuncNode.tsx
@@ -30,6 +30,7 @@ interface Props {
   isYielding: boolean
   isYieldable: boolean
   onDeleteBody: (bodyID: string) => void
+  isYieldedInScript: boolean
 }
 
 interface State {
@@ -182,19 +183,14 @@ export default class FuncNode extends PureComponent<Props, State> {
       index,
       bodyID,
       declarationID,
-      isYieldable,
       onToggleYieldWithLast,
-      isYielding,
+      isYieldedInScript,
     } = this.props
 
-    if (isYieldable) {
+    if (isYieldedInScript) {
       onToggleYield(bodyID, declarationID, index)
     } else {
-      if (isYielding) {
-        onToggleYield(bodyID, declarationID, index)
-      } else {
-        onToggleYieldWithLast(index)
-      }
+      onToggleYieldWithLast(index)
     }
   }
 

--- a/ui/src/flux/components/FuncNode.tsx
+++ b/ui/src/flux/components/FuncNode.tsx
@@ -184,12 +184,17 @@ export default class FuncNode extends PureComponent<Props, State> {
       declarationID,
       isYieldable,
       onToggleYieldWithLast,
+      isYielding,
     } = this.props
 
     if (isYieldable) {
       onToggleYield(bodyID, declarationID, index)
     } else {
-      onToggleYieldWithLast(index)
+      if (isYielding) {
+        onToggleYield(bodyID, declarationID, index)
+      } else {
+        onToggleYieldWithLast(index)
+      }
     }
   }
 

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -344,7 +344,7 @@ export class FluxPage extends PureComponent<Props, State> {
     declarationID: string,
     funcNodeIndex: number,
     isYieldable: boolean
-  ) => {
+  ): string => {
     const {body: bodies} = this.state
 
     const bodyIndex = bodies.findIndex(b => b.id === bodyID)

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -5,7 +5,7 @@ import uuid from 'uuid'
 import {FluxTable} from 'src/types'
 
 export const parseResponseError = (response: string): FluxTable[] => {
-  const {data} = Papa.parse(response.trim())
+  const data = Papa.parse(response.trim()).data as string[][]
 
   return [
     {

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -4,6 +4,19 @@ import uuid from 'uuid'
 
 import {FluxTable} from 'src/types'
 
+export const parseResponseError = (response: string): FluxTable[] => {
+  const {data} = Papa.parse(response.trim())
+
+  return [
+    {
+      id: uuid.v4(),
+      name: 'Error',
+      partitionKey: {},
+      data,
+    },
+  ]
+}
+
 export const parseResponse = (response: string): FluxTable[] => {
   const trimmedReponse = response.trim()
 

--- a/ui/src/types/flux.ts
+++ b/ui/src/types/flux.ts
@@ -12,7 +12,7 @@ export type OnToggleYield = (
   declarationID: string,
   funcNodeIndex: number
 ) => void
-export type OnGenerateScript = (script: string) => void
+export type OnGenerateScript = () => void
 export type OnChangeScript = (script: string) => void
 export type OnSubmitScript = () => void
 export type ScriptUpToYield = (


### PR DESCRIPTION
Closes #3681

_Briefly describe your proposed changes:_
_What was the problem?_
Toggling a yield func before filter and range funcs require a `last()` before the yield to avoid crashing the browser. The implicit yield functionality was conflicting with toggling a yield with last() before it.
It was not previously handling yields manually entered in the script  before a filter and range.

_What was the solution?_
No longer showing implicit yields
Checking the next index func in script to see if it's a yield before rendering to avoid duplicate yields.

  - [x] Rebased/mergeable
  - [x] Tests pass
