### PR TITLE
Call showCellEditorOverlay action when new cell added to dashboard

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -15,6 +15,7 @@ import {
 } from 'src/dashboards/apis'
 import {getMe} from 'src/shared/apis/auth'
 import {hydrateTemplates} from 'src/tempVars/utils/graph'
+import {showCellEditorOverlay} from 'src/dashboards/actions/cellEditorOverlay'
 
 import {notify} from 'src/shared/actions/notifications'
 import {errorThrown} from 'src/shared/actions/errors'
@@ -522,6 +523,7 @@ export const addDashboardCellAsync = (
     )
     dispatch(addDashboardCell(dashboard, data))
     dispatch(notify(notifyCellAdded(data.name)))
+    dispatch(showCellEditorOverlay(data))
   } catch (error) {
     console.error(error)
     dispatch(errorThrown(error))


### PR DESCRIPTION
Closes #4136

_What was the problem?_
Clicking the "Add Cell" button added an empty cell to the dashboard, at which point the user would have to click on the edit button in order to open the Cell Editor Overlay in order to add information to the cell

_What was the solution?_
Have the CEO open when the user clicks the "Add Cell" button by adding a call to the `showCellEditorOverlay` action in the `addDashboardCellAsync` action.

  - [x] Rebased/mergeable
  - [x] Tests pass