### PR TITLE
Add localSelected value to StatusPage constant template variables

### DIFF
--- a/ui/src/status/containers/StatusPage.tsx
+++ b/ui/src/status/containers/StatusPage.tsx
@@ -48,6 +48,7 @@ class StatusPage extends Component<Props, State> {
           value: timeRange.lower,
           type: 'constant',
           selected: true,
+          localSelected: true,
         },
       ],
     }
@@ -61,6 +62,7 @@ class StatusPage extends Component<Props, State> {
           value: 'now()',
           type: 'constant',
           selected: true,
+          localSelected: true,
         },
       ],
     }


### PR DESCRIPTION
Status page was not making queries because its template Vars did not have localSelected values.