### PR TITLE
If no current source for log viewer, use default

### DIFF
--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -698,7 +698,7 @@ export const populateNamespacesAsync = (
 
   if (namespaces && namespaces.length > 0) {
     dispatch(setNamespaces(namespaces))
-    if (source) {
+    if (source && source.telegraf) {
       const defaultNamespace = namespaces.find(
         namespace => namespace.database === source.telegraf
       )

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -146,7 +146,12 @@ class LogsPage extends Component<Props, State> {
 
   public componentDidUpdate() {
     if (!this.props.currentSource && this.props.sources.length > 0) {
-      this.props.getSource(this.props.sources[0].id)
+      const source =
+        this.props.sources.find(src => {
+          return src.default
+        }) || this.props.sources[0]
+
+      this.props.getSource(source.id)
     }
   }
 


### PR DESCRIPTION
Closes #4029

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)