### PR TITLE
Ensure Map templates track selections

### DIFF
--- a/ui/test/tempVars/utils/graph.test.ts
+++ b/ui/test/tempVars/utils/graph.test.ts
@@ -3,6 +3,7 @@ import {
   graphFromTemplates,
   hydrateTemplates,
   newTemplateValues,
+  newConstantTemplateValues,
   topologicalSort,
 } from 'src/tempVars/utils/graph'
 
@@ -472,6 +473,180 @@ describe('newTemplateValues', () => {
         localSelected: false,
       },
     ])
+  })
+})
+
+describe('newConstantTemplateValues', () => {
+  test('maintains current selections for Map template variables', () => {
+    const template = {
+      id: '',
+      label: '',
+      query: {},
+      tempVar: ':a:',
+      type: TemplateType.Map,
+      values: [
+        {
+          type: TemplateValueType.Map,
+          key: 'k1',
+          value: 'v1',
+          selected: true,
+          localSelected: false,
+        },
+        {
+          type: TemplateValueType.Map,
+          key: 'k2',
+          value: 'v2',
+          selected: false,
+          localSelected: true,
+        },
+      ],
+    }
+
+    const expected = [
+      {
+        type: TemplateValueType.Map,
+        key: 'k1',
+        value: 'v1',
+        selected: true,
+        localSelected: false,
+      },
+      {
+        type: TemplateValueType.Map,
+        key: 'k2',
+        value: 'v2',
+        selected: false,
+        localSelected: true,
+      },
+    ]
+
+    expect(newConstantTemplateValues(template)).toEqual(expected)
+  })
+
+  test('maintains current selections for CSV template variables', () => {
+    const template = {
+      id: '',
+      label: '',
+      query: {},
+      tempVar: ':a:',
+      type: TemplateType.CSV,
+      values: [
+        {
+          type: TemplateValueType.CSV,
+          value: 'v1',
+          selected: true,
+          localSelected: false,
+        },
+        {
+          type: TemplateValueType.CSV,
+          value: 'v2',
+          selected: false,
+          localSelected: true,
+        },
+      ],
+    }
+
+    const expected = [
+      {
+        type: TemplateValueType.CSV,
+        value: 'v1',
+        selected: true,
+        localSelected: false,
+      },
+      {
+        type: TemplateValueType.CSV,
+        value: 'v2',
+        selected: false,
+        localSelected: true,
+      },
+    ]
+
+    expect(newConstantTemplateValues(template)).toEqual(expected)
+  })
+
+  test('applies a selected value for Map template variables', () => {
+    const template = {
+      id: '',
+      label: '',
+      query: {},
+      tempVar: ':a:',
+      type: TemplateType.Map,
+      values: [
+        {
+          type: TemplateValueType.Map,
+          key: 'k1',
+          value: 'v1',
+          selected: true,
+          localSelected: false,
+        },
+        {
+          type: TemplateValueType.Map,
+          key: 'k2',
+          value: 'v2',
+          selected: false,
+          localSelected: true,
+        },
+      ],
+    }
+
+    const expected = [
+      {
+        type: TemplateValueType.Map,
+        key: 'k1',
+        value: 'v1',
+        selected: true,
+        localSelected: true,
+      },
+      {
+        type: TemplateValueType.Map,
+        key: 'k2',
+        value: 'v2',
+        selected: false,
+        localSelected: false,
+      },
+    ]
+
+    expect(newConstantTemplateValues(template, 'k1')).toEqual(expected)
+  })
+
+  test('applies a selected value for CSV template variables', () => {
+    const template = {
+      id: '',
+      label: '',
+      query: {},
+      tempVar: ':a:',
+      type: TemplateType.CSV,
+      values: [
+        {
+          type: TemplateValueType.CSV,
+          value: 'v1',
+          selected: true,
+          localSelected: false,
+        },
+        {
+          type: TemplateValueType.CSV,
+          value: 'v2',
+          selected: false,
+          localSelected: true,
+        },
+      ],
+    }
+
+    const expected = [
+      {
+        type: TemplateValueType.CSV,
+        value: 'v1',
+        selected: true,
+        localSelected: true,
+      },
+      {
+        type: TemplateValueType.CSV,
+        value: 'v2',
+        selected: false,
+        localSelected: false,
+      },
+    ]
+
+    expect(newConstantTemplateValues(template, 'v1')).toEqual(expected)
   })
 })
 


### PR DESCRIPTION
The recent template variable hydration refactors (#3924, #3950, 9eb897cce63fe090bf66af10ff246e75e97cde0f) broke our support for `Map` template variables. 

From a user perspective, the issue presents like this:

![kapture 2018-07-18 at 15 49 03](https://user-images.githubusercontent.com/638955/42913231-9cce0310-8aa8-11e8-929d-037c1375b093.gif)

Internally, the issue is that we don't propagate `Map` template variable selections (e.g. `selected` and `localSelected` state) correctly during template variable rehydration. 

This PR addresses the issue by splitting our resolution of template variable selections into two cases: query-backed template variables, and non-query backed template variables. The non-query backed selection resolution now handles `Map` selections appropriately.