### PR TITLE
Update Reusable UI Style Imports

### DIFF
--- a/ui/src/reusable_ui/components/Button/Button.scss
+++ b/ui/src/reusable_ui/components/Button/Button.scss
@@ -3,10 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 .button {
   font-weight: 700;
   font-family: $ix-text-font;

--- a/ui/src/reusable_ui/components/Button/index.tsx
+++ b/ui/src/reusable_ui/components/Button/index.tsx
@@ -11,9 +11,6 @@ import {
   IconFont,
 } from 'src/reusable_ui/types'
 
-// Styles
-import './Button.scss'
-
 interface Props {
   text: string
   onClick?: () => void

--- a/ui/src/reusable_ui/components/dropdowns/Dropdown.scss
+++ b/ui/src/reusable_ui/components/dropdowns/Dropdown.scss
@@ -3,10 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 /* Dropdown Menu */
 .dropdown--menu-container {
   overflow: hidden;

--- a/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
@@ -18,9 +18,6 @@ import {
   IconFont,
 } from 'src/reusable_ui/types'
 
-// Styles
-import './Dropdown.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/dropdowns/DropdownButton.scss
+++ b/ui/src/reusable_ui/components/dropdowns/DropdownButton.scss
@@ -3,10 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-
-
 /* Button */
 .dropdown--button {
   position: relative;

--- a/ui/src/reusable_ui/components/dropdowns/DropdownButton.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/DropdownButton.tsx
@@ -11,10 +11,6 @@ import {
   DropdownChild,
 } from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/button/Button.scss'
-import './DropdownButton.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/form_layout/Form.scss
+++ b/ui/src/reusable_ui/components/form_layout/Form.scss
@@ -3,10 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 $grid--form-gutter: 6px;
 
 

--- a/ui/src/reusable_ui/components/form_layout/Form.tsx
+++ b/ui/src/reusable_ui/components/form_layout/Form.tsx
@@ -8,9 +8,6 @@ import FormLabel from 'src/reusable_ui/components/form_layout/FormLabel'
 import FormDivider from 'src/reusable_ui/components/form_layout/FormDivider'
 import FormFooter from 'src/reusable_ui/components/form_layout/FormFooter'
 
-// Styles
-import './Form.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/inputs/Input.scss
+++ b/ui/src/reusable_ui/components/inputs/Input.scss
@@ -3,10 +3,6 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 $input-bg: $g2-kevlar;
 $input-disabled-bg: $g3-castle;
 

--- a/ui/src/reusable_ui/components/inputs/Input.tsx
+++ b/ui/src/reusable_ui/components/inputs/Input.tsx
@@ -10,9 +10,6 @@ import classnames from 'classnames'
 // Types
 import {ComponentStatus, ComponentSize, IconFont} from 'src/reusable_ui/types'
 
-// Styles
-import './Input.scss'
-
 export enum InputType {
   Text = 'text',
   Number = 'number',

--- a/ui/src/reusable_ui/components/overlays/Overlay.scss
+++ b/ui/src/reusable_ui/components/overlays/Overlay.scss
@@ -3,10 +3,6 @@
    -----------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 $overlay-title-height: $chronograf-page-header-height;
 $overlay-gutter: 30px;
 $overlay-min-height: 150px;

--- a/ui/src/reusable_ui/components/overlays/OverlayTechnology.tsx
+++ b/ui/src/reusable_ui/components/overlays/OverlayTechnology.tsx
@@ -1,7 +1,8 @@
+// Libraries
 import React, {Component} from 'react'
 import classnames from 'classnames'
+
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import './overlays.scss'
 
 interface Props {
   children: JSX.Element

--- a/ui/src/reusable_ui/components/panel/Panel.scss
+++ b/ui/src/reusable_ui/components/panel/Panel.scss
@@ -3,10 +3,6 @@
    -----------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-@import 'src/style/modules/mixins';
-
 $panel-gutter: 30px;
 $panel-background: $g3-castle;
 

--- a/ui/src/reusable_ui/components/panel/Panel.tsx
+++ b/ui/src/reusable_ui/components/panel/Panel.tsx
@@ -8,9 +8,6 @@ import PanelHeader from 'src/reusable_ui/components/panel/PanelHeader'
 import PanelBody from 'src/reusable_ui/components/panel/PanelBody'
 import PanelFooter from 'src/reusable_ui/components/panel/PanelFooter'
 
-// Styles
-import 'src/reusable_ui/components/panel/Panel.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 export enum PanelType {

--- a/ui/src/reusable_ui/components/slide_toggle/SlideToggle.scss
+++ b/ui/src/reusable_ui/components/slide_toggle/SlideToggle.scss
@@ -3,18 +3,13 @@
   ------------------------------------------------------------------------------
 */
 
-@import 'src/style/modules/influx-colors';
-@import 'src/style/modules/variables';
-
-$slide-toggle-border: 2px;
-
 .slide-toggle {
   background-color: $g1-raven;
   position: relative;
-  padding: 0 ($slide-toggle-border * 2);
+  padding: 0 ($ix-border * 2);
   display: inline-block;
   transition: background-color 0.25s ease, border-color 0.25s ease;
-  border: $slide-toggle-border solid $g5-pepper;
+  border: $ix-border solid $g5-pepper;
 
   &:hover {
     cursor: pointer;

--- a/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
+++ b/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
@@ -1,9 +1,11 @@
+// Libraries
 import React, {Component} from 'react'
 import classnames from 'classnames'
-import {ErrorHandling} from 'src/shared/decorators/errors'
-import './slide-toggle.scss'
 
+// Types
 import {ComponentColor, ComponentSize} from 'src/reusable_ui/types'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   onChange: () => void

--- a/ui/src/reusable_ui/index.ts
+++ b/ui/src/reusable_ui/index.ts
@@ -2,7 +2,7 @@
 import Button from './components/Button'
 import Dropdown from './components/dropdowns/Dropdown'
 import Form from './components/form_layout/Form'
-import Input from './components/inputs/Input'
+import Input, {InputType} from './components/inputs/Input'
 import OverlayTechnology from './components/overlays/OverlayTechnology'
 import OverlayContainer from './components/overlays/OverlayContainer'
 import OverlayHeading from './components/overlays/OverlayHeading'
@@ -32,6 +32,7 @@ export {
   Dropdown,
   Form,
   Input,
+  InputType,
   OverlayTechnology,
   OverlayContainer,
   OverlayHeading,

--- a/ui/src/reusable_ui/index.ts
+++ b/ui/src/reusable_ui/index.ts
@@ -1,0 +1,54 @@
+// Import Components
+import Button from './components/Button'
+import Dropdown from './components/dropdowns/Dropdown'
+import Form from './components/form_layout/Form'
+import Input from './components/inputs/Input'
+import OverlayTechnology from './components/overlays/OverlayTechnology'
+import OverlayContainer from './components/overlays/OverlayContainer'
+import OverlayHeading from './components/overlays/OverlayHeading'
+import OverlayBody from './components/overlays/OverlayBody'
+import PageHeader from './components/page_layout/PageHeader'
+import PageHeaderTitle from './components/page_layout/PageHeaderTitle'
+import Panel, {PanelType} from './components/panel/Panel'
+import RadioButtons from './components/radio_buttons/RadioButtons'
+import SlideToggle from './components/slide_toggle/SlideToggle'
+
+// Import Types
+import {
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  DropdownMenuColors,
+  DropdownChild,
+  ButtonShape,
+  Greys,
+  IconFont,
+  Columns,
+} from './types'
+
+// Fire de lazer
+export {
+  Button,
+  Dropdown,
+  Form,
+  Input,
+  OverlayTechnology,
+  OverlayContainer,
+  OverlayHeading,
+  OverlayBody,
+  PageHeader,
+  PageHeaderTitle,
+  Panel,
+  PanelType,
+  RadioButtons,
+  SlideToggle,
+  ComponentColor,
+  ComponentSize,
+  ComponentStatus,
+  DropdownMenuColors,
+  DropdownChild,
+  ButtonShape,
+  Greys,
+  IconFont,
+  Columns,
+}

--- a/ui/src/reusable_ui/styles.scss
+++ b/ui/src/reusable_ui/styles.scss
@@ -1,0 +1,9 @@
+// Reusable UI Components
+@import 'components/Button/Button';
+@import 'components/dropdowns/Dropdown';
+@import 'components/dropdowns/DropdownButton';
+@import 'components/form_layout/Form';
+@import 'components/inputs/Input';
+@import 'components/overlays/Overlay';
+@import 'components/panel/Panel';
+@import 'components/slide_toggle/SlideToggle';

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -76,6 +76,16 @@
 @import 'components/histogram-chart';
 @import 'components/import-dashboard-mappings';
 
+// Reusable UI Components
+@import '../reusable_ui/components/Button/Button';
+@import '../reusable_ui/components/dropdowns/Dropdown';
+@import '../reusable_ui/components/dropdowns/DropdownButton';
+@import '../reusable_ui/components/form_layout/Form';
+@import '../reusable_ui/components/inputs/Input';
+@import '../reusable_ui/components/overlays/Overlay';
+@import '../reusable_ui/components/panel/Panel';
+@import '../reusable_ui/components/slide_toggle/SlideToggle';
+
 // Pages
 @import 'pages/config-endpoints';
 @import 'pages/auth-page';

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -77,14 +77,7 @@
 @import 'components/import-dashboard-mappings';
 
 // Reusable UI Components
-@import '../reusable_ui/components/Button/Button';
-@import '../reusable_ui/components/dropdowns/Dropdown';
-@import '../reusable_ui/components/dropdowns/DropdownButton';
-@import '../reusable_ui/components/form_layout/Form';
-@import '../reusable_ui/components/inputs/Input';
-@import '../reusable_ui/components/overlays/Overlay';
-@import '../reusable_ui/components/panel/Panel';
-@import '../reusable_ui/components/slide_toggle/SlideToggle';
+@import '../reusable_ui/styles';
 
 // Pages
 @import 'pages/config-endpoints';


### PR DESCRIPTION
_What was the problem?_
Cannot currently import `.scss` files directly into components without build failure

_What was the solution?_
Keep all the `reusable_ui` stylesheets where they are, but instead of importing them into their components import them into the main stylesheet `chronograf.scss`. Also removing the now redundant module imports in each stylesheet.

For icing on the cake I have created `reusable_ui/index.ts` file that exports all the enums and components which should make usage easier

  - [x] Rebased/mergeable
  - [x] Tests pass