### PR TITLE
Create / update template variables correctly

### DIFF
--- a/ui/src/tempVars/components/KeysTemplateBuilder.tsx
+++ b/ui/src/tempVars/components/KeysTemplateBuilder.tsx
@@ -196,7 +196,15 @@ class KeysTemplateBuilder extends PureComponent<Props, State> {
         nextValues[0].selected = true
       }
 
-      onUpdateTemplate({...template, values: nextValues})
+      onUpdateTemplate({
+        ...template,
+        query: {
+          ...template.query,
+          db: selectedDatabase,
+          measurement: selectedMeasurement,
+        },
+        values: nextValues,
+      })
     } catch (error) {
       this.setState({keysStatus: RemoteDataState.Error})
       console.error(error)

--- a/ui/src/tempVars/components/TagValuesTemplateBuilder.tsx
+++ b/ui/src/tempVars/components/TagValuesTemplateBuilder.tsx
@@ -236,7 +236,16 @@ class KeysTemplateBuilder extends PureComponent<TemplateBuilderProps, State> {
         nextValues[0].selected = true
       }
 
-      onUpdateTemplate({...template, values: nextValues})
+      onUpdateTemplate({
+        ...template,
+        values: nextValues,
+        query: {
+          ...template.query,
+          db: selectedDatabase,
+          measurement: selectedMeasurement,
+          tagKey: selectedTagKey,
+        },
+      })
     } catch (error) {
       this.setState({tagValuesStatus: RemoteDataState.Error})
       console.error(error)


### PR DESCRIPTION
Closes #3830

_What was the problem?_

Creating a “tag values” template variable, a user is presented a UI with three dropdowns:

![screen shot 2018-07-13 at 11 55 53 am](https://user-images.githubusercontent.com/638955/42708977-bb21d846-8693-11e8-99fe-2e8109f9e91c.png)

Selecting the value of a dropdown triggers an asynchronous request to populate the subsequent dropdowns. When these requests complete, they set state on the `TagValuesTemplateBuilder`. 

Selecting dropdowns in rapid succession creates race conditions between asynchronous requests. If the requests fulfill in the wrong order, the draft template state (i.e. the template created when a user clicks “Create”) may be invalid (#3830).

This also happens with the two `KeysTemplateBuilder`s.

_What was the solution?_

The final update to the draft template state now collects the appropriate values (stored as component state up until then), which ensures that the saved template is consistent with the UI.

I view this as a stopgap solution. I think eventually we should refactor the various `TemplateBuilder` classes to eliminate the race conditions altogether. One way of achieving this would be to extract all async control flow to a [saga](https://redux-saga.js.org/), where we would have the tools to deal with a tricky scenario like this (task cancellation, child tasks, etc.) Doing so would also let us test the various `TemplateBuilder` classes 😎 
