### PR TITLE
Fix template variables in title when no values

### DIFF
--- a/ui/src/shared/components/LayoutCell.tsx
+++ b/ui/src/shared/components/LayoutCell.tsx
@@ -78,7 +78,7 @@ export default class LayoutCell extends Component<Props> {
         (acc, template) => {
           const {tempVar} = template
           const templateValue = template.values.find(v => v.localSelected)
-          const value = _.get(templateValue, 'value', str)
+          const value = _.get(templateValue, 'value', tempVar)
           const regex = new RegExp(tempVar, 'g')
           return acc.replace(regex, value)
         },


### PR DESCRIPTION
_What was the problem?_
If a template variable had no values, it replaced the string with the entire title instead of just the template variable name.
_What was the solution?_
Replace the template variable with the template variable name if no values are used.

  - [x] Rebased/mergeable
  - [x] Tests pass