### PR TITLE
Fix stale dashboard switcher

### DIFF
--- a/ui/src/dashboards/apis/index.ts
+++ b/ui/src/dashboards/apis/index.ts
@@ -2,7 +2,7 @@ import AJAX from 'src/utils/ajax'
 
 import {
   linksFromDashboards,
-  updateActiveDashboardLink,
+  updateDashboardLinks,
 } from 'src/dashboards/utils/dashboardSwitcherLinks'
 
 import {AxiosResponse} from 'axios'
@@ -30,7 +30,7 @@ export const loadDashboardLinks = async (
   } = await dashboardsAJAX()
 
   const links = linksFromDashboards(dashboards, source)
-  const dashboardLinks = updateActiveDashboardLink(links, activeDashboard)
+  const dashboardLinks = updateDashboardLinks(links, activeDashboard)
 
   return dashboardLinks
 }

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -24,6 +24,7 @@ import * as notifyActions from 'src/shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
+import {updateActiveDashboardLink} from 'src/dashboards/utils/dashboardSwitcherLinks'
 
 // APIs
 import {loadDashboardLinks} from 'src/dashboards/apis'
@@ -352,7 +353,14 @@ class DashboardPage extends Component<Props, State> {
   private getDashboard = async () => {
     const {dashboardID, source, getDashboardWithTemplatesAsync} = this.props
 
-    return getDashboardWithTemplatesAsync(dashboardID, source)
+    await getDashboardWithTemplatesAsync(dashboardID, source)
+
+    const dashboardLinks = updateActiveDashboardLink(
+      this.state.dashboardLinks,
+      this.props.dashboard
+    )
+
+    this.setState({dashboardLinks})
   }
 
   private inView = (cell: DashboardsModels.Cell): boolean => {

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -24,10 +24,7 @@ import * as notifyActions from 'src/shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
-import {
-  updateActiveDashboardLink,
-  updateDashboardLinkName,
-} from 'src/dashboards/utils/dashboardSwitcherLinks'
+import {updateDashboardLinks} from 'src/dashboards/utils/dashboardSwitcherLinks'
 
 // APIs
 import {loadDashboardLinks} from 'src/dashboards/apis'
@@ -362,7 +359,7 @@ class DashboardPage extends Component<Props, State> {
 
   private updateActiveDashboard(): void {
     this.setState((prevState, props) => ({
-      dashboardLinks: updateActiveDashboardLink(
+      dashboardLinks: updateDashboardLinks(
         prevState.dashboardLinks,
         props.dashboard
       ),
@@ -448,16 +445,7 @@ class DashboardPage extends Component<Props, State> {
 
     this.props.updateDashboard(newDashboard)
     await this.props.putDashboard(newDashboard)
-    this.updateLinkName()
-  }
-
-  private updateLinkName(): void {
-    this.setState((prevState, props) => ({
-      dashboardLinks: updateDashboardLinkName(
-        prevState.dashboardLinks,
-        props.dashboard
-      ),
-    }))
+    this.updateActiveDashboard()
   }
 
   private handleDeleteDashboardCell = (cell: DashboardsModels.Cell): void => {

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -357,13 +357,16 @@ class DashboardPage extends Component<Props, State> {
     const {dashboardID, source, getDashboardWithTemplatesAsync} = this.props
 
     await getDashboardWithTemplatesAsync(dashboardID, source)
+    this.updateActiveDashboard()
+  }
 
-    const dashboardLinks = updateActiveDashboardLink(
-      this.state.dashboardLinks,
-      this.props.dashboard
-    )
-
-    this.setState({dashboardLinks})
+  private updateActiveDashboard(): void {
+    this.setState((prevState, props) => ({
+      dashboardLinks: updateActiveDashboardLink(
+        prevState.dashboardLinks,
+        props.dashboard
+      ),
+    }))
   }
 
   private inView = (cell: DashboardsModels.Cell): boolean => {
@@ -450,7 +453,6 @@ class DashboardPage extends Component<Props, State> {
 
   private updateLinkName(): void {
     this.setState((prevState, props) => ({
-      ...prevState,
       dashboardLinks: updateDashboardLinkName(
         prevState.dashboardLinks,
         props.dashboard

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -24,7 +24,10 @@ import * as notifyActions from 'src/shared/actions/notifications'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
-import {updateActiveDashboardLink} from 'src/dashboards/utils/dashboardSwitcherLinks'
+import {
+  updateActiveDashboardLink,
+  updateDashboadLinkName,
+} from 'src/dashboards/utils/dashboardSwitcherLinks'
 
 // APIs
 import {loadDashboardLinks} from 'src/dashboards/apis'
@@ -442,7 +445,17 @@ class DashboardPage extends Component<Props, State> {
 
     this.props.updateDashboard(newDashboard)
     await this.props.putDashboard(newDashboard)
-    await this.getDashboardLinks()
+    this.updateLinkName()
+  }
+
+  private updateLinkName = () => {
+    this.setState((prevState, props) => ({
+      ...prevState,
+      dashboardLinks: updateDashboadLinkName(
+        prevState.dashboardLinks,
+        props.dashboard
+      ),
+    }))
   }
 
   private handleDeleteDashboardCell = (cell: DashboardsModels.Cell): void => {

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -26,7 +26,7 @@ import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
 import {
   updateActiveDashboardLink,
-  updateDashboadLinkName,
+  updateDashboardLinkName,
 } from 'src/dashboards/utils/dashboardSwitcherLinks'
 
 // APIs
@@ -448,10 +448,10 @@ class DashboardPage extends Component<Props, State> {
     this.updateLinkName()
   }
 
-  private updateLinkName = () => {
+  private updateLinkName(): void {
     this.setState((prevState, props) => ({
       ...prevState,
-      dashboardLinks: updateDashboadLinkName(
+      dashboardLinks: updateDashboardLinkName(
         prevState.dashboardLinks,
         props.dashboard
       ),

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -434,6 +434,7 @@ class DashboardPage extends Component<Props, State> {
 
     this.props.updateDashboard(newDashboard)
     await this.props.putDashboard(newDashboard)
+    await this.getDashboardLinks()
   }
 
   private handleDeleteDashboardCell = (cell: DashboardsModels.Cell): void => {

--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -35,3 +35,27 @@ export const updateActiveDashboardLink = (
 
   return {...dashboardLinks, active}
 }
+
+export const updateDashboadLinkName = (
+  dashboardLinks: DashboardSwitcherLinks,
+  dashboard: Dashboard
+): DashboardSwitcherLinks => {
+  const {name} = dashboard
+  let active = dashboardLinks.active
+
+  const links = dashboardLinks.links.map(link => {
+    if (link.key === String(dashboard.id)) {
+      const newLink = {...link, text: name}
+
+      if (link === active) {
+        active = newLink
+      }
+
+      return newLink
+    }
+
+    return link
+  })
+
+  return {links, active}
+}

--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -21,7 +21,20 @@ export const linksFromDashboards = (
   return {links, active: null}
 }
 
-export const updateActiveDashboardLink = (
+export const updateDashboardLinks = (
+  dashboardLinks: DashboardSwitcherLinks,
+  activeDashboard: Dashboard
+) => {
+  const {active} = dashboardLinks
+
+  if (!active || active.key !== String(activeDashboard.id)) {
+    return updateActiveDashboardLink(dashboardLinks, activeDashboard)
+  }
+
+  return updateDashboardLinkName(dashboardLinks, activeDashboard)
+}
+
+const updateActiveDashboardLink = (
   dashboardLinks: DashboardSwitcherLinks,
   dashboard: Dashboard
 ) => {
@@ -36,7 +49,7 @@ export const updateActiveDashboardLink = (
   return {...dashboardLinks, active}
 }
 
-export const updateDashboardLinkName = (
+const updateDashboardLinkName = (
   dashboardLinks: DashboardSwitcherLinks,
   dashboard: Dashboard
 ): DashboardSwitcherLinks => {

--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -31,7 +31,7 @@ export const updateDashboardLinks = (
     return updateActiveDashboardLink(dashboardLinks, activeDashboard)
   }
 
-  return updateDashboardLinkName(dashboardLinks, activeDashboard)
+  return updateActiveDashboardLinkName(dashboardLinks, activeDashboard)
 }
 
 const updateActiveDashboardLink = (
@@ -49,22 +49,18 @@ const updateActiveDashboardLink = (
   return {...dashboardLinks, active}
 }
 
-const updateDashboardLinkName = (
+const updateActiveDashboardLinkName = (
   dashboardLinks: DashboardSwitcherLinks,
   dashboard: Dashboard
 ): DashboardSwitcherLinks => {
   const {name} = dashboard
-  let active = dashboardLinks.active
+  let {active} = dashboardLinks
 
   const links = dashboardLinks.links.map(link => {
     if (link.key === String(dashboard.id)) {
-      const newLink = {...link, text: name}
+      active = {...link, text: name}
 
-      if (link === active) {
-        active = newLink
-      }
-
-      return newLink
+      return active
     }
 
     return link

--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -36,7 +36,7 @@ export const updateActiveDashboardLink = (
   return {...dashboardLinks, active}
 }
 
-export const updateDashboadLinkName = (
+export const updateDashboardLinkName = (
   dashboardLinks: DashboardSwitcherLinks,
   dashboard: Dashboard
 ): DashboardSwitcherLinks => {

--- a/ui/test/dashboards/utils/dashboardSwitcherLinks.test.ts
+++ b/ui/test/dashboards/utils/dashboardSwitcherLinks.test.ts
@@ -1,7 +1,6 @@
 import {
   linksFromDashboards,
-  updateActiveDashboardLink,
-  updateDashboardLinkName,
+  updateDashboardLinks,
 } from 'src/dashboards/utils/dashboardSwitcherLinks'
 import {dashboard, source} from 'test/resources'
 
@@ -35,19 +34,19 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
     })
   })
 
-  const link1 = {
-    key: '9001',
-    text: 'Low Dash',
-    to: '/sources/897/dashboards/9001',
-  }
+  describe('updateDashboardLinks', () => {
+    const link1 = {
+      key: '9001',
+      text: 'Low Dash',
+      to: '/sources/897/dashboards/9001',
+    }
 
-  const link2 = {
-    key: '2282',
-    text: 'Other Dash',
-    to: '/sources/897/dashboards/2282',
-  }
+    const link2 = {
+      key: '2282',
+      text: 'Other Dash',
+      to: '/sources/897/dashboards/2282',
+    }
 
-  describe('updateActiveDashboardLink', () => {
     const activeDashboard = {
       ...dashboard,
       id: 123,
@@ -63,10 +62,7 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
     const links = [link1, activeLink, link2]
     it('can set the active link', () => {
       const loadedLinks = {links, active: null}
-      const actualLinks = updateActiveDashboardLink(
-        loadedLinks,
-        activeDashboard
-      )
+      const actualLinks = updateDashboardLinks(loadedLinks, activeDashboard)
       const expectedLinks = {links, active: activeLink}
 
       expect(actualLinks).toEqual(expectedLinks)
@@ -74,14 +70,12 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
 
     it('can handle a missing dashboard', () => {
       const loadedLinks = {links, active: null}
-      const actualLinks = updateActiveDashboardLink(loadedLinks, undefined)
+      const actualLinks = updateDashboardLinks(loadedLinks, undefined)
       const expectedLinks = {links, active: null}
 
       expect(actualLinks).toEqual(expectedLinks)
     })
-  })
 
-  describe('updateDashboardLinkName', () => {
     const staleDashboard = {
       ...dashboard,
       id: 3000,
@@ -94,40 +88,17 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
       to: '/sources/897/dashboards/3000',
     }
 
-    const links = [link1, staleLink, link2]
+    const staleLinks = [link1, staleLink, link2]
     const updatedDashboard = {...staleDashboard, name: 'New Dashboard Name'}
 
-    const dashboardLinks = {
-      links,
-      active: link1,
+    const staleDashboardLinks = {
+      links: staleLinks,
+      active: staleLink,
     }
 
-    it('can update the name of a provided dashboard', () => {
-      const actualDashLinks = updateDashboardLinkName(
-        dashboardLinks,
-        updatedDashboard
-      )
-
-      const expectedDashlinks = {
-        links: [
-          link1,
-          {
-            key: '3000',
-            text: 'New Dashboard Name',
-            to: '/sources/897/dashboards/3000',
-          },
-          link2,
-        ],
-        active: link1,
-      }
-
-      expect(actualDashLinks).toEqual(expectedDashlinks)
-    })
-
-    it('can update name for active link', () => {
-      const linksWithStaleActive = {...dashboardLinks, active: staleLink}
-      const actualLinks = updateDashboardLinkName(
-        linksWithStaleActive,
+    it('can update name for dashboard', () => {
+      const actualLinks = updateDashboardLinks(
+        staleDashboardLinks,
         updatedDashboard
       )
 

--- a/ui/test/dashboards/utils/dashboardSwitcherLinks.test.ts
+++ b/ui/test/dashboards/utils/dashboardSwitcherLinks.test.ts
@@ -1,6 +1,7 @@
 import {
   linksFromDashboards,
   updateActiveDashboardLink,
+  updateDashboardLinkName,
 } from 'src/dashboards/utils/dashboardSwitcherLinks'
 import {dashboard, source} from 'test/resources'
 
@@ -34,6 +35,18 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
     })
   })
 
+  const link1 = {
+    key: '9001',
+    text: 'Low Dash',
+    to: '/sources/897/dashboards/9001',
+  }
+
+  const link2 = {
+    key: '2282',
+    text: 'Other Dash',
+    to: '/sources/897/dashboards/2282',
+  }
+
   describe('updateActiveDashboardLink', () => {
     const activeDashboard = {
       ...dashboard,
@@ -45,18 +58,6 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
       key: '123',
       text: 'Test Dashboard',
       to: '/sources/897/dashboards/123',
-    }
-
-    const link1 = {
-      key: '9001',
-      text: 'Low Dash',
-      to: '/sources/897/dashboards/9001',
-    }
-
-    const link2 = {
-      key: '2282',
-      text: 'Low Dash',
-      to: '/sources/897/dashboards/2282',
     }
 
     const links = [link1, activeLink, link2]
@@ -77,6 +78,72 @@ describe('dashboards.utils.dashboardSwitcherLinks', () => {
       const expectedLinks = {links, active: null}
 
       expect(actualLinks).toEqual(expectedLinks)
+    })
+  })
+
+  describe('updateDashboardLinkName', () => {
+    const staleDashboard = {
+      ...dashboard,
+      id: 3000,
+      name: 'Stale Dashboard Name',
+    }
+
+    const staleLink = {
+      key: '3000',
+      text: 'Stale Dashboard Name',
+      to: '/sources/897/dashboards/3000',
+    }
+
+    const links = [link1, staleLink, link2]
+    const updatedDashboard = {...staleDashboard, name: 'New Dashboard Name'}
+
+    const dashboardLinks = {
+      links,
+      active: link1,
+    }
+
+    it('can update the name of a provided dashboard', () => {
+      const actualDashLinks = updateDashboardLinkName(
+        dashboardLinks,
+        updatedDashboard
+      )
+
+      const expectedDashlinks = {
+        links: [
+          link1,
+          {
+            key: '3000',
+            text: 'New Dashboard Name',
+            to: '/sources/897/dashboards/3000',
+          },
+          link2,
+        ],
+        active: link1,
+      }
+
+      expect(actualDashLinks).toEqual(expectedDashlinks)
+    })
+
+    it('can update name for active link', () => {
+      const linksWithStaleActive = {...dashboardLinks, active: staleLink}
+      const actualLinks = updateDashboardLinkName(
+        linksWithStaleActive,
+        updatedDashboard
+      )
+
+      const renamedLink = {
+        key: '3000',
+        text: 'New Dashboard Name',
+        to: '/sources/897/dashboards/3000',
+      }
+
+      const expectedDashlinks = {
+        links: [link1, renamedLink, link2],
+        active: renamedLink,
+      }
+
+      expect(actualLinks).toEqual(expectedDashlinks)
+      expect(actualLinks.active).toBe(actualLinks.links[1])
     })
   })
 })


### PR DESCRIPTION
Closes #3886

_What was the problem?_
Dashboard links were stale after rename and had a stale active link when switching between dashboards.
_What was the solution?_
Ensure dashboard links are updated when a dashboard is renamed. Also, ensure the active dashboard link is updated when a new dashboard is fetched using `updateDashboardLinks` which avoids an request using `getDashboards`.

  - [x] Rebased/mergeable
  - [x] Tests pass