### PR TITLE
Change axes options to have valid defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1.  [#3698](https://github.com/influxdata/chronograf/pull/3698): Fix error in cell when tempVar returns no values
 1.  [#3733](https://github.com/influxdata/chronograf/pull/3733): Change arrows in table columns so that ascending sort points up and descending points down
 1.  [#3751](https://github.com/influxdata/chronograf/pull/3751): Fix crosshairs moving passed the edges of graphs
+1.  [#3759](https://github.com/influxdata/chronograf/pull/3759): Change y-axis options to have valid defaults
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -14,6 +14,7 @@ import {
   TOOLTIP_Y_VALUE_FORMAT,
 } from 'src/dashboards/constants/cellEditor'
 import {GRAPH_TYPES} from 'src/dashboards/graphics/graph'
+import {getDeep} from 'src/utils/wrappers'
 
 import {updateAxes} from 'src/dashboards/actions/cellEditorOverlay'
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -157,6 +158,11 @@ class AxesOptions extends Component {
               tipID="Y-Values's Format"
               tipContent={TOOLTIP_Y_VALUE_FORMAT}
             >
+              <Tab
+                text="Raw"
+                isActive={base === ''}
+                onClickTab={this.handleSetBase('')}
+              />
               <Tab
                 text="K/M/B"
                 isActive={base === BASE_10}

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -14,7 +14,6 @@ import {
   TOOLTIP_Y_VALUE_FORMAT,
 } from 'src/dashboards/constants/cellEditor'
 import {GRAPH_TYPES} from 'src/dashboards/graphics/graph'
-import {getDeep} from 'src/utils/wrappers'
 
 import {updateAxes} from 'src/dashboards/actions/cellEditorOverlay'
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/ui/src/dashboards/components/AxesOptions.js
+++ b/ui/src/dashboards/components/AxesOptions.js
@@ -177,7 +177,7 @@ class AxesOptions extends Component {
             <Tabber labelText="Scale">
               <Tab
                 text="Linear"
-                isActive={scale === LINEAR}
+                isActive={scale === LINEAR || scale === ''}
                 onClickTab={this.handleSetScale(LINEAR)}
               />
               <Tab


### PR DESCRIPTION
Closes #3746

_Briefly describe your proposed changes:_
Add raw as the default option for base instead of having an unselected tabs. To get rid of the other two formats, select raw.
Set default for scale to be linear so deselection.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
