### PR TITLE
Fix table time as horizontal

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -100,14 +100,16 @@ const updateMaxWidths = (
       const {widths: Widths} = maxColumnWidths
       const maxWidth = _.get(Widths, `${columnLabel}`, 0)
 
-      if ((isTopRow || currentWidth > maxWidth) && _.isString(columnLabel)) {
+      if (isTopRow || currentWidth > maxWidth) {
         acc.widths[columnLabel] = currentWidth
         acc.totalWidths += currentWidth - maxWidth
       }
+
       return acc
     },
     {...maxColumnWidths}
   )
+
   return maxWidths
 }
 


### PR DESCRIPTION
Closes #3801 

_What was the problem?_
The `columnWidths` object did not include / consider that times could be columns.  

_What was the solution?_
Add times to the `columnWidths` object when they are in the 'topRow'.

### Notes
Debugging this issue makes me sad.  There is SO much untested code that does SO much data transformation.  I have no idea if my solution breaks something else.

@russorat I recommend that we put aside dev time to test the `utils/tableGraph` at a minimum.