### PR TITLE
Easier to get into hover legend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v1.6.1 [unreleased]
 
+### UI Improvements
+1.  [#4009](https://github.com/influxdata/chronograf/pull/4009): Make it to get mouse into hover legend
+
 ### Bug Fixes
 
 1.  [#3976](https://github.com/influxdata/chronograf/pull/3976): Ensure text template variables reflect query parameters

--- a/ui/src/shared/graphs/helpers.ts
+++ b/ui/src/shared/graphs/helpers.ts
@@ -120,6 +120,7 @@ export const makeLegendStyles = (graph, legend, hoverTimeX) => {
   const screenHeight = window.innerHeight
   const legendMaxLeft = graphWidth - legendWidth / 2
 
+  let marginTop = 0
   let legendLeft = hoverTimeX
 
   // Enforcing max & min legend offsets
@@ -139,6 +140,7 @@ export const makeLegendStyles = (graph, legend, hoverTimeX) => {
   // If legend is only clipped on the bottom, position above graph
   if (isLegendBottomClipped && !isLegendTopClipped) {
     legendTop = -legendHeight
+    marginTop = 7
   }
 
   // If legend is clipped on top and bottom, posiition on either side of crosshair
@@ -157,6 +159,7 @@ export const makeLegendStyles = (graph, legend, hoverTimeX) => {
   return {
     left: `${legendLeft}px`,
     top: `${legendTop}px`,
+    marginTop: `${marginTop}px`,
   }
 }
 


### PR DESCRIPTION
Closes #3992

_Briefly describe your proposed changes:_
add a small margin top to push dygraph legend down if the dygraph legend is rendering at the top of the graph instead of the bottom

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass