### PR TITLE
fix(server): health for source returns status no content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 1.  [#3751](https://github.com/influxdata/chronograf/pull/3751): Fix crosshairs moving passed the edges of graphs
 1.  [#3759](https://github.com/influxdata/chronograf/pull/3759): Change y-axis options to have valid defaults
 1.  [#3793](https://github.com/influxdata/chronograf/pull/3793): Stop making requests for old sources after changing sources
+1.  [#3888](https://github.com/influxdata/chronograf/pull/3888): Fix health check status code creating firefox error
 
 ## v1.5.0.0 [2018-05-15-RC]
 

--- a/server/sources.go
+++ b/server/sources.go
@@ -265,7 +265,7 @@ func (s *Service) SourceHealth(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }
 
 // removeSrcsKapa will remove all kapacitors and kapacitor rules from the stores.

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -402,7 +402,7 @@
           }
         ],
         "responses": {
-          "200": {
+          "204": {
             "description": "Source was able to be contacted"
           },
           "404": {


### PR DESCRIPTION
Closes #3207 

_Briefly describe your proposed changes:_
Update health endpoint to return Status No Content.

_What was the problem?_
The health endpoint was returning Status OK causing firefox to complain there was no content.  

_What was the solution?_
Once the server returns a No Content, firefox is happy.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)