### PR TITLE
Fix dashboard name 

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -68,13 +68,11 @@ import * as TempVarsModels from 'src/types/tempVars'
 import * as NotificationsActions from 'src/types/actions/notifications'
 
 export const loadDashboards: DashboardsActions.LoadDashboardsActionCreator = (
-  dashboards: DashboardsModels.Dashboard[],
-  dashboardID?: number
+  dashboards: DashboardsModels.Dashboard[]
 ): DashboardsActions.LoadDashboardsAction => ({
   type: 'LOAD_DASHBOARDS',
   payload: {
     dashboards,
-    dashboardID,
   },
 })
 

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -24,9 +24,17 @@ const ui = (state = initialState, action) => {
       const {dashboards: dashboardsInState} = state
       const {dashboards: loadedDashboards} = action.payload
 
-      const dashboards = loadedDashboards.map(loadedDash =>
-        _.find(dashboardsInState, d => d.id === loadedDash.id, loadedDash)
-      )
+      const dashboards = loadedDashboards.map(loadedDash => {
+        const dashInState = _.find(
+          dashboardsInState,
+          d => d.id === loadedDash.id
+        )
+
+        if (dashInState) {
+          return dashInState
+        }
+        return loadedDash
+      })
 
       const newState = {
         dashboards,

--- a/ui/src/dashboards/reducers/ui.js
+++ b/ui/src/dashboards/reducers/ui.js
@@ -21,7 +21,13 @@ import {TEMPLATE_VARIABLE_TYPES} from 'src/tempVars/constants'
 const ui = (state = initialState, action) => {
   switch (action.type) {
     case 'LOAD_DASHBOARDS': {
-      const {dashboards} = action.payload
+      const {dashboards: dashboardsInState} = state
+      const {dashboards: loadedDashboards} = action.payload
+
+      const dashboards = loadedDashboards.map(loadedDash =>
+        _.find(dashboardsInState, d => d.id === loadedDash.id, loadedDash)
+      )
+
       const newState = {
         dashboards,
       }

--- a/ui/src/types/actions/dashboards.ts
+++ b/ui/src/types/actions/dashboards.ts
@@ -19,7 +19,6 @@ export interface LoadDashboardsAction {
   type: 'LOAD_DASHBOARDS'
   payload: {
     dashboards: DashboardsModels.Dashboard[]
-    dashboardID: number
   }
 }
 

--- a/ui/test/dashboards/reducers/ui.test.ts
+++ b/ui/test/dashboards/reducers/ui.test.ts
@@ -59,7 +59,7 @@ const dashboards = [d1, d2]
 
 describe('DataExplorer.Reducers.UI', () => {
   it('can load the dashboards', () => {
-    const actual = reducer(state, loadDashboards(dashboards, d1.id))
+    const actual = reducer(state, loadDashboards(dashboards))
     const expected = {
       dashboards,
     }

--- a/ui/test/dashboards/reducers/ui.test.ts
+++ b/ui/test/dashboards/reducers/ui.test.ts
@@ -58,6 +58,10 @@ const d2 = {...dashboard, id: 2, cells: [], name: 'd2', templates: []}
 const dashboards = [d1, d2]
 
 describe('DataExplorer.Reducers.UI', () => {
+  beforeEach(() => {
+    state = undefined
+  })
+
   it('can load the dashboards', () => {
     const actual = reducer(state, loadDashboards(dashboards))
     const expected = {

--- a/ui/test/dashboards/reducers/ui.test.ts
+++ b/ui/test/dashboards/reducers/ui.test.ts
@@ -71,6 +71,22 @@ describe('DataExplorer.Reducers.UI', () => {
     expect(actual.dashboards).toEqual(expected.dashboards)
   })
 
+  it('can load dashbaords into existing dashboards state', () => {
+    const newTemplate = {id: '3', ...template}
+    const updatedD1 = {...d1, templates: [...d1.templates, newTemplate]}
+
+    state = {
+      dashboards: [updatedD1],
+    }
+
+    const actual = reducer(state, loadDashboards(dashboards))
+    const expected = {
+      dashboards: [updatedD1, d2],
+    }
+
+    expect(actual.dashboards).toEqual(expected.dashboards)
+  })
+
   it('can delete a dashboard', () => {
     const actual = reducer({...initialState, dashboards}, deleteDashboard(d1))
     const expected = dashboards.filter(dash => dash.id !== d1.id)


### PR DESCRIPTION
_What was the problem?_
A call to load dashboards was replacing loaded dashboard data and causing template variable values to disappear in the dash.
_What was the solution?_
Update load dashboards to merge **loaded** and **unloaded** dashboards 

  - [x] Rebased/mergeable
  - [x] Tests pass