### PR TITLE
Fix Data Explorer fetch cell data

### DIFF
--- a/ui/src/data_explorer/components/Table.tsx
+++ b/ui/src/data_explorer/components/Table.tsx
@@ -20,6 +20,7 @@ import {
   stylePixelOffset,
   defaultColumnWidth,
 } from 'src/data_explorer/constants/table'
+import {noop} from 'src/shared/actions/app'
 
 import {Source, Template} from 'src/types'
 
@@ -228,7 +229,8 @@ class ChronoTable extends PureComponent<Props, State> {
         source,
         [query],
         NULL_RESOLUTION,
-        templates
+        templates,
+        noop
       )
 
       const results = getDeep(queriesResponse, '0.results', [])

--- a/ui/src/data_explorer/components/Table.tsx
+++ b/ui/src/data_explorer/components/Table.tsx
@@ -20,7 +20,6 @@ import {
   stylePixelOffset,
   defaultColumnWidth,
 } from 'src/data_explorer/constants/table'
-import {noop} from 'src/shared/actions/app'
 
 import {Source, Template} from 'src/types'
 
@@ -215,7 +214,12 @@ class ChronoTable extends PureComponent<Props, State> {
     return _.get(series, `${activeSeriesIndex}`, emptySeries)
   }
 
-  private fetchCellData = async ({source, query, templates}: Props) => {
+  private fetchCellData = async ({
+    source,
+    query,
+    templates,
+    editQueryStatus,
+  }: Props) => {
     if (!query || !query.text) {
       return
     }
@@ -230,7 +234,7 @@ class ChronoTable extends PureComponent<Props, State> {
         [query],
         NULL_RESOLUTION,
         templates,
-        noop
+        editQueryStatus
       )
 
       const results = getDeep(queriesResponse, '0.results', [])

--- a/ui/src/data_explorer/components/Table.tsx
+++ b/ui/src/data_explorer/components/Table.tsx
@@ -2,13 +2,14 @@ import React, {PureComponent, CSSProperties} from 'react'
 
 import Dimensions from 'react-dimensions'
 import _ from 'lodash'
+import {getDeep} from 'src/utils/wrappers'
 
 import {Table, Column, Cell} from 'fixed-data-table-2'
 import Dropdown from 'src/shared/components/Dropdown'
 import CustomCell from 'src/data_explorer/components/CustomCell'
 import TabItem from 'src/data_explorer/components/TableTabItem'
 
-import {fetchTimeSeriesAsync} from 'src/shared/actions/timeSeries'
+import {fetchTimeSeries} from 'src/shared/apis/query'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {
   emptySeries,
@@ -20,7 +21,7 @@ import {
   defaultColumnWidth,
 } from 'src/data_explorer/constants/table'
 
-import {Source} from 'src/types'
+import {Source, Template} from 'src/types'
 
 interface DataExplorerTableQuery {
   text: string
@@ -40,6 +41,7 @@ interface ColumnWidths {
 interface Props {
   height: number
   query: DataExplorerTableQuery
+  templates: Template[]
   editQueryStatus: () => void
   containerHeight: number
   containerWidth: number
@@ -52,6 +54,8 @@ interface State {
   activeSeriesIndex: number
   isLoading: boolean
 }
+
+const NULL_RESOLUTION = null
 
 @ErrorHandling
 class ChronoTable extends PureComponent<Props, State> {
@@ -67,7 +71,7 @@ class ChronoTable extends PureComponent<Props, State> {
   }
 
   public componentDidMount() {
-    this.fetchCellData(this.props.query)
+    this.fetchCellData(this.props)
   }
 
   public componentWillReceiveProps(nextProps) {
@@ -75,7 +79,7 @@ class ChronoTable extends PureComponent<Props, State> {
       return
     }
 
-    this.fetchCellData(nextProps.query)
+    this.fetchCellData(nextProps)
   }
 
   public render() {
@@ -210,7 +214,7 @@ class ChronoTable extends PureComponent<Props, State> {
     return _.get(series, `${activeSeriesIndex}`, emptySeries)
   }
 
-  private fetchCellData = async (query: DataExplorerTableQuery) => {
+  private fetchCellData = async ({source, query, templates}: Props) => {
     if (!query || !query.text) {
       return
     }
@@ -220,10 +224,14 @@ class ChronoTable extends PureComponent<Props, State> {
     })
 
     try {
-      const {results} = await fetchTimeSeriesAsync({
-        source: this.props.source.links.proxy,
-        query,
-      })
+      const queriesResponse = await fetchTimeSeries(
+        source,
+        [query],
+        NULL_RESOLUTION,
+        templates
+      )
+
+      const results = getDeep(queriesResponse, '0.results', [])
 
       this.setState({
         isLoading: false,

--- a/ui/src/data_explorer/components/VisView.tsx
+++ b/ui/src/data_explorer/components/VisView.tsx
@@ -37,7 +37,12 @@ const DataExplorerVisView: SFC<Props> = ({
     }
 
     return (
-      <Table query={query} editQueryStatus={editQueryStatus} source={source} />
+      <Table
+        query={query}
+        editQueryStatus={editQueryStatus}
+        source={source}
+        templates={templates}
+      />
     )
   }
 

--- a/ui/src/shared/actions/timeSeries.ts
+++ b/ui/src/shared/actions/timeSeries.ts
@@ -1,9 +1,6 @@
-import {proxy} from 'src/utils/queryUrlGenerator'
-import {noop} from 'src/shared/actions/app'
-
-import {errorThrown} from 'src/shared/actions/errors'
 import {TimeSeriesResponse, TimeSeriesSeries} from 'src/types/series'
 import {Status} from 'src/types'
+
 import {getDeep} from 'src/utils/wrappers'
 
 interface Query {
@@ -14,16 +11,9 @@ interface Query {
   rp?: string
 }
 
-interface Payload {
-  source: string
-  query: Query
-  db?: string
-  rp?: string
-}
-
 type EditQueryStatusFunction = (queryID: string, status: Status) => void
 
-const handleLoading = (
+export const handleLoading = (
   query: Query,
   editQueryStatus: EditQueryStatusFunction
 ): void =>
@@ -31,7 +21,7 @@ const handleLoading = (
     loading: true,
   })
 
-const handleSuccess = (
+export const handleSuccess = (
   data: TimeSeriesResponse,
   query: Query,
   editQueryStatus: EditQueryStatusFunction
@@ -62,7 +52,7 @@ const handleSuccess = (
   return data
 }
 
-const handleError = (
+export const handleError = (
   error,
   query: Query,
   editQueryStatus: EditQueryStatusFunction
@@ -75,23 +65,4 @@ const handleError = (
   editQueryStatus(query.id, {
     error: message,
   })
-}
-
-export const fetchTimeSeriesAsync = async (
-  {source, db, rp, query}: Payload,
-  editQueryStatus: EditQueryStatusFunction = noop
-): Promise<TimeSeriesResponse> => {
-  handleLoading(query, editQueryStatus)
-  try {
-    const {data} = await proxy({
-      source,
-      db,
-      rp,
-      query: query.text,
-    })
-    return handleSuccess(data, query, editQueryStatus)
-  } catch (error) {
-    errorThrown(error)
-    handleError(error, query, editQueryStatus)
-  }
 }

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -9,7 +9,6 @@ import {analyzeQueries} from 'src/shared/apis'
 import {DEFAULT_DURATION_MS} from 'src/shared/constants'
 import replaceTemplates, {replaceInterval} from 'src/tempVars/utils/replace'
 import {proxy} from 'src/utils/queryUrlGenerator'
-import {noop} from 'src/shared/actions/app'
 
 import {Source} from 'src/types'
 
@@ -28,7 +27,7 @@ export const fetchTimeSeries = async (
   queries: Query[],
   resolution: number,
   templates: Template[],
-  editQueryStatus: () => any = noop
+  editQueryStatus: () => any
 ) => {
   const timeSeriesPromises = queries.map(async query => {
     const {database, rp} = query

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -9,6 +9,7 @@ import {analyzeQueries} from 'src/shared/apis'
 import {DEFAULT_DURATION_MS} from 'src/shared/constants'
 import replaceTemplates, {replaceInterval} from 'src/tempVars/utils/replace'
 import {proxy} from 'src/utils/queryUrlGenerator'
+import {noop} from 'src/shared/actions/app'
 
 import {Source} from 'src/types'
 
@@ -27,7 +28,7 @@ export const fetchTimeSeries = async (
   queries: Query[],
   resolution: number,
   templates: Template[],
-  editQueryStatus: () => any
+  editQueryStatus: () => any = noop
 ) => {
   const timeSeriesPromises = queries.map(async query => {
     const {database, rp} = query


### PR DESCRIPTION
Closes #3862 

_What was the problem?_
Fetching cell data was using a `fetchTimeSeriesAsync` action that wasn't replacing `:interval:` in queries. 
_What was the solution?_
Remove `fetchTimeSeriesAsync` and use `fetchTimeSeries` to retrieve results for a Table's cell data and replace `:interval:`. The `fetchTimeSeriesAsync` was also only used directly by `Table` and `fetchTimeSeries` so the most natural refactor was to move the `fetchTimeSeriesAsync` logic into the API call.

  - [x] Rebased/mergeable
  - [x] Tests pass