### PR TITLE
Prevent creating empty cell upon cancel in CEO

### DIFF
--- a/ui/src/dashboards/actions/cellEditorOverlay.ts
+++ b/ui/src/dashboards/actions/cellEditorOverlay.ts
@@ -8,7 +8,7 @@ import {
   ThresholdType,
   TableOptions,
 } from 'src/types/dashboards'
-import {NewDefaultCell} from '../constants'
+import {NewDefaultCell} from 'src/types/dashboards'
 
 export enum ActionType {
   ShowCellEditorOverlay = 'SHOW_CELL_EDITOR_OVERLAY',

--- a/ui/src/dashboards/actions/cellEditorOverlay.ts
+++ b/ui/src/dashboards/actions/cellEditorOverlay.ts
@@ -8,6 +8,7 @@ import {
   ThresholdType,
   TableOptions,
 } from 'src/types/dashboards'
+import {NewDefaultCell} from '../constants'
 
 export enum ActionType {
   ShowCellEditorOverlay = 'SHOW_CELL_EDITOR_OVERLAY',
@@ -43,7 +44,7 @@ export type Action =
 export interface ShowCellEditorOverlayAction {
   type: ActionType.ShowCellEditorOverlay
   payload: {
-    cell: Cell
+    cell: Cell | NewDefaultCell
   }
 }
 
@@ -129,7 +130,7 @@ export interface UpdateFieldOptionsAction {
 }
 
 export const showCellEditorOverlay = (
-  cell: Cell
+  cell: Cell | NewDefaultCell
 ): ShowCellEditorOverlayAction => ({
   type: ActionType.ShowCellEditorOverlay,
   payload: {

--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -26,10 +26,7 @@ import {
   templateSelectionsFromTemplates,
 } from 'src/dashboards/utils/tempVars'
 import {validTimeRange, validAbsoluteTimeRange} from 'src/dashboards/utils/time'
-import {
-  getNewDashboardCell,
-  getClonedDashboardCell,
-} from 'src/dashboards/utils/cellGetters'
+import {getClonedDashboardCell} from 'src/dashboards/utils/cellGetters'
 import {
   notifyDashboardDeleted,
   notifyDashboardDeleteFailed,
@@ -53,13 +50,13 @@ import {defaultTimeRange} from 'src/shared/data/timeRanges'
 import {
   Dashboard,
   Cell,
-  CellType,
   TimeRange,
   Source,
   Template,
   TemplateValue,
   TemplateType,
 } from 'src/types'
+import {NewDefaultCell} from '../constants'
 
 export enum ActionType {
   LoadDashboards = 'LOAD_DASHBOARDS',
@@ -482,9 +479,10 @@ export const putDashboardByID = (dashboardID: number) => async (
   }
 }
 
-export const updateDashboardCell = (dashboard: Dashboard, cell: Cell) => async (
-  dispatch: Dispatch<Action>
-): Promise<void> => {
+export const updateDashboardCell = (
+  dashboard: Dashboard,
+  cell: Cell | NewDefaultCell
+) => async (dispatch: Dispatch<Action>): Promise<void> => {
   try {
     const {data} = await updateDashboardCellAJAX(cell)
     dispatch(syncDashboardCell(dashboard, data))
@@ -514,16 +512,12 @@ export const deleteDashboardAsync = (dashboard: Dashboard) => async (
 
 export const addDashboardCellAsync = (
   dashboard: Dashboard,
-  cellType?: CellType
+  cell: NewDefaultCell
 ) => async (dispatch: Dispatch<Action>): Promise<void> => {
   try {
-    const {data} = await addDashboardCellAJAX(
-      dashboard,
-      getNewDashboardCell(dashboard, cellType)
-    )
+    const {data} = await addDashboardCellAJAX(dashboard, cell)
     dispatch(addDashboardCell(dashboard, data))
     dispatch(notify(notifyCellAdded(data.name)))
-    dispatch(showCellEditorOverlay(data))
   } catch (error) {
     console.error(error)
     dispatch(errorThrown(error))

--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -15,7 +15,6 @@ import {
 } from 'src/dashboards/apis'
 import {getMe} from 'src/shared/apis/auth'
 import {hydrateTemplates} from 'src/tempVars/utils/graph'
-import {showCellEditorOverlay} from 'src/dashboards/actions/cellEditorOverlay'
 
 import {notify} from 'src/shared/actions/notifications'
 import {errorThrown} from 'src/shared/actions/errors'
@@ -56,7 +55,7 @@ import {
   TemplateValue,
   TemplateType,
 } from 'src/types'
-import {NewDefaultCell} from '../constants'
+import {NewDefaultCell} from 'src/types/dashboards'
 
 export enum ActionType {
   LoadDashboards = 'LOAD_DASHBOARDS',

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -45,6 +45,7 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import {Service} from 'src/types'
 import {Template} from 'src/types/tempVars'
+import {NewDefaultCell} from 'src/dashboards/constants/index'
 
 type QueryTransitions = typeof queryTransitions
 type EditRawTextAsyncFunc = (
@@ -75,7 +76,7 @@ interface Props {
   services: Service[]
   editQueryStatus: typeof editCellQueryStatus
   onCancel: () => void
-  onSave: (cell: DashboardsModels.Cell) => void
+  onSave: (cell: DashboardsModels.Cell | NewDefaultCell) => void
   source: SourcesModels.Source
   dashboardID: number
   queryStatus: QueryStatus
@@ -86,7 +87,7 @@ interface Props {
   thresholdsListColors: ColorsModels.ColorNumber[]
   gaugeColors: ColorsModels.ColorNumber[]
   lineColors: ColorsModels.ColorString[]
-  cell: DashboardsModels.Cell
+  cell: DashboardsModels.Cell | NewDefaultCell
 }
 
 interface State {
@@ -359,7 +360,7 @@ class CellEditorOverlay extends Component<Props, State> {
       lineColors,
     })
 
-    const newCell: DashboardsModels.Cell = {
+    const newCell: DashboardsModels.Cell | NewDefaultCell = {
       ...cell,
       queries,
       colors,

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -45,7 +45,7 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import {Service} from 'src/types'
 import {Template} from 'src/types/tempVars'
-import {NewDefaultCell} from 'src/dashboards/constants/index'
+import {NewDefaultCell} from 'src/types/dashboards'
 
 type QueryTransitions = typeof queryTransitions
 type EditRawTextAsyncFunc = (

--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -2,12 +2,13 @@ import {
   DEFAULT_VERTICAL_TIME_AXIS,
   DEFAULT_FIX_FIRST_COLUMN,
 } from 'src/shared/constants/tableGraph'
-import {Cell, QueryConfig} from 'src/types'
+import {QueryConfig} from 'src/types'
 import {
   CellType,
   Dashboard,
   DecimalPlaces,
   SourceItemValue,
+  NewDefaultCell,
 } from 'src/types/dashboards'
 
 export const UNTITLED_GRAPH: string = 'Untitled Graph'
@@ -52,10 +53,6 @@ export const FORMAT_OPTIONS: Array<{text: string}> = [
   {text: TIME_FORMAT_CUSTOM},
 ]
 
-export type NewDefaultCell = Pick<
-  Cell,
-  Exclude<keyof Cell, 'i' | 'axes' | 'colors' | 'links' | 'legend'>
->
 export const NEW_DEFAULT_DASHBOARD_CELL: NewDefaultCell = {
   x: 0,
   y: 0,

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -63,7 +63,7 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import * as TempVarsModels from 'src/types/tempVars'
 import * as NotificationsActions from 'src/types/actions/notifications'
-import {NewDefaultCell} from 'src/dashboards/constants/index'
+import {NewDefaultCell} from 'src/types/dashboards'
 import {Service} from 'src/types'
 
 interface Props extends ManualRefreshProps, WithRouterProps {

--- a/ui/src/dashboards/reducers/cellEditorOverlay.ts
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.ts
@@ -18,9 +18,10 @@ import {Action, ActionType} from 'src/dashboards/actions/cellEditorOverlay'
 import {CellType, Cell} from 'src/types'
 import {ThresholdType, TableOptions} from 'src/types/dashboards'
 import {ThresholdColor, GaugeColor, LineColor} from 'src/types/colors'
+import {NewDefaultCell} from 'src/dashboards/constants/index'
 
 interface CEOInitialState {
-  cell: Cell | null
+  cell: Cell | NewDefaultCell | null
   thresholdsListType: ThresholdType
   thresholdsListColors: ThresholdColor[]
   gaugeColors: GaugeColor[]
@@ -38,17 +39,7 @@ export const initialState = {
 export default (state = initialState, action: Action): CEOInitialState => {
   switch (action.type) {
     case ActionType.ShowCellEditorOverlay: {
-      const {
-        cell,
-        cell: {colors},
-      } = action.payload
-
-      const thresholdsListType = getThresholdsListType(colors)
-      const thresholdsListColors = validateThresholdsListColors(
-        colors,
-        thresholdsListType
-      )
-      const gaugeColors = validateGaugeColors(colors)
+      const {cell} = action.payload
 
       const tableOptions = getDeep<TableOptions>(
         cell,
@@ -56,15 +47,29 @@ export default (state = initialState, action: Action): CEOInitialState => {
         initializeOptions(CellType.Table)
       )
 
-      const lineColors = validateLineColors(colors)
+      const colors = (cell as any).colors
+      if (colors !== undefined) {
+        const thresholdsListType = getThresholdsListType(colors)
+        const thresholdsListColors = validateThresholdsListColors(
+          colors,
+          thresholdsListType
+        )
+        const gaugeColors = validateGaugeColors(colors)
 
+        const lineColors = validateLineColors(colors)
+
+        return {
+          ...state,
+          cell: {...cell, tableOptions},
+          thresholdsListType,
+          thresholdsListColors,
+          gaugeColors,
+          lineColors,
+        }
+      }
       return {
         ...state,
         cell: {...cell, tableOptions},
-        thresholdsListType,
-        thresholdsListColors,
-        gaugeColors,
-        lineColors,
       }
     }
 

--- a/ui/src/dashboards/reducers/cellEditorOverlay.ts
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.ts
@@ -47,8 +47,9 @@ export default (state = initialState, action: Action): CEOInitialState => {
         initializeOptions(CellType.Table)
       )
 
-      const colors = (cell as any).colors
-      if (colors !== undefined) {
+      if ((cell as Cell).colors) {
+        const colors = (cell as Cell).colors
+
         const thresholdsListType = getThresholdsListType(colors)
         const thresholdsListColors = validateThresholdsListColors(
           colors,

--- a/ui/src/dashboards/reducers/cellEditorOverlay.ts
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.ts
@@ -18,7 +18,7 @@ import {Action, ActionType} from 'src/dashboards/actions/cellEditorOverlay'
 import {CellType, Cell} from 'src/types'
 import {ThresholdType, TableOptions} from 'src/types/dashboards'
 import {ThresholdColor, GaugeColor, LineColor} from 'src/types/colors'
-import {NewDefaultCell} from 'src/dashboards/constants/index'
+import {NewDefaultCell} from 'src/types/dashboards'
 
 interface CEOInitialState {
   cell: Cell | NewDefaultCell | null

--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -1,6 +1,6 @@
 import {NEW_DEFAULT_DASHBOARD_CELL} from 'src/dashboards/constants'
-import {Cell, CellType, Dashboard} from 'src/types/dashboards'
-import {NewDefaultCell, UNTITLED_GRAPH} from 'src/dashboards/constants'
+import {Cell, CellType, Dashboard, NewDefaultCell} from 'src/types/dashboards'
+import {UNTITLED_GRAPH} from 'src/dashboards/constants'
 
 const getMostCommonValue = (values: number[]): number => {
   const results = values.reduce(

--- a/ui/src/types/dashboards.ts
+++ b/ui/src/types/dashboards.ts
@@ -193,3 +193,8 @@ export interface DashboardFile {
   meta?: DashboardFileMetaSection
   dashboard: Dashboard
 }
+
+export type NewDefaultCell = Pick<
+  Cell,
+  Exclude<keyof Cell, 'i' | 'axes' | 'colors' | 'links' | 'legend'>
+>

--- a/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
+++ b/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
@@ -12,6 +12,7 @@ import {
   updateAxes,
 } from 'src/dashboards/actions/cellEditorOverlay'
 import {DEFAULT_TABLE_OPTIONS} from 'src/dashboards/constants'
+import {Cell} from 'src/types/dashboards'
 
 import {
   validateGaugeColors,

--- a/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
+++ b/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
@@ -103,8 +103,9 @@ describe('Dashboards.Reducers.cellEditorOverlay', () => {
   it('should update the cell axes', () => {
     const actual = reducer(initialState, updateAxes(axes))
     const expected = axes
+    const actualCell = actual.cell as Cell
 
-    expect(actual.cell.axes).toBe(expected)
+    expect(actualCell.axes).toBe(expected)
   })
 
   it('should update the cell line graph colors', () => {


### PR DESCRIPTION
Closes #4153

_What was the problem?_
Clicking the "Add Cell" button would take the user to the Cell Editor Overlay but the new cell was already created, so that if the user clicked "cancel," there would already be a new empty cell in the dashboard.

_What was the solution?_
Open the CEO without saving a new cell, then only save the new cell once a query has been added.

  - [x] Rebased/mergeable
  - [x] Tests pass