### PR TITLE
Fix source extraction regex in dash imports

### DIFF
--- a/ui/src/dashboards/utils/importDashboardMappings.ts
+++ b/ui/src/dashboards/utils/importDashboardMappings.ts
@@ -137,6 +137,7 @@ export const getSourceInfo = (source: Source): SourceInfo => {
 
 export const getSourceIDFromLink = (sourceLink: string): string => {
   // first capture group
-  const sourceLinkSID = REGEX_SOURCE_ID.exec(sourceLink)[1]
+  const matcher = new RegExp(REGEX_SOURCE_ID)
+  const sourceLinkSID = matcher.exec(sourceLink)[1]
   return sourceLinkSID
 }


### PR DESCRIPTION
_What was the problem?_
With the move of the regex into a constant, running exec on it multiple times returns different results.

_What was the solution?_
Make a regex object to ensure returning the same values

  - [x] Rebased/mergeable
  - [ ] Tests pass