### PR TITLE
Refactor drag and drop to listen for events directly on window.

### DIFF
--- a/ui/src/style/components/drag-and-drop.scss
+++ b/ui/src/style/components/drag-and-drop.scss
@@ -3,16 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-.drag-and-drop--dropzone {
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 1000%;
-  height: 1000%;
-  transform: translate(-50%, -50%);
-  z-index: $drag-and-drop--z-dropzone;
-}
-
 .drag-and-drop--form {
   position: relative;
   z-index: $drag-and-drop--z-form;
@@ -69,7 +59,9 @@ input[type='file'].drag-and-drop--input {
   flex-wrap: nowrap;
   margin-top: 18px;
 
-  > button.btn {margin: 0 4px;}
+  > button.btn {
+    margin: 0 4px;
+  }
 }
 
 /*


### PR DESCRIPTION
Co-authored-by: Alex Paxton <thealexpaxton@gmail.com>
Co-authored-by: Deniz Kusefoglu <deniz@influxdata.com>

Closes #

_Briefly describe your proposed changes:_
drag and drop was creating a new div with a high z-index to listen to drag and drop events on, the high z-index would block functionality buttons or other ui elements underneath. We added event listeners to window instead. It works, and is better :)

_What was the problem?_
_What was the solution?_

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)