### PR TITLE
Fix histogram overflow issue when using basepath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure cells with broken queries display “No Data”
 1.  [#3978](https://github.com/influxdata/chronograf/pull/3978): Fix use of template variables within InfluxQL regexes
 1.  [#3994](https://github.com/influxdata/chronograf/pull/3994): Pressing play on log viewer goes to now
+1.  [#4008](https://github.com/influxdata/chronograf/pull/4008): Fix display of log viewer histogram when a basepath is enabled
 
 
 ## v1.6.0 [2018-06-18]

--- a/ui/src/shared/components/HistogramChart.tsx
+++ b/ui/src/shared/components/HistogramChart.tsx
@@ -8,6 +8,7 @@ import HistogramChartTooltip from 'src/shared/components/HistogramChartTooltip'
 import HistogramChartSkeleton from 'src/shared/components/HistogramChartSkeleton'
 
 import extentBy from 'src/utils/extentBy'
+import {clipPathUrl} from 'src/utils/svg'
 
 import {
   HistogramData,
@@ -114,7 +115,7 @@ class HistogramChart extends PureComponent<Props, State> {
           <g
             transform={bodyTransform}
             className="histogram-chart--bars"
-            clipPath="url(#histogram-chart--bars-clip)"
+            clipPath={clipPathUrl('histogram-chart--bars-clip')}
           >
             <HistogramChartBars
               width={adjustedWidth}

--- a/ui/src/shared/components/HistogramChartBars.tsx
+++ b/ui/src/shared/components/HistogramChartBars.tsx
@@ -4,6 +4,7 @@ import {ScaleLinear, ScaleTime} from 'd3-scale'
 import {color} from 'd3-color'
 
 import {getDeep} from 'src/utils/wrappers'
+import {clipPathUrl} from 'src/utils/svg'
 
 import {
   HistogramData,
@@ -202,7 +203,7 @@ class HistogramChartBars extends PureComponent<Props, State> {
               width={d.width}
               height={d.height}
               fill={d.fill}
-              clipPath={`url(#histogram-chart-bars--clip-${key})`}
+              clipPath={clipPathUrl(`histogram-chart-bars--clip-${key}`)}
               data-group={d.group}
               data-key={d.key}
             />

--- a/ui/src/utils/svg.ts
+++ b/ui/src/utils/svg.ts
@@ -1,0 +1,19 @@
+export const clipPathUrl = elementId => {
+  // Other SVG elements are often referenced in SVG attributes like `clip-path`
+  // and `mask` using a url, e.g.
+  //
+  //     <rect clip-path="url(#some-svg-element-id") ... />
+  //
+  // Chronograf supports a [`--basepath`][0] option that rewrites all instances
+  // of `url(` occuring in asset files as they are served, which breaks usages
+  // of `url(#...)` strings in SVG elements. This issue has been fixed for
+  // standalone SVG files by [#3402][1], but not for inline SVG elements (i.e.
+  // those rendered by components). This workaround renders `url(#...)` strings
+  // dynamically on the client to evade the server asset rewriting.
+  //
+  // [0]: https://docs.influxdata.com/chronograf/v1.6/administration/config-options/#chronograf-service-options
+  // [1]: https://github.com/influxdata/chronograf/pull/3402
+  const leftParen = String.fromCharCode(40)
+
+  return `url${leftParen}#${elementId})`
+}


### PR DESCRIPTION
Closes #3968

The `HistogramChart` uses SVG `clip-path=url(#some-element-id)` properties in it's implementation. With basepath enabled, Chronograf rewrites all instances of `url(` as `url(/basepath` when serving assets, which breaks these usages of `clip-path`.

This commit introduces a utility to properly encode urls in `clip-path` properties using a hacky workaround (dynamically render `url(` client-side so it's never rewritten by Chronograf). While we could address the issue server side (in `server/url_prefixer.go`), it's likely not worth it given the looming Chronograf 2.0 epoch.

See also https://github.com/influxdata/chronograf/pull/3402