### PR TITLE
Pass editQueryStatus to the timeseries component

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -62,7 +62,14 @@ class RefreshingGraph extends PureComponent<Props> {
   }
 
   public render() {
-    const {inView, type, queries, source, templates} = this.props
+    const {
+      inView,
+      type,
+      queries,
+      source,
+      templates,
+      editQueryStatus,
+    } = this.props
 
     if (!queries.length) {
       return (
@@ -78,6 +85,7 @@ class RefreshingGraph extends PureComponent<Props> {
         inView={inView}
         queries={this.queries}
         templates={templates}
+        editQueryStatus={editQueryStatus}
       >
         {({timeSeries, loading}) => {
           switch (type) {

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -25,6 +25,7 @@ interface Props {
   children: (r: RenderProps) => JSX.Element
   inView?: boolean
   templates?: Template[]
+  editQueryStatus?: () => void
 }
 
 interface State {
@@ -67,7 +68,7 @@ class TimeSeries extends Component<Props, State> {
   }
 
   public executeQueries = async (isFirstFetch: boolean = false) => {
-    const {source, inView, queries, templates} = this.props
+    const {source, inView, queries, templates, editQueryStatus} = this.props
 
     if (!inView) {
       return
@@ -86,7 +87,8 @@ class TimeSeries extends Component<Props, State> {
         source,
         queries,
         TEMP_RES,
-        templates
+        templates,
+        editQueryStatus
       )
 
       const newSeries = timeSeries.map((response: TimeSeriesResponse) => ({


### PR DESCRIPTION
Closes #3937 

_What was the solution?_
editQueryStatus was not being passed to the new timeSeries

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)