### PR TITLE
feat(server): add profiling routes to chronograf server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1.  [#3522](https://github.com/influxdata/chronograf/pull/3522): Add support for Template Variables in Cell Titles
 1.  [#3559](https://github.com/influxdata/chronograf/pull/3559): Add ability to export and import dashboards
 1.  [#3556](https://github.com/influxdata/chronograf/pull/3556): Add ability to override template variables and time ranges via URL query
+1.  [#3814](https://github.com/influxdata/chronograf/pull/3814): Add pprof routes to chronograf server
 
 ### UI Improvements
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -8,6 +8,8 @@ import (
 	"strconv"
 	"strings"
 
+	_ "net/http/pprof"
+
 	"github.com/NYTimes/gziphandler"
 	"github.com/bouk/httprouter"
 	"github.com/influxdata/chronograf" // When julienschmidt/httprouter v2 w/ context is out, switch
@@ -30,6 +32,7 @@ type MuxOpts struct {
 	ProviderFuncs []func(func(oauth2.Provider, oauth2.Mux))
 	StatusFeedURL string            // JSON Feed URL for the client Status page News Feed
 	CustomLinks   map[string]string // Any custom external links for client's User menu
+	PprofEnabled  bool              // Mount pprof routes for profiling
 }
 
 // NewMux attaches all the route handlers; handler returned servers chronograf.
@@ -125,6 +128,11 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 			opts.Logger,
 			next,
 		)
+	}
+
+	if opts.PprofEnabled {
+		// add profiling routes
+		router.GET("/debug/pprof/:thing", http.DefaultServeMux.ServeHTTP)
 	}
 
 	/* Documentation */

--- a/server/server.go
+++ b/server/server.go
@@ -40,6 +40,8 @@ type Server struct {
 	Host string `long:"host" description:"The IP to listen on" default:"0.0.0.0" env:"HOST"`
 	Port int    `long:"port" description:"The port to listen on for insecure connections, defaults to a random value" default:"8888" env:"PORT"`
 
+	PprofEnabled bool `long:"pprof-enabled" description:"Enable the /debug/pprof/* HTTP routes" env:"PPROF_ENABLED"`
+
 	Cert flags.Filename `long:"cert" description:"Path to PEM encoded public key certificate. " env:"TLS_CERTIFICATE"`
 	Key  flags.Filename `long:"key" description:"Path to private key associated with given certificate. " env:"TLS_PRIVATE_KEY"`
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Add profiling routes to chronograf server.

_What was the problem?_
[Dashboards are slow](https://github.com/influxdata/chronograf/issues/3602) and in order to be able to diagnose the issue, we'll need access to the debug rotues.

_What was the solution?_
Add profiling routes.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass