### PR TITLE
Reusable Panel Component Family

### DIFF
--- a/ui/src/dashboards/components/DashboardsPageContents.tsx
+++ b/ui/src/dashboards/components/DashboardsPageContents.tsx
@@ -8,6 +8,7 @@ import SearchBar from 'src/hosts/components/SearchBar'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
+import Panel from 'src/reusable_ui/components/panel/Panel'
 
 import {Dashboard} from 'src/types'
 import {Notification} from 'src/types/notifications'
@@ -51,27 +52,30 @@ class DashboardsPageContents extends Component<Props, State> {
     } = this.props
 
     return (
-      <FancyScrollbar className="page-contents">
-        <div className="container-fluid">
-          <div className="row">
-            <div className="col-md-12">
-              <div className="panel">
-                {this.renderPanelHeading}
-                <div className="panel-body">
-                  <DashboardsTable
-                    dashboards={this.filteredDashboards}
-                    onDeleteDashboard={onDeleteDashboard}
-                    onCreateDashboard={onCreateDashboard}
-                    onCloneDashboard={onCloneDashboard}
-                    onExportDashboard={onExportDashboard}
-                    dashboardLink={dashboardLink}
-                  />
-                </div>
+      <>
+        <FancyScrollbar className="page-contents">
+          <div className="container-fluid">
+            <div className="row">
+              <div className="col-md-12">
+                <Panel>
+                  {this.renderPanelHeading}
+                  <Panel.Body>
+                    <DashboardsTable
+                      dashboards={this.filteredDashboards}
+                      onDeleteDashboard={onDeleteDashboard}
+                      onCreateDashboard={onCreateDashboard}
+                      onCloneDashboard={onCloneDashboard}
+                      onExportDashboard={onExportDashboard}
+                      dashboardLink={dashboardLink}
+                    />
+                  </Panel.Body>
+                </Panel>
               </div>
             </div>
           </div>
-        </div>
-      </FancyScrollbar>
+        </FancyScrollbar>
+        {this.renderImportOverlay}
+      </>
     )
   }
 
@@ -79,34 +83,28 @@ class DashboardsPageContents extends Component<Props, State> {
     const {onCreateDashboard} = this.props
 
     return (
-      <>
-        <div className="panel-heading">
-          <h2 className="panel-title">{this.panelTitle}</h2>
-          <div className="panel-controls">
-            <SearchBar
-              placeholder="Filter by Name..."
-              onSearch={this.filterDashboards}
-            />
-            <Authorized requiredRole={EDITOR_ROLE}>
-              <>
-                <button
-                  className="btn btn-sm btn-default"
-                  onClick={this.handleToggleOverlay}
-                >
-                  <span className="icon import" /> Import Dashboard
-                </button>
-                <button
-                  className="btn btn-sm btn-primary"
-                  onClick={onCreateDashboard}
-                >
-                  <span className="icon plus" /> Create Dashboard
-                </button>
-              </>
-            </Authorized>
-          </div>
-        </div>
-        {this.renderImportOverlay}
-      </>
+      <Panel.Header title={this.panelTitle}>
+        <SearchBar
+          placeholder="Filter by Name..."
+          onSearch={this.filterDashboards}
+        />
+        <Authorized requiredRole={EDITOR_ROLE}>
+          <>
+            <button
+              className="btn btn-sm btn-default"
+              onClick={this.handleToggleOverlay}
+            >
+              <span className="icon import" /> Import Dashboard
+            </button>
+            <button
+              className="btn btn-sm btn-primary"
+              onClick={onCreateDashboard}
+            >
+              <span className="icon plus" /> Create Dashboard
+            </button>
+          </>
+        </Authorized>
+      </Panel.Header>
     )
   }
 

--- a/ui/src/dashboards/components/DashboardsPageContents.tsx
+++ b/ui/src/dashboards/components/DashboardsPageContents.tsx
@@ -8,7 +8,6 @@ import SearchBar from 'src/hosts/components/SearchBar'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
-import Panel from 'src/reusable_ui/components/panel/Panel'
 
 import {Dashboard} from 'src/types'
 import {Notification} from 'src/types/notifications'
