### PR TITLE
build: fix parcel hang via clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,10 +59,10 @@ canned/bin_gen.go: canned/*.json
 	go generate -x ./canned
 
 .jssrc: $(UISOURCES)
-	cd ui && yarn run clean && yarn run build
+	cd ui && yarn run build
 	@touch .jssrc
 
-dep: .jsdep .godep
+dep: clean .jsdep .godep
 
 .godep:
 ifndef GOBINDATA


### PR DESCRIPTION
This introduces `clean` as the first step in `make dep`, which
is the first command run by our CircleCI process. It's not clear
why this solves this problem, or exactly _if_ it solves the problem
to be honest, but the build does pass. A simple `yarn run clean` only
rimrafs `./build/*` and `./.cache` and was not preventing parcel from
timing out. This PR hypothesizes that the problem may be related to
`node_modules` and other caching that Circle may do, so we start by
cleaning everything.

Aspires to close #4055 