### PR TITLE
Remove AutoRefresh check for local selected values

### DIFF
--- a/ui/src/shared/components/AutoRefresh.tsx
+++ b/ui/src/shared/components/AutoRefresh.tsx
@@ -4,7 +4,7 @@ import _ from 'lodash'
 import {fetchTimeSeries} from 'src/shared/apis/query'
 import {DEFAULT_TIME_SERIES} from 'src/shared/constants/series'
 import {TimeSeriesServerResponse, TimeSeriesResponse} from 'src/types/series'
-import {Template, Source, TemplateValue} from 'src/types'
+import {Template, Source} from 'src/types'
 
 interface Axes {
   bounds: {
@@ -69,13 +69,11 @@ const AutoRefresh = (
     }
 
     public async componentDidMount() {
-      if (!this.isAwaitingSelectedValues) {
-        this.startNewPolling()
-      }
+      this.startNewPolling()
     }
 
     public async componentDidUpdate(prevProps: Props) {
-      if (this.isAwaitingSelectedValues || !this.isPropsDifferent(prevProps)) {
+      if (!this.isPropsDifferent(prevProps)) {
         return
       }
       this.startNewPolling()
@@ -233,18 +231,6 @@ const AutoRefresh = (
       data.every(({resp}) =>
         _.get(resp, 'results', []).every(r => Object.keys(r).length > 1)
       )
-    }
-
-    private get isAwaitingSelectedValues(): boolean {
-      const {templates} = this.props
-
-      const isAwaitingLocalSelection = (v: TemplateValue): boolean =>
-        v.localSelected === undefined
-
-      const allValues = _.flatMap(templates, t => t.values)
-      const valuesAwaitingSelection = allValues.filter(isAwaitingLocalSelection)
-
-      return valuesAwaitingSelection.length !== 0
     }
   }
 


### PR DESCRIPTION
_What was the problem?_
 The changes in #3829 removes the need for a guard in AutoRefresh componentDidMount and componentDidUpdate
_What was the solution?_
Remove the check for localSelected values in AutoRefresh

  - [x] Rebased/mergeable
  - [x] Tests pass