### PR TITLE
Add truncation to procid and host

### DIFF
--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -41,9 +41,10 @@ export const formatColumnValue = (
   switch (column) {
     case 'timestamp':
       return moment(+value / 1000000).format('YYYY/MM/DD HH:mm:ss')
+    case 'procid':
+    case 'host':
     case 'appname':
-      const length = Math.floor(DEFAULT_COLUMN_WIDTH / CHAR_WIDTH) - 2
-      return _.truncate(value || '', {length})
+      return truncateText(value, column)
     case 'message':
       value = (value || 'No Message Provided').replace('\\n', '')
       if (value.indexOf(' ') > charLimit - 5) {
@@ -63,6 +64,13 @@ export const header = (
 
   const headerOption = _.find(headerOptions, h => h.internalName === key)
   return _.get(headerOption, 'displayName') || _.capitalize(key)
+}
+
+const truncateText = (value: string, column: string): string => {
+  const columnWidth = getColumnWidth(column)
+  const length = Math.floor(columnWidth / CHAR_WIDTH) - 2
+
+  return _.truncate(value || '', {length})
 }
 
 export const getColumnWidth = (column: string): number => {


### PR DESCRIPTION
Closes #4016

_What was the problem?_
The **Proc ID** and **Host** columns truncated in the log viewer and text would overlap.
_What was the solution?_
Apply the `truncateText` formula for a given column to both the **Proc ID** and **Host** columns. 

  - [ ] Rebased/mergeable
  - [ ] Tests pass