### PR TITLE
Centralize Sass imports

### DIFF
--- a/ui/src/dashboards/components/import_dashboard_mappings/ImportDashboardMappings.tsx
+++ b/ui/src/dashboards/components/import_dashboard_mappings/ImportDashboardMappings.tsx
@@ -25,9 +25,6 @@ import {
   SourceItemValue,
 } from 'src/types/dashboards'
 
-// Styles
-import 'src/dashboards/components/import_dashboard_mappings/ImportDashboardMappings.scss'
-
 interface Props {
   cells: Cell[]
   source: Source

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -1,6 +1,5 @@
 import React, {Component} from 'react'
 
-import './ExpandableMessage.scss'
 import {ClickOutside} from 'src/shared/components/ClickOutside'
 
 interface State {

--- a/ui/src/reusable_ui/components/Button/index.tsx
+++ b/ui/src/reusable_ui/components/Button/index.tsx
@@ -11,9 +11,6 @@ import {
   IconFont,
 } from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/Button/Button.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/card_select/CardSelectCard.tsx
+++ b/ui/src/reusable_ui/components/card_select/CardSelectCard.tsx
@@ -5,9 +5,6 @@ import classnames from 'classnames'
 // Types
 import {CardSelectCardProps} from 'src/types/cardSelect'
 
-// Styles
-import 'src/reusable_ui/components/card_select/CardSelectCard.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface State {

--- a/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
@@ -18,9 +18,6 @@ import {
   IconFont,
 } from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/dropdowns/Dropdown.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/dropdowns/DropdownButton.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/DropdownButton.tsx
@@ -11,10 +11,6 @@ import {
   DropdownChild,
 } from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/Button/Button.scss'
-import 'src/reusable_ui/components/dropdowns/DropdownButton.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/form_layout/Form.tsx
+++ b/ui/src/reusable_ui/components/form_layout/Form.tsx
@@ -8,9 +8,6 @@ import FormLabel from 'src/reusable_ui/components/form_layout/FormLabel'
 import FormDivider from 'src/reusable_ui/components/form_layout/FormDivider'
 import FormFooter from 'src/reusable_ui/components/form_layout/FormFooter'
 
-// Styles
-import 'src/reusable_ui/components/form_layout/Form.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/inputs/Input.tsx
+++ b/ui/src/reusable_ui/components/inputs/Input.tsx
@@ -10,9 +10,6 @@ import classnames from 'classnames'
 // Types
 import {ComponentStatus, ComponentSize, IconFont} from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/inputs/Input.scss'
-
 export enum InputType {
   Text = 'text',
   Number = 'number',

--- a/ui/src/reusable_ui/components/overlays/OverlayTechnology.tsx
+++ b/ui/src/reusable_ui/components/overlays/OverlayTechnology.tsx
@@ -2,9 +2,6 @@
 import React, {Component} from 'react'
 import classnames from 'classnames'
 
-// Styles
-import 'src/reusable_ui/components/overlays/Overlay.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/panel/Panel.tsx
+++ b/ui/src/reusable_ui/components/panel/Panel.tsx
@@ -8,9 +8,6 @@ import PanelHeader from 'src/reusable_ui/components/panel/PanelHeader'
 import PanelBody from 'src/reusable_ui/components/panel/PanelBody'
 import PanelFooter from 'src/reusable_ui/components/panel/PanelFooter'
 
-// Styles
-import 'src/reusable_ui/components/panel/Panel.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 export enum PanelType {

--- a/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
+++ b/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
@@ -5,9 +5,6 @@ import classnames from 'classnames'
 // Types
 import {ComponentColor, ComponentSize} from 'src/reusable_ui/types'
 
-// Styles
-import 'src/reusable_ui/components/slide_toggle/SlideToggle.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/wizard/ProgressConnector.tsx
+++ b/ui/src/reusable_ui/components/wizard/ProgressConnector.tsx
@@ -4,9 +4,6 @@ import React, {PureComponent} from 'react'
 // Types
 import {ConnectorState} from 'src/reusable_ui/constants/wizard'
 
-// Styles
-import 'src/reusable_ui/components/wizard/ProgressConnector.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/wizard/WizardButtonBar.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardButtonBar.tsx
@@ -1,9 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 
-// Styles
-import 'src/reusable_ui/components/wizard/WizardButtonBar.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/wizard/WizardController.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardController.tsx
@@ -8,9 +8,6 @@ import WizardProgressBar from 'src/reusable_ui/components/wizard/WizardProgressB
 import {WizardStepProps, Step} from 'src/types/wizard'
 import {StepStatus} from 'src/reusable_ui/constants/wizard'
 
-// Styles
-import 'src/reusable_ui/components/wizard/WizardController.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface State {

--- a/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
@@ -8,9 +8,6 @@ import WizardController from 'src/reusable_ui/components/wizard/WizardController
 // Types
 import {WizardStepProps} from 'src/types/wizard'
 
-// Styles
-import 'src/reusable_ui/components/wizard/WizardFullScreen.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/wizard/WizardProgressBar.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardProgressBar.tsx
@@ -8,9 +8,6 @@ import ProgressConnector from 'src/reusable_ui/components/wizard/ProgressConnect
 import {Step} from 'src/types/wizard'
 import {ConnectorState, StepStatus} from 'src/reusable_ui/constants/wizard'
 
-// Types
-import 'src/reusable_ui/components/wizard/WizardProgressBar.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/reusable_ui/components/wizard/WizardStep.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardStep.tsx
@@ -5,9 +5,6 @@ import React, {PureComponent, ReactNode} from 'react'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import WizardButtonBar from 'src/reusable_ui/components/wizard/WizardButtonBar'
 
-// Styles
-import 'src/reusable_ui/components/wizard/WizardStep.scss'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -71,6 +71,24 @@
 @import 'components/kapacitor-logs-table';
 @import 'components/dropdown-placeholder';
 @import 'components/histogram-chart';
+@import '../logs/components/expandable_message/ExpandableMessage';
+@import '../reusable_ui/components/panel/Panel.scss';
+@import '../reusable_ui/components/overlays/Overlay.scss';
+@import '../dashboards/components/import_dashboard_mappings/ImportDashboardMappings.scss';
+@import '../reusable_ui/components/card_select/CardSelectCard.scss';
+@import '../reusable_ui/components/wizard/WizardController.scss';
+@import '../reusable_ui/components/wizard/WizardButtonBar.scss';
+@import '../reusable_ui/components/wizard/WizardFullScreen.scss';
+@import '../reusable_ui/components/wizard/ProgressConnector.scss';
+@import '../reusable_ui/components/wizard/WizardProgressBar.scss';
+@import '../reusable_ui/components/wizard/WizardStep.scss';
+@import '../reusable_ui/components/Button/Button.scss';
+@import '../reusable_ui/components/dropdowns/Dropdown.scss';
+@import '../reusable_ui/components/slide_toggle/SlideToggle.scss';
+@import '../reusable_ui/components/Button/Button.scss';
+@import '../reusable_ui/components/dropdowns/DropdownButton.scss';
+@import '../reusable_ui/components/inputs/Input.scss';
+@import '../reusable_ui/components/form_layout/Form.scss';
 
 // Pages
 @import 'pages/config-endpoints';


### PR DESCRIPTION
We shouldn't have to do this, but it fixes a nefarious CI build issue that has been haunting us of late. We should be able to revert this after [this](https://github.com/parcel-bundler/parcel/pull/1847) PR lands in our build too, Parcel.