### PR TITLE
Fix horizontal scrolling in logs table

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -297,11 +297,10 @@ class LogsTable extends Component<Props, State> {
   private handleScrollbarScroll = (e: MouseEvent<JSX.Element>): void => {
     e.stopPropagation()
     e.preventDefault()
-    const {scrollTop, scrollLeft} = e.target as HTMLElement
+    const {scrollTop} = e.target as HTMLElement
 
     this.handleScroll({
       scrollTop,
-      scrollLeft,
     })
   }
 


### PR DESCRIPTION
Closes #3931 

_What was the problem?_
Function dealing with vertical scroll was always setting ScrollLeft to 0. 

_What was the solution?_
Dont set scrollLeft in the function dealing with vertical scroll.

  - [x] Rebased/mergeable
  - [x] Tests pass
