### PR TITLE
Make template variable names visible to visitors

### DIFF
--- a/ui/src/tempVars/components/TemplateControl.tsx
+++ b/ui/src/tempVars/components/TemplateControl.tsx
@@ -60,16 +60,18 @@ class TemplateControl extends PureComponent<Props, State> {
         ) : (
           <TemplateDropdown template={template} onPickValue={onPickValue} />
         )}
-        <Authorized requiredRole={EDITOR_ROLE}>
-          <label className="template-control--label">
-            {template.tempVar}
+
+        <label className="template-control--label">
+          {template.tempVar}
+          <Authorized requiredRole={EDITOR_ROLE}>
             <span
               className="icon cog-thick"
               onClick={this.handleShowSettings}
               data-test="edit"
             />
-          </label>
-        </Authorized>
+          </Authorized>
+        </label>
+
         <OverlayTechnology visible={isEditing}>
           <TemplateVariableEditor
             template={template}


### PR DESCRIPTION
Closes #3912

_What was the problem?_
It was checking for role of editor around the entire label instead of just the cog.

_What was the solution?_
Move the authorization check to only include the cog and not the entire temp var label.

  - [x] Rebased/mergeable
  - [x] Tests pass