### PR TITLE
Bugfix/tempvar autoinsert buttons

### DIFF
--- a/ui/src/dashboards/components/QueryMaker.tsx
+++ b/ui/src/dashboards/components/QueryMaker.tsx
@@ -9,7 +9,7 @@ import {buildQuery} from 'src/utils/influxql'
 import {TYPE_QUERY_CONFIG} from 'src/dashboards/constants'
 import {TEMPLATE_RANGE} from 'src/tempVars/constants'
 
-import {QueryConfig, Source, SourceLinks, TimeRange} from 'src/types'
+import {QueryConfig, Source, SourceLinks, TimeRange, Template} from 'src/types'
 import {CellEditorOverlayActions} from 'src/dashboards/components/CellEditorOverlay'
 
 const rawTextBinder = (
@@ -20,10 +20,6 @@ const rawTextBinder = (
 
 const buildText = (q: QueryConfig): string =>
   q.rawText || buildQuery(TYPE_QUERY_CONFIG, q.range || TEMPLATE_RANGE, q) || ''
-
-interface Template {
-  tempVar: string
-}
 
 interface Props {
   source: Source

--- a/ui/src/dashboards/components/QueryTextArea.js
+++ b/ui/src/dashboards/components/QueryTextArea.js
@@ -39,7 +39,7 @@ class QueryTextArea extends Component {
   }
 
   handleMouseOverTempVar = template => () => {
-    this.handleTemplateReplace(template)
+    this.handleTemplateReplace(template, true)
   }
 
   handleClickTempVar = template => () => {

--- a/ui/src/dashboards/components/QueryTextArea.tsx
+++ b/ui/src/dashboards/components/QueryTextArea.tsx
@@ -110,7 +110,7 @@ class QueryTextArea extends Component<Props, State> {
   }
 
   private handleMouseOverTempVar = (template: Template) => () => {
-    this.handleTemplateReplace(template, true)
+    this.handleTemplateReplace(template, false)
   }
 
   private handleClickTempVar = (template: Template) => () => {

--- a/ui/src/dashboards/components/QueryTextArea.tsx
+++ b/ui/src/dashboards/components/QueryTextArea.tsx
@@ -34,10 +34,11 @@ interface Props {
 
 @ErrorHandling
 class QueryTextArea extends Component<Props, State> {
-  private textArea: HTMLTextAreaElement
+  private textArea: React.RefObject<HTMLTextAreaElement>
 
   constructor(props: Props) {
     super(props)
+    this.textArea = React.createRef()
     this.state = {
       value: this.props.query,
       isTemplating: false,
@@ -66,7 +67,7 @@ class QueryTextArea extends Component<Props, State> {
           onChange={this.handleChange}
           onKeyDown={this.handleKeyDown}
           onBlur={this.handleUpdate}
-          ref={this.handleTextAreaRef}
+          ref={this.textArea}
           value={value}
           placeholder="Enter a query or select database, measurement, and field below and have us build one for you..."
           autoComplete="off"
@@ -102,8 +103,6 @@ class QueryTextArea extends Component<Props, State> {
       this.setState({value: nextProps.query})
     }
   }
-
-  private handleTextAreaRef = (r: HTMLTextAreaElement) => (this.textArea = r)
 
   private handleCloseDrawer = () => {
     this.setState({isTemplating: false})
@@ -160,7 +159,7 @@ class QueryTextArea extends Component<Props, State> {
   }
 
   private handleTemplateReplace = (selectedTemplate, replaceWholeTemplate) => {
-    const {selectionStart, value} = this.textArea
+    const {selectionStart, value} = this.textArea.current
     const {tempVar} = selectedTemplate
     const newTempVar = replaceWholeTemplate
       ? tempVar
@@ -181,7 +180,7 @@ class QueryTextArea extends Component<Props, State> {
       tempVar.length - _.get(matched, '0', []).length + enterModifier
 
     this.setState({value: templatedValue, selectedTemplate}, () =>
-      this.textArea.setSelectionRange(
+      this.textArea.current.setSelectionRange(
         selectionStart + diffInLength,
         selectionStart + diffInLength
       )
@@ -215,7 +214,7 @@ class QueryTextArea extends Component<Props, State> {
   private handleChange = () => {
     const {templates} = this.props
     const {selectedTemplate} = this.state
-    const value = this.textArea.value
+    const value = this.textArea.current.value
 
     // mask matches that will confuse our regex
     const masked = applyMasks(value)
@@ -223,9 +222,9 @@ class QueryTextArea extends Component<Props, State> {
 
     if (matched && !_.isEmpty(templates)) {
       // maintain cursor poition
-      const start = this.textArea.selectionStart
+      const start = this.textArea.current.selectionStart
 
-      const end = this.textArea.selectionEnd
+      const end = this.textArea.current.selectionEnd
       const filterText = matched[0].substr(1).toLowerCase()
 
       const filteredTemplates = templates.filter(t =>
@@ -243,7 +242,7 @@ class QueryTextArea extends Component<Props, State> {
         filteredTemplates,
         value,
       })
-      this.textArea.setSelectionRange(start, end)
+      this.textArea.current.setSelectionRange(start, end)
     } else {
       this.setState({isTemplating: false, value})
     }

--- a/ui/src/shared/components/QueryStatus.tsx
+++ b/ui/src/shared/components/QueryStatus.tsx
@@ -5,7 +5,7 @@ import {Status} from 'src/types'
 
 interface Props {
   status: Status
-  children: ReactNode
+  children?: ReactNode
 }
 
 const QueryStatus: SFC<Props> = ({status, children}) => {

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -1,9 +1,20 @@
-import React from 'react'
-import PropTypes from 'prop-types'
+import React, {SFC, MouseEvent} from 'react'
 import OnClickOutside from 'react-onclickoutside'
 import classnames from 'classnames'
 
-const TemplateDrawer = ({
+import {Template} from 'src/types'
+
+interface Props {
+  templates: Template[]
+  selected: Template
+  onMouseOverTempVar: (
+    template: Template
+  ) => (e: MouseEvent<HTMLDivElement>) => void
+  onClickTempVar: (
+    template: Template
+  ) => (e: MouseEvent<HTMLDivElement>) => void
+}
+const TemplateDrawer: SFC<Props> = ({
   templates,
   selected,
   onMouseOverTempVar,
@@ -25,20 +36,5 @@ const TemplateDrawer = ({
     ))}
   </div>
 )
-
-const {arrayOf, func, shape, string} = PropTypes
-
-TemplateDrawer.propTypes = {
-  templates: arrayOf(
-    shape({
-      tempVar: string.isRequired,
-    })
-  ),
-  selected: shape({
-    tempVar: string,
-  }),
-  onMouseOverTempVar: func.isRequired,
-  onClickTempVar: func.isRequired,
-}
 
 export default OnClickOutside(TemplateDrawer)

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -27,7 +27,7 @@ const TemplateDrawer: SFC<Props> = ({
           'template-drawer--selected': t.tempVar === selected.tempVar,
         })}
         onMouseOver={onMouseOverTempVar(t)}
-        onClick={onClickTempVar(t)}
+        onMouseDown={onClickTempVar(t)}
         key={t.tempVar}
       >
         {' '}


### PR DESCRIPTION
Closes #3807 

_What was the problem?_
clicking on tempVar suggestion buttons would cause an onBlur event in the enclosing textArea, and an execution of the query, before the click event could properly edit the query text. 

_What was the solution?_
call the function to replace query text at onMouseDown rather than onClick, which runs before the onBlur event fires, editing query text, before query execution. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
