### PR TITLE
Add v2 cells API to chronograf

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,6 +1,6 @@
 [bumpversion]
 current_version = 1.5.0.0
-files = README.md server/swagger.json
+files = README.md server/swagger.json server/swagger_v2.yml
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)\.(?P<release>\d+)
 serialize = {major}.{minor}.{patch}.{release}
 

--- a/bolt/cell.go
+++ b/bolt/cell.go
@@ -1,0 +1,294 @@
+package bolt
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/boltdb/bolt"
+	chronograf "github.com/influxdata/chronograf/v2"
+	"github.com/influxdata/platform"
+)
+
+var (
+	cellBucket = []byte("cellsv2")
+)
+
+func (c *Client) initializeCells(ctx context.Context, tx *bolt.Tx) error {
+	if _, err := tx.CreateBucketIfNotExists([]byte(cellBucket)); err != nil {
+		return err
+	}
+	return nil
+}
+
+//func (c *Client) setOrganizationOnCell(ctx context.Context, tx *bolt.Tx, d *chronograf.Cell) error {
+//	o, err := c.findOrganizationByID(ctx, tx, d.OrganizationID)
+//	if err != nil {
+//		return err
+//	}
+//	d.Organization = o.Name
+//	return nil
+//}
+
+// FindCellByID retrieves a cell by id.
+func (c *Client) FindCellByID(ctx context.Context, id platform.ID) (*chronograf.Cell, error) {
+	var d *chronograf.Cell
+
+	err := c.db.View(func(tx *bolt.Tx) error {
+		dash, err := c.findCellByID(ctx, tx, id)
+		if err != nil {
+			return err
+		}
+		d = dash
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return d, nil
+}
+
+func (c *Client) findCellByID(ctx context.Context, tx *bolt.Tx, id platform.ID) (*chronograf.Cell, error) {
+	var d chronograf.Cell
+
+	v := tx.Bucket(cellBucket).Get(id)
+
+	if len(v) == 0 {
+		// TODO: Make standard error
+		return nil, fmt.Errorf("cell not found")
+	}
+
+	if err := json.Unmarshal(v, &d); err != nil {
+		return nil, err
+	}
+
+	//if err := c.setOrganizationOnCell(ctx, tx, &d); err != nil {
+	//	return nil, err
+	//}
+
+	return &d, nil
+}
+
+// FindCell retrieves a cell using an arbitrary cell filter.
+// Filters using ID, or OrganizationID and cell Name should be efficient.
+// Other filters will do a linear scan across cells until it finds a match.
+func (c *Client) FindCell(ctx context.Context, filter chronograf.CellFilter) (*chronograf.Cell, error) {
+	if filter.ID != nil {
+		return c.FindCellByID(ctx, *filter.ID)
+	}
+
+	var d *chronograf.Cell
+	err := c.db.View(func(tx *bolt.Tx) error {
+		//if filter.Organization != nil {
+		//	o, err := c.findOrganizationByName(ctx, tx, *filter.Organization)
+		//	if err != nil {
+		//		return err
+		//	}
+		//	filter.OrganizationID = &o.ID
+		//}
+
+		filterFn := filterCellsFn(filter)
+		return c.forEachCell(ctx, tx, func(dash *chronograf.Cell) bool {
+			if filterFn(dash) {
+				d = dash
+				return false
+			}
+			return true
+		})
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if d == nil {
+		return nil, fmt.Errorf("cell not found")
+	}
+
+	return d, nil
+}
+
+func filterCellsFn(filter chronograf.CellFilter) func(d *chronograf.Cell) bool {
+	if filter.ID != nil {
+		return func(d *chronograf.Cell) bool {
+			return bytes.Equal(d.ID, *filter.ID)
+		}
+	}
+
+	//if filter.OrganizationID != nil {
+	//	return func(d *chronograf.Cell) bool {
+	//		return bytes.Equal(d.OrganizationID, *filter.OrganizationID)
+	//	}
+	//}
+
+	return func(d *chronograf.Cell) bool { return true }
+}
+
+// FindCells retrives all cells that match an arbitrary cell filter.
+// Filters using ID, or OrganizationID and cell Name should be efficient.
+// Other filters will do a linear scan across all cells searching for a match.
+func (c *Client) FindCells(ctx context.Context, filter chronograf.CellFilter) ([]*chronograf.Cell, int, error) {
+	if filter.ID != nil {
+		d, err := c.FindCellByID(ctx, *filter.ID)
+		if err != nil {
+			return nil, 0, err
+		}
+
+		return []*chronograf.Cell{d}, 1, nil
+	}
+
+	ds := []*chronograf.Cell{}
+	err := c.db.View(func(tx *bolt.Tx) error {
+		dashs, err := c.findCells(ctx, tx, filter)
+		if err != nil {
+			return err
+		}
+		ds = dashs
+		return nil
+	})
+
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return ds, len(ds), nil
+}
+
+func (c *Client) findCells(ctx context.Context, tx *bolt.Tx, filter chronograf.CellFilter) ([]*chronograf.Cell, error) {
+	ds := []*chronograf.Cell{}
+	//if filter.Organization != nil {
+	//	o, err := c.findOrganizationByName(ctx, tx, *filter.Organization)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+	//	filter.OrganizationID = &o.ID
+	//}
+
+	filterFn := filterCellsFn(filter)
+	err := c.forEachCell(ctx, tx, func(d *chronograf.Cell) bool {
+		if filterFn(d) {
+			ds = append(ds, d)
+		}
+		return true
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return ds, nil
+}
+
+// CreateCell creates a platform cell and sets d.ID.
+func (c *Client) CreateCell(ctx context.Context, d *chronograf.Cell) error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		//if len(d.OrganizationID) == 0 {
+		//	o, err := c.findOrganizationByName(ctx, tx, d.Organization)
+		//	if err != nil {
+		//		return err
+		//	}
+		//	d.OrganizationID = o.ID
+		//}
+
+		id, err := tx.Bucket(cellBucket).NextSequence()
+		if err != nil {
+			return err
+		}
+		d.ID = platform.ID(fmt.Sprintf("%d", id))
+
+		return c.putCell(ctx, tx, d)
+	})
+}
+
+// PutCell will put a cell without setting an ID.
+func (c *Client) PutCell(ctx context.Context, d *chronograf.Cell) error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		return c.putCell(ctx, tx, d)
+	})
+}
+
+func (c *Client) putCell(ctx context.Context, tx *bolt.Tx, d *chronograf.Cell) error {
+	//d.Organization = ""
+	v, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	if err := tx.Bucket(cellBucket).Put(d.ID, v); err != nil {
+		return err
+	}
+	//return c.setOrganizationOnCell(ctx, tx, d)
+	return nil
+}
+
+// forEachCell will iterate through all cells while fn returns true.
+func (c *Client) forEachCell(ctx context.Context, tx *bolt.Tx, fn func(*chronograf.Cell) bool) error {
+	cur := tx.Bucket(cellBucket).Cursor()
+	for k, v := cur.First(); k != nil; k, v = cur.Next() {
+		d := &chronograf.Cell{}
+		if err := json.Unmarshal(v, d); err != nil {
+			return err
+		}
+		//if err := c.setOrganizationOnCell(ctx, tx, d); err != nil {
+		//	return err
+		//}
+		if !fn(d) {
+			break
+		}
+	}
+
+	return nil
+}
+
+// UpdateCell updates a cell according the parameters set on upd.
+func (c *Client) UpdateCell(ctx context.Context, id platform.ID, upd chronograf.CellUpdate) (*chronograf.Cell, error) {
+	var d *chronograf.Cell
+	err := c.db.Update(func(tx *bolt.Tx) error {
+		dash, err := c.updateCell(ctx, tx, id, upd)
+		if err != nil {
+			return err
+		}
+		d = dash
+		return nil
+	})
+
+	return d, err
+}
+
+func (c *Client) updateCell(ctx context.Context, tx *bolt.Tx, id platform.ID, upd chronograf.CellUpdate) (*chronograf.Cell, error) {
+	d, err := c.findCellByID(ctx, tx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	if upd.Name != nil {
+		d.Name = *upd.Name
+	}
+
+	if err := c.putCell(ctx, tx, d); err != nil {
+		return nil, err
+	}
+
+	//if err := c.setOrganizationOnCell(ctx, tx, d); err != nil {
+	//	return nil, err
+	//}
+
+	return d, nil
+}
+
+// DeleteCell deletes a cell and prunes it from the index.
+func (c *Client) DeleteCell(ctx context.Context, id platform.ID) error {
+	return c.db.Update(func(tx *bolt.Tx) error {
+		return c.deleteCell(ctx, tx, id)
+	})
+}
+
+func (c *Client) deleteCell(ctx context.Context, tx *bolt.Tx, id platform.ID) error {
+	_, err := c.findCellByID(ctx, tx, id)
+	if err != nil {
+		return err
+	}
+	return tx.Bucket(cellBucket).Delete(id)
+}

--- a/bolt/client.go
+++ b/bolt/client.go
@@ -167,6 +167,9 @@ func (c *Client) initialize(ctx context.Context) error {
 		if _, err := tx.CreateBucketIfNotExists(OrganizationConfigBucket); err != nil {
 			return err
 		}
+		// Always create Cells bucket.
+		if err := c.initializeCells(ctx, tx); err != nil {
+		}
 		return nil
 	}); err != nil {
 		return err

--- a/bolt/client.go
+++ b/bolt/client.go
@@ -169,6 +169,7 @@ func (c *Client) initialize(ctx context.Context) error {
 		}
 		// Always create Cells bucket.
 		if err := c.initializeCells(ctx, tx); err != nil {
+			return err
 		}
 		return nil
 	}); err != nil {

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -3403,7 +3403,46 @@ func TestServer(t *testing.T) {
 			},
 			wants: wants{
 				statusCode: 200,
-				body:       `{"layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"auth":[{"name":"github","label":"Github","login":"/oauth/github/login","logout":"/oauth/github/logout","callback":"/oauth/github/callback"}],"logout":"/oauth/logout","external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}`,
+				body: `
+{
+  "layouts": "/chronograf/v1/layouts",
+	"cells": "/chronograf/v2/cells",
+  "users": "/chronograf/v1/organizations/default/users",
+  "allUsers": "/chronograf/v1/users",
+  "organizations": "/chronograf/v1/organizations",
+  "mappings": "/chronograf/v1/mappings",
+  "sources": "/chronograf/v1/sources",
+  "me": "/chronograf/v1/me",
+  "environment": "/chronograf/v1/env",
+  "dashboards": "/chronograf/v1/dashboards",
+  "config": {
+    "self": "/chronograf/v1/config",
+    "auth": "/chronograf/v1/config/auth"
+  },
+  "auth": [
+    {
+      "name": "github",
+      "label": "Github",
+      "login": "/oauth/github/login",
+      "logout": "/oauth/github/logout",
+      "callback": "/oauth/github/callback"
+    }
+  ],
+  "logout": "/oauth/logout",
+  "external": {
+    "statusFeed": ""
+  },
+  "orgConfig": {
+    "logViewer": "/chronograf/v1/org_config/logviewer",
+    "self": "/chronograf/v1/org_config"
+	},
+  "flux": {
+    "ast": "/chronograf/v1/flux/ast",
+    "self": "/chronograf/v1/flux",
+    "suggestions": "/chronograf/v1/flux/suggestions"
+  }
+}
+`,
 			},
 		},
 		{
@@ -3457,7 +3496,46 @@ func TestServer(t *testing.T) {
 			},
 			wants: wants{
 				statusCode: 200,
-				body:       `{"layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/1/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"auth":[{"name":"github","label":"Github","login":"/oauth/github/login","logout":"/oauth/github/logout","callback":"/oauth/github/callback"}],"logout":"/oauth/logout","external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}`,
+				body: `
+{
+	"layouts": "/chronograf/v1/layouts",
+	"cells": "/chronograf/v2/cells",
+	"users": "/chronograf/v1/organizations/1/users",
+	"allUsers": "/chronograf/v1/users",
+	"organizations": "/chronograf/v1/organizations",
+	"mappings": "/chronograf/v1/mappings",
+	"sources": "/chronograf/v1/sources",
+	"me": "/chronograf/v1/me",
+	"environment": "/chronograf/v1/env",
+	"dashboards": "/chronograf/v1/dashboards",
+	"config": {
+		"self": "/chronograf/v1/config",
+		"auth": "/chronograf/v1/config/auth"
+	},
+  "orgConfig": {
+    "logViewer": "/chronograf/v1/org_config/logviewer",
+    "self": "/chronograf/v1/org_config"
+	},
+	"auth": [
+		{
+			"name": "github",
+			"label": "Github",
+			"login": "/oauth/github/login",
+			"logout": "/oauth/github/logout",
+			"callback": "/oauth/github/callback"
+		}
+	],
+	"logout": "/oauth/logout",
+	"external": {
+		"statusFeed": ""
+	},
+	"flux": {
+		"ast": "/chronograf/v1/flux/ast",
+		"self": "/chronograf/v1/flux",
+		"suggestions": "/chronograf/v1/flux/suggestions"
+	}
+}
+`,
 			},
 		},
 	}

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -3406,7 +3406,7 @@ func TestServer(t *testing.T) {
 				body: `
 {
   "layouts": "/chronograf/v1/layouts",
-	"cells": "/chronograf/v2/cells",
+  "cells": "/chronograf/v2/cells",
   "users": "/chronograf/v1/organizations/default/users",
   "allUsers": "/chronograf/v1/users",
   "organizations": "/chronograf/v1/organizations",
@@ -3435,7 +3435,7 @@ func TestServer(t *testing.T) {
   "orgConfig": {
     "logViewer": "/chronograf/v1/org_config/logviewer",
     "self": "/chronograf/v1/org_config"
-	},
+  },
   "flux": {
     "ast": "/chronograf/v1/flux/ast",
     "self": "/chronograf/v1/flux",
@@ -3498,42 +3498,42 @@ func TestServer(t *testing.T) {
 				statusCode: 200,
 				body: `
 {
-	"layouts": "/chronograf/v1/layouts",
-	"cells": "/chronograf/v2/cells",
-	"users": "/chronograf/v1/organizations/1/users",
-	"allUsers": "/chronograf/v1/users",
-	"organizations": "/chronograf/v1/organizations",
-	"mappings": "/chronograf/v1/mappings",
-	"sources": "/chronograf/v1/sources",
-	"me": "/chronograf/v1/me",
-	"environment": "/chronograf/v1/env",
-	"dashboards": "/chronograf/v1/dashboards",
-	"config": {
-		"self": "/chronograf/v1/config",
-		"auth": "/chronograf/v1/config/auth"
-	},
+  "layouts": "/chronograf/v1/layouts",
+  "cells": "/chronograf/v2/cells",
+  "users": "/chronograf/v1/organizations/1/users",
+  "allUsers": "/chronograf/v1/users",
+  "organizations": "/chronograf/v1/organizations",
+  "mappings": "/chronograf/v1/mappings",
+  "sources": "/chronograf/v1/sources",
+  "me": "/chronograf/v1/me",
+  "environment": "/chronograf/v1/env",
+  "dashboards": "/chronograf/v1/dashboards",
+  "config": {
+    "self": "/chronograf/v1/config",
+    "auth": "/chronograf/v1/config/auth"
+  },
   "orgConfig": {
     "logViewer": "/chronograf/v1/org_config/logviewer",
     "self": "/chronograf/v1/org_config"
-	},
-	"auth": [
-		{
-			"name": "github",
-			"label": "Github",
-			"login": "/oauth/github/login",
-			"logout": "/oauth/github/logout",
-			"callback": "/oauth/github/callback"
-		}
-	],
-	"logout": "/oauth/logout",
-	"external": {
-		"statusFeed": ""
-	},
-	"flux": {
-		"ast": "/chronograf/v1/flux/ast",
-		"self": "/chronograf/v1/flux",
-		"suggestions": "/chronograf/v1/flux/suggestions"
-	}
+  },
+  "auth": [
+    {
+      "name": "github",
+      "label": "Github",
+      "login": "/oauth/github/login",
+      "logout": "/oauth/github/logout",
+      "callback": "/oauth/github/callback"
+    }
+  ],
+  "logout": "/oauth/logout",
+  "external": {
+    "statusFeed": ""
+  },
+  "flux": {
+    "ast": "/chronograf/v1/flux/ast",
+    "self": "/chronograf/v1/flux",
+    "suggestions": "/chronograf/v1/flux/suggestions"
+  }
 }
 `,
 			},

--- a/mocks/cells.go
+++ b/mocks/cells.go
@@ -3,35 +3,35 @@ package mocks
 import (
 	"context"
 
-	chronograf "github.com/influxdata/chronograf/v2"
+	"github.com/influxdata/chronograf/v2"
 )
 
-var _ chronograf.CellService = &CellService{}
+var _ platform.CellService = &CellService{}
 
 type CellService struct {
-	CreateCellF   func(context.Context, *chronograf.Cell) error
-	FindCellByIDF func(context.Context, chronograf.ID) (*chronograf.Cell, error)
-	FindCellsF    func(context.Context, chronograf.CellFilter) ([]*chronograf.Cell, int, error)
-	UpdateCellF   func(context.Context, chronograf.ID, chronograf.CellUpdate) (*chronograf.Cell, error)
-	DeleteCellF   func(context.Context, chronograf.ID) error
+	CreateCellF   func(context.Context, *platform.Cell) error
+	FindCellByIDF func(context.Context, platform.ID) (*platform.Cell, error)
+	FindCellsF    func(context.Context, platform.CellFilter) ([]*platform.Cell, int, error)
+	UpdateCellF   func(context.Context, platform.ID, platform.CellUpdate) (*platform.Cell, error)
+	DeleteCellF   func(context.Context, platform.ID) error
 }
 
-func (s *CellService) FindCellByID(ctx context.Context, id chronograf.ID) (*chronograf.Cell, error) {
+func (s *CellService) FindCellByID(ctx context.Context, id platform.ID) (*platform.Cell, error) {
 	return s.FindCellByIDF(ctx, id)
 }
 
-func (s *CellService) FindCells(ctx context.Context, filter chronograf.CellFilter) ([]*chronograf.Cell, int, error) {
+func (s *CellService) FindCells(ctx context.Context, filter platform.CellFilter) ([]*platform.Cell, int, error) {
 	return s.FindCellsF(ctx, filter)
 }
 
-func (s *CellService) CreateCell(ctx context.Context, b *chronograf.Cell) error {
+func (s *CellService) CreateCell(ctx context.Context, b *platform.Cell) error {
 	return s.CreateCellF(ctx, b)
 }
 
-func (s *CellService) UpdateCell(ctx context.Context, id chronograf.ID, upd chronograf.CellUpdate) (*chronograf.Cell, error) {
+func (s *CellService) UpdateCell(ctx context.Context, id platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
 	return s.UpdateCellF(ctx, id, upd)
 }
 
-func (s *CellService) DeleteCell(ctx context.Context, id chronograf.ID) error {
+func (s *CellService) DeleteCell(ctx context.Context, id platform.ID) error {
 	return s.DeleteCellF(ctx, id)
 }

--- a/mocks/cells.go
+++ b/mocks/cells.go
@@ -1,0 +1,37 @@
+package mocks
+
+import (
+	"context"
+
+	chronograf "github.com/influxdata/chronograf/v2"
+)
+
+var _ chronograf.CellService = &CellService{}
+
+type CellService struct {
+	CreateCellF   func(context.Context, *chronograf.Cell) error
+	FindCellByIDF func(context.Context, chronograf.ID) (*chronograf.Cell, error)
+	FindCellsF    func(context.Context, chronograf.CellFilter) ([]*chronograf.Cell, int, error)
+	UpdateCellF   func(context.Context, chronograf.ID, chronograf.CellUpdate) (*chronograf.Cell, error)
+	DeleteCellF   func(context.Context, chronograf.ID) error
+}
+
+func (s *CellService) FindCellByID(ctx context.Context, id chronograf.ID) (*chronograf.Cell, error) {
+	return s.FindCellByIDF(ctx, id)
+}
+
+func (s *CellService) FindCells(ctx context.Context, filter chronograf.CellFilter) ([]*chronograf.Cell, int, error) {
+	return s.FindCellsF(ctx, filter)
+}
+
+func (s *CellService) CreateCell(ctx context.Context, b *chronograf.Cell) error {
+	return s.CreateCellF(ctx, b)
+}
+
+func (s *CellService) UpdateCell(ctx context.Context, id chronograf.ID, upd chronograf.CellUpdate) (*chronograf.Cell, error) {
+	return s.UpdateCellF(ctx, id, upd)
+}
+
+func (s *CellService) DeleteCell(ctx context.Context, id chronograf.ID) error {
+	return s.DeleteCellF(ctx, id)
+}

--- a/mocks/store.go
+++ b/mocks/store.go
@@ -4,7 +4,7 @@ import (
 	"context"
 
 	"github.com/influxdata/chronograf"
-	chronografv2 "github.com/influxdata/chronograf/v2"
+	"github.com/influxdata/chronograf/v2"
 )
 
 // Store is a server.DataStore
@@ -18,7 +18,7 @@ type Store struct {
 	OrganizationsStore      chronograf.OrganizationsStore
 	ConfigStore             chronograf.ConfigStore
 	OrganizationConfigStore chronograf.OrganizationConfigStore
-	CellService             chronografv2.CellService
+	CellService             platform.CellService
 }
 
 func (s *Store) Sources(ctx context.Context) chronograf.SourcesStore {
@@ -56,6 +56,6 @@ func (s *Store) OrganizationConfig(ctx context.Context) chronograf.OrganizationC
 	return s.OrganizationConfigStore
 }
 
-func (s *Store) Cells(ctx context.Context) chronografv2.CellService {
+func (s *Store) Cells(ctx context.Context) platform.CellService {
 	return s.CellService
 }

--- a/mocks/store.go
+++ b/mocks/store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/influxdata/chronograf"
+	chronografv2 "github.com/influxdata/chronograf/v2"
 )
 
 // Store is a server.DataStore
@@ -17,6 +18,7 @@ type Store struct {
 	OrganizationsStore      chronograf.OrganizationsStore
 	ConfigStore             chronograf.ConfigStore
 	OrganizationConfigStore chronograf.OrganizationConfigStore
+	CellService             chronografv2.CellService
 }
 
 func (s *Store) Sources(ctx context.Context) chronograf.SourcesStore {
@@ -52,4 +54,8 @@ func (s *Store) Config(ctx context.Context) chronograf.ConfigStore {
 
 func (s *Store) OrganizationConfig(ctx context.Context) chronograf.OrganizationConfigStore {
 	return s.OrganizationConfigStore
+}
+
+func (s *Store) Cells(ctx context.Context) chronografv2.CellService {
+	return s.CellService
 }

--- a/server/cellsv2.go
+++ b/server/cellsv2.go
@@ -1,0 +1,220 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/bouk/httprouter"
+	chronograf "github.com/influxdata/chronograf/v2"
+)
+
+type cellV2Links struct {
+	Self string `json:"self"`
+}
+
+type cellV2Response struct {
+	chronograf.Cell
+	Links cellV2Links `json:"links"`
+}
+
+func (r cellV2Response) MarshalJSON() ([]byte, error) {
+	vis, err := chronograf.MarshalVisualizationJSON(r.Visualization)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(struct {
+		chronograf.CellContents
+		Links         cellV2Links     `json:"links"`
+		Visualization json.RawMessage `json:"visualization"`
+	}{
+		CellContents:  r.CellContents,
+		Links:         r.Links,
+		Visualization: vis,
+	})
+}
+
+func newCellV2Response(c *chronograf.Cell) cellV2Response {
+	return cellV2Response{
+		Links: cellV2Links{
+			Self: fmt.Sprintf("/chronograf/v1/cells/%s", c.ID),
+		},
+		Cell: *c,
+	}
+}
+
+// CellsV2 returns all cells within the store.
+func (s *Service) CellsV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	// TODO: support filtering via query params
+	cells, _, err := s.Store.Cells(ctx).FindCells(ctx, chronograf.CellFilter{})
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Error loading cells", s.Logger)
+		return
+	}
+
+	s.encodeGetCellsResponse(w, cells)
+}
+
+type getCellsLinks struct {
+	Self string `json:"self"`
+}
+
+type getCellsResponse struct {
+	Links getCellsLinks    `json:"links"`
+	Cells []cellV2Response `json:"cells"`
+}
+
+func (s *Service) encodeGetCellsResponse(w http.ResponseWriter, cells []*chronograf.Cell) {
+	res := getCellsResponse{
+		Links: getCellsLinks{
+			Self: "/chronograf/v2/cells",
+		},
+		Cells: make([]cellV2Response, 0, len(cells)),
+	}
+
+	for _, cell := range cells {
+		res.Cells = append(res.Cells, newCellV2Response(cell))
+	}
+
+	encodeJSON(w, http.StatusOK, res, s.Logger)
+}
+
+// NewCellV2 creates a new cell.
+func (s *Service) NewCellV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodePostCellRequest(ctx, r)
+	if err != nil {
+		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
+		return
+	}
+	if err := s.Store.Cells(ctx).CreateCell(ctx, req.Cell); err != nil {
+		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error loading cells: %v", err), s.Logger)
+		return
+	}
+
+	s.encodePostCellResponse(w, req.Cell)
+}
+
+type postCellRequest struct {
+	Cell *chronograf.Cell
+}
+
+func decodePostCellRequest(ctx context.Context, r *http.Request) (*postCellRequest, error) {
+	c := &chronograf.Cell{}
+	if err := json.NewDecoder(r.Body).Decode(c); err != nil {
+		return nil, err
+	}
+	return &postCellRequest{
+		Cell: c,
+	}, nil
+}
+
+func (s *Service) encodePostCellResponse(w http.ResponseWriter, cell *chronograf.Cell) {
+	encodeJSON(w, http.StatusCreated, newCellV2Response(cell), s.Logger)
+}
+
+// CellIDV2 retrieves a cell by ID.
+func (s *Service) CellIDV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodeGetCellRequest(ctx, r)
+	if err != nil {
+		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
+		return
+	}
+	cell, err := s.Store.Cells(ctx).FindCellByID(ctx, req.CellID)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error loading cell: %v", err), s.Logger)
+		return
+	}
+
+	s.encodeGetCellResponse(w, cell)
+}
+
+type getCellRequest struct {
+	CellID chronograf.ID
+}
+
+func decodeGetCellRequest(ctx context.Context, r *http.Request) (*getCellRequest, error) {
+	param := httprouter.GetParamFromContext(ctx, "id")
+	return &getCellRequest{
+		CellID: chronograf.ID(param),
+	}, nil
+}
+
+func (s *Service) encodeGetCellResponse(w http.ResponseWriter, cell *chronograf.Cell) {
+	encodeJSON(w, http.StatusOK, newCellV2Response(cell), s.Logger)
+}
+
+// RemoveCellV2 removes a cell by ID.
+func (s *Service) RemoveCellV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodeDeleteCellRequest(ctx, r)
+	if err != nil {
+		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
+		return
+	}
+	if err := s.Store.Cells(ctx).DeleteCell(ctx, req.CellID); err != nil {
+		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error deleting cell: %v", err), s.Logger)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+type deleteCellRequest struct {
+	CellID chronograf.ID
+}
+
+func decodeDeleteCellRequest(ctx context.Context, r *http.Request) (*deleteCellRequest, error) {
+	param := httprouter.GetParamFromContext(ctx, "id")
+	return &deleteCellRequest{
+		CellID: chronograf.ID(param),
+	}, nil
+}
+
+// UpdateCellV2 updates a cell.
+func (s *Service) UpdateCellV2(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
+	req, err := decodePatchCellRequest(ctx, r)
+	if err != nil {
+		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
+		return
+	}
+	cell, err := s.Store.Cells(ctx).UpdateCell(ctx, req.CellID, req.Upd)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error updating cell: %v", err), s.Logger)
+		return
+	}
+
+	s.encodePatchCellResponse(w, cell)
+}
+
+type patchCellRequest struct {
+	CellID chronograf.ID
+	Upd    chronograf.CellUpdate
+}
+
+func decodePatchCellRequest(ctx context.Context, r *http.Request) (*patchCellRequest, error) {
+	upd := chronograf.CellUpdate{}
+	if err := json.NewDecoder(r.Body).Decode(&upd); err != nil {
+		return nil, err
+	}
+
+	param := httprouter.GetParamFromContext(ctx, "id")
+
+	return &patchCellRequest{
+		CellID: chronograf.ID(param),
+		Upd:    upd,
+	}, nil
+}
+
+func (s *Service) encodePatchCellResponse(w http.ResponseWriter, cell *chronograf.Cell) {
+	encodeJSON(w, http.StatusOK, newCellV2Response(cell), s.Logger)
+}

--- a/server/cellsv2.go
+++ b/server/cellsv2.go
@@ -127,6 +127,11 @@ func (s *Service) CellIDV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cell, err := s.Store.Cells(ctx).FindCellByID(ctx, req.CellID)
+	if err == platform.ErrCellNotFound {
+		Error(w, http.StatusNotFound, err.Error(), s.Logger)
+		return
+	}
+
 	if err != nil {
 		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error loading cell: %v", err), s.Logger)
 		return
@@ -159,7 +164,13 @@ func (s *Service) RemoveCellV2(w http.ResponseWriter, r *http.Request) {
 		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
 		return
 	}
-	if err := s.Store.Cells(ctx).DeleteCell(ctx, req.CellID); err != nil {
+	err = s.Store.Cells(ctx).DeleteCell(ctx, req.CellID)
+	if err == platform.ErrCellNotFound {
+		Error(w, http.StatusNotFound, err.Error(), s.Logger)
+		return
+	}
+
+	if err != nil {
 		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error deleting cell: %v", err), s.Logger)
 		return
 	}
@@ -188,6 +199,11 @@ func (s *Service) UpdateCellV2(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cell, err := s.Store.Cells(ctx).UpdateCell(ctx, req.CellID, req.Upd)
+	if err == platform.ErrCellNotFound {
+		Error(w, http.StatusNotFound, err.Error(), s.Logger)
+		return
+	}
+
 	if err != nil {
 		Error(w, http.StatusInternalServerError, fmt.Sprintf("Error updating cell: %v", err), s.Logger)
 		return

--- a/server/cellvs2_test.go
+++ b/server/cellvs2_test.go
@@ -115,6 +115,28 @@ func TestService_CellsV2(t *testing.T) {
 }`,
 			},
 		},
