### PR TITLE
Fix/query viewer update

### DIFF
--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component} from 'react'
+import React, {Component, MouseEvent} from 'react'
 import _ from 'lodash'
 import classnames from 'classnames'
 
@@ -119,7 +119,7 @@ class InfluxQLEditor extends Component<Props, State> {
     return (
       <div
         className="query-editor"
-        onMouseDown={this.handleVarmojiFocus}
+        onMouseDown={this.handleMouseDown}
         onBlur={this.handleBlurEditor}
       >
         {this.dismissPreviewButton}
@@ -216,7 +216,7 @@ class InfluxQLEditor extends Component<Props, State> {
     this.closeDrawer()
   }
 
-  private handleVarmojiFocus = (e: MouseEvent): void => {
+  private handleMouseDown = (e: MouseEvent): void => {
     this.setState({focused: true})
 
     e.stopPropagation()
@@ -372,7 +372,6 @@ class InfluxQLEditor extends Component<Props, State> {
         <button
           className="query-editor--dismiss"
           onClick={this.handleHideAndFocus}
-          onMouseDown={this.handleVarmojiFocus}
         />
       )
     }

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -325,10 +325,6 @@ class InfluxQLEditor extends Component<Props, State> {
     }
   }
 
-  private hideTemplateValues = (): void => {
-    this.setState({isShowingTemplateValues: false})
-  }
-
   private handleHideAndFocus = (): void => {
     this.setState({isShowingTemplateValues: false, focused: true})
   }

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -8,7 +8,6 @@ import ReactCodeMirror from 'src/dashboards/components/ReactCodeMirror'
 import TemplateDrawer from 'src/shared/components/TemplateDrawer'
 import QueryStatus from 'src/shared/components/QueryStatus'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import OnClickOutside from 'src/shared/components/OnClickOutside'
 
 // Utils
 import {getDeep} from 'src/utils/wrappers'
@@ -41,7 +40,6 @@ interface Props {
   onUpdate: (text: string) => Promise<void>
   config: QueryConfig
   templates: Template[]
-  onClickOutside: () => void
 }
 
 const FIRST_TEMP_VAR = '0.tempVar'
@@ -172,13 +170,6 @@ class InfluxQLEditor extends Component<Props, State> {
         </div>
       </div>
     )
-  }
-
-  public handleClickOutside = (): void => {
-    this.setState({focused: false})
-
-    this.hideTemplateValues()
-    this.handleBlurEditor()
   }
 
   private handleTemplateSelection = (
@@ -410,4 +401,4 @@ class InfluxQLEditor extends Component<Props, State> {
   }
 }
 
-export default OnClickOutside(InfluxQLEditor)
+export default InfluxQLEditor

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -115,11 +115,7 @@ class InfluxQLEditor extends Component<Props, State> {
     } = this.state
 
     return (
-      <div
-        className="query-editor"
-        onMouseDown={this.handleMouseDown}
-        onBlur={this.handleBlurEditor}
-      >
+      <div className="query-editor" onMouseDown={this.handleMouseDown}>
         {this.dismissPreviewButton}
         <ReactCodeMirror
           ref={this.codeMirrorRef}
@@ -133,6 +129,7 @@ class InfluxQLEditor extends Component<Props, State> {
           readOnly={isShowingTemplateValues}
           onChange={this.handleChange}
           onFocus={this.handleFocusEditor}
+          onBlur={this.handleBlurEditor}
           isShowingTemplateValues={isShowingTemplateValues}
           onKeyDown={this.handleKeyDownEditor}
           onBeforeChange={this.handleUpdateTemplatingQueryText}

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -117,7 +117,11 @@ class InfluxQLEditor extends Component<Props, State> {
     } = this.state
 
     return (
-      <div className="query-editor">
+      <div
+        className="query-editor"
+        onMouseDown={this.handleVarmojiFocus}
+        onBlur={this.handleBlurEditor}
+      >
         {this.dismissPreviewButton}
         <ReactCodeMirror
           ref={this.codeMirrorRef}
@@ -142,7 +146,6 @@ class InfluxQLEditor extends Component<Props, State> {
             focus: focused,
             'read-only': isShowingTemplateValues,
           })}
-          onClick={this.handleVarmojiFocus}
         >
           <div className="varmoji-container">
             <div className="varmoji-front">
@@ -175,7 +178,7 @@ class InfluxQLEditor extends Component<Props, State> {
     this.setState({focused: false})
 
     this.hideTemplateValues()
-    this.handleUpdate()
+    this.handleBlurEditor()
   }
 
   private handleTemplateSelection = (
@@ -191,6 +194,10 @@ class InfluxQLEditor extends Component<Props, State> {
 
   private handleFocusEditor = (): void => {
     this.setState({focused: true})
+  }
+
+  private handleBlurEditor = (): void => {
+    this.handleUpdate()
   }
 
   private handleCloseDrawer = (): void => {
@@ -209,8 +216,11 @@ class InfluxQLEditor extends Component<Props, State> {
     this.closeDrawer()
   }
 
-  private handleVarmojiFocus = (): void => {
+  private handleVarmojiFocus = (e: MouseEvent): void => {
     this.setState({focused: true})
+
+    e.stopPropagation()
+    e.preventDefault()
   }
 
   private handleUpdateTemplatingQueryText = (value: string): void => {
@@ -362,6 +372,7 @@ class InfluxQLEditor extends Component<Props, State> {
         <button
           className="query-editor--dismiss"
           onClick={this.handleHideAndFocus}
+          onMouseDown={this.handleVarmojiFocus}
         />
       )
     }

--- a/ui/src/dashboards/components/QueryMaker.tsx
+++ b/ui/src/dashboards/components/QueryMaker.tsx
@@ -15,7 +15,7 @@ import {CellEditorOverlayActions} from 'src/dashboards/components/CellEditorOver
 const rawTextBinder = (
   links: SourceLinks,
   id: string,
-  action: (linksQueries: string, id: string, text: string) => void
+  action: (linksQueries: string, id: string, text: string) => Promise<void>
 ) => (text: string) => action(links.queries, id, text)
 
 const buildText = (q: QueryConfig): string =>

--- a/ui/src/dashboards/components/ReactCodeMirror.tsx
+++ b/ui/src/dashboards/components/ReactCodeMirror.tsx
@@ -36,6 +36,7 @@ interface Props {
   isTemplating: boolean
   isShowingTemplateValues: boolean
   onFocus: () => void
+  onBlur: () => void
   onChange: (value: string) => void
   onKeyDown: (e: KeyboardEvent) => void
   onBeforeChange: (value: string) => void
@@ -76,7 +77,7 @@ class ReactCodeMirror extends PureComponent<Props, State> {
   private editor?: CMEditor
 
   public render() {
-    const {value, onFocus} = this.props
+    const {value, onFocus, onBlur} = this.props
 
     return (
       <div className={this.queryCodeClassName}>
@@ -88,6 +89,7 @@ class ReactCodeMirror extends PureComponent<Props, State> {
           value={value}
           onChange={this.handleChange}
           onFocus={onFocus}
+          onBlur={onBlur}
           onKeyDown={this.handleKeyDownEditor}
           editorWillUnmount={this.handleUnmountEditor}
           editorDidMount={this.handleMountEditor}


### PR DESCRIPTION
Closes #3916 

_What was the problem?_
Using `onClickOutside` caused the CEO to update the raw text of a query after the cell and it's working drafts were saved.
_What was the solution?_
Replace `onClickOutside` with both an `onBlur` and an `onMouseDown` that prevents clicks on editor buttons from blurring  the editor unnecessarily. Clicking on the checkbox to save the CEO contents will now update the active query raw text and then save the cell contents .

  - [ ] Rebased/mergeable
  - [ ] Tests pass
