### PR TITLE
Ensure hoverTime is a valid time range for the dygraph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 1.  [#3697](https://github.com/influxdata/chronograf/pull/3697): Fix allowing hyphens in basepath
 1.  [#3698](https://github.com/influxdata/chronograf/pull/3698): Fix error in cell when tempVar returns no values
 1.  [#3733](https://github.com/influxdata/chronograf/pull/3733): Change arrows in table columns so that ascending sort points up and descending points down
+1.  [#3751](https://github.com/influxdata/chronograf/pull/3751): Fix crosshairs moving passed the edges of graphs
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/ui/src/shared/components/Crosshair.tsx
+++ b/ui/src/shared/components/Crosshair.tsx
@@ -34,9 +34,17 @@ class Crosshair extends PureComponent<Props> {
   }
 
   private get isVisible() {
-    const {hoverTime} = this.props
+    const {dygraph, hoverTime} = this.props
+    const timeRanges = dygraph.xAxisRange()
 
-    return hoverTime !== 0 && _.isFinite(hoverTime)
+    const minTimeRange = timeRanges[0]
+    const isBeforeMinTimeRange = hoverTime < minTimeRange
+
+    const maxTimeRange = timeRanges[1]
+    const isPastMaxTimeRange = hoverTime > maxTimeRange
+
+    const isValidHoverTime = !isBeforeMinTimeRange && !isPastMaxTimeRange
+    return hoverTime !== 0 && _.isFinite(hoverTime) && isValidHoverTime
   }
 
   private get crosshairLeft(): number {

--- a/ui/src/shared/components/Crosshair.tsx
+++ b/ui/src/shared/components/Crosshair.tsx
@@ -44,7 +44,7 @@ class Crosshair extends PureComponent<Props> {
     const isPastMaxTimeRange = hoverTime > maxTimeRange
 
     const isValidHoverTime = !isBeforeMinTimeRange && !isPastMaxTimeRange
-    return hoverTime !== 0 && _.isFinite(hoverTime) && isValidHoverTime
+    return isValidHoverTime && hoverTime !== 0 && _.isFinite(hoverTime)
   }
 
   private get crosshairLeft(): number {

--- a/ui/src/shared/components/Crosshair.tsx
+++ b/ui/src/shared/components/Crosshair.tsx
@@ -37,10 +37,10 @@ class Crosshair extends PureComponent<Props> {
     const {dygraph, hoverTime} = this.props
     const timeRanges = dygraph.xAxisRange()
 
-    const minTimeRange = timeRanges[0]
+    const minTimeRange = _.get(timeRanges, '0', 0)
     const isBeforeMinTimeRange = hoverTime < minTimeRange
 
-    const maxTimeRange = timeRanges[1]
+    const maxTimeRange = _.get(timeRanges, '1', Infinity)
     const isPastMaxTimeRange = hoverTime > maxTimeRange
 
     const isValidHoverTime = !isBeforeMinTimeRange && !isPastMaxTimeRange


### PR DESCRIPTION
Closes #3715

_What was the problem?_
Dygraph was figuring out where the crosshair would be on a graph even if that time was past or before the range of the current graph.

_What was the solution?_
Ensure that the hovertime is within the time range on the graph and don't display it otherwise.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass