### PR TITLE
Fix/logs scrolling

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -299,14 +299,15 @@ class LogsTable extends Component<Props, State> {
 
   private handleScroll = scrollInfo => {
     const {scrollLeft, scrollTop} = scrollInfo
+    const previousScrolltop = this.state.scrollTop
+
+    this.setState({scrollLeft, scrollTop})
 
     if (scrollTop === 0) {
       this.props.onScrolledToTop()
-    } else if (scrollTop !== this.state.scrollTop) {
+    } else if (scrollTop !== previousScrolltop) {
       this.props.onScrollVertical()
     }
-
-    this.setState({scrollLeft, scrollTop})
   }
 
   private headerRenderer = ({key, style, columnIndex}) => {
@@ -346,7 +347,7 @@ class LogsTable extends Component<Props, State> {
           className={classnames('logs-viewer--cell', {
             highlight: highlightRow,
           })}
-          title={`Filter by "${formattedValue}"`}
+          title={`Filter by '${formattedValue}'`}
           style={{...style, padding: '5px'}}
           key={key}
           data-index={rowIndex}

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -32,11 +32,15 @@ export const formatColumnValue = (
     case 'timestamp':
       return moment(+value / 1000000).format('YYYY/MM/DD HH:mm:ss')
     case 'message':
-      if (value.indexOf(' ') > charLimit - 5) {
-        return _.truncate(value, {length: charLimit - 5}).replace('\\n', '')
-      } else {
-        return value.replace('\\n', '')
+      if (value) {
+        if (value.indexOf(' ') > charLimit - 5) {
+          return _.truncate(value, {length: charLimit - 5}).replace('\\n', '')
+        } else {
+          return value.replace('\\n', '')
+        }
       }
+      return ''
+
     default:
       return value
   }


### PR DESCRIPTION
Closes #3732 

_What was the problem?_
Race condition between the state of the logs table and the logs page caused the page to get rerendered twice

_What was the solution?_
change the order of state setting

  - [x] Rebased/mergeable
  - [x] Tests pass
 