@@ -52,30 +51,27 @@ class DashboardsPageContents extends Component<Props, State> {
     } = this.props
 
     return (
-      <>
-        <FancyScrollbar className="page-contents">
-          <div className="container-fluid">
-            <div className="row">
-              <div className="col-md-12">
-                <Panel>
-                  {this.renderPanelHeading}
-                  <Panel.Body>
-                    <DashboardsTable
-                      dashboards={this.filteredDashboards}
-                      onDeleteDashboard={onDeleteDashboard}
-                      onCreateDashboard={onCreateDashboard}
-                      onCloneDashboard={onCloneDashboard}
-                      onExportDashboard={onExportDashboard}
-                      dashboardLink={dashboardLink}
-                    />
-                  </Panel.Body>
-                </Panel>
+      <FancyScrollbar className="page-contents">
+        <div className="container-fluid">
+          <div className="row">
+            <div className="col-md-12">
+              <div className="panel">
+                {this.renderPanelHeading}
+                <div className="panel-body">
+                  <DashboardsTable
+                    dashboards={this.filteredDashboards}
+                    onDeleteDashboard={onDeleteDashboard}
+                    onCreateDashboard={onCreateDashboard}
+                    onCloneDashboard={onCloneDashboard}
+                    onExportDashboard={onExportDashboard}
+                    dashboardLink={dashboardLink}
+                  />
+                </div>
               </div>
             </div>
           </div>
-        </FancyScrollbar>
-        {this.renderImportOverlay}
-      </>
+        </div>
+      </FancyScrollbar>
     )
   }
 
@@ -83,28 +79,34 @@ class DashboardsPageContents extends Component<Props, State> {
     const {onCreateDashboard} = this.props
 
     return (
-      <Panel.Header title={this.panelTitle}>
-        <SearchBar
-          placeholder="Filter by Name..."
-          onSearch={this.filterDashboards}
-        />
-        <Authorized requiredRole={EDITOR_ROLE}>
-          <>
-            <button
-              className="btn btn-sm btn-default"
-              onClick={this.handleToggleOverlay}
-            >
-              <span className="icon import" /> Import Dashboard
-            </button>
-            <button
-              className="btn btn-sm btn-primary"
-              onClick={onCreateDashboard}
-            >
-              <span className="icon plus" /> Create Dashboard
-            </button>
-          </>
-        </Authorized>
-      </Panel.Header>
+      <>
+        <div className="panel-heading">
+          <h2 className="panel-title">{this.panelTitle}</h2>
+          <div className="panel-controls">
+            <SearchBar
+              placeholder="Filter by Name..."
+              onSearch={this.filterDashboards}
+            />
+            <Authorized requiredRole={EDITOR_ROLE}>
+              <>
+                <button
+                  className="btn btn-sm btn-default"
+                  onClick={this.handleToggleOverlay}
+                >
+                  <span className="icon import" /> Import Dashboard
+                </button>
+                <button
+                  className="btn btn-sm btn-primary"
+                  onClick={onCreateDashboard}
+                >
+                  <span className="icon plus" /> Create Dashboard
+                </button>
+              </>
+            </Authorized>
+          </div>
+        </div>
+        {this.renderImportOverlay}
+      </>
     )
   }
 

