### PR TITLE
Fix each cell making multiple queries

### DIFF
--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -243,7 +243,7 @@ const AutoRefresh = (
     private getActiveTemplates(tempVars: Template[]): Template[] {
       return _.map(tempVars, tempVar => ({
         ...tempVar,
-        values: tempVar.values.filter(v => v.selected || v.picked),
+        values: tempVar.values.filter(v => v.selected || v.localSelected),
       }))
     }
   }

--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import {fetchTimeSeries} from 'src/shared/apis/query'
 import {DEFAULT_TIME_SERIES} from 'src/shared/constants/series'
 import {TimeSeriesServerResponse, TimeSeriesResponse} from 'src/types/series'
-import {Template, Source} from 'src/types'
+import {Template, Source, TemplateValue} from 'src/types'
 
 interface Axes {
   bounds: {
@@ -69,11 +69,13 @@ const AutoRefresh = (
     }
 
     public async componentDidMount() {
-      this.startNewPolling()
+      if (!this.isAwaitingSelectedValues) {
+        this.startNewPolling()
+      }
     }
 
     public async componentDidUpdate(prevProps: Props) {
-      if (!this.isPropsDifferent(prevProps)) {
+      if (this.isAwaitingSelectedValues || !this.isPropsDifferent(prevProps)) {
         return
       }
       this.startNewPolling()
@@ -195,7 +197,7 @@ const AutoRefresh = (
       return (
         this.props.inView !== nextProps.inView ||
         !!this.queryDifference(this.props.queries, nextProps.queries).length ||
-        this.isActiveTemplatesDifferent(nextProps) ||
+        !_.isEqual(this.props.templates, nextProps.templates) ||
         this.props.autoRefresh !== nextProps.autoRefresh ||
         isSourceDifferent
       )
@@ -233,18 +235,16 @@ const AutoRefresh = (
       )
     }
 
-    private isActiveTemplatesDifferent(prevProps: Props) {
-      const prevTemplates = this.getActiveTemplates(prevProps.templates)
-      const templates = this.getActiveTemplates(this.props.templates)
+    private get isAwaitingSelectedValues(): boolean {
+      const {templates} = this.props
 
-      return !_.isEqual(prevTemplates, templates)
-    }
+      const isAwaitingLocalSelection = (v: TemplateValue): boolean =>
+        v.localSelected === undefined
 
-    private getActiveTemplates(tempVars: Template[]): Template[] {
-      return _.map(tempVars, tempVar => ({
-        ...tempVar,
-        values: tempVar.values.filter(v => v.selected || v.localSelected),
-      }))
+      const allValues = _.flatMap(templates, t => t.values)
+      const valuesAwaitingSelection = allValues.filter(isAwaitingLocalSelection)
+
+      return valuesAwaitingSelection.length !== 0
     }
   }
 

--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -191,10 +191,11 @@ const AutoRefresh = (
 
     private isPropsDifferent(nextProps: Props) {
       const isSourceDifferent = !_.isEqual(this.props.source, nextProps.source)
+
       return (
         this.props.inView !== nextProps.inView ||
         !!this.queryDifference(this.props.queries, nextProps.queries).length ||
-        !_.isEqual(this.props.templates, nextProps.templates) ||
+        this.isActiveTemplatesDifferent(nextProps) ||
         this.props.autoRefresh !== nextProps.autoRefresh ||
         isSourceDifferent
       )
@@ -230,6 +231,20 @@ const AutoRefresh = (
       data.every(({resp}) =>
         _.get(resp, 'results', []).every(r => Object.keys(r).length > 1)
       )
+    }
+
+    private isActiveTemplatesDifferent(prevProps: Props) {
+      const prevTemplates = this.getActiveTemplates(prevProps.templates)
+      const templates = this.getActiveTemplates(this.props.templates)
+
+      return !_.isEqual(prevTemplates, templates)
+    }
+
+    private getActiveTemplates(tempVars: Template[]): Template[] {
+      return _.map(tempVars, tempVar => ({
+        ...tempVar,
+        values: tempVar.values.filter(v => v.selected || v.picked),
+      }))
     }
   }
 


### PR DESCRIPTION
Closes #3576 

_What was the problem?_
Multiple duplicate queries were being made in Dashboard cells after template variable values were loaded. 
_What was the solution?_
The auto refresh wrapper compares current and previous templates, but filters out values that aren't selected or picked.

  - [x] Rebased/mergeable
  - [x] Tests pass