### PR TITLE
Fix expressions to display yield name in script

### DIFF
--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -110,12 +110,18 @@ class ExpressionNode extends PureComponent<Props, State> {
                     isYieldable
                   )
 
+                  let yieldFunc = func
+
+                  if (this.isYieldNodeIndex(i + 1)) {
+                    yieldFunc = funcs[i + 1]
+                  }
+
                   return (
                     <Fragment key={`${i}-notInScript`}>
                       {funcNode}
                       <YieldFuncNode
                         index={i}
-                        func={func}
+                        func={yieldFunc}
                         data={data}
                         script={script}
                         bodyID={bodyID}


### PR DESCRIPTION
_What was the problem?_
A change in [`ExpressionNode`](https://github.com/influxdata/chronograf/pull/3730/files#diff-0e4c943c072bd44f822dee6e638560c6) rendering in 3730 did not include the yield node from the script when present and yielded results were not displaying their name from the script.

_What was the solution?_
Check for yield node in script and render `YieldFuncNode` with this func so it can derive the correct `yieldName`.

  - [x] Rebased/mergeable
  - [x] Tests pass