--- a/ui/src/reusable_ui/components/panel/Panel.scss
+++ b/ui/src/reusable_ui/components/panel/Panel.scss
@@ -1,0 +1,123 @@
+/*
+   Panels
+   -----------------------------------------------------------------------------
+*/
+
+@import 'src/style/modules/influx-colors';
+@import 'src/style/modules/variables';
+@import 'src/style/modules/mixins';
+
+$panel-gutter: 30px;
+$panel-background: $g3-castle;
+
+.panel {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  margin-bottom: $panel-gutter;
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: $panel-gutter 0;
+}
+
+.panel-title {
+  font-weight: 400;
+  font-size: 19px;
+  color: $g12-forge;
+  letter-spacing: 0.015em;
+  margin: 0;
+  line-height: 1em;
+  @extend %no-user-select;
+}
+
+.panel-controls {
+  display: flex;
+  align-items: center;
+
+  &:nth-child(1) {
+    justify-content: flex-start;
+    > * {
+      margin-right: $ix-marg-b;
+    }
+  }
+
+  &:nth-child(2) {
+    justify-content: flex-end;
+    > * {
+      margin-left: $ix-marg-b;
+    }
+  }
+}
+
+.panel-body {
+  background-color: $panel-background;
+  padding: $panel-gutter;
+
+  .panel-header + &,
+  &:first-child {
+    border-top-left-radius: $ix-radius;
+    border-top-right-radius: $ix-radius;
+  }
+  &:last-child {
+    border-bottom-left-radius: $ix-radius;
+    border-bottom-right-radius: $ix-radius;
+  }
+
+  > *:first-child {
+    margin-top: 0;
+  }
+  > *:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.panel-footer {
+  padding: $ix-marg-c $panel-gutter;
+  border-radius: 0 0 $ix-radius $ix-radius;
+  @include gradient-v($g2-kevlar, $panel-background);
+  color: $g9-mountain;
+}
+
+//  Tables directly inside Panels
+//  ----------------------------------------------------------------------------
+.panel > .table {
+  border-top: $ix-border;
+  * {
+    border-color: $g19-ghost;
+  }
+}
+.panel-header + .table {
+  border: none;
+}
+.panel > .table td:first-child,
+.panel > .table th:first-child {
+  padding-left: $panel-gutter;
+}
+.panel > .table td:last-child,
+.panel > .table th:last-child {
+  padding-right: $panel-gutter;
+}
+
+//  Solid Panels
+//  ----------------------------------------------------------------------------
+.panel.panel-solid {
+  background-color: $panel-background;
+  border-radius: $ix-radius;
+
+  .panel-header {
+    padding: $panel-gutter;
+  }
+  .panel-body {
+    background-color: transparent;
+  }
+}
+
+//  Horizontal Rules directly inside Panels
+//  ----------------------------------------------------------------------------
+.panel-body hr {
+  margin: $ix-marg-c 0;
+}

--- a/ui/src/reusable_ui/components/panel/Panel.tsx
+++ b/ui/src/reusable_ui/components/panel/Panel.tsx
@@ -1,6 +1,7 @@
 // Libraries
-import React, {Component, Children} from 'react'
+import React, {Component, ComponentClass} from 'react'
 import classnames from 'classnames'
+import _ from 'lodash'
 
 // Components
 import PanelHeader from 'src/reusable_ui/components/panel/PanelHeader'
@@ -32,6 +33,21 @@ class Panel extends Component<Props> {
   public static Body = PanelBody
   public static Footer = PanelFooter
 
+  public static ValidChildTypes: ComponentClass[] = [
+    PanelHeader,
+    PanelBody,
+    PanelFooter,
+  ]
+
+  public static ValidChildNames: string = _.map(
+    Panel.ValidChildTypes,
+    child => {
+      const name = child.displayName.split('Panel').pop()
+
+      return `<Panel.${name}>`
+    }
+  ).join(', ')
+
   public render() {
     const {children} = this.props
 
@@ -47,29 +63,25 @@ class Panel extends Component<Props> {
   }
 
   private validateChildren = (): void => {
-    const {children} = this.props
+    const childArray = React.Children.toArray(this.props.children)
 
-    let invalidCount = 0
-
-    Children.forEach(children, (child: JSX.Element) => {
-      if (
-        child.type === PanelHeader ||
-        child.type === PanelBody ||
-        child.type === PanelFooter
-      ) {
-        return
-      }
-
-      invalidCount += 1
-      return
-    })
-
-    if (invalidCount > 0) {
+    if (childArray.length === 0) {
       throw new Error(
-        'Panel expected children of type <Panel.Header>, <Panel.Body>, or <Panel.Footer>'
+        '<Panel> requires at least 1 child element. We recommend using <Panel.Body>'
+      )
+    }
+
+    const childrenAreValid = _.every(childArray, this.childTypeIsValid)
+
+    if (!childrenAreValid) {
+      throw new Error(
+        `<Panel> expected children of type ${Panel.ValidChildNames}`
       )
     }
   }
+
+  private childTypeIsValid = (child: JSX.Element): boolean =>
+    _.includes(Panel.ValidChildTypes, child.type)
 }
 
 export default Panel

--- a/ui/src/reusable_ui/components/panel/Panel.tsx
+++ b/ui/src/reusable_ui/components/panel/Panel.tsx
@@ -1,0 +1,75 @@
+// Libraries
+import React, {Component, Children} from 'react'
+import classnames from 'classnames'
+
+// Components
+import PanelHeader from 'src/reusable_ui/components/panel/PanelHeader'
+import PanelBody from 'src/reusable_ui/components/panel/PanelBody'
+import PanelFooter from 'src/reusable_ui/components/panel/PanelFooter'
+
+// Styles
+import 'src/reusable_ui/components/panel/Panel.scss'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+export enum PanelType {
+  Default = '',
+  Solid = 'solid',
+}
+
+interface Props {
+  children: JSX.Element[]
+  type?: PanelType
+}
+
+@ErrorHandling
+class Panel extends Component<Props> {
+  public static defaultProps: Partial<Props> = {
+    type: PanelType.Default,
+  }
+
+  public static Header = PanelHeader
+  public static Body = PanelBody
+  public static Footer = PanelFooter
+
+  public render() {
+    const {children} = this.props
+
+    this.validateChildren()
+
+    return <div className={this.className}>{children}</div>
+  }
+
+  private get className(): string {
+    const {type} = this.props
+
+    return classnames('panel', {'panel-solid': type === PanelType.Solid})
+  }
+
+  private validateChildren = (): void => {
+    const {children} = this.props
+
+    let invalidCount = 0
+
+    Children.forEach(children, (child: JSX.Element) => {
+      if (
+        child.type === PanelHeader ||
+        child.type === PanelBody ||
+        child.type === PanelFooter
+      ) {
+        return
+      }
+
+      invalidCount += 1
+      return
+    })
+
+    if (invalidCount > 0) {
+      throw new Error(
+        'Panel expected children of type <Panel.Header>, <Panel.Body>, or <Panel.Footer>'
+      )
+    }
+  }
+}
+
+export default Panel

--- a/ui/src/reusable_ui/components/panel/PanelBody.tsx
+++ b/ui/src/reusable_ui/components/panel/PanelBody.tsx
@@ -1,0 +1,19 @@
+// Libraries
+import React, {Component} from 'react'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  children: JSX.Element[] | JSX.Element
+}
+
+@ErrorHandling
+class PanelBody extends Component<Props> {
+  public render() {
+    const {children} = this.props
+
+    return <div className="panel-body">{children}</div>
+  }
+}
+
+export default PanelBody

--- a/ui/src/reusable_ui/components/panel/PanelFooter.tsx
+++ b/ui/src/reusable_ui/components/panel/PanelFooter.tsx
@@ -1,0 +1,19 @@
+// Libraries
+import React, {Component} from 'react'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  children: JSX.Element[]
+}
+
+@ErrorHandling
+class PanelFooter extends Component<Props> {
+  public render() {
+    const {children} = this.props
+
+    return <div className="panel-footer">{children}</div>
+  }
+}
+
+export default PanelFooter

--- a/ui/src/reusable_ui/components/panel/PanelHeader.tsx
+++ b/ui/src/reusable_ui/components/panel/PanelHeader.tsx
@@ -1,0 +1,25 @@
+// Libraries
+import React, {Component} from 'react'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  children?: JSX.Element[]
+  title: string
+}
+
+@ErrorHandling
+class PanelHeader extends Component<Props> {
+  public render() {
+    const {children, title} = this.props
+
+    return (
+      <div className="panel-header">
+        <div className="panel-title">{title}</div>
+        <div className="panel-controls">{children}</div>
+      </div>
+    )
+  }
+}
+
+export default PanelHeader


### PR DESCRIPTION
This work is a subset of https://github.com/influxdata/chronograf/issues/3946

Introducing a set of components that render panels. Panels are a fairly common UI element found in most of the index pages.

### Composable API

```
import Panel, {PanelType} from 'src/reusable_ui/components/panel/Panel'

<Panel type={PanelType.Solid}>
  <Panel.Header title="Dashboards">
    <button>+ Create Dashboard</button>
  </Panel.Header>
  <Panel.Body>
    (Contents)
  </Panel.Body>
</Panel>
```

The `Panel` component will throw an error if you try to pass in a child that is not `Panel.Header`, `Panel.Body`, or `Panel.Footer`.

I have implemented this set of components on the Dashboards Index page as an example of usage

  - [x] Rebased/mergeable
  - [x] Tests pass