### PR TITLE
Add support for user-defined annotation tags

### DIFF
--- a/influx/annotations_test.go
+++ b/influx/annotations_test.go
@@ -25,7 +25,6 @@ func Test_toPoint(t *testing.T) {
 			anno: &chronograf.Annotation{
 				ID:   "1",
 				Text: "mytext",
-				Type: "mytype",
 			},
 			now: time.Unix(0, 0),
 			want: chronograf.Point{
@@ -41,7 +40,6 @@ func Test_toPoint(t *testing.T) {
 					"start_time":       time.Time{}.UnixNano(),
 					"modified_time_ns": int64(time.Unix(0, 0).UnixNano()),
 					"text":             "mytext",
-					"type":             "mytype",
 				},
 			},
 		},
@@ -50,7 +48,6 @@ func Test_toPoint(t *testing.T) {
 			anno: &chronograf.Annotation{
 				ID:        "1",
 				Text:      "mytext",
-				Type:      "mytype",
 				StartTime: time.Unix(100, 0),
 				EndTime:   time.Unix(200, 0),
 			},
@@ -68,7 +65,6 @@ func Test_toPoint(t *testing.T) {
 					"start_time":       time.Unix(100, 0).UnixNano(),
 					"modified_time_ns": int64(time.Unix(0, 0).UnixNano()),
 					"text":             "mytext",
-					"type":             "mytype",
 				},
 			},
 		},
@@ -109,7 +105,6 @@ func Test_toDeletedPoint(t *testing.T) {
 					"start_time":       int64(0),
 					"modified_time_ns": int64(0),
 					"text":             "",
-					"type":             "",
 				},
 			},
 		},
@@ -310,7 +305,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 									"modified_time_ns",
 									"start_time",
 									"text",
-									"type"
 								],
 								"values": [
 									[
@@ -320,7 +314,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 										1517425994487495051,
 										0,
 										"",
-										""
 									]
 								]
 							}
@@ -345,7 +338,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 										"start_time",
 										"modified_time_ns",
 										"text",
-										"type",
 										"id"
 									],
 									"values": [
@@ -354,7 +346,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 											0,
 											1516989242129417403,
 											"mytext",
-											"mytype",
 											"ecf3a75d-f1c0-40e8-9790-902701467e92"
 										],
 										[
@@ -362,7 +353,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 											0,
 											1517425914433539296,
 											"mytext2",
-											"mytype2",
 											"ea0aa94b-969a-4cd5-912a-5db61d502268"
 										]
 									]
@@ -377,15 +367,15 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 					EndTime:   time.Unix(0, 1516920177345000000),
 					StartTime: time.Unix(0, 0),
 					Text:      "mytext2",
-					Type:      "mytype2",
 					ID:        "ea0aa94b-969a-4cd5-912a-5db61d502268",
+					Tags:      chronograf.AnnotationTags{},
 				},
 				{
 					EndTime:   time.Unix(0, 1516920177345000000),
 					StartTime: time.Unix(0, 0),
 					Text:      "mytext",
-					Type:      "mytype",
 					ID:        "ecf3a75d-f1c0-40e8-9790-902701467e92",
+					Tags:      chronograf.AnnotationTags{},
 				},
 			},
 		},
@@ -403,7 +393,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 										"start_time",
 										"modified_time_ns",
 										"text",
-										"type",
 										"id"
 									],
 									"values": [
@@ -412,7 +401,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 											0,
 											1516989242129417403,
 											"mytext",
-											"mytype",
 											"ea0aa94b-969a-4cd5-912a-5db61d502268"
 										],
 										[
@@ -420,7 +408,6 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 											0,
 											1517425914433539296,
 											"mytext2",
-											"mytype2",
 											"ea0aa94b-969a-4cd5-912a-5db61d502268"
 										]
 									]
