### PR TITLE
Connect Rule Graph to redux store to set hover time on hover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 1.  [#3978](https://github.com/influxdata/chronograf/pull/3978): Fix use of template variables within InfluxQL regexes
 1.  [#3994](https://github.com/influxdata/chronograf/pull/3994): Pressing play on log viewer goes to now
 1.  [#4008](https://github.com/influxdata/chronograf/pull/4008): Fix display of log viewer histogram when a basepath is enabled
-
+1.  [#4038](https://github.com/influxdata/chronograf/pull/4038): Fix crosshairs and hover legend display in Alert Rule visualization
 
 ## v1.6.0 [2018-06-18]
 

--- a/ui/src/kapacitor/components/RuleGraph.tsx
+++ b/ui/src/kapacitor/components/RuleGraph.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent, CSSProperties} from 'react'
+import {connect} from 'react-redux'
 import TimeSeries from 'src/shared/components/time_series/TimeSeries'
 
 // Components
@@ -19,6 +20,7 @@ import {LINE_COLORS_RULE_GRAPH} from 'src/shared/constants/graphColorPalettes'
 import {Source, AlertRule, QueryConfig, Query, TimeRange} from 'src/types'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import {setHoverTime as setHoverTimeAction} from 'src/dashboards/actions'
 
 interface Props {
   source: Source
@@ -26,6 +28,7 @@ interface Props {
   rule: AlertRule
   timeRange: TimeRange
   onChooseTimeRange: (tR: TimeRange) => void
+  setHoverTime: typeof setHoverTimeAction
 }
 
 @ErrorHandling
@@ -60,7 +63,6 @@ class RuleGraph extends PureComponent<Props> {
                 data.timeSeries,
                 'rule-builder'
               )
-
               return (
                 <Dygraph
                   labels={labels}
@@ -75,6 +77,7 @@ class RuleGraph extends PureComponent<Props> {
                   colors={LINE_COLORS_RULE_GRAPH}
                   containerStyle={this.containerStyle}
                   underlayCallback={underlayCallback(rule)}
+                  handleSetHoverTime={this.props.setHoverTime}
                 />
               )
             }}
@@ -124,4 +127,8 @@ class RuleGraph extends PureComponent<Props> {
   }
 }
 
-export default RuleGraph
+const mdtp = {
+  setHoverTime: setHoverTimeAction,
+}
+
+export default connect(null, mdtp)(RuleGraph)


### PR DESCRIPTION
Closes #3973

_Briefly describe your proposed changes:_
_What was the problem?_
The hover line was not showing up in alert rule. 

_What was the solution?_
Connect rule graph to redux store. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)