### PR TITLE
Unify Log Viewer Time Selection UI

### DIFF
--- a/ui/src/logs/components/LogViewerHeader.tsx
+++ b/ui/src/logs/components/LogViewerHeader.tsx
@@ -5,6 +5,7 @@ import {Source, Namespace} from 'src/types'
 import RadioButtons from 'src/reusable_ui/components/radio_buttons/RadioButtons'
 import {ButtonShape, ComponentColor} from 'src/reusable_ui/types'
 import Dropdown from 'src/shared/components/Dropdown'
+import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 import PageHeaderTitle from 'src/reusable_ui/components/page_layout/PageHeaderTitle'
 import TimeMarkerDropdown from 'src/logs/components/TimeMarkerDropdown'
@@ -30,6 +31,10 @@ interface Props {
   timeRange: TimeRange
   onSetTimeMarker: (timeMarker: TimeMarker) => void
   onSetTimeWindow: (timeWindow: TimeWindow) => void
+  customTime?: string
+  relativeTime?: number
+  onChooseCustomTime: (time: string) => void
+  onChooseRelativeTime: (time: number) => void
 }
 
 class LogViewerHeader extends PureComponent<Props> {
@@ -53,7 +58,15 @@ class LogViewerHeader extends PureComponent<Props> {
   }
 
   private get optionsComponents(): JSX.Element {
-    const {onShowOptionsOverlay, onSetTimeWindow, onSetTimeMarker} = this.props
+    const {
+      onShowOptionsOverlay,
+      onSetTimeWindow,
+      onSetTimeMarker,
+      customTime,
+      relativeTime,
+      onChooseCustomTime,
+      onChooseRelativeTime,
+    } = this.props
 
     // Todo: Replace w/ getDeep
     const timeRange = _.get(this.props, 'timeRange', {
@@ -78,6 +91,12 @@ class LogViewerHeader extends PureComponent<Props> {
           items={this.namespaceDropDownItems}
           selected={this.selectedNamespace}
           onChoose={this.handleChooseNamespace}
+        />
+        <PointInTimeDropDown
+          customTime={customTime}
+          relativeTime={relativeTime}
+          onChooseCustomTime={onChooseCustomTime}
+          onChooseRelativeTime={onChooseRelativeTime}
         />
         <TimeMarkerDropdown
           onSetTimeMarker={onSetTimeMarker}

--- a/ui/src/logs/components/LogViewerHeader.tsx
+++ b/ui/src/logs/components/LogViewerHeader.tsx
@@ -8,10 +8,9 @@ import Dropdown from 'src/shared/components/Dropdown'
 import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 import PageHeaderTitle from 'src/reusable_ui/components/page_layout/PageHeaderTitle'
-import TimeMarkerDropdown from 'src/logs/components/TimeMarkerDropdown'
 import TimeWindowDropdown from 'src/logs/components/TimeWindowDropdown'
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
-import {TimeRange, TimeWindow, TimeMarker, LiveUpdating} from 'src/types/logs'
+import {TimeRange, TimeWindow, LiveUpdating} from 'src/types/logs'
 
 interface SourceItem {
   id: string
@@ -29,7 +28,6 @@ interface Props {
   onChangeLiveUpdatingStatus: () => void
   onShowOptionsOverlay: () => void
   timeRange: TimeRange
-  onSetTimeMarker: (timeMarker: TimeMarker) => void
   onSetTimeWindow: (timeWindow: TimeWindow) => void
   customTime?: string
   relativeTime?: number
@@ -61,7 +59,6 @@ class LogViewerHeader extends PureComponent<Props> {
     const {
       onShowOptionsOverlay,
       onSetTimeWindow,
-      onSetTimeMarker,
       customTime,
       relativeTime,
       onChooseCustomTime,
@@ -97,10 +94,6 @@ class LogViewerHeader extends PureComponent<Props> {
           relativeTime={relativeTime}
           onChooseCustomTime={onChooseCustomTime}
           onChooseRelativeTime={onChooseRelativeTime}
-        />
-        <TimeMarkerDropdown
-          onSetTimeMarker={onSetTimeMarker}
-          selectedTimeMarker={timeRange.timeOption}
         />
         <TimeWindowDropdown
           selectedTimeWindow={timeRange}

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -59,6 +59,7 @@ interface Props {
     forward: TableData
     backward: TableData
   }
+  onChooseCustomTime: (time: string) => void
 }
 
 interface State {
@@ -528,6 +529,32 @@ class LogsTable extends Component<Props, State> {
 
     const highlightRow = rowIndex === this.state.currentRow
 
+    if (column === 'timestamp') {
+      return (
+        <div
+          className={classnames('logs-viewer--cell', {
+            highlight: highlightRow,
+          })}
+          title={`Jump to '${title}'`}
+          key={key}
+          style={style}
+          data-index={rowIndex}
+          onMouseOver={this.handleMouseOver}
+        >
+          <div
+            data-tag-key={column}
+            data-tag-value={value}
+            onClick={this.handleTimestampClick(`${formattedValue}`)}
+            data-index={rowIndex}
+            onMouseOver={this.handleMouseOver}
+            className="logs-viewer--clickable"
+          >
+            {formattedValue}
+          </div>
+        </div>
+      )
+    }
+
     if (isClickable(column)) {
       return (
         <div
@@ -587,6 +614,12 @@ class LogsTable extends Component<Props, State> {
     const target = e.target as HTMLElement
     const index = target.dataset.index || target.parentElement.dataset.index
     this.setState({currentRow: +index})
+  }
+
+  private handleTimestampClick = (time: string) => () => {
+    const {onChooseCustomTime} = this.props
+    const formattedTime = moment(time, 'YYYY/MM/DD HH:mm:ss').toISOString()
+    onChooseCustomTime(formattedTime)
   }
 
   private handleTagClick = (e: MouseEvent<HTMLElement>) => {

--- a/ui/src/logs/components/PointInTimeDropDown.tsx
+++ b/ui/src/logs/components/PointInTimeDropDown.tsx
@@ -107,8 +107,8 @@ class TimeRangeDropdown extends Component<Props, State> {
     const absoluteTimeRange = !!this.props.customTime
 
     return classnames('dropdown', {
-      'dropdown-290': absoluteTimeRange,
-      'dropdown-120': !absoluteTimeRange,
+      'dropdown-180': absoluteTimeRange,
+      'dropdown-110': !absoluteTimeRange,
       open: isOpen,
     })
   }

--- a/ui/src/logs/components/PointInTimeDropDown.tsx
+++ b/ui/src/logs/components/PointInTimeDropDown.tsx
@@ -133,7 +133,7 @@ class TimeRangeDropdown extends Component<Props, State> {
         return point.text
       }
 
-      return 'None'
+      return 'now'
     }
 
     return format(this.props.customTime)

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -199,6 +199,7 @@ class LogsPage extends Component<Props, State> {
               severityLevelColors={this.severityLevelColors}
               hasScrolled={this.state.hasScrolled}
               tableInfiniteData={this.props.tableInfiniteData}
+              onChooseCustomTime={this.handleChooseCustomTime}
             />
           </div>
         </div>

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -228,14 +228,33 @@ class LogsPage extends Component<Props, State> {
     )
   }
 
-  private handleChooseCustomTime = (time: string) => {
+  private handleChooseCustomTime = async (time: string) => {
     this.props.setTableCustomTime(time)
     this.setState({hasScrolled: false})
+
+    await this.props.setTimeMarker({
+      timeOption: time,
+    })
+
+    this.handleSetTimeBounds()
   }
 
-  private handleChooseRelativeTime = (time: number) => {
+  private handleChooseRelativeTime = async (time: number) => {
     this.props.setTableRelativeTime(time)
     this.setState({hasScrolled: false})
+
+    let timeOption = {
+      timeOption: moment()
+        .subtract(time, 'seconds')
+        .toISOString(),
+    }
+
+    if (time === 0) {
+      timeOption = {timeOption: 'now'}
+    }
+
+    await this.props.setTimeMarker(timeOption)
+    this.handleSetTimeBounds()
   }
 
   private get tableData(): TableData {
@@ -353,7 +372,6 @@ class LogsPage extends Component<Props, State> {
     return (
       <LogViewerHeader
         timeRange={timeRange}
-        onSetTimeMarker={this.handleSetTimeMarker}
         onSetTimeWindow={this.handleSetTimeWindow}
         liveUpdating={this.liveUpdatingStatus}
         availableSources={sources}
@@ -418,9 +436,9 @@ class LogsPage extends Component<Props, State> {
   }
 
   private handleBarClick = (time: string): void => {
-    const timeOption = moment(time).toISOString()
+    const formattedTime = moment(time).toISOString()
 
-    this.handleSetTimeMarker({timeOption})
+    this.handleChooseCustomTime(formattedTime)
   }
 
   private handleSetTimeBounds = async () => {
@@ -448,11 +466,6 @@ class LogsPage extends Component<Props, State> {
 
   private handleSetTimeWindow = async (timeWindow: TimeWindow) => {
     await this.props.setTimeWindow(timeWindow)
-    this.handleSetTimeBounds()
-  }
-
-  private handleSetTimeMarker = async (timeMarker: TimeMarker) => {
-    await this.props.setTimeMarker(timeMarker)
     this.handleSetTimeBounds()
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -32,7 +32,6 @@ import OptionsOverlay from 'src/logs/components/OptionsOverlay'
 import SearchBar from 'src/logs/components/LogsSearchBar'
 import FilterBar from 'src/logs/components/LogsFilterBar'
 import LogsTable from 'src/logs/components/LogsTable'
-import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 import {getDeep} from 'src/utils/wrappers'
 import {colorForSeverity} from 'src/logs/utils/colors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
@@ -164,7 +163,7 @@ class LogsPage extends Component<Props, State> {
   }
 
   public render() {
-    const {searchTerm, filters, queryCount, timeRange, tableTime} = this.props
+    const {searchTerm, filters, queryCount, timeRange} = this.props
 
     return (
       <>
@@ -172,17 +171,6 @@ class LogsPage extends Component<Props, State> {
           {this.header}
           <div className="page-contents logs-viewer">
             <LogsGraphContainer>{this.chart}</LogsGraphContainer>
-            <div style={{height: '50px', position: 'relative'}}>
-              <div style={{position: 'absolute', right: '10px', top: '10px'}}>
-                <span style={{marginRight: '10px'}}>Go to </span>
-                <PointInTimeDropDown
-                  customTime={tableTime.custom}
-                  relativeTime={tableTime.relative}
-                  onChooseCustomTime={this.handleChooseCustomTime}
-                  onChooseRelativeTime={this.handleChooseRelativeTime}
-                />
-              </div>
-            </div>
             <SearchBar
               searchString={searchTerm}
               onSearch={this.handleSubmitSearch}
@@ -359,6 +347,7 @@ class LogsPage extends Component<Props, State> {
       currentNamespaces,
       currentNamespace,
       timeRange,
+      tableTime,
     } = this.props
 
     return (
@@ -375,6 +364,10 @@ class LogsPage extends Component<Props, State> {
         currentNamespace={currentNamespace}
         onChangeLiveUpdatingStatus={this.handleChangeLiveUpdatingStatus}
         onShowOptionsOverlay={this.handleToggleOverlay}
+        customTime={tableTime.custom}
+        relativeTime={tableTime.relative}
+        onChooseCustomTime={this.handleChooseCustomTime}
+        onChooseRelativeTime={this.handleChooseRelativeTime}
       />
     )
   }

--- a/ui/src/logs/data/timePoints.ts
+++ b/ui/src/logs/data/timePoints.ts
@@ -1,26 +1,26 @@
 export default [
   {
-    text: '1 minute ago',
+    text: '1m ago',
     value: 60,
   },
   {
-    text: '5 minute ago',
+    text: '5m ago',
     value: 300,
   },
   {
-    text: '10 minute ago',
+    text: '10m ago',
     value: 600,
   },
   {
-    text: '30 minute ago',
+    text: '30m ago',
     value: 1800,
   },
   {
-    text: '1 hour ago',
+    text: '1h ago',
     value: 3600,
   },
   {
-    text: '3 hour ago',
+    text: '3h ago',
     value: 10800,
   },
 ]

--- a/ui/src/logs/data/timePoints.ts
+++ b/ui/src/logs/data/timePoints.ts
@@ -1,5 +1,9 @@
 export default [
   {
+    text: 'now',
+    value: 0,
+  },
+  {
     text: '1m ago',
     value: 60,
   },


### PR DESCRIPTION
_Briefly describe your proposed changes:_
I am combining the time selector in the logs table with the time selection in the page header to form a single UI for selecting time in the logs viewer. Clicking a histogram bar also updates the logs table, and clicking a timestamp in the logs table updates the histogram. Both halves of the experience are more closely tied together now.

  - [x] Rebased/mergeable
  - [x] Tests pass