### PR TITLE
Add util for loading dashboard switcher links

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -47,7 +47,6 @@ import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {defaultTimeRange} from 'src/shared/data/timeRanges'
 
 // Types
-import {AxiosResponse} from 'axios'
 import {
   Dashboard,
   Cell,
@@ -58,7 +57,6 @@ import {
   TemplateValue,
   TemplateType,
 } from 'src/types'
-import * as DashboardsApis from 'src/types/apis/dashboards'
 
 export enum ActionType {
   LoadDashboards = 'LOAD_DASHBOARDS',
@@ -401,9 +399,7 @@ export const getDashboardsAsync = () => async (
   try {
     const {
       data: {dashboards},
-    } = (await getDashboardsAJAX()) as AxiosResponse<
-      DashboardsApis.DashboardsResponse
-    >
+    } = await getDashboardsAJAX()
     dispatch(loadDashboards(dashboards))
     return dashboards
   } catch (error) {
@@ -584,9 +580,8 @@ export const importDashboardAsync = (dashboard: Dashboard) => async (
 
     const {
       data: {dashboards},
-    } = (await getDashboardsAJAX()) as AxiosResponse<
-      DashboardsApis.DashboardsResponse
-    >
+    } = await getDashboardsAJAX()
+
     dispatch(loadDashboards(dashboards))
 
     dispatch(notify(notifyDashboardImported(name)))

--- a/ui/src/dashboards/apis/index.ts
+++ b/ui/src/dashboards/apis/index.ts
@@ -1,15 +1,13 @@
 import AJAX from 'src/utils/ajax'
 
 import {AxiosResponse} from 'axios'
-import {DashboardsResponse} from 'src/types/apis/dashboards'
+import {DashboardsResponse, GetDashboards} from 'src/types/apis/dashboards'
 
-export const getDashboards = (): Promise<
-  AxiosResponse<DashboardsResponse> | DashboardsResponse
-> => {
-  return AJAX({
+export const getDashboards: GetDashboards = () => {
+  return AJAX<DashboardsResponse>({
     method: 'GET',
     resource: 'dashboards',
-  })
+  }) as Promise<AxiosResponse<DashboardsResponse>>
 }
 
 export const getDashboard = async dashboardID => {

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -32,8 +32,7 @@ interface Props {
   zoomedTimeRange: QueriesModels.TimeRange
   onCancel: () => void
   onSave: (name: string) => Promise<void>
-  dashboardLinks: DashboardsModels.DashboardSwitcherLink[]
-  activeDashboardLink?: DashboardsModels.DashboardSwitcherLink
+  dashboardLinks: DashboardsModels.DashboardSwitcherLinks
   isHidden: boolean
 }
 
@@ -146,15 +145,10 @@ class DashboardHeader extends Component<Props> {
   }
 
   private get dashboardSwitcher(): JSX.Element {
-    const {dashboardLinks, activeDashboardLink} = this.props
+    const {dashboardLinks} = this.props
 
-    if (dashboardLinks.length > 1) {
-      return (
-        <DashboardSwitcher
-          links={dashboardLinks}
-          activeLink={activeDashboardLink}
-        />
-      )
+    if (dashboardLinks.links.length > 1) {
+      return <DashboardSwitcher dashboardLinks={dashboardLinks} />
     }
   }
 

--- a/ui/src/dashboards/components/DashboardSwitcher.tsx
+++ b/ui/src/dashboards/components/DashboardSwitcher.tsx
@@ -9,10 +9,7 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'src/shared/constants/index'
-import {
-  DashboardSwitcherLinks,
-  DashboardSwitcherLink,
-} from 'src/types/dashboards'
+import {DashboardSwitcherLinks} from 'src/types/dashboards'
 
 interface Props {
   dashboardLinks: DashboardSwitcherLinks
@@ -68,12 +65,14 @@ class DashboardSwitcher extends PureComponent<Props, State> {
   }
 
   private get links(): JSX.Element[] {
-    return _.sortBy(this.dashLinks, ['text', 'key']).map(link => {
+    const {links, active} = this.props.dashboardLinks
+
+    return _.sortBy(links, ['text', 'key']).map(link => {
       return (
         <li
           key={link.key}
           className={classnames('dropdown-item', {
-            active: link === this.activeLink,
+            active: link === active,
           })}
         >
           <Link to={link.to} onClick={this.handleCloseMenu}>
@@ -82,14 +81,6 @@ class DashboardSwitcher extends PureComponent<Props, State> {
         </li>
       )
     })
-  }
-
-  private get activeLink(): DashboardSwitcherLink {
-    return this.props.dashboardLinks.active
-  }
-
-  private get dashLinks(): DashboardSwitcherLink[] {
-    return this.props.dashboardLinks.links
   }
 }
 

--- a/ui/src/dashboards/components/DashboardSwitcher.tsx
+++ b/ui/src/dashboards/components/DashboardSwitcher.tsx
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
+import classnames from 'classnames'
 
 import OnClickOutside from 'src/shared/components/OnClickOutside'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
@@ -8,12 +9,13 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'src/shared/constants/index'
-
-import {DashboardSwitcherLink} from 'src/types/dashboards'
+import {
+  DashboardSwitcherLinks,
+  DashboardSwitcherLink,
+} from 'src/types/dashboards'
 
 interface Props {
-  links: DashboardSwitcherLink[]
-  activeLink?: DashboardSwitcherLink
+  dashboardLinks: DashboardSwitcherLinks
 }
 
 interface State {
@@ -66,23 +68,28 @@ class DashboardSwitcher extends PureComponent<Props, State> {
   }
 
   private get links(): JSX.Element[] {
-    const {links, activeLink} = this.props
-
-    return _.sortBy(links, ['text', 'key']).map(link => {
-      let activeClass = ''
-
-      if (activeLink && link.key === activeLink.key) {
-        activeClass = 'active'
-      }
-
+    return _.sortBy(this.dashLinks, ['text', 'key']).map(link => {
       return (
-        <li key={link.key} className={`dropdown-item ${activeClass}`}>
+        <li
+          key={link.key}
+          className={classnames('dropdown-item', {
+            active: link === this.activeLink,
+          })}
+        >
           <Link to={link.to} onClick={this.handleCloseMenu}>
             {link.text}
           </Link>
         </li>
       )
     })
+  }
+
+  private get activeLink(): DashboardSwitcherLink {
+    return this.props.dashboardLinks.active
+  }
+
+  private get dashLinks(): DashboardSwitcherLink[] {
+    return this.props.dashboardLinks.links
   }
 }
 

--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -1,0 +1,51 @@
+import {getDashboards} from 'src/dashboards/apis'
+
+import {GetDashboards} from 'src/types/apis/dashboards'
+import {Source} from 'src/types/sources'
+import {Dashboard, DashboardSwitcherLinks} from 'src/types/dashboards'
+
+export const EMPTY_LINKS = {
+  links: [],
+  active: null,
+}
+
+export const loadDashboardLinks = async (
+  source: Source,
+  dashboardsAJAX: GetDashboards = getDashboards
+): Promise<DashboardSwitcherLinks> => {
+  const {
+    data: {dashboards},
+  } = await dashboardsAJAX()
+
+  return linksFromDashboards(dashboards, source)
+}
+
+const linksFromDashboards = (
+  dashboards: Dashboard[],
+  source: Source
+): DashboardSwitcherLinks => {
+  const links = dashboards.map(d => {
+    return {
+      key: String(d.id),
+      text: d.name,
+      to: `/sources/${source.id}/dashboards/${d.id}`,
+    }
+  })
+
+  return {links, active: null}
+}
+
+export const updateActiveDashboardLink = (
+  dashboardLinks: DashboardSwitcherLinks,
+  dashboard: Dashboard
+) => {
+  if (!dashboard) {
+    return {...dashboardLinks, active: null}
+  }
+
+  const active = dashboardLinks.links.find(
+    link => link.key === String(dashboard.id)
+  )
+
+  return {...dashboardLinks, active}
+}

--- a/ui/src/types/apis/dashboards.ts
+++ b/ui/src/types/apis/dashboards.ts
@@ -1,5 +1,8 @@
 import {Dashboard} from 'src/types/dashboards'
+import {AxiosResponse} from 'axios'
 
 export interface DashboardsResponse {
   dashboards: Dashboard[]
 }
+
+export type GetDashboards = () => Promise<AxiosResponse<DashboardsResponse>>

--- a/ui/src/types/dashboards.ts
+++ b/ui/src/types/dashboards.ts
@@ -151,3 +151,8 @@ export interface DashboardUIState {
   hoverTime: string
   activeCellID: string
 }
+
+export interface DashboardSwitcherLinks {
+  active?: DashboardSwitcherLink
+  links: DashboardSwitcherLink[]
+}

--- a/ui/test/dashboards/utils/dashboardNameLinks.ts
+++ b/ui/test/dashboards/utils/dashboardNameLinks.ts
@@ -1,0 +1,96 @@
+import {
+  loadDashboardLinks,
+  updateActiveDashboardLink,
+} from 'src/dashboards/utils/dashboardSwitcherLinks'
+import {dashboard, source} from 'test/resources'
+
+describe('dashboards.utils.dashboardSwitcherLinks', () => {
+  describe('loadDashboardLinks', () => {
+    const socure = {...source, id: '897'}
+
+    const dashboards = [
+      {
+        ...dashboard,
+        id: 123,
+        name: 'Test Dashboard',
+      },
+    ]
+
+    const data = {
+      dashboards,
+    }
+
+    const axiosResponse = {
+      data,
+      status: 200,
+      statusText: 'Okay',
+      headers: null,
+      config: null,
+    }
+
+    const getDashboards = async () => axiosResponse
+
+    it('can load dashboard links for source', async () => {
+      const actualLinks = await loadDashboardLinks(socure, getDashboards)
+
+      const expectedLinks = {
+        links: [
+          {
+            key: '123',
+            text: 'Test Dashboard',
+            to: '/sources/897/dashboards/123',
+          },
+        ],
+        active: null,
+      }
+
+      expect(actualLinks).toEqual(expectedLinks)
+    })
+  })
+
+  describe('updateActiveDashboardLink', () => {
+    const activeDashboard = {
+      ...dashboard,
+      id: 123,
+      name: 'Test Dashboard',
+    }
+
+    const activeLink = {
+      key: '123',
+      text: 'Test Dashboard',
+      to: '/sources/897/dashboards/123',
+    }
+
+    const link1 = {
+      key: '9001',
+      text: 'Low Dash',
+      to: '/sources/897/dashboards/9001',
+    }
+
+    const link2 = {
+      key: '2282',
+      text: 'Low Dash',
+      to: '/sources/897/dashboards/2282',
+    }
+
+    const links = [link1, activeLink, link2]
+    it('can set the active link', () => {
+      const loadedLinks = {links, active: null}
+      const actualLinks = updateActiveDashboardLink(
+        loadedLinks,
+        activeDashboard
+      )
+      const expectedLinks = {links, active: activeLink}
+
+      expect(actualLinks).toEqual(expectedLinks)
+    })
+
+    it('can handle a missing dashboard', () => {
+      const loadedLinks = {links, active: null}
+      const actualLinks = updateActiveDashboardLink(loadedLinks, undefined)
+      const expectedLinks = {links, active: null}
+
+      expect(actualLinks).toEqual(expectedLinks)
+    })
+  })
+})


### PR DESCRIPTION
_What was the problem?_
Putting dashboards in redux state from `DashboardPage` was clobbering the state for template variables.
_What was the solution?_
Remove the redux dispatch for loading dashboards and replace it with an internal request to get dashboard links.

  - [x] Rebased/mergeable
  - [x] Tests pass