### PR TITLE
Add a swagger definition for UI config settings and API Routes

### DIFF
--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2865,39 +2865,21 @@
         }
       }
     },
-    "/chronograf/v1/config/ui": {
+    "/chronograf/v1/config/:section": {
       "get": {
-        "tags": ["config", "ui"],
-        "summary": "Returns all UI settings",
-        "description": "All UI section settings",
+        "tags": ["config"],
+        "summary": "Returns the settings for a specific section of the app",
+        "description": "All settings for a specific section of the app",
         "responses": {
           "200": {
-            "description": "Returns an object with all UI settings for the app",
-            "schema": {
-              "$ref": "#/definitions/UIConfig"
-            }
-          },
-          "default": {
-            "description": "Unexpected internal server error",
-            "schema": {
-              "$ref": "#/definitions/Error"
-            }
-          }
-        }
-      }
-    },
-    "/chronograf/v1/config/ui/:section": {
-      "get": {
-        "tags": ["config", "ui"],
-        "summary": "Returns the UI settings for a specific section of the app",
-        "description": "All UI settings for a specific section of the app",
-        "responses": {
-          "200": {
-            "description": "Returns an object with the UI settings for a section of the app",
+            "description": "Returns an object with the settings for a section of the app",
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/definitions/LogViewerUISettings"
+                  "$ref": "#/definitions/LogViewerUIConfig"
+                },
+                {
+                  "$ref": "#/definitions/AuthConfig"
                 }
               ]
             }
@@ -2917,28 +2899,31 @@
         }
       },
       "put": {
-        "tags": ["config", "ui"],
-        "summary": "Updates the UI settings for a specific section of the app",
-        "description": "Updates UI settings for a specific section of the app",
+        "tags": ["config"],
+        "summary": "Updates the settings for a specific section of the app",
+        "description": "Updates settings for a specific section of the app",
         "parameters": [
           {
             "name": "section",
             "in": "path",
             "type": "string",
-            "description": "Section name for the target UI section settings",
+            "description": "Section name for the target section settings",
             "required": true
           },
           {
             "name": {
-              "enum": ["logViewer"]
+              "enum": ["logViewer", "auth"]
             },
             "in": "body",
             "description":
-              "UI section configuration update parameters",
+              "Section configuration update parameters",
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/definitions/LogViewerUISettings"
+                  "$ref": "#/definitions/LogViewerUIConfig"
+                },
+                {
+                  "$ref": "#/definitions/AuthConfig"
                 }
               ]
             },
@@ -2951,7 +2936,7 @@
             "schema": {
               "oneOf": [
                 {
-                  "$ref": "#/definitions/LogViewerUISettings"
+                  "$ref": "#/definitions/LogViewerUIConfig"
                 }
               ]
             }
@@ -5158,7 +5143,7 @@
         }
       }
     },
-    "LogViewerUISettings": {
+    "LogViewerUIConfig": {
       "description": "Contains the settings for the log viewer page UI",
       "type": "object",
       "required": ["columns", "columnOptions"],
@@ -5203,12 +5188,13 @@
         }
       }
     },
