### PR TITLE
Prevent infinite looping of API call

### DIFF
--- a/ui/src/shared/components/DatabaseList.tsx
+++ b/ui/src/shared/components/DatabaseList.tsx
@@ -52,6 +52,7 @@ class DatabaseList extends Component<DatabaseListProps, DatabaseListState> {
 
   public componentDidUpdate({
     querySource: prevSource,
+    query: prevQuery,
   }: {
     querySource?: Source
     query: QueryConfig
@@ -60,10 +61,12 @@ class DatabaseList extends Component<DatabaseListProps, DatabaseListState> {
     const differentSource = !_.isEqual(prevSource, nextSource)
 
     const newMetaQuery =
-      nextQuery.rawText && nextQuery.rawText.match(/^(create|drop)/i)
+      nextQuery.rawText &&
+      nextQuery.rawText.match(/^(create|drop)/i) &&
+      nextQuery.rawText !== prevQuery.rawText
 
     if (differentSource || newMetaQuery) {
-      setTimeout(this.getDbRp, 100)
+      this.getDbRp()
     }
   }
 


### PR DESCRIPTION
Closes #3863

_What was the problem?_

An infinite loop caused the Data Explorer to crash: `DatabaseList.componentDidUpdate` called a function which set state which triggered `DatabaseList.componentDidUpdate`. 

_What was the solution?_

Guard against the function call better. I also removed an superfluous `setTimeout`.