### PR TITLE
Fix multiple base paths added when routing dashboards

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -17,6 +17,7 @@ import {hydrateTemplate, isTemplateNested} from 'src/tempVars/apis'
 
 import {notify} from 'src/shared/actions/notifications'
 import {errorThrown} from 'src/shared/actions/errors'
+import {stripPrefix} from 'src/utils/basepath'
 
 import {
   applyLocalSelections,
@@ -364,6 +365,7 @@ export const setActiveCell = (activeCellID: string): SetActiveCellAction => ({
 
 export const updateQueryParams = (updatedQueryParams: object): RouterAction => {
   const {search, pathname} = window.location
+  const strippedPathname = stripPrefix(pathname)
 
   const newQueryParams = _.pickBy(
     {
@@ -374,7 +376,7 @@ export const updateQueryParams = (updatedQueryParams: object): RouterAction => {
   )
 
   const newSearch = qs.stringify(newQueryParams)
-  const newLocation = {pathname, search: `?${newSearch}`}
+  const newLocation = {pathname: strippedPathname, search: `?${newSearch}`}
 
   return replace(newLocation)
 }


### PR DESCRIPTION
Closes #3835

_What was the problem?_
Multiple base paths were prepended when selecting a dashboard from the dashboards page resulting in a `404` page because react router expects pathname to not include the base path. The pathname supplied to React Router `replace` was `window.location.pathname` which includes the base path. Previously, we'd been passing `location` with the stripped pathname into the action creator from components, but that pattern was a source of indirection/pain we refactored.

Note: Just calling `replace({search: newSearch})` results in an error when a base path is set and navigating to `/` when no base path is present. 

_What was the solution?_ 
Using the `stripPrefix` util to remove the pathname prefix before calling replace. 

Also, we are on React Router v3, but V4 might offer better support for just being able to leave off the pathname when only updating the search params. 

  - [x] Rebased/mergeable
  - [x] Tests pass