### PR TITLE
Fix display of TemplateVariableEditor header

### DIFF
--- a/ui/src/style/components/edit-template-variable.scss
+++ b/ui/src/style/components/edit-template-variable.scss
@@ -13,6 +13,13 @@ $padding: 20px 30px;
   justify-content: space-between;
 }
 
+.edit-temp-var--header > h1 {
+  color: #eeeff2;
+  letter-spacing: 0;
+  font-size: 19px;
+  font-weight: 400;
+}
+
 .edit-temp-var--header-controls > button {
   display: inline-block;
   margin: 0 5px;

--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -102,9 +102,7 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
     return (
       <div className="edit-temp-var">
         <div className="edit-temp-var--header">
-          <h1 className="page-header__title">
-            {isNew ? 'Create' : 'Edit'} Template Variable
-          </h1>
+          <h1>{isNew ? 'Create' : 'Edit'} Template Variable</h1>
           <div className="edit-temp-var--header-controls">
             <button
               className="btn btn-default"


### PR DESCRIPTION
Before:

<img width="650" alt="screen shot 2018-06-21 at 11 33 52 am" src="https://user-images.githubusercontent.com/638955/41738709-a8fd062a-7547-11e8-81e8-40c4346cbbe4.png">

Move... that... bus! After:

<img width="649" alt="screen shot 2018-06-21 at 11 36 42 am" src="https://user-images.githubusercontent.com/638955/41738718-ac47a650-7547-11e8-9ef6-1c59872e074c.png">
