### PR TITLE
Bugfix Meta Query DataExplorer

### DIFF
--- a/ui/src/data_explorer/components/Table.tsx
+++ b/ui/src/data_explorer/components/Table.tsx
@@ -20,8 +20,9 @@ import {
   defaultColumnWidth,
 } from 'src/data_explorer/constants/table'
 
+import {Source} from 'src/types'
+
 interface DataExplorerTableQuery {
-  host: string[]
   text: string
   id: string
 }
@@ -42,6 +43,7 @@ interface Props {
   editQueryStatus: () => void
   containerHeight: number
   containerWidth: number
+  source: Source
 }
 
 interface State {
@@ -208,10 +210,6 @@ class ChronoTable extends PureComponent<Props, State> {
     return _.get(series, `${activeSeriesIndex}`, emptySeries)
   }
 
-  private get source(): string {
-    return _.get(this.props.query, 'host.0', '')
-  }
-
   private fetchCellData = async (query: DataExplorerTableQuery) => {
     if (!query || !query.text) {
       return
@@ -223,7 +221,7 @@ class ChronoTable extends PureComponent<Props, State> {
 
     try {
       const {results} = await fetchTimeSeriesAsync({
-        source: this.source,
+        source: this.props.source.links.proxy,
         query,
       })
 

--- a/ui/src/data_explorer/components/VisView.tsx
+++ b/ui/src/data_explorer/components/VisView.tsx
@@ -3,13 +3,13 @@ import React, {SFC} from 'react'
 import Table from './Table'
 import RefreshingGraph from 'src/shared/components/RefreshingGraph'
 import {DEFAULT_LINE_COLORS} from 'src/shared/constants/graphColorPalettes'
-import {SourceContext} from 'src/CheckSources'
 
 import {Source, Query, Template} from 'src/types'
 
 interface Props {
   view: string
   query?: Query
+  source: Source
   queries: Query[]
   templates: Template[]
   autoRefresh: number
@@ -20,6 +20,7 @@ interface Props {
 const DataExplorerVisView: SFC<Props> = ({
   view,
   query,
+  source,
   queries,
   templates,
   autoRefresh,
@@ -35,24 +36,22 @@ const DataExplorerVisView: SFC<Props> = ({
       )
     }
 
-    return <Table query={query} editQueryStatus={editQueryStatus} />
+    return (
+      <Table query={query} editQueryStatus={editQueryStatus} source={source} />
+    )
   }
 
   return (
-    <SourceContext.Consumer>
-      {(source: Source) => (
-        <RefreshingGraph
-          type="line-graph"
-          source={source}
-          queries={queries}
-          templates={templates}
-          autoRefresh={autoRefresh}
-          colors={DEFAULT_LINE_COLORS}
-          manualRefresh={manualRefresh}
-          editQueryStatus={editQueryStatus}
-        />
-      )}
-    </SourceContext.Consumer>
+    <RefreshingGraph
+      type="line-graph"
+      source={source}
+      queries={queries}
+      templates={templates}
+      autoRefresh={autoRefresh}
+      colors={DEFAULT_LINE_COLORS}
+      manualRefresh={manualRefresh}
+      editQueryStatus={editQueryStatus}
+    />
   )
 }
 

--- a/ui/src/data_explorer/components/Visualization.tsx
+++ b/ui/src/data_explorer/components/Visualization.tsx
@@ -82,6 +82,7 @@ class DataExplorerVisualization extends PureComponent<Props, State> {
         <div className={this.visualizationClass}>
           <VisView
             view={view}
+            source={source}
             query={this.query}
             templates={templates}
             queries={this.queries}


### PR DESCRIPTION
Closes #3800 

_What was the problem?_

Table Component was still using the vestigial `host` string

_What was the solution?_

Use app source object for proxy requests for the table
