### PR TITLE
Remove unused dashboardNames types and state

### DIFF
--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -115,7 +115,6 @@ interface State {
   selectedCell: DashboardsModels.Cell | null
   scrollTop: number
   windowHeight: number
-  dashboardsNames: DashboardsModels.DashboardName[]
 }
 
 @ErrorHandling
@@ -130,7 +129,6 @@ class DashboardPage extends Component<Props, State> {
       selectedCell: null,
       scrollTop: 0,
       windowHeight: window.innerHeight,
-      dashboardsNames: [],
     }
   }
 

--- a/ui/src/types/actions/dashboards.ts
+++ b/ui/src/types/actions/dashboards.ts
@@ -298,14 +298,6 @@ export type GetDashboardsThunk = (
   dispatch: Dispatch<ErrorsActions.ErrorThrownActionCreator>
 ) => Promise<DashboardsModels.Dashboard[] | void>
 
-export type GetDashboardsNamesDispatcher = (
-  sourceID: string
-) => GetDashboardsNamesThunk
-
-export type GetDashboardsNamesThunk = (
-  dispatch: Dispatch<ErrorsActions.ErrorThrownActionCreator>
-) => Promise<DashboardsModels.DashboardName[] | void>
-
 export type PutDashboardDispatcher = (
   dashboard: DashboardsModels.Dashboard
 ) => PutDashboardThunk


### PR DESCRIPTION

_What was the problem?_
Types and state that didn't seem to be used
_What was the solution?_
Removing types and state related to dashboard page names that were not
caught by typescript.

  - [x] Rebased/mergeable
  - [x] Tests pass