-    "UIConfig": {
-      "description": "UIConfig describes UI settings for chronograf",
+    "AuthConfig": {
       "type": "object",
+      "required": ["superAdminNewUsers"],
       "properties": {
-        "logViewer": {
-          "$ref": "#/definitions/LogViewerUISettings"
+        "superAdminNewUsers": {
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -5148,12 +5148,17 @@
       "type": "object",
       "required": [
         "name",
-        "encoding"
+        "encoding",
+        "position"
       ],
       "properties": {
         "name": {
           "description": "Unique identifier name of the column",
           "type": "string"
+        },
+        "position": {
+          "type": "integer",
+          "format": "int32"
         },
         "encoding": {
           "description": "Composable encoding options for the column",
@@ -5177,6 +5182,7 @@
         },
         "example": {
           "name": "severity",
+          "position": 0,
           "encoding": [
             {
               "type": "label",
@@ -5224,6 +5230,7 @@
         "columns": [
           {
             "name": "severity",
+            "position": 0,
             "encoding": [
               {
                 "type": "label",
@@ -5255,11 +5262,13 @@
           },
           {
             "name": "messages",
-            "encoding": []
-          },
-          {
-            "name": "timestamp",
-            "encoding": []
+            "position": 1,
+            "encoding": [
+              {
+                "type": "visibility",
+                "value": "hidden"
+              }
+            ]
           }
         ]
       }

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -5143,6 +5143,60 @@
         }
       }
     },
+    "LogViewerUIColumn": {
+      "description": "Contains the settings for the log viewer page UI",
+      "type": "object",
+      "required": [
+        "name",
+        "formatting",
+        "mappings"
+      ],
+      "properties": {
+        "name": {
+          "description": "Unique identifier name of the column",
+          "type": "string"
+        },
+        "formatting": {
+          "description": "Composable formatting options for the column",
+          "type": "array",
+          "items": {
+            "description":"Type and value of a formatting option",
+            "type": "object",
+            "required": ["type", "value"],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "mappings": {
+          "description": "Mapping from a arbitrary type and possibly name, to a value",
+          "type": "array",
+          "items": {
+            "description": "Type and value of a formatting option",
+            "type": "object",
+            "required": [
+              "type",
+              "value"
+            ],
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        }
+    },
     "LogViewerUIConfig": {
       "description": "Contains the settings for the log viewer page UI",
       "type": "object",
@@ -5152,39 +5206,8 @@
           "description": "Defines the order, names, and visibility of columns in the log viewer table",
           "type": "array",
             "items": {
-              "$ref": "#/definitions/RenamableField"
+              "$ref": "#/definitions/LogViewerUIColumn"
             }
-        },
-        "columnOptions": {
-          "type": "object",
-          "required": ["severity"],
-          "properties": {
-            "severity": {
-              "type": "object",
-              "required": ["displayFormat", "colors"],
-              "properties": {
-                "displayFormat": {
-                  "type": "string"
-                },
-                "colors": {
-                  "description": "Defines the display colors for each severity level",
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": ["name", "value"],
-                    "properties": {
-                      "name": {
-                        "type": "string"
-                      },
-                      "value": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                } 
-              }
-            }
-          }
         }
       }
     },

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -5151,6 +5151,32 @@
         "formatting",
         "mappings"
       ],
+      "example": {
+        "name": "severity",
+        "formatting": [
+          {
+            "type": "text",
+            "value": "dotText"
+          }
+        ],
+        "mappings": [
+          {
+            "type": "color",
+            "name": "ruby",
+            "value": "emergency"
+          },
+          {
+            "type": "color",
+            "name": "rainforest",
+            "value": "info"
+          },
+          {
+            "type": "text",
+            "name": "displayName",
+            "value": "Severity"
+          }
+        ]
+      },
       "properties": {
         "name": {
           "description": "Unique identifier name of the column",
@@ -5201,6 +5227,46 @@
       "description": "Contains the settings for the log viewer page UI",
       "type": "object",
       "required": ["columns", "columnOptions"],
+      "example": {
+        "columns": [
+          {
+            "name": "severity",
+            "formatting": [
+              {
+                "type": "text",
+                "value": "dotText"
+              }
+            ],
+            "mappings": [
+              {
+                "type": "color",
+                "name": "ruby",
+                "value": "emergency"
+              },
+              {
+                "type": "color",
+                "name": "rainforest",
+                "value": "info"
+              },
+              {
+                "type": "text",
+                "name": "displayName",
+                "value": "Severity"
+              }
+            ]
+          },
+          {
+            "name": "messages",
+            "formatting": [],
+            "mappings": []
+          },
+          {
+            "name": "timestamp",
+            "formatting": [],
+            "mappings": []
+          }
+        ]
+      },
       "properties": {
         "columns": {
           "description": "Defines the order, names, and visibility of columns in the log viewer table",

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -5136,33 +5136,6 @@
         }
       }
     },
-    "SeverityColor": {
-      "type": "object",
-      "description":
-        "Color defines an encoding of a data value into color space",
-      "properties": {
-        "id": {
-          "description": "ID is the unique id of the cell color",
-          "readOnly": true,
-          "type": "string"
-        },
-        "type": {
-          "description": "Type is how the color is used",
-          "type": "string",
-          "enum": ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
-        },
-        "hex": {
-          "description": "Hex is the hex number of the color",
-          "type": "string",
-          "maxLength": 7,
-          "minLength": 7
-        },
-        "name": {
-          "description": "Name is the user-facing name of the hex color",
-          "type": "string"
-        }
-      }
-    },
     "RenamableField": {
       "description":
         "Describes a field that can be renamed and made visible or invisible",
@@ -5188,7 +5161,7 @@
     "LogViewerUISettings": {
       "description": "Contains the settings for the log viewer page UI",
       "type": "object",
-      "required": ["columns", "severityColors", "severityColumnFormat"],
+      "required": ["columns", "columnOptions"],
       "properties": {
         "columns": {
           "description": "Defines the order, names, and visibility of columns in the log viewer table",
@@ -5197,17 +5170,36 @@
               "$ref": "#/definitions/RenamableField"
             }
         },
-        "severityColors": {
-          "description": "Defines the name and color associated with log severity levels",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/SeverityColor"
+        "columnOptions": {
+          "type": "object",
+          "required": ["severity"],
+          "properties": {
+            "severity": {
+              "type": "object",
+              "required": ["displayFormat", "colors"],
+              "properties": {
+                "displayFormat": {
+                  "type": "string"
+                },
+                "colors": {
+                  "description": "Defines the display colors for each severity level",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["name", "value"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                } 
+              }
+            }
           }
-        },
-        "severityColumnFormat": {
-          "description": "Describes the format for displaying the log severity to the user",
-          "type": "string",
-          "enum": ["dot", "text", "dot-text"]
         }
       }
     },

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -5148,67 +5148,20 @@
       "type": "object",
       "required": [
         "name",
-        "formatting",
-        "mappings"
+        "encoding"
       ],
-      "example": {
-        "name": "severity",
-        "formatting": [
-          {
-            "type": "text",
-            "value": "dotText"
-          }
-        ],
-        "mappings": [
-          {
-            "type": "color",
-            "name": "ruby",
-            "value": "emergency"
-          },
-          {
-            "type": "color",
-            "name": "rainforest",
-            "value": "info"
-          },
-          {
-            "type": "text",
-            "name": "displayName",
-            "value": "Severity"
-          }
-        ]
-      },
       "properties": {
         "name": {
           "description": "Unique identifier name of the column",
           "type": "string"
         },
-        "formatting": {
-          "description": "Composable formatting options for the column",
+        "encoding": {
+          "description": "Composable encoding options for the column",
           "type": "array",
           "items": {
-            "description":"Type and value of a formatting option",
+            "description":"Type and value and optional name of an encoding",
             "type": "object",
             "required": ["type", "value"],
-            "properties": {
-              "type": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            }
-          }
-        },
-        "mappings": {
-          "description": "Mapping from a arbitrary type and possibly name, to a value",
-          "type": "array",
-          "items": {
-            "description": "Type and value of a formatting option",
-            "type": "object",
-            "required": [
-              "type",
-              "value"
-            ],
             "properties": {
               "type": {
                 "type": "string"
@@ -5221,23 +5174,69 @@
               }
             }
           }
+        },
+        "example": {
+          "name": "severity",
+          "encoding": [
+            {
+              "type": "label",
+              "value": "icon"
+            },
+            {
+              "type": "label",
+              "value": "text"
+            },
+            {
+              "type": "visibility",
+              "value": "visible"
+            },
+            {
+              "type": "color",
+              "name": "ruby",
+              "value": "emergency"
+            },
+            {
+              "type": "color",
+              "name": "rainforest",
+              "value": "info"
+            },
+            {
+              "type": "displayName",
+              "value": "Log Severity!"
+            }
+          ]
         }
-    },
-    "LogViewerUIConfig": {
+      },
+      "LogViewerUIConfig": {
       "description": "Contains the settings for the log viewer page UI",
       "type": "object",
-      "required": ["columns", "columnOptions"],
+      "required": ["columns"],
+      "properties": {
+        "columns": {
+          "description": "Defines the order, names, and visibility of columns in the log viewer table",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LogViewerUIColumn"
+          }
+        }
+      },
       "example": {
         "columns": [
           {
             "name": "severity",
-            "formatting": [
+            "encoding": [
               {
-                "type": "text",
-                "value": "dotText"
-              }
-            ],
-            "mappings": [
+                "type": "label",
+                "value": "icon"
+              },
+              {
+                "type": "label",
+                "value": "text"
+              },
+              {
+                "type": "visibility",
+                "value": "visible"
+              },
               {
                 "type": "color",
                 "name": "ruby",
@@ -5249,32 +5248,20 @@
                 "value": "info"
               },
               {
-                "type": "text",
-                "name": "displayName",
-                "value": "Severity"
+                "type": "displayName",
+                "value": "Log Severity!"
               }
             ]
           },
           {
             "name": "messages",
-            "formatting": [],
-            "mappings": []
+            "encoding": []
           },
           {
             "name": "timestamp",
-            "formatting": [],
-            "mappings": []
+            "encoding": []
           }
         ]
-      },
-      "properties": {
-        "columns": {
-          "description": "Defines the order, names, and visibility of columns in the log viewer table",
-          "type": "array",
-            "items": {
-              "$ref": "#/definitions/LogViewerUIColumn"
-            }
-        }
       }
     },
     "AuthConfig": {

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2864,6 +2864,112 @@
           }
         }
       }
+    },
+    "/chronograf/v1/config/ui": {
+      "get": {
+        "tags": ["config", "ui"],
+        "summary": "Returns all UI settings",
+        "description": "All UI section settings",
+        "responses": {
+          "200": {
+            "description": "Returns an object with all UI settings for the app",
+            "schema": {
+              "$ref": "#/definitions/UIConfig"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/chronograf/v1/config/ui/:section": {
+      "get": {
+        "tags": ["config", "ui"],
+        "summary": "Returns the UI settings for a specific section of the app",
+        "description": "All UI settings for a specific section of the app",
+        "responses": {
+          "200": {
+            "description": "Returns an object with the UI settings for a section of the app",
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/LogViewerUISettings"
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Could not find requested section",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["config", "ui"],
+        "summary": "Updates the UI settings for a specific section of the app",
+        "description": "Updates UI settings for a specific section of the app",
+        "parameters": [
+          {
+            "name": "section",
+            "in": "path",
+            "type": "string",
+            "description": "Section name for the target UI section settings",
+            "required": true
+          },
+          {
+            "name": {
+              "enum": ["logViewer"]
+            },
+            "in": "body",
+            "description":
+              "UI section configuration update parameters",
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/LogViewerUISettings"
+                }
+              ]
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Returns an object with the updated UI settings for a specific section",
+            "schema": {
+              "oneOf": [
+                {
+                  "$ref": "#/definitions/LogViewerUISettings"
+                }
+              ]
+            }
+          },
+          "404": {
+            "description": "Could not find requested section",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -5030,24 +5136,87 @@
         }
       }
     },
+    "SeverityColor": {
+      "type": "object",
+      "description":
+        "Color defines an encoding of a data value into color space",
+      "properties": {
+        "id": {
+          "description": "ID is the unique id of the cell color",
+          "readOnly": true,
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is how the color is used",
+          "type": "string",
+          "enum": ["emergency", "alert", "critical", "error", "warning", "notice", "info", "debug"]
+        },
+        "hex": {
+          "description": "Hex is the hex number of the color",
+          "type": "string",
+          "maxLength": 7,
+          "minLength": 7
+        },
+        "name": {
+          "description": "Name is the user-facing name of the hex color",
+          "type": "string"
+        }
+      }
+    },
     "RenamableField": {
       "description":
-        "renamableField describes a field that can be renamed and made visible or invisible",
+        "Describes a field that can be renamed and made visible or invisible",
       "type": "object",
       "properties": {
         "internalName": {
-          "description": "internalName is the calculated name of a field",
+          "description": "This is the calculated name of a field",
+          "readOnly": true,
           "type": "string"
         },
         "displayName": {
           "description":
-            "displayName is the name that a field is renamed to by the user",
+            "This is the name that a field is renamed to by the user",
           "type": "string"
         },
         "visible": {
           "description":
-            "visible indicates whether this field should be visible on the table",
+            "Indicates whether this field should be visible on the table",
           "type": "boolean"
+        }
+      }
+    },
+    "LogViewerUISettings": {
+      "description": "Contains the settings for the log viewer page UI",
+      "type": "object",
+      "required": ["columns", "severityColors", "severityColumnFormat"],
+      "properties": {
+        "columns": {
+          "description": "Defines the order, names, and visibility of columns in the log viewer table",
+          "type": "array",
+            "items": {
+              "$ref": "#/definitions/RenamableField"
+            }
+        },
+        "severityColors": {
+          "description": "Defines the name and color associated with log severity levels",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SeverityColor"
+          }
+        },
+        "severityColumnFormat": {
+          "description": "Describes the format for displaying the log severity to the user",
+          "type": "string",
+          "enum": ["dot", "text", "dot-text"]
+        }
+      }
+    },
+    "UIConfig": {
+      "description": "UIConfig describes UI settings for chronograf",
+      "type": "object",
+      "properties": {
+        "logViewer": {
+          "$ref": "#/definitions/LogViewerUISettings"
         }
       }
     },


### PR DESCRIPTION
Closes #3777.

This is an API proposal for solving: https://github.com/influxdata/chronograf/issues/3713 and https://github.com/influxdata/chronograf/issues/3714. 

The user needs a way to configure their log viewer display settings and persist it on the backend per organization. 

This PR uses the existing config/:section endpoint and introduces a Swagger definition (`LogViewerConfig`) for a new section (`logViewer`). This config has two properties: a `columns` array and a `columnOptions` object with a `severity` property that defines the colors and names for the severity levels associated with logs.

  - [x] Rebased/mergeable
  - [x] Tests pass