### PR TITLE
Handle deletion of a tempVar used in nested tempVar

### DIFF
--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -168,7 +168,20 @@ class DashboardPage extends Component<Props, State> {
     const prevPath = getDeep(prevProps.location, 'pathname', null)
     const thisPath = getDeep(this.props.location, 'pathname', null)
 
-    if (prevPath && thisPath && prevPath !== thisPath) {
+    const templates = getDeep<TempVarsModels.Template[]>(
+      this.props.dashboard,
+      'templates',
+      []
+    ).map(t => t.tempVar)
+    const prevTemplates = getDeep<TempVarsModels.Template[]>(
+      prevProps.dashboard,
+      'templates',
+      []
+    ).map(t => t.tempVar)
+    const isTemplateDeleted: boolean =
+      _.intersection(templates, prevTemplates).length !== prevTemplates.length
+
+    if ((prevPath && thisPath && prevPath !== thisPath) || isTemplateDeleted) {
       this.getDashboard()
     }
   }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -526,6 +526,16 @@ export const notifyBuilderDisabled = (): Notification => ({
 
 //  Template Variables & URL Queries
 //  ----------------------------------------------------------------------------
+export const notifyInvalidTempVarValueInMetaQuery = (
+  tempVar: string,
+  errorMessage: string
+): Notification => ({
+  ...defaultErrorNotification,
+  icon: 'cube',
+  duration: 7500,
+  message: `Invalid query supplied for template variable ${tempVar}: ${errorMessage}`,
+})
+
 export const notifyInvalidTempVarValueInURLQuery = ({
   key,
   value,

--- a/ui/src/tempVars/apis/index.ts
+++ b/ui/src/tempVars/apis/index.ts
@@ -16,28 +16,35 @@ export const hydrateTemplate = async (
     return template
   }
 
-  const query = templateReplace(makeQueryForTemplate(template.query), templates)
-  const response = await proxy({source: proxyLink, query})
-  const values = parseMetaQuery(query, response.data)
-  const type = TEMPLATE_VARIABLE_TYPES[template.type]
-  const selectedValue = getSelectedValue(template)
-  const selectedLocalValue = getLocalSelectedValue(template)
+  try {
+    const query = templateReplace(
+      makeQueryForTemplate(template.query),
+      templates
+    )
+    const response = await proxy({source: proxyLink, query})
+    const values = parseMetaQuery(query, response.data)
+    const type = TEMPLATE_VARIABLE_TYPES[template.type]
+    const selectedValue = getSelectedValue(template)
+    const selectedLocalValue = getLocalSelectedValue(template)
 
-  const templateValues = values.map(value => {
-    return {
-      type,
-      value,
-      selected: value === selectedValue,
-      localSelected: value === selectedLocalValue,
+    const templateValues = values.map(value => {
+      return {
+        type,
+        value,
+        selected: value === selectedValue,
+        localSelected: value === selectedLocalValue,
+      }
+    })
+
+    if (templateValues.length && !templateValues.find(v => v.selected)) {
+      // Handle stale selected value
+      templateValues[0].selected = true
     }
-  })
 
-  if (templateValues.length && !templateValues.find(v => v.selected)) {
-    // Handle stale selected value
-    templateValues[0].selected = true
+    return {...template, values: templateValues}
+  } catch (error) {
+    throw error
   }
-
-  return {...template, values: templateValues}
 }
 
 export const isTemplateNested = (template: Template): boolean => {

--- a/ui/src/tempVars/components/TemplateControlBar.tsx
+++ b/ui/src/tempVars/components/TemplateControlBar.tsx
@@ -1,6 +1,8 @@
 import React, {Component} from 'react'
 import classnames from 'classnames'
 
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
 import TemplateControlDropdown from 'src/tempVars/components/TemplateControlDropdown'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
 import TemplateVariableEditor from 'src/tempVars/components/TemplateVariableEditor'
@@ -22,6 +24,7 @@ interface State {
   isAdding: boolean
 }
 
+@ErrorHandling
 class TemplateControlBar extends Component<Props, State> {
   constructor(props) {
     super(props)


### PR DESCRIPTION
Closes #3833 

_What was the problem?_
When a template variable used in a nested template variable is deleted, an error was thrown and the dashboard didnt render

_What was the solution?_
Catch error and send notification of error


  - [x] Rebased/mergeable
  - [x] Tests pass
 