### PR TITLE
Truncate log messages & display overlay when clicked

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -12,7 +12,6 @@ import {colorForSeverity} from 'src/logs/utils/colors'
 import {
   ROW_HEIGHT,
   calculateRowCharWidth,
-  calculateMessageHeight,
   getColumnFromData,
   getValueFromData,
   getValuesFromData,
@@ -72,13 +71,13 @@ interface State {
   visibleColumnsCount: number
 }
 
-const calculateScrollTop = (currentMessageWidth, data, scrollToRow) => {
-  const rowCharLimit = calculateRowCharWidth(currentMessageWidth)
+const calculateScrollTop = scrollToRow => {
+  // const rowCharLimit = calculateRowCharWidth(currentMessageWidth)
 
   return _.reduce(
     _.range(0, scrollToRow),
-    (acc, index) => {
-      return acc + calculateMessageHeight(index, data, rowCharLimit)
+    acc => {
+      return acc + ROW_HEIGHT
     },
     0
   )
@@ -109,7 +108,7 @@ class LogsTable extends Component<Props, State> {
     }
 
     if (scrollToRow) {
-      scrollTop = calculateScrollTop(currentMessageWidth, data, scrollToRow)
+      scrollTop = calculateScrollTop(scrollToRow)
     }
 
     const scrollLeft = _.get(state, 'scrollLeft', 0)
@@ -448,18 +447,12 @@ class LogsTable extends Component<Props, State> {
 
     return _.reduce(
       data,
-      (acc, __, index) => {
-        return (
-          acc +
-          calculateMessageHeight(index, this.props.data, this.rowCharLimit)
-        )
+      (acc, __) => {
+        return acc + ROW_HEIGHT
       },
       0
     )
   }
-
-  private calculateRowHeight = ({index}: {index: number}): number =>
-    calculateMessageHeight(index, this.props.data, this.rowCharLimit)
 
   private headerRenderer = ({key, style, columnIndex}) => {
     const column = getColumnFromData(this.props.data, columnIndex)

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -6,6 +6,7 @@ import {Grid, AutoSizer, InfiniteLoader} from 'react-virtualized'
 import {color} from 'd3-color'
 
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+import ExpandableMessage from 'src/logs/components/expandable_message/ExpandableMessage'
 import {getDeep} from 'src/utils/wrappers'
 
 import {colorForSeverity} from 'src/logs/utils/colors'
@@ -517,6 +518,10 @@ class LogsTable extends Component<Props, State> {
     } else {
       formattedValue = formatColumnValue(column, value, this.rowCharLimit)
       title = formattedValue
+    }
+
+    if (column === 'message') {
+      formattedValue = <ExpandableMessage formattedValue={formattedValue} />
     }
 
     const highlightRow = rowIndex === this.state.currentRow

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -244,6 +244,7 @@ class LogsTable extends Component<Props, State> {
                   autoHide={false}
                 >
                   <Grid
+                    rowHeight={ROW_HEIGHT}
                     {...this.gridProperties(
                       width,
                       height,
@@ -277,7 +278,6 @@ class LogsTable extends Component<Props, State> {
     const result: any = {
       width,
       height,
-      rowHeight: this.calculateRowHeight,
       rowCount: this.rowCount(),
       scrollLeft,
       scrollTop,

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -73,8 +73,6 @@ interface State {
 }
 
 const calculateScrollTop = scrollToRow => {
-  // const rowCharLimit = calculateRowCharWidth(currentMessageWidth)
-
   return _.reduce(
     _.range(0, scrollToRow),
     acc => {

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.scss
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.scss
@@ -31,9 +31,12 @@
   display: block;
   box-sizing: border-box;
   position: absolute;
+  top: 0;
   white-space: pre-wrap;
   padding: $ix-marg-c;
   width: 100%;
+  max-height: 300px;
+  overflow-y: auto;
   background-color: $g5-pepper;
   z-index: 100;
   @extend %drop-shadow;

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.scss
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.scss
@@ -19,6 +19,7 @@
     overflow: hidden;
     text-overflow: ellipsis;
     display: block;
+    pointer-events: none;
   }
 }
 

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.scss
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.scss
@@ -1,0 +1,42 @@
+/*
+   ExpandableMessage
+   -----------------------------------------------------------------------------
+*/
+
+@import 'src/style/modules/influx-colors';
+@import 'src/style/modules/mixins';
+@import 'src/style/modules/variables';
+
+.expandable--message {
+  display: flex;
+  min-height: 100%;
+  min-width: 100%;
+  align-items: center;
+  cursor: pointer;
+  
+  .expandable--text {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
+  }
+}
+
+.collapsed--message {
+  display: none;
+}
+
+.expanded--message { 
+  display: block;
+  box-sizing: border-box;
+  position: absolute;
+  white-space: pre-wrap;
+  padding: $ix-marg-c;
+  width: 100%;
+  background-color: $g5-pepper;
+  z-index: 100;
+  @extend %drop-shadow;
+  color: $g19-ghost;
+  border-radius: $radius;
+  cursor: text;
+}

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -1,0 +1,59 @@
+import React, {Component} from 'react'
+
+import './ExpandableMessage.scss'
+import {ClickOutside} from 'src/shared/components/ClickOutside'
+
+interface State {
+  expanded: boolean
+}
+
+interface Props {
+  formattedValue: string | JSX.Element
+}
+
+export class ExpandableMessage extends Component<Props, State> {
+  constructor(props) {
+    super(props)
+    this.state = {
+      expanded: false,
+    }
+  }
+
+  public render() {
+    const {formattedValue} = this.props
+
+    return (
+      <ClickOutside onClickOutside={this.collapse}>
+        <>
+          <div onClick={this.expand} className="expandable--message">
+            <div className="expandable--text">{formattedValue}</div>
+            <div className={this.isExpanded}>{formattedValue}</div>
+          </div>
+        </>
+      </ClickOutside>
+    )
+  }
+
+  private get isExpanded() {
+    const {expanded} = this.state
+    if (expanded) {
+      return 'expanded--message'
+    } else {
+      return 'collapsed--message'
+    }
+  }
+
+  private expand = () => {
+    this.setState({
+      expanded: true,
+    })
+  }
+
+  private collapse = () => {
+    this.setState({
+      expanded: false,
+    })
+  }
+}
+
+export default ExpandableMessage

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -259,13 +259,6 @@ $logs-viewer-gutter: 60px;
   border-bottom: 2px solid $g5-pepper;
 }
 
-.message--cell {
-  overflow: hidden;
-  white-space: nowrap;
-  display: block;
-  text-overflow: ellipsis;
-}
-
 // Clickable Cells
 .logs-viewer--clickable {
   display: inline-flex;

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -238,10 +238,6 @@ $logs-viewer-gutter: 60px;
   margin-right: 10px;
 }
 
-.message--cell {
-  word-break: break-all;
-}
-
 // Table Cell Styles
 .logs-viewer--cell {
   font-size: 12px;
@@ -261,6 +257,13 @@ $logs-viewer-gutter: 60px;
   font-weight: 600;
   color: $g15-platinum;
   border-bottom: 2px solid $g5-pepper;
+}
+
+.message--cell {
+  overflow: hidden;
+  white-space: nowrap;
+  display: block;
+  text-overflow: ellipsis;
 }
 
 // Clickable Cells


### PR DESCRIPTION
![logmessageoverlay_top](https://user-images.githubusercontent.com/11937365/42668502-d7a27bf8-8605-11e8-8689-e51f735ef18b.gif)

Closes Issue verbally discussed by @nhaugo.

_Briefly describe your proposed changes:_
Each row in logs table has set height and long messages are truncated. When the user clicks on a message, it opens in overlay on row.

_What was the problem?_
The variable row height from wrapped log messages were problematic for the virtualized list.

_What was the solution?_
Truncate long messages and display longer message in overlay.

  - [ ] Rebased/mergeable
  - [ ] Tests pass
