### PR TITLE
Fix scrollbar blocking header names

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -214,6 +214,7 @@ class LogsTable extends Component<Props, State> {
               cellRenderer={this.headerRenderer}
               columnCount={columnCount}
               columnWidth={this.getColumnWidth}
+              style={{overflowX: 'hidden'}}
             />
           )}
         </AutoSizer>


### PR DESCRIPTION
Closes #4110 

_What was the problem?_
Firefox displays a horizontal scrollbar that covers text.
_What was the solution?_
Set `overflow-x` to `hidden` to hide the scroll bar. Since the width of the header grid is computed this remedies the issue without clipping header text.

  - [x] Rebased/mergeable
  - [x] Tests pass