+		{
+			name: "get all cells when there are none",
+			fields: fields{
+				&mocks.CellService{
+					FindCellsF: func(ctx context.Context, filter platform.CellFilter) ([]*platform.Cell, int, error) {
+						return []*platform.Cell{}, 0, nil
+					},
+				},
+			},
+			args: args{},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body: `
+{
+  "links": {
+    "self": "/chronograf/v2/cells"
+  },
+  "cells": []
+}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -213,6 +235,24 @@ func TestService_CellIDV2(t *testing.T) {
   }
 }
 `,
+			},
+		},
+		{
+			name: "not found",
+			fields: fields{
+				&mocks.CellService{
+					FindCellByIDF: func(ctx context.Context, id platform.ID) (*platform.Cell, error) {
+						return nil, platform.ErrCellNotFound
+					},
+				},
+			},
+			args: args{
+				id: "2",
+			},
+			wants: wants{
+				statusCode:  http.StatusNotFound,
+				contentType: "application/json",
+				body:        `{"code":404,"message":"cell not found"}`,
 			},
 		},
 	}
@@ -412,6 +452,24 @@ func TestService_RemoveCellV2(t *testing.T) {
 				statusCode: http.StatusNoContent,
 			},
 		},
+		{
+			name: "cell not found",
+			fields: fields{
+				&mocks.CellService{
+					DeleteCellF: func(ctx context.Context, id platform.ID) error {
+						return platform.ErrCellNotFound
+					},
+				},
+			},
+			args: args{
+				id: "2",
+			},
+			wants: wants{
+				statusCode:  http.StatusNotFound,
+				contentType: "application/json",
+				body:        `{"code":404,"message":"cell not found"}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -567,6 +625,25 @@ func TestService_UpdateCellV2(t *testing.T) {
 				statusCode:  http.StatusBadRequest,
 				contentType: "application/json",
 				body:        `{"code":400,"message":"expected at least one attribute to be updated"}`,
+			},
+		},
+		{
+			name: "cell not found",
+			fields: fields{
+				&mocks.CellService{
+					UpdateCellF: func(ctx context.Context, id platform.ID, upd platform.CellUpdate) (*platform.Cell, error) {
+						return nil, platform.ErrCellNotFound
+					},
+				},
+			},
+			args: args{
+				id:   "2",
+				name: "hello",
+			},
+			wants: wants{
+				statusCode:  http.StatusNotFound,
+				contentType: "application/json",
+				body:        `{"code":404,"message":"cell not found"}`,
 			},
 		},
 	}

--- a/server/cellvs2_test.go
+++ b/server/cellvs2_test.go
@@ -1,0 +1,553 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bouk/httprouter"
+	"github.com/influxdata/chronograf/log"
+	"github.com/influxdata/chronograf/mocks"
+	chronograf "github.com/influxdata/chronograf/v2"
+)
+
+func TestService_CellsV2(t *testing.T) {
+	type fields struct {
+		CellService chronograf.CellService
+	}
+	type args struct {
+		queryParams map[string][]string
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get all cells",
+			fields: fields{
+				&mocks.CellService{
+					FindCellsF: func(ctx context.Context, filter chronograf.CellFilter) ([]*chronograf.Cell, int, error) {
+						return []*chronograf.Cell{
+							{
+								CellContents: chronograf.CellContents{
+									ID:   chronograf.ID("0"),
+									Name: "hello",
+								},
+								Visualization: chronograf.V1Visualization{
+									Type: "line",
+								},
+							},
+							{
+								CellContents: chronograf.CellContents{
+									ID:   chronograf.ID("2"),
+									Name: "example",
+								},
+							},
+						}, 2, nil
+					},
+				},
+			},
+			args: args{},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body: `
+{
+  "links": {
+    "self": "/chronograf/v2/cells"
+  },
+  "cells": [
+    {
+      "id": "0",
+      "name": "hello",
+      "links": {
+        "self": "/chronograf/v1/cells/0"
+      },
+      "visualization": {
+        "type": "chronograf-v1",
+        "queries": null,
+        "axes": null,
+        "visualizationType": "line",
+        "colors": null,
+        "legend": {},
+        "tableOptions": {
+          "verticalTimeAxis": false,
+          "sortBy": {
+            "internalName": "",
+            "displayName": "",
+            "visible": false
+          },
+          "wrapping": "",
+          "fixFirstColumn": false
+        },
+        "fieldOptions": null,
+        "timeFormat": "",
+        "decimalPlaces": {
+          "isEnforced": false,
+          "digits": 0
+        }
+      }
+    },
+    {
+      "id": "2",
+      "name": "example",
+      "links": {
+        "self": "/chronograf/v1/cells/2"
+      },
+      "visualization": {
+        "type": "empty"
+      }
+    }
+  ]
+}`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Store: &mocks.Store{
+					CellService: tt.fields.CellService,
+				},
+				Logger: log.New(log.DebugLevel),
+			}
+
+			r := httptest.NewRequest("GET", "http://any.url", nil)
+
+			qp := r.URL.Query()
+			for k, vs := range tt.args.queryParams {
+				for _, v := range vs {
+					qp.Add(k, v)
+				}
+			}
+			r.URL.RawQuery = qp.Encode()
+
+			w := httptest.NewRecorder()
+
+			s.CellsV2(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. CellsV2() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. CellsV2() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. CellsV2() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+
+		})
+	}
+}
+
+func TestService_CellIDV2(t *testing.T) {
+	type fields struct {
+		CellService chronograf.CellService
+	}
+	type args struct {
+		id string
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "get a cell by id",
+			fields: fields{
+				&mocks.CellService{
+					FindCellByIDF: func(ctx context.Context, id chronograf.ID) (*chronograf.Cell, error) {
+						if id == "2" {
+							return &chronograf.Cell{
+								CellContents: chronograf.CellContents{
+									ID:   chronograf.ID("2"),
+									Name: "example",
+								},
+							}, nil
+						}
+
+						return nil, fmt.Errorf("not found")
+					},
+				},
+			},
+			args: args{
+				id: "2",
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body: `
+{
+  "id": "2",
+  "name": "example",
+  "links": {
+    "self": "/chronograf/v1/cells/2"
+  },
+  "visualization": {
+    "type": "empty"
+  }
+}
+`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Store: &mocks.Store{
+					CellService: tt.fields.CellService,
+				},
+				Logger: log.New(log.DebugLevel),
+			}
+
+			r := httptest.NewRequest("GET", "http://any.url", nil)
+
+			r = r.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: tt.args.id,
+					},
+				}))
+
+			w := httptest.NewRecorder()
+
+			s.CellIDV2(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. CellIDV2() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. CellIDV2() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. CellIDV2() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+		})
+	}
+}
+
+func TestService_NewCellV2(t *testing.T) {
+	type fields struct {
+		CellService chronograf.CellService
+	}
+	type args struct {
+		cell *chronograf.Cell
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "create a new cell",
+			fields: fields{
+				&mocks.CellService{
+					CreateCellF: func(ctx context.Context, c *chronograf.Cell) error {
+						c.ID = "2"
+						return nil
+					},
+				},
+			},
+			args: args{
+				cell: &chronograf.Cell{
+					CellContents: chronograf.CellContents{
+						Name: "hello",
+					},
+					Visualization: chronograf.V1Visualization{
+						Type: "line",
+					},
+				},
+			},
+			wants: wants{
+				statusCode:  http.StatusCreated,
+				contentType: "application/json",
+				body: `
+{
+  "id": "2",
+  "name": "hello",
+  "links": {
+    "self": "/chronograf/v1/cells/2"
+  },
+  "visualization": {
+    "type": "chronograf-v1",
+    "queries": null,
+    "axes": null,
+    "visualizationType": "line",
+    "colors": null,
+    "legend": {},
+    "tableOptions": {
+      "verticalTimeAxis": false,
+      "sortBy": {
+        "internalName": "",
+        "displayName": "",
+        "visible": false
+      },
+      "wrapping": "",
+      "fixFirstColumn": false
+    },
+    "fieldOptions": null,
+    "timeFormat": "",
+    "decimalPlaces": {
+      "isEnforced": false,
+      "digits": 0
+    }
+  }
+}
+`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Store: &mocks.Store{
+					CellService: tt.fields.CellService,
+				},
+				Logger: log.New(log.DebugLevel),
+			}
+
+			b, err := json.Marshal(tt.args.cell)
+			if err != nil {
+				t.Fatalf("failed to unmarshal cell: %v", err)
+			}
+
+			r := httptest.NewRequest("GET", "http://any.url", bytes.NewReader(b))
+			w := httptest.NewRecorder()
+
+			s.NewCellV2(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. CellIDV2() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. CellIDV2() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. CellIDV2() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+		})
+	}
+}
+
+func TestService_RemoveCellV2(t *testing.T) {
+	type fields struct {
+		CellService chronograf.CellService
+	}
+	type args struct {
+		id string
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "remove a cell by id",
+			fields: fields{
+				&mocks.CellService{
+					DeleteCellF: func(ctx context.Context, id chronograf.ID) error {
+						if id == "2" {
+							return nil
+						}
+
+						return fmt.Errorf("wrong id")
+					},
+				},
+			},
+			args: args{
+				id: "2",
+			},
+			wants: wants{
+				statusCode: http.StatusNoContent,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Store: &mocks.Store{
+					CellService: tt.fields.CellService,
+				},
+				Logger: log.New(log.DebugLevel),
+			}
+
+			r := httptest.NewRequest("GET", "http://any.url", nil)
+
+			r = r.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: tt.args.id,
+					},
+				}))
+
+			w := httptest.NewRecorder()
+
+			s.RemoveCellV2(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. RemoveCellV2() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. RemoveCellV2() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. RemoveCellV2() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+		})
+	}
+}
+
+func TestService_UpdateCellV2(t *testing.T) {
+	type fields struct {
+		CellService chronograf.CellService
+	}
+	type args struct {
+		id  string
+		upd chronograf.CellUpdate
+	}
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		wants  wants
+	}{
+		{
+			name: "update a cell",
+			fields: fields{
+				&mocks.CellService{
+					UpdateCellF: func(ctx context.Context, id chronograf.ID, upd chronograf.CellUpdate) (*chronograf.Cell, error) {
+						if id == "2" {
+							return &chronograf.Cell{
+								CellContents: chronograf.CellContents{
+									ID:   chronograf.ID("2"),
+									Name: "example",
+								},
+								Visualization: chronograf.V1Visualization{
+									Type: "line",
+								},
+							}, nil
+						}
+
+						return nil, fmt.Errorf("not found")
+					},
+				},
+			},
+			args: args{
+				id: "2",
+			},
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &Service{
+				Store: &mocks.Store{
+					CellService: tt.fields.CellService,
+				},
+				Logger: log.New(log.DebugLevel),
+			}
+
+			b, err := json.Marshal(tt.args.upd)
+			if err != nil {
+				t.Fatalf("failed to unmarshal cell update: %v", err)
+			}
+
+			r := httptest.NewRequest("GET", "http://any.url", bytes.NewReader(b))
+
+			r = r.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: tt.args.id,
+					},
+				}))
+
+			w := httptest.NewRecorder()
+
+			s.UpdateCellV2(w, r)
+
+			res := w.Result()
+			content := res.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(res.Body)
+
+			if res.StatusCode != tt.wants.statusCode {
+				t.Errorf("%q. RemoveCellV2() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)
+			}
+			if tt.wants.contentType != "" && content != tt.wants.contentType {
+				t.Errorf("%q. RemoveCellV2() = %v, want %v", tt.name, content, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); tt.wants.body != "" && !eq {
+				t.Errorf("%q. RemoveCellV2() = \n***%v***\n,\nwant\n***%v***", tt.name, string(body), tt.wants.body)
+			}
+		})
+	}
+}

--- a/server/mux.go
+++ b/server/mux.go
@@ -323,6 +323,14 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 
 	router.GET("/chronograf/v1/env", EnsureViewer(service.Environment))
 
+	/// V2 Cells
+	router.GET("/chronograf/v2/cells", EnsureViewer(service.CellsV2))
+	router.POST("/chronograf/v2/cells", EnsureEditor(service.NewCellV2))
+
+	router.GET("/chronograf/v2/cells/:id", EnsureViewer(service.CellIDV2))
+	router.DELETE("/chronograf/v2/cells/:id", EnsureEditor(service.RemoveCellV2))
+	router.PATCH("/chronograf/v2/cells/:id", EnsureEditor(service.UpdateCellV2))
+
 	allRoutes := &AllRoutes{
 		Logger:      opts.Logger,
 		StatusFeed:  opts.StatusFeedURL,

--- a/server/routes.go
+++ b/server/routes.go
@@ -41,10 +41,11 @@ type getRoutesResponse struct {
 	Environment        string                             `json:"environment"`      // Location of the environement endpoint
 	Dashboards         string                             `json:"dashboards"`       // Location of the dashboards endpoint
 	Config             getConfigLinksResponse             `json:"config"`           // Location of the config endpoint and its various sections
-	OrganizationConfig getOrganizationConfigLinksResponse `json:"orgConfig"`        // Location of the organization config endpoint
+	Cells              string                             `json:"cells"`            // Location of the v2 cells
 	Auth               []AuthRoute                        `json:"auth"`             // Location of all auth routes.
 	Logout             *string                            `json:"logout,omitempty"` // Location of the logout route for all auth routes
 	ExternalLinks      getExternalLinksResponse           `json:"external"`         // All external links for the client to use
+	OrganizationConfig getOrganizationConfigLinksResponse `json:"orgConfig"`        // Location of the organization config endpoint
 	Flux               getFluxLinksResponse               `json:"flux"`
 }
 
@@ -87,6 +88,7 @@ func (a *AllRoutes) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Environment:   "/chronograf/v1/env",
 		Mappings:      "/chronograf/v1/mappings",
 		Dashboards:    "/chronograf/v1/dashboards",
+		Cells:         "/chronograf/v2/cells",
 		Config: getConfigLinksResponse{
 			Self: "/chronograf/v1/config",
 			Auth: "/chronograf/v1/config/auth",

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -29,9 +29,14 @@ func TestAllRoutes(t *testing.T) {
 	if err := json.Unmarshal(body, &routes); err != nil {
 		t.Error("TestAllRoutes not able to unmarshal JSON response")
 	}
-	want := `{"layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"auth":[],"external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
+	want := `{"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"cells":"/chronograf/v2/cells","layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"auth":[],"external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
 `
-	if want != string(body) {
+
+	eq, err := jsonEqual(want, string(body))
+	if err != nil {
+		t.Fatalf("error decoding json: %v", err)
+	}
+	if !eq {
 		t.Errorf("TestAllRoutes\nwanted\n*%s*\ngot\n*%s*", want, string(body))
 	}
 
@@ -67,9 +72,13 @@ func TestAllRoutesWithAuth(t *testing.T) {
 	if err := json.Unmarshal(body, &routes); err != nil {
 		t.Error("TestAllRoutesWithAuth not able to unmarshal JSON response")
 	}
-	want := `{"layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"auth":[{"name":"github","label":"GitHub","login":"/oauth/github/login","logout":"/oauth/github/logout","callback":"/oauth/github/callback"}],"logout":"/oauth/logout","external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
+	want := `{"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"cells":"/chronograf/v2/cells","layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"auth":[{"name":"github","label":"GitHub","login":"/oauth/github/login","logout":"/oauth/github/logout","callback":"/oauth/github/callback"}],"logout":"/oauth/logout","external":{"statusFeed":""},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
 `
-	if want != string(body) {
+	eq, err := jsonEqual(want, string(body))
+	if err != nil {
+		t.Fatalf("error decoding json: %v", err)
+	}
+	if !eq {
 		t.Errorf("TestAllRoutesWithAuth\nwanted\n*%s*\ngot\n*%s*", want, string(body))
 	}
 }
@@ -100,9 +109,13 @@ func TestAllRoutesWithExternalLinks(t *testing.T) {
 	if err := json.Unmarshal(body, &routes); err != nil {
 		t.Error("TestAllRoutesWithExternalLinks not able to unmarshal JSON response")
 	}
-	want := `{"layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"auth":[],"external":{"statusFeed":"http://pineapple.life/feed.json","custom":[{"name":"cubeapple","url":"https://cube.apple"}]},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
+	want := `{"orgConfig":{"self":"/chronograf/v1/org_config","logViewer":"/chronograf/v1/org_config/logviewer"},"cells":"/chronograf/v2/cells","layouts":"/chronograf/v1/layouts","users":"/chronograf/v1/organizations/default/users","allUsers":"/chronograf/v1/users","organizations":"/chronograf/v1/organizations","mappings":"/chronograf/v1/mappings","sources":"/chronograf/v1/sources","me":"/chronograf/v1/me","environment":"/chronograf/v1/env","dashboards":"/chronograf/v1/dashboards","config":{"self":"/chronograf/v1/config","auth":"/chronograf/v1/config/auth"},"auth":[],"external":{"statusFeed":"http://pineapple.life/feed.json","custom":[{"name":"cubeapple","url":"https://cube.apple"}]},"flux":{"ast":"/chronograf/v1/flux/ast","self":"/chronograf/v1/flux","suggestions":"/chronograf/v1/flux/suggestions"}}
 `
-	if want != string(body) {
+	eq, err := jsonEqual(want, string(body))
+	if err != nil {
+		t.Fatalf("error decoding json: %v", err)
+	}
+	if !eq {
 		t.Errorf("TestAllRoutesWithExternalLinks\nwanted\n*%s*\ngot\n*%s*", want, string(body))
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -495,6 +495,7 @@ func openService(ctx context.Context, buildInfo chronograf.BuildInfo, boltPath s
 			ConfigStore:             db.ConfigStore,
 			MappingsStore:           db.MappingsStore,
 			OrganizationConfigStore: db.OrganizationConfigStore,
+			CellService:             db,
 		},
 		Logger:    logger,
 		UseAuth:   useAuth,

--- a/server/stores.go
+++ b/server/stores.go
@@ -93,7 +93,6 @@ type DataStore interface {
 	Dashboards(ctx context.Context) chronograf.DashboardsStore
 	Config(ctx context.Context) chronograf.ConfigStore
 	OrganizationConfig(ctx context.Context) chronograf.OrganizationConfigStore
-
 	Cells(ctx context.Context) chronografv2.CellService
 }
 
@@ -111,8 +110,7 @@ type Store struct {
 	OrganizationsStore      chronograf.OrganizationsStore
 	ConfigStore             chronograf.ConfigStore
 	OrganizationConfigStore chronograf.OrganizationConfigStore
-
-	CellService chronografv2.CellService
+	CellService             chronografv2.CellService
 }
 
 // Sources returns a noop.SourcesStore if the context has no organization specified

--- a/server/stores.go
+++ b/server/stores.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/chronograf/noop"
 	"github.com/influxdata/chronograf/organizations"
 	"github.com/influxdata/chronograf/roles"
+	chronografv2 "github.com/influxdata/chronograf/v2"
 )
 
 // hasOrganizationContext retrieves organization specified on context
@@ -92,6 +93,8 @@ type DataStore interface {
 	Dashboards(ctx context.Context) chronograf.DashboardsStore
 	Config(ctx context.Context) chronograf.ConfigStore
 	OrganizationConfig(ctx context.Context) chronograf.OrganizationConfigStore
+
+	Cells(ctx context.Context) chronografv2.CellService
 }
 
 // ensure that Store implements a DataStore
@@ -108,6 +111,8 @@ type Store struct {
 	OrganizationsStore      chronograf.OrganizationsStore
 	ConfigStore             chronograf.ConfigStore
 	OrganizationConfigStore chronograf.OrganizationConfigStore
+
+	CellService chronografv2.CellService
 }
 
 // Sources returns a noop.SourcesStore if the context has no organization specified
@@ -216,4 +221,9 @@ func (s *Store) Mappings(ctx context.Context) chronograf.MappingsStore {
 		return s.MappingsStore
 	}
 	return &noop.MappingsStore{}
+}
+
+// Cells returns the underlying CellService.
+func (s *Store) Cells(ctx context.Context) chronografv2.CellService {
+	return s.CellService
 }

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -2965,7 +2965,7 @@
           "200": {
             "description": "Returns an object with the organization-specific configurations",
             "schema": {
-              "$ref": "#/definitions/OrganizationConfig" 
+              "$ref": "#/definitions/OrganizationConfig"
             }
           },
           "404": {

--- a/server/swagger_v2.yml
+++ b/server/swagger_v2.yml
@@ -1,0 +1,482 @@
+openapi: "3.0.0"
+info:
+  title: Gateway Service
+  version: 0.1.0
+servers:
+  - url: /chronograf/v2
+paths:
+  /cells:
+    post:
+      tags:
+        - Cells
+      summary: Create a cell
+      requestBody:
+          description: cell to create
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cell"
+      responses:
+        '201':
+          description: Added cell
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cell"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    get:
+      tags:
+        - Cells
+      summary: Get all cells
+      parameters:
+        - in: query
+          name: organization
+          schema:
+            type: string
+          description: filter for dashboards belonging to a particular organization
+        - in: query
+          name: organizationID
+          schema:
+            type: string
+          description: filter for dashboards belonging to a particular organizationID
+        - in: query
+          name: user
+          schema:
+            type: string
+          description: filter for dashboards belonging to a particular user
+        - in: query
+          name: userID
+          schema:
+            type: string
+          description: filter for dashboards belonging to a particular userID
+      responses:
+        '200':
+          description: all cells
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cells"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  '/cells/{cellID}':
+   get:
+    tags:
+      - Cells
+    summary: Get a single Cell
+    parameters:
+        - in: path
+          name: cellID
+          schema:
+            type: string
+          required: true
+          description: ID of cell to update
+    responses:
+        '200':
+          description: get a single cell
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cell"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+   patch:
+      tags:
+        - Cells
+      summary: Update a single cell
+      requestBody:
+          description: patching of a cell
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cell"
+      parameters:
+        - in: path
+          name: cellID
+          schema:
+            type: string
+          required: true
+          description: ID of cell to update
+      responses:
+        '200':
+          description: Updated cell
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Cell"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+   delete:
+      tags:
+        - Cells
+      summary: Delete a cell
+      parameters:
+        - in: path
+          name: cellID
+          schema:
+            type: string
+          required: true
+          description: ID of cell to update
+      responses:
+        '202':
+          description: delete has been accepted
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Link:
+      type: object
+      readOnly: true
+      description: URI of resource.
+      properties:
+        href:
+          type: string
+          format: url
+      required: [href]
+    Links:
+      type: object
+      readOnly: true
+      properties:
+        self:
+          $ref: "#/components/schemas/Link"
+      required: [self]
+    Field:
+      type: object
+      properties:
+        value:
+          description: >-
+            value is the value of the field.  Meaning of the value is implied by
+            the `type` key
+          type: string
+        type:
+          description: >-
+            type describes the field type. func is a function; field is a field
+            reference
+          type: string
+          enum:
+            - func
+            - field
+            - integer
+            - number
+            - regex
+            - wildcard
+        alias:
+          description: >-
+            Alias overrides the field name in the returned response.  Applies only
+            if type is `func`
+          type: string
+        args:
+          description: Args are the arguments to the function
+          type: array
+          items:
+            $ref: '#/components/schemas/Field'
+    QueryConfig:
+      type: object
+      required:
+        - database
+        - measurement
+        - retentionPolicy
+        - areTagsAccepted
+        - tags
+        - groupBy
+        - fields
+      properties:
+        id:
+          type: string
+        database:
+          type: string
+        measurement:
+          type: string
+        retentionPolicy:
+          type: string
+        areTagsAccepted:
+          type: boolean
+        rawText:
+          type: string
+        tags:
+          type: object
+        groupBy:
+          type: object
+          properties:
+            time:
+              type: string
+            tags:
+              type: array
+              items:
+                type: string
+          required:
+            - time
+            - tags
+        fields:
+          type: array
+          items:
+            $ref: '#/components/schemas/Field'
+        range:
+          type: object
+          properties:
+            lower:
+              type: string
+            upper:
+              type: string
+          required:
+            - lower
+            - upper
+    DashboardQuery:
+      type: object
+      required:
+        - query
+      properties:
+        label:
+          type: string
+          description: Optional Y-axis user-facing label
+        range:
+          description: Optional default range of the Y-axis
+          type: object
+          required:
+            - upper
+            - lower
+          properties:
+            upper:
+              description: Upper bound of the display range of the Y-axis
+              type: integer
+              format: int64
+            lower:
+              description: Lower bound of the display range of the Y-axis
+              type: integer
+              format: int64
+        query:
+          type: string
+        source:
+          type: string
+          format: url
+          description: Optional URI for data source for this query
+        queryConfig:
+          $ref: '#/components/schemas/QueryConfig'
+    Axis:
+      type: object
+      description: A description of a particular axis for a visualization
+      properties:
+        bounds:
+          type: array
+          minItems: 0
+          maxItems: 2
+          description: >-
+            The extents of an axis in the form [lower, upper]. Clients determine
+            whether bounds are to be inclusive or exclusive of their limits
+          items:
+            type: integer
+            format: int64
+        label:
+          description: label is a description of this Axis
+          type: string
+        prefix:
+          description: Prefix represents a label prefix for formatting axis values.
+          type: string
+        suffix:
+          description: Suffix represents a label suffix for formatting axis values.
+          type: string
+        base:
+          description: Base represents the radix for formatting axis values.
+          type: string
+        scale:
+          description: 'Scale is the axis formatting scale. Supported: "log", "linear"'
+          type: string
+    DashboardColor:
+      type: object
+      description: Color defines an encoding of data value into color space
+      properties:
+        id:
+          description: ID is the unique id of the cell color
+          type: string
+        type:
+          description: Type is how the color is used.
+          type: string
+          enum:
+            - min
+            - max
+            - threshold
+        hex:
+          description: Hex is the hex number of the color
+          type: string
+          maxLength: 7
+          minLength: 7
+        name:
+          description: Name is the user-facing name of the hex color
+          type: string
+        value:
+          description: Value is the data value mapped to this color
+          type: string
+    RenamableField:
+      description: Describes a field that can be renamed and made visible or invisible
+      type: object
+      properties:
+        internalName:
+          description: This is the calculated name of a field
+          readOnly: true
+          type: string
+        displayName:
+          description: This is the name that a field is renamed to by the user
+          type: string
+        visible:
+          description: Indicates whether this field should be visible on the table
+          type: boolean
+    V1Visualization:
+      properties:
+        type:
+          type: string
+          enum: ["chronograf-v1"]
+        queries:
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardQuery"
+        axes:
+          description: The viewport for a Cell's visualizations
+          type: object
+          properties:
+            x:
+              $ref: '#/components/schemas/Axis'
+            y:
+              $ref: '#/components/schemas/Axis'
+            y2:
+              $ref: '#/components/schemas/Axis'
+        graphType:
+          description: The viewport for a cell's graph/visualization
+          type: string
+          enum:
+            - single-stat
+            - line
+            - line-plus-single-stat
+            - line-stacked
+            - line-stepplot
+            - bar
+            - gauge
+            - table
+          default: line
+        colors:
+          description: Colors define color encoding of data into a visualization
+          type: array
+          items:
+            $ref: "#/components/schemas/DashboardColor"
+        legend:
+          description: Legend define encoding of data into a cell's legend
+          type: object
+          properties:
+            type:
+              description: type is the style of the legend
+              type: string
+              enum:
+                - static
+            orientation:
+              description: >-
+                orientation is the location of the legend with respect to the cell
+                graph
+              type: string
+              enum:
+                - top
+                - bottom
+                - left
+                - right
+        tableOptions:
+          properties:
+            verticalTimeAxis:
+              description: >-
+                verticalTimeAxis describes the orientation of the table by
+                indicating whether the time axis will be displayed vertically
+              type: boolean
+            sortBy:
+              $ref: "#/components/schemas/RenamableField"
+            wrapping:
+              description: wrapping describes the text wrapping style to be used in table cells
+              type: string
+              enum:
+                - truncate
+                - wrap
+                - single-line
+            fixFirstColumn:
+              description: >-
+                fixFirstColumn indicates whether the first column of the table
+                should be locked
+              type: boolean
+        fieldOptions:
+          description: >-
+            fieldOptions represent the fields retrieved by the query with
+            customization options
+          type: array
+          items:
+            $ref: '#/components/schemas/RenamableField'
+        timeFormat:
+          description: >-
+            timeFormat describes the display format for time values according to
+            moment.js date formatting
+          type: string
+        decimalPoints:
+          description: >-
+            decimal points indicates whether and how many digits to show after
+            decimal point
+          type: object
+          properties:
+            isEnforced:
+              description: Indicates whether decimal point setting should be enforced
+              type: boolean
+            digits:
+              description: The number of digists after decimal to display
+              type: integer
+    EmptyVisualization:
+      properties:
+        type:
+          type: string
+          enum: ["empty"]
+    Cell:
+      properties:
+        links:
+          $ref: "#/components/schemas/Links"
+        id:
+          readOnly: true
+          type: string
+        name:
+          type: string
+        visualization:
+          oneOf:
+            - $ref: "#/components/schemas/V1Visualization"
+            - $ref: "#/components/schemas/EmptyVisualization"
+    Cells:
+      type: object
+      properties:
+        links:
+          $ref: "#/components/schemas/Links"
+        cells:
+          type: array
+          items:
+            $ref: "#/components/schemas/Cell"
+    Error:
+      properties:
+        code:
+          readOnly: true
+          type: integer
+          format: int32
+        message:
+          readOnly: true
+          type: string
+      required: [code, message]

--- a/server/swagger_v2.yml
+++ b/server/swagger_v2.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 info:
-  title: Gateway Service
-  version: 0.1.0
+  title: Chronograf
+  version: 1.5.0.0
 servers:
   - url: /chronograf/v2
 paths:
@@ -34,27 +34,6 @@ paths:
       tags:
         - Cells
       summary: Get all cells
-      parameters:
-        - in: query
-          name: organization
-          schema:
-            type: string
-          description: filter for dashboards belonging to a particular organization
-        - in: query
-          name: organizationID
-          schema:
-            type: string
-          description: filter for dashboards belonging to a particular organizationID
-        - in: query
-          name: user
-          schema:
-            type: string
-          description: filter for dashboards belonging to a particular user
-        - in: query
-          name: userID
-          schema:
-            type: string
-          description: filter for dashboards belonging to a particular userID
       responses:
         '200':
           description: all cells
@@ -136,7 +115,7 @@ paths:
           required: true
           description: ID of cell to update
       responses:
-        '202':
+        '204':
           description: delete has been accepted
         default:
           description: unexpected error

--- a/v2/cell.go
+++ b/v2/cell.go
@@ -1,10 +1,13 @@
-package chronograf
+package platform
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
 )
+
+// ErrCellNotFound is the error for a missing cell.
+const ErrCellNotFound = Error("cell not found")
 
 // ID is an ID
 type ID string
@@ -33,6 +36,16 @@ type CellService interface {
 type CellUpdate struct {
 	CellContentsUpdate
 	Visualization Visualization
+}
+
+// Valid validates the update struct. It expects minimal values to be set.
+func (u CellUpdate) Valid() error {
+	_, ok := u.Visualization.(EmptyVisualization)
+	if u.Name == nil && ok {
+		return fmt.Errorf("expected at least one attribute to be updated")
+	}
+
+	return nil
 }
 
 // CellContentsUpdate is a struct for updating the non visualization content of a cell.

--- a/v2/cell.go
+++ b/v2/cell.go
@@ -1,0 +1,260 @@
+package chronograf
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/influxdata/platform"
+)
+
+// CellService represents a service for managing cell data.
+type CellService interface {
+	// FindCellByplatform.ID returns a single cell by platform.ID.
+	FindCellByID(ctx context.Context, id platform.ID) (*Cell, error)
+
+	// FindCells returns a list of cells that match filter and the total count of matching cells.
+	// Additional options provide pagination & sorting.
+	FindCells(ctx context.Context, filter CellFilter) ([]*Cell, int, error)
+
+	// CreateCell creates a new cell and sets b.platform.ID with the new identifier.
+	CreateCell(ctx context.Context, b *Cell) error
+
+	// UpdateCell updates a single cell with changeset.
+	// Returns the new cell state after update.
+	UpdateCell(ctx context.Context, id platform.ID, upd CellUpdate) (*Cell, error)
+
+	// DeleteCell removes a cell by platform.ID.
+	DeleteCell(ctx context.Context, id platform.ID) error
+}
+
+// CellUpdate is a struct for updating cells.
+type CellUpdate struct {
+	Name          *string       `json:"name"`
+	Visualization Visualization `json:"visualization"`
+}
+
+// CellFilter represents a set of filter that restrict the returned results.
+type CellFilter struct {
+	ID             *platform.ID
+	OrganizationID *platform.ID
+	Organization   *string
+}
+
+// Cell holds positional and visual information for a cell.
+type Cell struct {
+	CellContents
+	Visualization Visualization
+}
+
+type CellContents struct {
+	ID   platform.ID `json:"id"`
+	Name string      `json:"name"`
+}
+
+type Visualization interface {
+	Visualization()
+}
+
+func UnmarshalVisualizationJSON(b []byte) (Visualization, error) {
+	var v struct {
+		B json.RawMessage `json:"visualization"`
+	}
+
+	if err := json.Unmarshal(b, &v); err != nil {
+		return nil, err
+	}
+
+	var t struct {
+		Type string `json:"type"`
+	}
+
+	if err := json.Unmarshal(v.B, &t); err != nil {
+		return nil, err
+	}
+
+	var vis Visualization
+	switch t.Type {
+	case "chronograf-v1":
+		var qv V1Visualization
+		if err := json.Unmarshal(v.B, &qv); err != nil {
+			return nil, err
+		}
+		vis = qv
+	default:
+		return nil, fmt.Errorf("unknown type %v", t.Type)
+	}
+
+	return vis, nil
+}
+
+func MarshalVisualizationJSON(v Visualization) ([]byte, error) {
+	var s interface{}
+	switch vis := v.(type) {
+	case V1Visualization:
+		s = struct {
+			Type string `json:"type"`
+			V1Visualization
+		}{
+			Type:            "chronograf-v1",
+			V1Visualization: vis,
+		}
+	default:
+		return nil, fmt.Errorf("unsupported type")
+	}
+	return json.Marshal(s)
+}
+
+func (c Cell) MarshalJSON() ([]byte, error) {
+	vis, err := MarshalVisualizationJSON(c.Visualization)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(struct {
+		CellContents
+		Visualization json.RawMessage `json:"visualization"`
+	}{
+		CellContents:  c.CellContents,
+		Visualization: vis,
+	})
+}
+
+func (c *Cell) UnmarshalJSON(b []byte) error {
+	if err := json.Unmarshal(b, &c.CellContents); err != nil {
+		return err
+	}
+
+	v, err := UnmarshalVisualizationJSON(b)
+	if err != nil {
+		return err
+	}
+	c.Visualization = v
+	return nil
+}
+
+type V1Visualization struct {
+	Queries []DashboardQuery `json:"queries"`
+	Axes    map[string]Axis  `json:"axes"`
+	// TODO: chronograf will have to use visualizationType rather than type
+	Type          string           `json:"visualizationType"`
+	CellColors    []CellColor      `json:"colors"`
+	Legend        Legend           `json:"legend"`
+	TableOptions  TableOptions     `json:"tableOptions,omitempty"`
+	FieldOptions  []RenamableField `json:"fieldOptions"`
+	TimeFormat    string           `json:"timeFormat"`
+	DecimalPlaces DecimalPlaces    `json:"decimalPlaces"`
+}
+
+func (V1Visualization) Visualization() {}
+
+/////////////////////////////
+// Old Chronograf Types
+/////////////////////////////
+
+// DashboardQuery includes state for the query builder.  This is a transition
+// struct while we move to the full InfluxQL AST
+type DashboardQuery struct {
+	Command     string      `json:"query"`                 // Command is the query itself
+	Label       string      `json:"label,omitempty"`       // Label is the Y-Axis label for the data
+	Range       *Range      `json:"range,omitempty"`       // Range is the default Y-Axis range for the data
+	QueryConfig QueryConfig `json:"queryConfig,omitempty"` // QueryConfig represents the query state that is understood by the data explorer
+	Source      string      `json:"source"`                // Source is the optional URI to the data source for this queryConfig
+	Shifts      []TimeShift `json:"-"`                     // Shifts represents shifts to apply to an influxql query's time range.  Clients expect the shift to be in the generated QueryConfig
+}
+
+// Range represents an upper and lower bound for data
+type Range struct {
+	Upper int64 `json:"upper"` // Upper is the upper bound
+	Lower int64 `json:"lower"` // Lower is the lower bound
+}
+
+// QueryConfig represents UI query from the data explorer
+type QueryConfig struct {
+	ID              string              `json:"id,omitempty"`
+	Database        string              `json:"database"`
+	Measurement     string              `json:"measurement"`
+	RetentionPolicy string              `json:"retentionPolicy"`
+	Fields          []Field             `json:"fields"`
+	Tags            map[string][]string `json:"tags"`
+	GroupBy         GroupBy             `json:"groupBy"`
+	AreTagsAccepted bool                `json:"areTagsAccepted"`
+	Fill            string              `json:"fill,omitempty"`
+	RawText         *string             `json:"rawText"`
+	Range           *DurationRange      `json:"range"`
+	Shifts          []TimeShift         `json:"shifts"`
+}
+
+// TimeShift represents a shift to apply to an influxql query's time range
+type TimeShift struct {
+	Label    string `json:"label"`    // Label user facing description
+	Unit     string `json:"unit"`     // Unit influxql time unit representation i.e. ms, s, m, h, d
+	Quantity string `json:"quantity"` // Quantity number of units
+}
+
+// Field represent influxql fields and functions from the UI
+type Field struct {
+	Value interface{} `json:"value"`
+	Type  string      `json:"type"`
+	Alias string      `json:"alias"`
+	Args  []Field     `json:"args,omitempty"`
+}
+
+// GroupBy represents influxql group by tags from the UI
+type GroupBy struct {
+	Time string   `json:"time"`
+	Tags []string `json:"tags"`
+}
+
+// DurationRange represents the lower and upper durations of the query config
+type DurationRange struct {
+	Upper string `json:"upper"`
+	Lower string `json:"lower"`
+}
+
+// Axis represents the visible extents of a visualization
+type Axis struct {
+	Bounds       []string `json:"bounds"` // bounds are an arbitrary list of client-defined strings that specify the viewport for a cell
+	LegacyBounds [2]int64 `json:"-"`      // legacy bounds are for testing a migration from an earlier version of axis
+	Label        string   `json:"label"`  // label is a description of this Axis
+	Prefix       string   `json:"prefix"` // Prefix represents a label prefix for formatting axis values
+	Suffix       string   `json:"suffix"` // Suffix represents a label suffix for formatting axis values
+	Base         string   `json:"base"`   // Base represents the radix for formatting axis values
+	Scale        string   `json:"scale"`  // Scale is the axis formatting scale. Supported: "log", "linear"
+}
+
+// CellColor represents the encoding of data into visualizations
+type CellColor struct {
+	ID    string `json:"id"`    // ID is the unique id of the cell color
+	Type  string `json:"type"`  // Type is how the color is used. Accepted (min,max,threshold)
+	Hex   string `json:"hex"`   // Hex is the hex number of the color
+	Name  string `json:"name"`  // Name is the user-facing name of the hex color
+	Value string `json:"value"` // Value is the data value mapped to this color
+}
+
+// Legend represents the encoding of data into a legend
+type Legend struct {
+	Type        string `json:"type,omitempty"`
+	Orientation string `json:"orientation,omitempty"`
+}
+
+// TableOptions is a type of options for a DashboardCell with type Table
+type TableOptions struct {
+	VerticalTimeAxis bool           `json:"verticalTimeAxis"`
+	SortBy           RenamableField `json:"sortBy"`
+	Wrapping         string         `json:"wrapping"`
+	FixFirstColumn   bool           `json:"fixFirstColumn"`
+}
+
+// RenamableField is a column/row field in a DashboardCell of type Table
+type RenamableField struct {
+	InternalName string `json:"internalName"`
+	DisplayName  string `json:"displayName"`
+	Visible      bool   `json:"visible"`
+}
+
+// DecimalPlaces indicates whether decimal places should be enforced, and how many digits it should show.
+type DecimalPlaces struct {
+	IsEnforced bool  `json:"isEnforced"`
+	Digits     int32 `json:"digits"`
+}

--- a/v2/cell.go
+++ b/v2/cell.go
@@ -119,16 +119,14 @@ func MarshalVisualizationJSON(v Visualization) ([]byte, error) {
 			Type:            "chronograf-v1",
 			V1Visualization: vis,
 		}
-	case EmptyVisualization:
+	default:
 		s = struct {
 			Type string `json:"type"`
 			EmptyVisualization
 		}{
 			Type:               "empty",
-			EmptyVisualization: vis,
+			EmptyVisualization: EmptyVisualization{},
 		}
-	default:
-		return nil, fmt.Errorf("unsupported type")
 	}
 	return json.Marshal(s)
 }
@@ -172,6 +170,20 @@ func (u *CellUpdate) UnmarshalJSON(b []byte) error {
 	}
 	u.Visualization = v
 	return nil
+}
+func (u CellUpdate) MarshalJSON() ([]byte, error) {
+	vis, err := MarshalVisualizationJSON(u.Visualization)
+	if err != nil {
+		return nil, err
+	}
+
+	return json.Marshal(struct {
+		CellContentsUpdate
+		Visualization json.RawMessage `json:"visualization,omitempty"`
+	}{
+		CellContentsUpdate: u.CellContentsUpdate,
+		Visualization:      vis,
+	})
 }
 
 type V1Visualization struct {

--- a/v2/cell_test.go
+++ b/v2/cell_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/chronograf/v2"
-	"github.com/influxdata/platform"
 )
 
 func TestCell_MarshalJSON(t *testing.T) {
@@ -25,7 +24,7 @@ func TestCell_MarshalJSON(t *testing.T) {
 			args: args{
 				cell: chronograf.Cell{
 					CellContents: chronograf.CellContents{
-						ID:   platform.ID("0"), // This ends up being id 30 encoded
+						ID:   chronograf.ID("0"),
 						Name: "hello",
 					},
 					Visualization: chronograf.V1Visualization{
@@ -36,7 +35,7 @@ func TestCell_MarshalJSON(t *testing.T) {
 			wants: wants{
 				json: `
 {
-  "id": "30",
+  "id": "0",
   "name": "hello",
   "visualization": {
     "type": "chronograf-v1",

--- a/v2/cell_test.go
+++ b/v2/cell_test.go
@@ -1,4 +1,4 @@
-package chronograf_test
+package platform_test
 
 import (
 	"encoding/json"
@@ -10,7 +10,7 @@ import (
 
 func TestCell_MarshalJSON(t *testing.T) {
 	type args struct {
-		cell chronograf.Cell
+		cell platform.Cell
 	}
 	type wants struct {
 		json string
@@ -22,12 +22,12 @@ func TestCell_MarshalJSON(t *testing.T) {
 	}{
 		{
 			args: args{
-				cell: chronograf.Cell{
-					CellContents: chronograf.CellContents{
-						ID:   chronograf.ID("0"),
+				cell: platform.Cell{
+					CellContents: platform.CellContents{
+						ID:   platform.ID("0"),
 						Name: "hello",
 					},
-					Visualization: chronograf.V1Visualization{
+					Visualization: platform.V1Visualization{
 						Type: "line",
 					},
 				},

--- a/v2/cell_test.go
+++ b/v2/cell_test.go
@@ -1,0 +1,100 @@
+package chronograf_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/chronograf/v2"
+	"github.com/influxdata/platform"
+)
+
+func TestCell_MarshalJSON(t *testing.T) {
+	type args struct {
+		cell chronograf.Cell
+	}
+	type wants struct {
+		json string
+	}
+	tests := []struct {
+		name  string
+		args  args
+		wants wants
+	}{
+		{
+			args: args{
+				cell: chronograf.Cell{
+					CellContents: chronograf.CellContents{
+						ID:   platform.ID("0"), // This ends up being id 30 encoded
+						Name: "hello",
+					},
+					Visualization: chronograf.V1Visualization{
+						Type: "line",
+					},
+				},
+			},
+			wants: wants{
+				json: `
+{
+  "id": "30",
+  "name": "hello",
+  "visualization": {
+    "type": "chronograf-v1",
+    "queries": null,
+    "axes": null,
+    "visualizationType": "line",
+    "colors": null,
+    "legend": {},
+    "tableOptions": {
+      "verticalTimeAxis": false,
+      "sortBy": {
+        "internalName": "",
+        "displayName": "",
+        "visible": false
+      },
+      "wrapping": "",
+      "fixFirstColumn": false
+    },
+    "fieldOptions": null,
+    "timeFormat": "",
+    "decimalPlaces": {
+      "isEnforced": false,
+      "digits": 0
+    }
+  }
+}
+`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := json.MarshalIndent(tt.args.cell, "", "  ")
+			if err != nil {
+				t.Fatalf("error marshalling json")
+			}
+
+			eq, err := jsonEqual(string(b), tt.wants.json)
+			if err != nil {
+				t.Fatalf("error marshalling json")
+			}
+			if !eq {
+				t.Errorf("JSON did not match\nexpected:%s\ngot:\n%s\n", tt.wants.json, string(b))
+			}
+		})
+	}
+}
+
+func jsonEqual(s1, s2 string) (eq bool, err error) {
+	var o1, o2 interface{}
+
+	if err = json.Unmarshal([]byte(s1), &o1); err != nil {
+		return
+	}
+	if err = json.Unmarshal([]byte(s2), &o2); err != nil {
+		return
+	}
+
+	return cmp.Equal(o1, o2), nil
+}

--- a/v2/error.go
+++ b/v2/error.go
@@ -1,0 +1,9 @@
+package platform
+
+// Error is a domain error encountered while processing chronograf requests.
+type Error string
+
+// Error returns the string of an error.
+func (e Error) Error() string {
+	return string(e)
+}


### PR DESCRIPTION
_Briefly describe your proposed changes:_

This PR introduces a `cells` API for directly interacting with cells. Cells are now a separate resource from dashboards. This was done under `v2`. This work was done in progression towards a `v2` dashboards API.

TODO
 
  - [x] Add tests for API
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)