### PR TITLE
Fix template variable replacement within regexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure text template variables reflect query parameters
 1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Enable using a new, blank text template variable in a query
 1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure cells with broken queries display “No Data”
+1.  [#3978](https://github.com/influxdata/chronograf/pull/3978): Fix use of template variables within InfluxQL regexes
 
 ## v1.6.0 [2018-06-18]
 

--- a/ui/test/tempVars/utils/replace.test.ts
+++ b/ui/test/tempVars/utils/replace.test.ts
@@ -221,6 +221,38 @@ describe('templates.utils.replace', () => {
 
       expect(actual).toBe(expected)
     })
+
+    it('replaces a query with a single / properly', () => {
+      const templates = [
+        {
+          tempVar: ':Cluster_Id:',
+          values: [
+            {
+              value: 'e87a44cb9df65eb0d6fa50730842d926',
+              type: TemplateValueType.TagValue,
+              selected: true,
+              localSelected: true,
+            },
+          ],
+          id: 'e4731672-e3d6-4633-b2ed-146ea51cbb7f',
+          type: TemplateType.TagValues,
+          label: '',
+          query: {
+            influxql:
+              'SHOW TAG VALUES ON :database: FROM :measurement: WITH KEY=:tagKey:',
+            db: 'telegraf',
+            measurement: 'cpu',
+            tagKey: 'cluster_id',
+            fieldKey: '',
+          },
+        },
+      ]
+      const query = `SELECT last("max") from (SELECT max("total")/1073741824 FROM "telegraf".."mem" WHERE "cluster_id" = :Cluster_Id: AND (host =~ /.*data.*/ OR host =~ /tot-.*-(3|4)/) GROUP BY time(1s), host)`
+      const expected = `SELECT last("max") from (SELECT max("total")/1073741824 FROM "telegraf".."mem" WHERE "cluster_id" = 'e87a44cb9df65eb0d6fa50730842d926' AND (host =~ /.*data.*/ OR host =~ /tot-.*-(3|4)/) GROUP BY time(1s), host)`
+      const actual = templateReplace(query, templates)
+
+      expect(actual).toBe(expected)
+    })
   })
 
   describe('with no templates', () => {


### PR DESCRIPTION
Closes #3979 

Template variables used within regexes would not replace correctly when the query contained a `/` before the regex in the query, e.g. the following query breaks:

```
SELECT last("max") from (SELECT max("total")/1073741824 FROM "telegraf".."mem" WHERE "cluster_id" = :Cluster_Id: AND (host =~ /.*data.*/ OR host =~ /tot-.*-(3|4)/) GROUP BY time(1s), host)
```

This commit rewrites the logic for replacing template variables. It uses an iterative approach, since the `RegExp.match` used in the past has shown to be too unpredictable.  