@@ -435,8 +422,8 @@ func TestAnnotationStore_queryAnnotations(t *testing.T) {
 					EndTime:   time.Unix(0, 1516920177345000000),
 					StartTime: time.Unix(0, 0),
 					Text:      "mytext2",
-					Type:      "mytype2",
 					ID:        "ea0aa94b-969a-4cd5-912a-5db61d502268",
+					Tags:      chronograf.AnnotationTags{},
 				},
 			},
 		},
@@ -518,7 +505,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 											"start_time",
 											"modified_time_ns",
 											"text",
-											"type",
 											"id"
 										],
 										"values": [
@@ -527,7 +513,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 												0,
 												1516989242129417403,
 												"mytext",
-												"mytype",
 												"ecf3a75d-f1c0-40e8-9790-902701467e92"
 											],
 											[
@@ -535,7 +520,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 												0,
 												1517425914433539296,
 												"mytext2",
-												"mytype2",
 												"ea0aa94b-969a-4cd5-912a-5db61d502268"
 											]
 										]
@@ -573,7 +557,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 											"start_time",
 											"modified_time_ns",
 											"text",
-											"type",
 											"id"
 										],
 										"values": [
@@ -582,7 +565,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 												0,
 												1516989242129417403,
 												"mytext",
-												"mytype",
 												"ecf3a75d-f1c0-40e8-9790-902701467e92"
 											]
 										]
@@ -619,7 +601,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 											"start_time",
 											"modified_time_ns",
 											"text",
-											"type",
 											"id"
 										],
 										"values": [
@@ -628,7 +609,6 @@ func TestAnnotationStore_Update(t *testing.T) {
 												0,
 												1516989242129417403,
 												"mytext",
-												"mytype",
 												"ecf3a75d-f1c0-40e8-9790-902701467e92"
 											]
 										]

--- a/server/annotations_test.go
+++ b/server/annotations_test.go
@@ -13,6 +13,16 @@ import (
 	"github.com/influxdata/chronograf/mocks"
 )
 
