### PR TITLE
Bugfix/source switch

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -202,6 +202,7 @@ class CellEditorOverlay extends Component<Props, State> {
           initialBottomHeight={INITIAL_HEIGHTS.queryMaker}
         >
           <Visualization
+            source={this.source}
             timeRange={timeRange}
             templates={templates}
             autoRefresh={autoRefresh}

--- a/ui/src/dashboards/components/Visualization.tsx
+++ b/ui/src/dashboards/components/Visualization.tsx
@@ -4,7 +4,6 @@ import {connect} from 'react-redux'
 import RefreshingGraph from 'src/shared/components/RefreshingGraph'
 import buildQueries from 'src/utils/buildQueriesForGraphs'
 import VisualizationName from 'src/dashboards/components/VisualizationName'
-import {SourceContext} from 'src/CheckSources'
 
 import {getCellTypeColors} from 'src/dashboards/constants/cellEditor'
 
@@ -19,6 +18,7 @@ import {ColorString, ColorNumber} from 'src/types/colors'
 
 interface Props {
   type: CellType
+  source: Source
   autoRefresh: number
   templates: Template[]
   timeRange: TimeRange
@@ -40,21 +40,22 @@ interface Props {
 const DashVisualization: SFC<Props> = ({
   axes,
   type,
+  source,
+  isInCEO,
   templates,
   timeRange,
   lineColors,
+  timeFormat,
   autoRefresh,
   gaugeColors,
+  fieldOptions,
   queryConfigs,
+  staticLegend,
+  tableOptions,
+  decimalPlaces,
   editQueryStatus,
   resizerTopHeight,
-  staticLegend,
   thresholdsListColors,
-  tableOptions,
-  timeFormat,
-  decimalPlaces,
-  fieldOptions,
-  isInCEO,
 }) => {
   const colors: ColorString[] = getCellTypeColors({
     cellType: type,
@@ -67,27 +68,24 @@ const DashVisualization: SFC<Props> = ({
     <div className="graph">
       <VisualizationName />
       <div className="graph-container">
-        <SourceContext.Consumer>
-          {(source: Source) => (
-            <RefreshingGraph
-              source={source}
-              colors={colors}
-              axes={axes}
-              type={type}
-              tableOptions={tableOptions}
-              queries={buildQueries(queryConfigs, timeRange)}
-              templates={templates}
-              autoRefresh={autoRefresh}
-              editQueryStatus={editQueryStatus}
-              resizerTopHeight={resizerTopHeight}
-              staticLegend={staticLegend}
-              timeFormat={timeFormat}
-              decimalPlaces={decimalPlaces}
-              fieldOptions={fieldOptions}
-              isInCEO={isInCEO}
-            />
-          )}
-        </SourceContext.Consumer>
+        <RefreshingGraph
+          source={source}
+          colors={colors}
+          axes={axes}
+          type={type}
+          tableOptions={tableOptions}
+          queries={buildQueries(queryConfigs, timeRange)}
+          templates={templates}
+          autoRefresh={autoRefresh}
+          editQueryStatus={editQueryStatus}
+          resizerTopHeight={resizerTopHeight}
+          staticLegend={staticLegend}
+          timeFormat={timeFormat}
+          decimalPlaces={decimalPlaces}
+          fieldOptions={fieldOptions}
+          isInCEO={isInCEO}
+        />
+        )}
       </div>
     </div>
   )

--- a/ui/src/influxql/ast.js
+++ b/ui/src/influxql/ast.js
@@ -85,8 +85,6 @@ export const toString = ast => {
       dimensions.push(`time(${_.compact([interval, offset]).join(', ')})`)
     }
 
-    // console.log("THING THING", dimensions.concat(tags), tags, dimensions.concat(tags).join(','))
-
     if (tags) {
       strs.push(dimensions.concat(tags).join(','))
     } else {

--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -190,11 +190,13 @@ const AutoRefresh = (
     }
 
     private isPropsDifferent(nextProps: Props) {
+      const isSourceDifferent = !_.isEqual(this.props.source, nextProps.source)
       return (
         this.props.inView !== nextProps.inView ||
         !!this.queryDifference(this.props.queries, nextProps.queries).length ||
         !_.isEqual(this.props.templates, nextProps.templates) ||
-        this.props.autoRefresh !== nextProps.autoRefresh
+        this.props.autoRefresh !== nextProps.autoRefresh ||
+        isSourceDifferent
       )
     }
 


### PR DESCRIPTION
Closes #3799 

_What was the problem?_
Source switching in the CEO was broken.

_What was the solution?_
- Use props (which contain the appropriate source) instead of context (which will always be the app-wide source) for source in CEO visualization.
- Update auto refresh when source changes.