### PR TITLE
Render data when yield node receives new script

### DIFF
--- a/ui/src/flux/components/YieldFuncNode.tsx
+++ b/ui/src/flux/components/YieldFuncNode.tsx
@@ -37,11 +37,8 @@ class YieldFuncNode extends PureComponent<Props, State> {
     this.getData()
   }
 
-  public componentDidUpdate(prevProps) {
-    const {script: prevScript} = prevProps
-    const {script: currentScript} = this.props
-
-    if (prevScript !== currentScript) {
+  public componentDidUpdate(prevProps: Props) {
+    if (prevProps.script !== this.props.script) {
       this.getData()
     }
   }

--- a/ui/src/flux/components/YieldFuncNode.tsx
+++ b/ui/src/flux/components/YieldFuncNode.tsx
@@ -37,6 +37,15 @@ class YieldFuncNode extends PureComponent<Props, State> {
     this.getData()
   }
 
+  public componentDidUpdate(prevProps) {
+    const {script: prevScript} = prevProps
+    const {script: currentScript} = this.props
+
+    if (prevScript !== currentScript) {
+      this.getData()
+    }
+  }
+
   public render() {
     const {func} = this.props
     const {data} = this.state


### PR DESCRIPTION
Rendered yield data only currently happens on component mount and this
update checks for a script update to fetch yield results.

_What was the problem?_
Yield nodes were receiving new script props but data was not getting rendered. Scripts would change and users would have to toggle yields to see new results.
_What was the solution?_
Check when the script prop did update, fetch the script results, and update yield node state to see the results.

  - [x] Rebased/mergeable
  - [x] Tests pass