### PR TITLE
Improve save button copy in TemplateVariableEditor

### DIFF
--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -100,7 +100,9 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
     return (
       <div className="edit-temp-var">
         <div className="edit-temp-var--header">
-          <h1 className="page-header__title">Edit Template Variable</h1>
+          <h1 className="page-header__title">
+            {isNew ? 'Create' : 'Edit'} Template Variable
+          </h1>
           <div className="edit-temp-var--header-controls">
             <button
               className="btn btn-default"
@@ -115,7 +117,7 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
               onClick={this.handleSave}
               disabled={!this.canSave}
             >
-              {this.isSaving ? 'Saving...' : 'Save'}
+              {this.saveButtonText}
             </button>
           </div>
         </div>
@@ -275,6 +277,24 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
       '0.text',
       ''
     )
+  }
+
+  private get saveButtonText(): string {
+    const {isNew} = this.state
+
+    if (this.isSaving && isNew) {
+      return 'Creating...'
+    }
+
+    if (this.isSaving && !isNew) {
+      return 'Saving...'
+    }
+
+    if (!this.isSaving && isNew) {
+      return 'Create'
+    }
+
+    return 'Save'
   }
 
   private handleDelete = (): void => {


### PR DESCRIPTION
Displays different copy in the template variable editor depending on whether a user is creating a new template variable, or editing an existing one.

![screen shot 2018-06-19 at 1 23 06 pm](https://user-images.githubusercontent.com/638955/41629691-c45aeaea-73df-11e8-9f02-d2a02f3d4f14.png)
![screen shot 2018-06-19 at 1 23 14 pm](https://user-images.githubusercontent.com/638955/41629692-c5ab8968-73df-11e8-9377-8c4398c92616.png)
