### PR TITLE
Support auto group by queries in Data Explorer

### DIFF
--- a/ui/src/data_explorer/apis/index.ts
+++ b/ui/src/data_explorer/apis/index.ts
@@ -7,6 +7,8 @@ import {proxy} from 'src/utils/queryUrlGenerator'
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
 import {dataToCSV} from 'src/shared/parsing/dataToCSV'
 import {Source, QueryConfig} from 'src/types'
+import {duration} from 'src/shared/apis/query'
+import {replaceInterval} from 'src/tempVars/utils/replace'
 
 export const writeLineProtocol = async (
   source: Source,
@@ -32,9 +34,17 @@ export const getDataForCSV = (
   errorThrown
 ) => async () => {
   try {
+    let queryString = query.text
+
+    if (queryString.includes(':interval:')) {
+      const queryDuration = await duration(query.text, source)
+
+      queryString = replaceInterval(query.text, null, queryDuration)
+    }
+
     const response = await fetchTimeSeriesForCSV({
       source: source.links.proxy,
-      query: query.text,
+      query: queryString,
     })
 
     const {data} = timeSeriesToTableGraph([{response}])

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -63,7 +63,10 @@ const replace = async (
   }
 }
 
-const duration = async (query: string, source: Source): Promise<number> => {
+export const duration = async (
+  query: string,
+  source: Source
+): Promise<number> => {
   try {
     const analysis = await analyzeQueries(source.links.queries, [{query}])
     return getDeep<number>(analysis, '0.durationMs', DEFAULT_DURATION_MS)


### PR DESCRIPTION
Closes #3861

_What was the problem?_

After #3782, the Chronograf server is no longer capable of handling queries with the “auto group by” template variable `:interval:`. Attempting to export a CSV for a query including `:interval:` from the Data Explorer would result in a `400` error.

_What was the solution?_

If a query in the Data Explorer contains an `:interval:`, render that interval first before attempting to fetch data for a CSV export.