### PR TITLE
Delete func node and yield in builder

### DIFF
--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -75,12 +75,11 @@ class ExpressionNode extends PureComponent<Props, State> {
                 if (func.name === 'filter') {
                   isAfterFilter = true
                 }
-
                 const isYieldable = isAfterFilter && isAfterRange
 
                 const funcNode = (
                   <FuncNode
-                    key={i}
+                    key={func.id}
                     index={i}
                     func={func}
                     funcs={funcs}

--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -79,7 +79,7 @@ class ExpressionNode extends PureComponent<Props, State> {
 
                 const funcNode = (
                   <FuncNode
-                    key={func.id}
+                    key={i}
                     index={i}
                     func={func}
                     funcs={funcs}

--- a/ui/src/flux/components/FuncNode.tsx
+++ b/ui/src/flux/components/FuncNode.tsx
@@ -14,6 +14,7 @@ import {
 } from 'src/types/flux'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Service} from 'src/types'
+import {getDeep} from 'src/utils/wrappers'
 
 interface Props {
   func: Func
@@ -166,9 +167,31 @@ export default class FuncNode extends PureComponent<Props, State> {
   }
 
   private handleDelete = (): void => {
-    const {func, bodyID, declarationID} = this.props
+    const {
+      func,
+      funcs,
+      index,
+      bodyID,
+      declarationID,
+      isYielding,
+      isYieldedInScript,
+      onToggleYieldWithLast,
+    } = this.props
 
-    this.props.onDelete({funcID: func.id, bodyID, declarationID})
+    let yieldFuncNodeID: string
+
+    if (isYieldedInScript) {
+      yieldFuncNodeID = getDeep<string>(funcs, `${index + 1}.id`, '')
+    } else if (isYielding) {
+      onToggleYieldWithLast(index)
+    }
+
+    this.props.onDelete({
+      funcID: func.id,
+      yieldNodeID: yieldFuncNodeID,
+      bodyID,
+      declarationID,
+    })
   }
 
   private handleToggleEdit = (e: MouseEvent<HTMLElement>): void => {

--- a/ui/src/flux/components/FuncNode.tsx
+++ b/ui/src/flux/components/FuncNode.tsx
@@ -2,6 +2,7 @@ import React, {PureComponent, MouseEvent} from 'react'
 import classnames from 'classnames'
 import _ from 'lodash'
 
+import {getDeep} from 'src/utils/wrappers'
 import BodyDelete from 'src/flux/components/BodyDelete'
 import FuncArgs from 'src/flux/components/FuncArgs'
 import FuncArgsPreview from 'src/flux/components/FuncArgsPreview'
@@ -13,8 +14,8 @@ import {
   Func,
 } from 'src/types/flux'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+
 import {Service} from 'src/types'
-import {getDeep} from 'src/utils/wrappers'
 
 interface Props {
   func: Func

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -549,7 +549,9 @@ export class FluxPage extends PureComponent<Props, State> {
           return `${declaration.name} = ${this.formatLastSource(s, isLast)}`
         }
 
-        const funcs = body.funcs.filter(f => f.id !== funcID)
+        const funcs = body.funcs.filter(
+          f => f.id !== funcID && f.id !== yieldNodeID
+        )
         const source = this.funcsToSource(funcs)
         return this.formatLastSource(source, isLast)
       })

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -522,7 +522,7 @@ export class FluxPage extends PureComponent<Props, State> {
   }
 
   private handleDeleteFuncNode = (ids: DeleteFuncNodeArgs): void => {
-    const {funcID, declarationID = '', bodyID} = ids
+    const {funcID, declarationID = '', bodyID, yieldNodeID = ''} = ids
 
     const script = this.state.body
       .map((body, bodyIndex) => {
@@ -541,7 +541,10 @@ export class FluxPage extends PureComponent<Props, State> {
             return
           }
 
-          const functions = declaration.funcs.filter(f => f.id !== funcID)
+          const functions = declaration.funcs.filter(
+            f => f.id !== funcID && f.id !== yieldNodeID
+          )
+
           const s = this.funcsToSource(functions)
           return `${declaration.name} = ${this.formatLastSource(s, isLast)}`
         }

--- a/ui/src/types/flux.ts
+++ b/ui/src/types/flux.ts
@@ -45,6 +45,7 @@ export interface DeleteFuncNodeArgs {
   funcID: string
   bodyID: string
   declarationID?: string
+  yieldNodeID?: string
 }
 
 export interface InputArg {


### PR DESCRIPTION
Closes #3665

_What was the problem?_
When a func node was deleted it would not remove the yield node. This could cause a yield to run on part of a script unexpectedly and could be slow if it didn't follow a filter and range.
_What was the solution?_
Deleting a func node removes an associated yield node from the script or toggles the index of a yield with last in the expression node state. 

  - [x] Rebased/mergeable
  - [x] Tests pass