### PR TITLE
Fix encoding of empty source responses

### DIFF
--- a/server/sources.go
+++ b/server/sources.go
@@ -179,7 +179,7 @@ func (s *Service) Sources(w http.ResponseWriter, r *http.Request) {
 		Sources: make([]sourceResponse, len(srcs)),
 	}
 
-	var sources []sourceResponse
+	sources := make([]sourceResponse, 0)
 	for _, src := range srcs {
 		sources = append(sources, newSourceResponse(ctx, src))
 	}


### PR DESCRIPTION
Closes #3851

When a user ran a production build of Chronograf for the first time, the API for `GET /sources` returned
```
{"sources": null}
```
The client expects `“sources”` to be an empty array in this case (as documented by the [API docs](https://github.com/influxdata/chronograf/blob/dd7f8c2ecd0accd9b1a1fcfbc77e037df36849dd/server/swagger.json#L40-L45)). An app-breaking error ensued.

This PR ensures that `GET /sources` now returns
```
{"sources": []}
```
in the empty sources case.
