### PR TITLE
Less restrictive key equalness check in OAuth due to providers like Microsoft Azure

### DIFF
--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -143,7 +143,7 @@ func (j *JWT) KeyFuncRS256(token *gojwt.Token) (interface{}, error) {
 	// extract cert when kid and alg match
 	var certPkix []byte
 	for _, jwk := range jwks.Keys {
-		if token.Header["kid"] == jwk.Kid && token.Header["alg"] == jwk.Alg {
+		if token.Header["kid"] == jwk.Kid {
 			// FIXME: optionally walk the key chain, see rfc7517 section 4.7
 			certPkix, err = base64.StdEncoding.DecodeString(jwk.X5c[0])
 			if err != nil {


### PR DESCRIPTION
…who do not provide "alg" claim.

In most internet examples, a JWK provider should provide an `alg` claim for each offered key. Sadly, at least Microsoft Azure as a major authentication provider does not include that Claim currently and can thus not be used in combination with the current Chronograf implementation. 

See the current JWK response from Azure Active Directory here: https://login.microsoftonline.com/common/discovery/keys
```json
{
  "keys": [
    {
      "kty": "RSA",
      "use": "sig",
      "kid": "TioGywwlhvdFbXZ813WpPay9AlU",
      "x5t": "TioGywwlhvdFbXZ813WpPay9AlU",
      "n": "....",
      "e": "AQAB",
      "x5c": [
       "..."
      ]
    },
   ....
```

As a quick hotfix to make Azure Authentication useable for Chronograf, I made the check for key identification equalness less restrictive by not checking the algo for equalness when key identifier match up. 

Other implementations like Spring (Major Java framework) choose a "hybrid" mode where they used the verifier on the specified algorithm is given and otherwise just assume a default as you can see here. 

https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/token/store/jwk/JwkDefinitionSource.java
```java
if (rsaDefinition.getAlgorithm() != null) {
				result = new RsaVerifier(rsaPublicKey, rsaDefinition.getAlgorithm().standardName());
			} else {
				result = new RsaVerifier(rsaPublicKey);
}
```

This is something which can be made by a Go programmer, I just wanted to make sure that our application can use Chronograf Authentication after all.. 

Closes 
-InfluxDB enterprise support ticket #9436


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)