+var mockStore = &mocks.Store{
+	SourcesStore: &mocks.SourcesStore{
+		GetF: func(ctx context.Context, ID int) (chronograf.Source, error) {
+			return chronograf.Source{
+				ID: ID,
+			}, nil
+		},
+	},
+}
+
 func TestService_Annotations(t *testing.T) {
 	type fields struct {
 		Store            DataStore
@@ -48,6 +58,13 @@ func TestService_Annotations(t *testing.T) {
 			want: `{"code":422,"message":"parsing time \"howdy\" as \"2006-01-02T15:04:05.999Z07:00\": cannot parse \"howdy\" as \"2006\""}`,
 		},
 		{
+			name: "invalid tag parameter",
+			ID:   "1",
+			w:    httptest.NewRecorder(),
+			r:    httptest.NewRequest("GET", "/chronograf/v1/sources/1/annotations?since=2018-08-04T00:00:00.000Z&tag=nonsense", bytes.NewReader([]byte(`howdy`))),
+			want: `{"code":422,"message":"Invalid tag query param"}`,
+		},
+		{
 			name: "error is returned when get is an error",
 			fields: fields{
 				Store: &mocks.Store{
@@ -66,15 +83,7 @@ func TestService_Annotations(t *testing.T) {
 		{
 			name: "error is returned connect is an error",
 			fields: fields{
-				Store: &mocks.Store{
-					SourcesStore: &mocks.SourcesStore{
-						GetF: func(ctx context.Context, ID int) (chronograf.Source, error) {
-							return chronograf.Source{
-								ID: ID,
-							}, nil
-						},
-					},
-				},
+				Store: mockStore,
 				TimeSeriesClient: &mocks.TimeSeries{
 					ConnectF: func(context.Context, *chronograf.Source) error {
 						return fmt.Errorf("error)")
@@ -89,15 +98,7 @@ func TestService_Annotations(t *testing.T) {
 		{
 			name: "error returned when annotations are invalid",
 			fields: fields{
-				Store: &mocks.Store{
-					SourcesStore: &mocks.SourcesStore{
-						GetF: func(ctx context.Context, ID int) (chronograf.Source, error) {
-							return chronograf.Source{
-								ID: ID,
-							}, nil
-						},
-					},
-				},
+				Store: mockStore,
 				TimeSeriesClient: &mocks.TimeSeries{
 					ConnectF: func(context.Context, *chronograf.Source) error {
 						return nil
@@ -113,17 +114,9 @@ func TestService_Annotations(t *testing.T) {
 			want: `{"code":500,"message":"Unknown error: Error loading annotations: invalid character '[' looking for beginning of object key string"}`,
 		},
 		{
-			name: "error is returned connect is an error",
+			name: "returns annotations in store",
 			fields: fields{
-				Store: &mocks.Store{
-					SourcesStore: &mocks.SourcesStore{
-						GetF: func(ctx context.Context, ID int) (chronograf.Source, error) {
-							return chronograf.Source{
-								ID: ID,
-							}, nil
-						},
-					},
-				},
+				Store: mockStore,
 				TimeSeriesClient: &mocks.TimeSeries{
 					ConnectF: func(context.Context, *chronograf.Source) error {
 						return nil
@@ -139,7 +132,6 @@ func TestService_Annotations(t *testing.T) {
 											"start_time",
 											"modified_time_ns",
 											"text",
-											"type",
 											"id"
 										],
 										"values": [
@@ -148,7 +140,6 @@ func TestService_Annotations(t *testing.T) {
 												0,
 												1516989242129417403,
 												"mytext",
-												"mytype",
 												"ea0aa94b-969a-4cd5-912a-5db61d502268"
 											]
 										]
@@ -162,7 +153,26 @@ func TestService_Annotations(t *testing.T) {
 			ID: "1",
 			w:  httptest.NewRecorder(),
 			r:  httptest.NewRequest("GET", "/chronograf/v1/sources/1/annotations?since=1985-04-12T23:20:50.52Z", bytes.NewReader([]byte(`howdy`))),
-			want: `{"annotations":[{"id":"ea0aa94b-969a-4cd5-912a-5db61d502268","startTime":"1970-01-01T00:00:00Z","endTime":"2018-01-25T22:42:57.345Z","text":"mytext","type":"mytype","links":{"self":"/chronograf/v1/sources/1/annotations/ea0aa94b-969a-4cd5-912a-5db61d502268"}}]}
+			want: `{"annotations":[{"id":"ea0aa94b-969a-4cd5-912a-5db61d502268","startTime":"1970-01-01T00:00:00Z","endTime":"2018-01-25T22:42:57.345Z","text":"mytext","tags":{},"links":{"self":"/chronograf/v1/sources/1/annotations/ea0aa94b-969a-4cd5-912a-5db61d502268"}}]}
+`,
+		},
+		{
+			name: "returns annotations in store with valid tag query parameter",
+			fields: fields{
+				Store: mockStore,
+				TimeSeriesClient: &mocks.TimeSeries{
+					ConnectF: func(context.Context, *chronograf.Source) error {
+						return nil
+					},
+					QueryF: func(context.Context, chronograf.Query) (chronograf.Response, error) {
+						return mocks.NewResponse(`[]`, nil), nil
+					},
+				},
+			},
+			ID: "1",
+			w:  httptest.NewRecorder(),
+			r:  httptest.NewRequest("GET", "/chronograf/v1/sources/1/annotations?since=1985-04-12T23:20:50.52Z&tag=foo%20%3D~%20%2Fbar%2F", bytes.NewReader([]byte(`howdy`))),
+			want: `{"annotations":[]}
 `,
 		},
 	}
@@ -187,5 +197,85 @@ func TestService_Annotations(t *testing.T) {
 				t.Errorf("Annotations() got != want:\n%s\n%s", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestService_UpdateAnnotation(t *testing.T) {
+	url := "/chronograf/v1/sources/1/annotations/1"
+
+	timeSeriesClient := &mocks.TimeSeries{
+		ConnectF: func(context.Context, *chronograf.Source) error {
+			return nil
+		},
+		QueryF: func(context.Context, chronograf.Query) (chronograf.Response, error) {
+			return mocks.NewResponse(`[
+							{
+								"series": [
+									{
+										"name": "annotations",
+										"columns": [
+											"time",
+											"start_time",
+											"modified_time_ns",
+											"text",
+											"id"
+										],
+										"values": [
+											[
+												1516920177345000000,
+												0,
+												1516989242129417403,
+												"mytext",
+												"1"
+											]
+										]
+									}
+								]
+							}
+						]`, nil), nil
+		},
+		WriteF: func(context.Context, []chronograf.Point) error {
+			return nil
+		},
+	}
+
+	s := &Service{
+		Store:            mockStore,
+		TimeSeriesClient: timeSeriesClient,
+		Logger:           mocks.NewLogger(),
+	}
+
+	tests := []struct {
+		body string
+		want string
+	}{
+		{
+			body: `{"id":"1","text":"newtext","tags":{"foo":"bar"}}`,
+			want: `{"id":"1","startTime":"1970-01-01T00:00:00Z","endTime":"2018-01-25T22:42:57.345Z","text":"newtext","tags":{"foo":"bar"},"links":{"self":"/chronograf/v1/sources/1/annotations/1"}}
+`,
+		},
+		{
+			body: `{"id":"1","text":"newtext","tags":{"start_time":"0"}}`,
+			want: `{"code":400,"message":"Cannot use \"start_time\" as tag key"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		r := httptest.NewRequest("PATCH", url, bytes.NewReader([]byte(tt.body))).WithContext(httprouter.WithParams(
+			context.Background(),
+			httprouter.Params{
+				{
+					Key:   "id",
+					Value: "1",
+				},
+			}))
+
+		w := httptest.NewRecorder()
+		s.UpdateAnnotation(w, r)
+		got := w.Body.String()
+
+		if got != tt.want {
+			t.Errorf("UpdateAnnotation() got != want:\n%s\n%s", got, tt.want)
+		}
 	}
 }

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -3457,6 +3457,231 @@
           }
         }
       }
+    },
+    "/sources/{id}/annotations/": {
+      "get": {
+        "tags": ["sources", "annotations"],
+        "description": "Retrieve a list of user-defined annotations.",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the source",
+            "required": true
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "type": "string",
+            "description": "RFC3339 datetime to retrieve annotations after",
+            "required": true
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "type": "string",
+            "description": "RFC3339 datetime to retrieve annotations until (defaults to now if not supplied)",
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of annotations",
+            "schema": {
+              "$ref": "#/definitions/AnnotationsResponse"
+            }
+          },
+          "422": {
+            "description": "Source ID not supplied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["sources", "annotations"],
+        "description": "Create an annotation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the source",
+            "required": true
+          },
+          {
+            "name": "annotation",
+            "in": "body",
+            "description": "Annotation to be created",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAnnotationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "The created annotation",
+            "schema": {
+              "$ref": "#/definitions/Annotation"
+            }
+          },
+          "400": {
+            "description": "Invalid data schema provided to server for annotation",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
+    },
+    "/sources/{id}/annotations/{annotation_id}": {
+      "get": {
+        "tags": ["sources", "annotations"],
+        "description": "Retrieve a single annotation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the source",
+            "required": true
+          },
+          {
+            "name": "annotation_id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the annotation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Annotation for supplied ID",
+            "schema": {
+              "$ref": "#/definitions/Annotation"
+            }
+          },
+          "400": {
+            "description": "Annotation not found",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "422": {
+            "description": "Source or annotation ID not supplied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["sources", "annotations"],
+        "description": "Delete an annotation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the source",
+            "required": true
+          },
+          {
+            "name": "annotation_id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the annotation",
+            "required": true
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Annotation has been removed"
+          },
+          "422": {
+            "description": "Source or annotation ID not supplied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["sources", "annotations"],
+        "description": "Update an annotation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the source",
+            "required": true
+          },
+          {
+            "name": "annotation_id",
+            "in": "path",
+            "type": "string",
+            "description": "ID of the annotation",
+            "required": true
+          },
+          {
+            "name": "annotation",
+            "in": "body",
+            "description": "Updated annotation data",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/UpdateAnnotationRequest"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The updated annotation",
+            "schema": {
+              "$ref": "#/definitions/Annotation"
+            }
+          },
+          "422": {
+            "description": "Source or annotation ID not supplied",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          },
+          "default": {
+            "description": "Unexpected internal server error",
+            "schema": {
+              "$ref": "#/definitions/Error"
+            }
+          }
+        }
+      }
     }
   },
   "definitions": {
@@ -6074,6 +6299,134 @@
         "message": {
           "type": "string"
         }
+      }
+    },
+    "AnnotationsResponse": {
+      "type": "object",
+      "properties": {
+        "queries": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Annotation"
+          }
+        }
+      },
+      "example": {
+        "annotations": [
+          {
+            "id": "50ee18e8-8115-4fac-abed-24ce89e96047",
+            "startTime": "2018-07-09T18:08:15.933Z",
+            "endTime": "2018-07-09T18:08:15.933Z",
+            "text": "unknown event",
+            "type": "",
+            "links": {
+              "self": "/chronograf/v1/sources/1/annotations/50ee18e8-8115-4fac-abed-24ce89e96047"
+            }
+          },
+          {
+            "id": "59434c1c-fa16-40e9-8b92-af71544cc3eb",
+            "startTime": "2018-07-09T17:48:04.23Z",
+            "endTime": "2018-07-09T17:48:08.652Z",
+            "text": "todo: investigate this spike",
+            "type": "",
+            "links": {
+              "self": "/chronograf/v1/sources/1/annotations/59434c1c-fa16-40e9-8b92-af71544cc3eb"
+            }
+          }
+        ]
+      }
+    },
+    "Annotation": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "ID of the annotation",
+          "example": {
+            "id": "b19c707a-ac7b-4518-86e3-0ee52e563934"
+          }
+        },
+        "startTime": {
+          "type": "string",
+          "description": "RFC3339 datetime for the start of the annotation",
+          "example": {
+            "startTime": "2018-07-09T15:49:07.064Z"
+          }
+        },
+        "endTime": {
+          "type": "string",
+          "description": "RFC3339 datetime for the end of the annotation",
+          "example": {
+            "endTime": "2018-07-09T15:49:07.064Z"
+          }
+        },
+        "text": {
+          "type": "string",
+          "description": "A user-facing description of the annotation",
+          "example": {
+            "text": "my annotation"
+          }
+        },
+        "type": {
+          "type": "string",
+          "description": "A description of the type of annotation"
+        },
+        "links": {
+          "type": "object",
+          "properties": {
+            "self": {
+              "type": "string",
+              "description": "Self link mapping to this resource",
+              "format": "url"
+            }
+          }
+        }
+      },
+      "example": {
+        "id": "59434c1c-fa16-40e9-8b92-af71544cc3eb",
+        "startTime": "2018-07-09T17:48:04.23Z",
+        "endTime": "2018-07-09T17:48:08.652Z",
+        "text": "no name",
+        "type": "",
+        "links": {
+          "self": "/chronograf/v1/sources/1/annotations/59434c1c-fa16-40e9-8b92-af71544cc3eb"
+        }
+      }
+    },
+    "UpdateAnnotationRequest": {
+      "type": "object",
+      "properties": {
+        "startTime": {
+          "type": "string",
+          "description": "RFC3339 datetime for the start of the annotation",
+          "example": {
+            "startTime": "2018-07-09T15:49:07.064Z"
+          }
+        },
+        "endTime": {
+          "type": "string",
+          "description": "RFC3339 datetime for the end of the annotation",
+          "example": {
+            "endTime": "2018-07-09T15:49:07.064Z"
+          }
+        },
+        "text": {
+          "type": "string",
+          "description": "A user-facing description of the annotation",
+          "example": {
+            "text": "my annotation"
+          }
+        },
+        "type": {
+          "type": "string",
+          "description": "A description of the type of annotation"
+        }
+      },
+      "example": {
+        "startTime": "2018-07-10T17:48:04.23Z",
+        "endTime": "2018-07-10T17:48:08.652Z",
+        "text": "new annotation text",
+        "type": ""
       }
     }
   }

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -3483,6 +3483,14 @@
             "type": "string",
             "description": "RFC3339 datetime to retrieve annotations until (defaults to now if not supplied)",
             "required": false
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "type": "string",
+            "description": "An InfluxQL binary expression for querying annotations by their tags",
+            "required": false,
+            "example": "repo =~ /chronograf/"
           }
         ],
         "responses": {
@@ -6318,7 +6326,7 @@
             "startTime": "2018-07-09T18:08:15.933Z",
             "endTime": "2018-07-09T18:08:15.933Z",
             "text": "unknown event",
-            "type": "",
+            "tags": {},
             "links": {
               "self": "/chronograf/v1/sources/1/annotations/50ee18e8-8115-4fac-abed-24ce89e96047"
             }
@@ -6328,7 +6336,9 @@
             "startTime": "2018-07-09T17:48:04.23Z",
             "endTime": "2018-07-09T17:48:08.652Z",
             "text": "todo: investigate this spike",
-            "type": "",
+            "tags": {
+              "repo": "influxdata/chronograf"
+            },
             "links": {
               "self": "/chronograf/v1/sources/1/annotations/59434c1c-fa16-40e9-8b92-af71544cc3eb"
             }
@@ -6367,9 +6377,12 @@
             "text": "my annotation"
           }
         },
-        "type": {
-          "type": "string",
-          "description": "A description of the type of annotation"
+        "tags": {
+          "type": "object",
+          "description": "A set of user-defined tags associated with the annotation",
+          "additionalProperties": {
+            "type": "string"
+          }
         },
         "links": {
           "type": "object",
@@ -6387,7 +6400,9 @@
         "startTime": "2018-07-09T17:48:04.23Z",
         "endTime": "2018-07-09T17:48:08.652Z",
         "text": "no name",
-        "type": "",
+        "tags": {
+          "repo": "influxdata/chronograf"
+        },
         "links": {
           "self": "/chronograf/v1/sources/1/annotations/59434c1c-fa16-40e9-8b92-af71544cc3eb"
         }
@@ -6417,16 +6432,16 @@
             "text": "my annotation"
           }
         },
-        "type": {
-          "type": "string",
-          "description": "A description of the type of annotation"
+        "tags": {
+          "type": "object",
+          "description": "A set of user-defined tags associated with the annotation",
+          "additionalProperties": {
+            "type": "string"
+          }
         }
       },
       "example": {
-        "startTime": "2018-07-10T17:48:04.23Z",
-        "endTime": "2018-07-10T17:48:08.652Z",
-        "text": "new annotation text",
-        "type": ""
+        "text": "new annotation text"
       }
     }
   }


### PR DESCRIPTION
Closes #4072

Still need to add tests:

- [x] should be able to query for annotations using `tag` query param (with various comparators)
- [x] should be able to update an annotation (should fail with invalid tags)
- [ ] ~should be able to create an annotation (should fail with invalid tags)~

And also:

- [x] Update swagger
