### PR TITLE
Stop querying old sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 1.  [#3733](https://github.com/influxdata/chronograf/pull/3733): Change arrows in table columns so that ascending sort points up and descending points down
 1.  [#3751](https://github.com/influxdata/chronograf/pull/3751): Fix crosshairs moving passed the edges of graphs
 1.  [#3759](https://github.com/influxdata/chronograf/pull/3759): Change y-axis options to have valid defaults
+1.  [#3793](https://github.com/influxdata/chronograf/pull/3793): Stop making requests for old sources after changing sources
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -173,6 +173,7 @@ class DashboardPage extends Component<Props, State> {
     const {source, getAnnotationsAsync, timeRange} = this.props
     if (this.props.autoRefresh !== nextProps.autoRefresh) {
       clearInterval(this.intervalID)
+      this.intervalID = null
       const annotationRange = millisecondTimeRange(timeRange)
       if (nextProps.autoRefresh) {
         this.intervalID = window.setInterval(() => {
@@ -193,6 +194,7 @@ class DashboardPage extends Component<Props, State> {
 
   public componentWillUnmount() {
     clearInterval(this.intervalID)
+    this.intervalID = null
     window.removeEventListener('resize', this.handleWindowResize, true)
     this.props.handleDismissEditingAnnotation()
   }

--- a/ui/src/hosts/containers/HostsPage.js
+++ b/ui/src/hosts/containers/HostsPage.js
@@ -73,6 +73,7 @@ export class HostsPage extends Component {
 
   async componentDidMount() {
     const {notify, autoRefresh} = this.props
+    this.componentIsMounted = true
 
     this.setState({hostsLoading: true}) // Only print this once
     const results = await getLayouts()
@@ -88,7 +89,7 @@ export class HostsPage extends Component {
       return
     }
     await this.fetchHostsData()
-    if (autoRefresh) {
+    if (autoRefresh && this.componentIsMounted) {
       this.intervalID = setInterval(() => this.fetchHostsData(), autoRefresh)
     }
   }
@@ -151,6 +152,7 @@ export class HostsPage extends Component {
   }
 
   componentWillUnmount() {
+    this.componentIsMounted = false
     clearInterval(this.intervalID)
     this.intervalID = false
   }


### PR DESCRIPTION
Closes #3763

_What was the problem?_
in hosts page, set interval was happening after async requests and if component was unmounted before the interval was set, the intervalID was undefined and clearinterval wasn't clearing the interval

_What was the solution?_
add a property to the class to keep track of whether the component is mounted. If the component is getting unmounted before the interval is set, don't set the interval

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
 