### PR TITLE
Enhance histogram click behavior

### DIFF
--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -198,4 +198,7 @@ export const TIME_RANGE_VALUES = [
   {text: '30d', seconds: 30 * DAY},
 ]
 
+export const HISTOGRAM_CENTRAL_REGION = 3 / 5
+export const HISTOGRAM_SHIFT = 1 / 5
+
 export const SECONDS_TO_MS = 1000

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -39,11 +39,7 @@ import LogsTable from 'src/logs/components/LogsTable'
 import {getDeep} from 'src/utils/wrappers'
 import {colorForSeverity} from 'src/logs/utils/colors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
-import {
-  SeverityFormatOptions,
-  SEVERITY_SORTING_ORDER,
-  SECONDS_TO_MS,
-} from 'src/logs/constants'
+import {SeverityFormatOptions, SEVERITY_SORTING_ORDER} from 'src/logs/constants'
 import {Source, Namespace} from 'src/types'
 
 import {
@@ -65,6 +61,8 @@ import {
   TimeBounds,
 } from 'src/types/logs'
 import {applyChangesToTableData} from 'src/logs/utils/table'
+import extentBy from 'src/utils/extentBy'
+import {computeTimeBounds} from 'src/logs/utils/timeBounds'
 
 interface Props {
   sources: Source[]
@@ -377,8 +375,8 @@ class LogsPage extends Component<Props, State> {
             onBarClick={this.handleBarClick}
             sortBarGroups={this.handleSortHistogramBarGroups}
           >
-            {({adjustedWidth, adjustedHeight, margins}) => {
-              const x = margins.left + adjustedWidth / 2
+            {({xScale, adjustedHeight, margins}) => {
+              const x = xScale(new Date(timeOption).valueOf())
               const y1 = margins.top
               const y2 = margins.top + adjustedHeight
               const textSize = 11
@@ -551,24 +549,23 @@ class LogsPage extends Component<Props, State> {
       timeOption: null,
     })
 
-    let lower = `now() - ${windowOption}`
-    let upper = null
-
-    if (timeOption !== 'now') {
-      const numberTimeOption = new Date(timeOption).valueOf()
-      const milliseconds = Math.floor(seconds * SECONDS_TO_MS / 2)
-      lower = moment(numberTimeOption - milliseconds).toISOString()
-      upper = moment(numberTimeOption + milliseconds).toISOString()
+    let timeBounds: TimeBounds = {
+      lower: `now() - ${windowOption}`,
+      upper: null,
     }
 
-    const timeBounds: TimeBounds = {
-      lower,
-      upper,
+    if (timeOption !== 'now') {
+      const extentTimes = extentBy(this.props.histogramData, d => d.time).map(
+        d => d.time
+      )
+
+      timeBounds = computeTimeBounds(extentTimes, timeOption, seconds)
     }
 
     await this.props.setTimeBounds(timeBounds)
 
     this.props.setTimeRangeAsync(this.props.timeRange)
+
     this.fetchNewDataset()
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -556,7 +556,7 @@ class LogsPage extends Component<Props, State> {
 
     if (timeOption !== 'now') {
       const numberTimeOption = new Date(timeOption).valueOf()
-      const milliseconds = seconds * SECONDS_TO_MS
+      const milliseconds = Math.floor(seconds * SECONDS_TO_MS / 2)
       lower = moment(numberTimeOption - milliseconds).toISOString()
       upper = moment(numberTimeOption + milliseconds).toISOString()
     }

--- a/ui/src/logs/utils/timeBounds.ts
+++ b/ui/src/logs/utils/timeBounds.ts
@@ -1,0 +1,77 @@
+import moment from 'moment'
+
+import {
+  SECONDS_TO_MS,
+  HISTOGRAM_CENTRAL_REGION,
+  HISTOGRAM_SHIFT,
+} from 'src/logs/constants'
+
+import {TimeBounds} from 'src/types/logs'
+
+export const computeTimeBounds = (
+  extentTimes: number[],
+  timeOption: string,
+  seconds: number
+): TimeBounds => {
+  const numberTimeOption = new Date(timeOption).valueOf()
+  const period = seconds * SECONDS_TO_MS
+  const [lowerExtent] = extentTimes
+
+  if (!isValidExtent(extentTimes, period)) {
+    return centerTimeBounds(numberTimeOption, period)
+  } else {
+    return offsetTimeBounds(lowerExtent, numberTimeOption, period)
+  }
+}
+
+const isValidExtent = ([t0, t1]: number[], period: number): boolean => {
+  return t1 - t0 < period
+}
+
+const centerTimeBounds = (center: number, period: number): TimeBounds => {
+  const halfPeriod = Math.floor(period / 2)
+  const lower = moment(center - halfPeriod).toISOString()
+  const upper = moment(center + halfPeriod).toISOString()
+
+  return {lower, upper}
+}
+
+const offsetTimeBounds = (
+  lowerExtent: number,
+  numberTimeOption: number,
+  period: number
+): TimeBounds => {
+  const offset = doubleStepOffset({
+    maxOffset: period * HISTOGRAM_SHIFT,
+    center: lowerExtent + period / 2,
+    numberTimeOption,
+    period,
+  })
+
+  const lower = moment(lowerExtent + offset).toISOString()
+  const upper = moment(lowerExtent + period + offset).toISOString()
+
+  return {lower, upper}
+}
+
+interface OffsetParams {
+  numberTimeOption: number
+  period: number
+  maxOffset: number
+  center: number
+}
+
+const doubleStepOffset = ({
+  numberTimeOption,
+  period,
+  maxOffset,
+  center,
+}: OffsetParams): number => {
+  const x = (numberTimeOption - center) / period
+
+  if (Math.abs(x) < HISTOGRAM_CENTRAL_REGION / 2) {
+    return 0
+  } else {
+    return maxOffset * Math.sign(x)
+  }
+}


### PR DESCRIPTION
Closes #3970 

_What was the problem?_
Clicking on the histogram did not clearly indicate the time bounds shifts and time option overlay changes taking place in the histogram. The histogram would also change scale when clicked.
_What was the solution?_
Maintain scale to the user selected period and only shift (offset) histogram time bounds for clicks on bars outside the central region of the histogram. 

  - [x] Rebased/mergeable
  - [x] Tests pass