### PR TITLE
Show full value in filter tooltip

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -525,7 +525,7 @@ class LogsTable extends Component<Props, State> {
           className={classnames('logs-viewer--cell', {
             highlight: highlightRow,
           })}
-          title={`Jump to '${title}'`}
+          title={`Jump to '${value}'`}
           key={key}
           style={style}
           data-index={rowIndex}


### PR DESCRIPTION
Fixes showing truncated value in application filter tooltip

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)