### PR TITLE
Prevent Single Stat Text With Descenders From Clipping

### DIFF
--- a/ui/src/shared/components/SingleStat.tsx
+++ b/ui/src/shared/components/SingleStat.tsx
@@ -151,7 +151,7 @@ class SingleStat extends PureComponent<Props> {
         <svg width="100%" height="100%" viewBox={viewBox}>
           <text
             className="single-stat--text"
-            fontSize="100"
+            fontSize="87"
             y="59%"
             x="50%"
             dominantBaseline="middle"


### PR DESCRIPTION
Before:
![screen shot 2018-07-24 at 9 24 45 am](https://user-images.githubusercontent.com/2433762/43152619-d7b1f052-8f23-11e8-9b47-2cea0908a2dd.png)

After:
![screen shot 2018-07-24 at 9 25 01 am](https://user-images.githubusercontent.com/2433762/43152626-dcd602c6-8f23-11e8-9ffa-9a2fb1768f51.png)

  - [x] Rebased/mergeable
  - [x] Tests pass