### PR TITLE
Bugfix/canned layouts

### DIFF
--- a/canned/mysql.json
+++ b/canned/mysql.json
@@ -13,10 +13,15 @@
       "name": "MySQL – Reads/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(last(\"commands_select\"), 1s) AS selects_per_second FROM \":db:\".\":rp:\".\"mysql\"",
-          "groupbys": [
-            "\"server\""
-          ],
+          "query":
+            "SELECT non_negative_derivative(last(\"commands_select\"), 1s) AS selects_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
+          "wheres": []
+        },
+        {
+          "query":
+            "SELECT non_negative_derivative(last(\"cmd_select\"), 1s) AS selects_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
           "wheres": []
         }
       ]
@@ -30,10 +35,15 @@
       "name": "MySQL – Writes/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(last(\"commands_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"commands_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"commands_delete\"), 1s) AS deletes_per_second FROM \":db:\".\":rp:\".\"mysql\"",
-          "groupbys": [
-            "\"server\""
-          ],
+          "query":
+            "SELECT non_negative_derivative(last(\"commands_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"commands_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"commands_delete\"), 1s) AS deletes_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
+          "wheres": []
+        },
+        {
+          "query":
+            "SELECT non_negative_derivative(last(\"cmd_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"cmd_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"cmd_delete\"), 1s) AS deletes_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
           "wheres": []
         }
       ]
@@ -47,10 +57,9 @@
       "name": "MySQL – Connections/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(last(\"threads_connected\"), 1s) AS cxn_per_second, non_negative_derivative(last(\"threads_running\"), 1s) AS threads_running_per_second FROM \":db:\".\":rp:\".\"mysql\"",
-          "groupbys": [
-            "\"server\""
-          ],
+          "query":
+            "SELECT non_negative_derivative(last(\"threads_connected\"), 1s) AS cxn_per_second, non_negative_derivative(last(\"threads_running\"), 1s) AS threads_running_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
           "wheres": []
         }
       ]
@@ -64,10 +73,9 @@
       "name": "MySQL – Connections Errors/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(last(\"connection_errors_max_connections\"), 1s) AS cxn_errors_per_second, non_negative_derivative(last(\"connection_errors_internal\"), 1s) AS internal_cxn_errors_per_second, non_negative_derivative(last(\"aborted_connects\"), 1s) AS cxn_aborted_per_second FROM \":db:\".\":rp:\".\"mysql\"",
-          "groupbys": [
-            "\"server\""
-          ],
+          "query":
+            "SELECT non_negative_derivative(last(\"connection_errors_max_connections\"), 1s) AS cxn_errors_per_second, non_negative_derivative(last(\"connection_errors_internal\"), 1s) AS internal_cxn_errors_per_second, non_negative_derivative(last(\"aborted_connects\"), 1s) AS cxn_aborted_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+          "groupbys": ["\"server\""],
           "wheres": []
         }
       ]

--- a/canned/mysql.json
+++ b/canned/mysql.json
@@ -20,7 +20,7 @@
         },
         {
           "query":
-            "SELECT non_negative_derivative(last(\"cmd_select\"), 1s) AS selects_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+            "SELECT non_negative_derivative(last(\"com_select\"), 1s) AS selects_per_second FROM \":db:\".\":rp:\".\"mysql\"",
           "groupbys": ["\"server\""],
           "wheres": []
         }
@@ -42,7 +42,7 @@
         },
         {
           "query":
-            "SELECT non_negative_derivative(last(\"cmd_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"cmd_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"cmd_delete\"), 1s) AS deletes_per_second FROM \":db:\".\":rp:\".\"mysql\"",
+            "SELECT non_negative_derivative(last(\"com_insert\"), 1s) AS inserts_per_second, non_negative_derivative(last(\"com_update\"), 1s) AS updates_per_second, non_negative_derivative(last(\"com_delete\"), 1s) AS deletes_per_second FROM \":db:\".\":rp:\".\"mysql\"",
           "groupbys": ["\"server\""],
           "wheres": []
         }

--- a/canned/ping.json
+++ b/canned/ping.json
@@ -15,7 +15,7 @@
         {
           "query": "select max(\"percent_packet_loss\") as \"packet_loss\" from ping",
           "groupbys": [
-            "\"server\""
+            "\"url\""
           ],
           "wheres": []
         }
@@ -32,7 +32,7 @@
         {
           "query": "select mean(\"average_response_ms\") as \"average\", mean(\"minimum_response_ms\") as \"min\", mean(\"maximum_response_ms\") as \"max\" from ping",
           "groupbys": [
-            "\"server\""
+            "\"url\""
           ],
           "wheres": []
         }


### PR DESCRIPTION
Closes #3850 
Closes #3859 

Correctly change `server` tag to `url` for the "ping" canned dashboard.  

The mysql changes required a bit of a hack.  Telegraf recently changed its fields in the `mysql` plugin.  There is currently no way for us to retrieve this setting, the version of Telegraf they are using, or a way to version these canned dashboards.  Additionally, we are slated to change the entire canned dashboard experience in the near future so I'm reluctant to implement any of the above. 

So, a simple fix was to add an additional query with the updated `mysql` plugin fields to the respective canned dashboards.  If those fields don't exist influx will return no data, and no extra data will show up in the user's canned dashboard.  If they do have the field the data appears.  Perfecto.

