### PR TITLE
Use sorted templates in query template replacement

### DIFF
--- a/ui/src/tempVars/utils/replace.ts
+++ b/ui/src/tempVars/utils/replace.ts
@@ -1,4 +1,9 @@
-import {Template, TemplateValueType, TemplateValue} from 'src/types/tempVars'
+import {
+  Template,
+  TemplateType,
+  TemplateValueType,
+  TemplateValue,
+} from 'src/types/tempVars'
 import {
   TEMP_VAR_INTERVAL,
   DEFAULT_PIXELS,
@@ -28,12 +33,30 @@ export const replaceInterval = (
   return replaceAll(query, TEMP_VAR_INTERVAL, `${msPerPixel}ms`)
 }
 
-const templateReplace = (query: string, tempVars: Template[]) => {
-  const replacedQuery = tempVars.reduce((acc, template) => {
-    return renderTemplate(acc, template)
-  }, query)
+const TEMPLATES_SORTING_ORDER = {
+  [TemplateType.CSV]: 0,
+  [TemplateType.Map]: 0,
+  [TemplateType.AutoGroupBy]: 1,
+  [TemplateType.Constant]: 1,
+  [TemplateType.FieldKeys]: 1,
+  [TemplateType.Measurements]: 1,
+  [TemplateType.TagKeys]: 1,
+  [TemplateType.TagValues]: 1,
+  [TemplateType.Databases]: 1,
+  [TemplateType.MetaQuery]: 1,
+}
 
-  return replacedQuery
+const sortTemplates = (a: Template, b: Template): number => {
+  return TEMPLATES_SORTING_ORDER[a.type] - TEMPLATES_SORTING_ORDER[b.type]
+}
+
+const templateReplace = (query: string, tempVars: Template[]) => {
+  const sortedTempVars = [...tempVars].sort(sortTemplates)
+
+  return sortedTempVars.reduce(
+    (acc, template) => renderTemplate(acc, template),
+    query
+  )
 }
 
 const renderTemplate = (query: string, template: Template): string => {


### PR DESCRIPTION
Closes #3853 

The [templateReplace](https://github.com/influxdata/chronograf/blob/5734a8eda7397cbcbc01755c6aeb4b6f6ab2e74a/ui/src/tempVars/utils/replace.ts#L53-L60) accepts a query string with embedded template variables, and a list of templates used to replace those variables.

For example, given the query `SHOW MEASUREMENTS ON ":db:"` and the template `:db: = telegraf`, the `templateReplace`d query string should be `SHOW MEASUREMENTS ON "telegraf"`.

Here's another example:

- The query string is again `SHOW MEASUREMENTS ON ":db:"`
- The templates are
  - `:db: = :otherDb:` (this can be defined by the user in CSV and Map templates)
  - `:otherDb: = telegraf`

This query should also be replaced as `SHOW MEASUREMENTS ON "telegraf"`. A slightly less contrived example is given in #3853.

Due to the implementation of the `templateReplace` function, the correct rendering of this query is dependent on the order of the templates passed in.

This PR updates the `templateReplace` function so that irregardless of the order of the templates passed in, the query will render correctly.