### PR TITLE
Flux/switch source dropdown

### DIFF
--- a/ui/src/flux/components/FluxHeader.tsx
+++ b/ui/src/flux/components/FluxHeader.tsx
@@ -1,13 +1,16 @@
 import React, {PureComponent} from 'react'
 
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
+import SourceDropdown from 'src/flux/components/SourceDropdown'
 
-import {Service} from 'src/types'
+import {Service, Source} from 'src/types'
 
 interface Props {
   service: Service
   services: Service[]
+  sources: Source[]
   onGoToEditFlux: (service: Service) => void
+  onChangeService: (service: Service, source: Source) => void
 }
 
 class FluxHeader extends PureComponent<Props> {
@@ -28,13 +31,23 @@ class FluxHeader extends PureComponent<Props> {
   }
 
   private get optionsComponents(): JSX.Element {
+    const {service, services, sources, onChangeService} = this.props
     return (
-      <button
-        onClick={this.handleGoToEditFlux}
-        className="btn btn-sm btn-default"
-      >
-        Edit Connection
-      </button>
+      <>
+        <SourceDropdown
+          sources={sources}
+          services={services}
+          service={service}
+          allowInfluxQL={false}
+          onChangeService={onChangeService}
+        />
+        <button
+          onClick={this.handleGoToEditFlux}
+          className="btn btn-sm btn-default"
+        >
+          Edit Connection
+        </button>
+      </>
     )
   }
 

--- a/ui/src/flux/components/SourceDropdown.tsx
+++ b/ui/src/flux/components/SourceDropdown.tsx
@@ -1,0 +1,99 @@
+import React, {PureComponent} from 'react'
+
+import Dropdown from 'src/reusable_ui/components/dropdowns/Dropdown'
+
+import {Service, Source, ServiceLinks, SourceLinks} from 'src/types'
+
+interface Props {
+  service: Service
+  services: Service[]
+  sources: Source[]
+  allowInfluxQL: boolean
+  onChangeService: (service: Service, source: Source) => void
+}
+
+interface SourceDropdownItem {
+  sourceID: string
+  serviceID?: string
+  links: ServiceLinks | SourceLinks
+}
+
+class SourceDropdown extends PureComponent<Props> {
+  public render() {
+    return (
+      <Dropdown
+        onChange={this.handleSelect}
+        selectedID={this.selectedID}
+        widthPixels={250}
+      >
+        {this.dropdownItems}
+      </Dropdown>
+    )
+  }
+
+  private handleSelect = (choice: SourceDropdownItem) => {
+    const {sources, services} = this.props
+
+    const source = sources.find(src => {
+      return src.id === choice.sourceID
+    })
+    const service = services.find(s => {
+      return s.id === choice.serviceID
+    })
+
+    this.props.onChangeService(service, source)
+  }
+
+  private get dropdownItems(): JSX.Element[] {
+    const {services, sources, allowInfluxQL} = this.props
+
+    return sources.reduce((acc, source) => {
+      const servicesForSource = services.filter(service => {
+        return service.sourceID === source.id
+      })
+
+      const serviceItems = servicesForSource.map(service => {
+        const serviceDropdownItem: SourceDropdownItem = {
+          sourceID: source.id,
+          serviceID: service.id,
+          links: service.links,
+        }
+        return (
+          <Dropdown.Item
+            key={`${source.id}-${service.id}`}
+            id={`${source.id}-${service.id}`}
+            value={serviceDropdownItem}
+          >
+            {`${source.name} / ${service.name} (flux)`}
+          </Dropdown.Item>
+        )
+      })
+
+      if (allowInfluxQL) {
+        const sourceDropdownItem: SourceDropdownItem = {
+          sourceID: source.id,
+          links: source.links,
+        }
+
+        const influxQLDropdownItem = (
+          <Dropdown.Item
+            key={source.id}
+            id={source.id}
+            value={sourceDropdownItem}
+          >
+            {`${source.name} (InfluxQL)`}
+          </Dropdown.Item>
+        )
+        return [...acc, ...serviceItems, influxQLDropdownItem]
+      }
+      return [...acc, ...serviceItems]
+    }, [])
+  }
+
+  private get selectedID(): string {
+    const {service} = this.props
+    return service.sourceID + '-' + service.id
+  }
+}
+
+export default SourceDropdown

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -16,7 +16,6 @@ import {UpdateScript} from 'src/flux/actions'
 import {bodyNodes} from 'src/flux/helpers'
 import {getSuggestions, getAST, getTimeSeries} from 'src/flux/apis'
 import {builder, argTypes, emptyAST} from 'src/flux/constants'
-import {getDeep} from 'src/utils/wrappers'
 
 import {Source, Service, Notification, FluxTable} from 'src/types'
 import {
@@ -37,12 +36,15 @@ interface Status {
 
 interface Props {
   links: Links
+  service: Service
   services: Service[]
   source: Source
+  sources: Source[]
   notify: (message: Notification) => void
   script: string
   updateScript: UpdateScript
   onGoToEditFlux: (service: Service) => void
+  onChangeService: (service: Service, source: Source) => void
 }
 
 interface Body extends FlatBody {
@@ -98,7 +100,7 @@ export class FluxPage extends PureComponent<Props, State> {
 
   public render() {
     const {suggestions, body, status} = this.state
-    const {script} = this.props
+    const {script, service} = this.props
 
     return (
       <FluxContext.Provider value={this.getContext}>
@@ -109,7 +111,7 @@ export class FluxPage extends PureComponent<Props, State> {
               body={body}
               script={script}
               status={status}
-              service={this.service}
+              service={service}
               suggestions={suggestions}
               onValidate={this.handleValidate}
               onAppendFrom={this.handleAppendFrom}
@@ -125,7 +127,13 @@ export class FluxPage extends PureComponent<Props, State> {
   }
 
   private get header(): JSX.Element {
-    const {services, onGoToEditFlux} = this.props
+    const {
+      service,
+      services,
+      sources,
+      onGoToEditFlux,
+      onChangeService,
+    } = this.props
 
     if (!services.length) {
       return null
@@ -133,19 +141,13 @@ export class FluxPage extends PureComponent<Props, State> {
 
     return (
       <FluxHeader
-        service={this.service}
+        service={service}
+        sources={sources}
         services={services}
         onGoToEditFlux={onGoToEditFlux}
+        onChangeService={onChangeService}
       />
     )
-  }
-
-  private get service(): Service {
-    const {services} = this.props
-    const activeService = services.find(s => {
-      return getDeep<boolean>(s, 'metadata.active', false)
-    })
-    return activeService || services[0]
   }
 
   private get getContext(): Context {
@@ -157,7 +159,7 @@ export class FluxPage extends PureComponent<Props, State> {
       onDeleteFuncNode: this.handleDeleteFuncNode,
       onGenerateScript: this.handleGenerateScript,
       onToggleYield: this.handleToggleYield,
-      service: this.service,
+      service: this.props.service,
       data: this.state.data,
       scriptUpToYield: this.handleScriptUpToYield,
     }
@@ -647,7 +649,7 @@ export class FluxPage extends PureComponent<Props, State> {
   }
 
   private getTimeSeries = async () => {
-    const {script, links, notify} = this.props
+    const {script, service, links, notify} = this.props
 
     if (!script) {
       return
@@ -661,7 +663,7 @@ export class FluxPage extends PureComponent<Props, State> {
     }
 
     try {
-      const {tables, didTruncate} = await getTimeSeries(this.service, script)
+      const {tables, didTruncate} = await getTimeSeries(service, script)
 
       this.setState({data: tables})
 

--- a/ui/src/shared/reducers/services.ts
+++ b/ui/src/shared/reducers/services.ts
@@ -35,14 +35,21 @@ const servicesReducer = (state = initialState, action: Action): Service[] => {
 
     case 'SET_ACTIVE_SERVICE': {
       const {source, service} = action.payload
-      const services = state.filter(s => {
+      let otherServices = []
+      const currentServices = state.filter(s => {
+        if (s.sourceID !== source.id) {
+          otherServices = [...otherServices, s]
+        }
         return s.sourceID === source.id
       })
-      return services.map(s => {
-        const metadata = {active: s.id === service.id}
-        s.metadata = metadata
-        return s
+      const updatedServices = currentServices.map(s => {
+        if (s.sourceID === source.id) {
+          const metadata = {active: s.id === service.id}
+          s.metadata = metadata
+          return s
+        }
       })
+      return [...otherServices, ...updatedServices]
     }
   }
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,5 +1,5 @@
 import {LayoutCell, LayoutQuery} from './layouts'
-import {Service, NewService} from './services'
+import {Service, NewService, ServiceLinks} from './services'
 import {Links, Organization, Role, Permission, User, Me} from './auth'
 import {Cell, CellQuery, Legend, Axes, Dashboard, CellType} from './dashboards'
 import {
@@ -103,6 +103,7 @@ export {
   Dashboard,
   Service,
   NewService,
+  ServiceLinks,
   LayoutCell,
   LayoutQuery,
   FluxTable,

--- a/ui/src/types/services.ts
+++ b/ui/src/types/services.ts
@@ -10,6 +10,12 @@ export interface NewService {
   }
 }
 
+export interface ServiceLinks {
+  source: string
+  self: string
+  proxy: string
+}
+
 export interface Service {
   id?: string
   sourceID: string
@@ -22,9 +28,5 @@ export interface Service {
   metadata: {
     [x: string]: any
   }
-  links: {
-    source: string
-    self: string
-    proxy: string
-  }
+  links: ServiceLinks
 }

--- a/ui/test/flux/containers/FluxPage.test.tsx
+++ b/ui/test/flux/containers/FluxPage.test.tsx
@@ -15,8 +15,10 @@ const setup = () => {
       suggestions: '',
       ast: '',
     },
+    service: null,
     services: [],
     source,
+    sources: [source],
     script: '',
     notify: () => {},
     params: {
@@ -31,6 +33,7 @@ const setup = () => {
       }
     },
     onGoToEditFlux: () => {},
+    onChangeService: () => {},
   }
 
   const wrapper = shallow(<FluxPage {...props} />)


### PR DESCRIPTION
Connects #4020

_What was the problem?_
Previously, the user could only switch InfluxDB sources from the configuration page. From the Flux Editor page, the user could only edit their connection to the Flux service they were currently using. We wanted a way to switch to any Flux service on any InfluxDB source from the Flux Editor page

_What was the solution?_
Create a new component `SourceDropdown` that sets a new active source and/or service
Change CheckServices to use `fetchAllFluxServices` instead of `fetchServicesForSource`
Change `setActiveService` reducer to work when the state includes all services

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass