### PR TITLE
Unify log viewer loading state

### DIFF
--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -483,6 +483,5 @@ export const changeZoomAsync = (timeRange: TimeRange) => async (
 
   if (namespace && proxyLink) {
     await dispatch(setTimeRangeAsync(timeRange))
-    await dispatch(executeTableQueryAsync())
   }
 }

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -26,7 +26,7 @@ import LogsTable from 'src/logs/components/LogsTable'
 import {getDeep} from 'src/utils/wrappers'
 import {colorForSeverity} from 'src/logs/utils/colors'
 
-import {Source, Namespace, TimeRange, RemoteDataState} from 'src/types'
+import {Source, Namespace, TimeRange} from 'src/types'
 import {Filter} from 'src/types/logs'
 import {HistogramData, TimePeriod} from 'src/types/histogram'
 
@@ -48,7 +48,6 @@ interface Props {
   changeFilter: (id: string, operator: string, value: string) => void
   timeRange: TimeRange
   histogramData: HistogramData
-  histogramDataStatus: RemoteDataState
   tableData: {
     columns: string[]
     values: string[]
@@ -180,14 +179,13 @@ class LogsPage extends PureComponent<Props, State> {
   }
 
   private get chart(): JSX.Element {
-    const {histogramData, histogramDataStatus} = this.props
+    const {histogramData} = this.props
 
     return (
       <AutoSizer>
         {({width, height}) => (
           <HistogramChart
             data={histogramData}
-            dataStatus={histogramDataStatus}
             width={width}
             height={height}
             colorScale={colorForSeverity}
@@ -294,7 +292,6 @@ const mapStateToProps = ({
     timeRange,
     currentNamespace,
     histogramData,
-    histogramDataStatus,
     tableData,
     searchTerm,
     filters,
@@ -307,7 +304,6 @@ const mapStateToProps = ({
   timeRange,
   currentNamespace,
   histogramData,
-  histogramDataStatus,
   tableData,
   searchTerm,
   filters,

--- a/ui/src/logs/reducers/index.ts
+++ b/ui/src/logs/reducers/index.ts
@@ -10,7 +10,6 @@ import {
   ConcatMoreLogsAction,
 } from 'src/logs/actions'
 
-import {RemoteDataState} from 'src/types'
 import {LogsState} from 'src/types/logs'
 
 const defaultState: LogsState = {
@@ -22,7 +21,6 @@ const defaultState: LogsState = {
   tableQueryConfig: null,
   tableData: {columns: [], values: []},
   histogramData: [],
-  histogramDataStatus: RemoteDataState.NotStarted,
   searchTerm: '',
   filters: [],
   queryCount: 0,
@@ -111,8 +109,6 @@ export default (state: LogsState = defaultState, action: Action) => {
       return {...state, histogramQueryConfig: action.payload.queryConfig}
     case ActionTypes.SetHistogramData:
       return {...state, histogramData: action.payload.data}
-    case ActionTypes.SetHistogramDataStatus:
-      return {...state, histogramDataStatus: action.payload}
     case ActionTypes.SetTableQueryConfig:
       return {...state, tableQueryConfig: action.payload.queryConfig}
     case ActionTypes.SetTableData:

--- a/ui/src/shared/components/HistogramChart.tsx
+++ b/ui/src/shared/components/HistogramChart.tsx
@@ -10,7 +10,6 @@ import XBrush from 'src/shared/components/XBrush'
 
 import extentBy from 'src/utils/extentBy'
 
-import {RemoteDataState} from 'src/types'
 import {
   TimePeriod,
   HistogramData,
@@ -29,7 +28,6 @@ const PERIOD_DIGIT_WIDTH = 4
 
 interface Props {
   data: HistogramData
-  dataStatus: RemoteDataState
   width: number
   height: number
   colorScale: ColorScale
@@ -66,22 +64,11 @@ class HistogramChart extends PureComponent<Props, State> {
     }
 
     const {hoverData} = this.state
-    const {
-      xScale,
-      yScale,
-      adjustedWidth,
-      adjustedHeight,
-      bodyTransform,
-      loadingClass,
-    } = this
+    const {xScale, yScale, adjustedWidth, adjustedHeight, bodyTransform} = this
 
     return (
       <>
-        <svg
-          width={width}
-          height={height}
-          className={`histogram-chart ${loadingClass}`}
-        >
+        <svg width={width} height={height} className="histogram-chart">
           <defs>
             <clipPath id="histogram-chart--bars-clip">
               <rect x="0" y="0" width={adjustedWidth} height={adjustedHeight} />
@@ -187,12 +174,6 @@ class HistogramChart extends PureComponent<Props, State> {
     )
 
     return Math.max(...counts)
-  }
-
-  private get loadingClass(): string {
-    const {dataStatus} = this.props
-
-    return dataStatus === RemoteDataState.Loading ? 'loading' : ''
   }
 
   private handleBrush = (t: TimePeriod): void => {

--- a/ui/src/style/components/histogram-chart.scss
+++ b/ui/src/style/components/histogram-chart.scss
@@ -1,36 +1,5 @@
-@keyframes blur-in {
-  from {
-    filter: blur(0);
-  }
-
-  to {
-    filter: blur(2px);
-  }
-}
-
-@keyframes blur-out {
-  from {
-    filter: blur(2px);
-  }
-
-  to {
-    filter: blur(0);
-  }
-}
-
 .histogram-chart {
   user-select: none;
-
-  &:not(.loading) {
-    animation-duration: 0.1s;
-    animation-name: blur-out;
-  }
-
-  &.loading {
-    animation-duration: 0.3s;
-    animation-name: blur-in;
-    animation-fill-mode: forwards;
-  }
 }
 
 .histogram-chart-bars--bar {
@@ -64,7 +33,7 @@
 }
 
 
-.histogram-chart-skeleton, .histogram-chart:not(.loading) .x-brush--area {
+.histogram-chart-skeleton, .histogram-chart .x-brush--area {
   cursor: crosshair;
 }
 

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -3,7 +3,6 @@ import {
   TimeRange,
   Namespace,
   Source,
-  RemoteDataState,
 } from 'src/types'
 
 export interface Filter {
@@ -25,7 +24,6 @@ export interface LogsState {
   timeRange: TimeRange
   histogramQueryConfig: QueryConfig | null
   histogramData: object[]
-  histogramDataStatus: RemoteDataState
   tableQueryConfig: QueryConfig | null
   tableData: TableData
   searchTerm: string | null

--- a/ui/test/shared/components/HistogramChart.test.tsx
+++ b/ui/test/shared/components/HistogramChart.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {mount, shallow} from 'enzyme'
+import {mount} from 'enzyme'
 
 import HistogramChart from 'src/shared/components/HistogramChart'
 import HistogramChartTooltip from 'src/shared/components/HistogramChartTooltip'
@@ -88,20 +88,5 @@ describe('HistogramChart', () => {
     const tooltip = wrapper.find(HistogramChartTooltip)
 
     expect(tooltip).toMatchSnapshot()
-  })
-
-  test('has a "loading" class if data is reloading', () => {
-    const props = {
-      data: [{key: '', time: 0, value: 0, group: ''}],
-      dataStatus: RemoteDataState.Loading,
-      width: 600,
-      height: 400,
-      colorScale: () => 'blue',
-      onZoom: () => {},
-    }
-
-    const wrapper = shallow(<HistogramChart {...props} />)
-
-    expect(wrapper.find('.histogram-chart').hasClass('loading')).toBe(true)
   })
 })

--- a/ui/test/shared/components/__snapshots__/HistogramChart.test.tsx.snap
+++ b/ui/test/shared/components/__snapshots__/HistogramChart.test.tsx.snap
@@ -174,7 +174,7 @@ exports[`HistogramChart displays the visualization with bars if nonempty data is
   width={600}
 >
   <svg
-    className="histogram-chart "
+    className="histogram-chart"
     height={400}
     width={600}
   >


### PR DESCRIPTION
Should be merged after #3785

Previously, the loading state for the histogram and table in the log viewer were separate. This PR unifies the loading states so that the loading spinner will display if _either_ the table or histogram is loading.

![histogram new loading state](https://user-images.githubusercontent.com/638955/42053722-2ca7cea4-7ac7-11e8-8b55-cee6441438e5.gif)
