### PR TITLE
Annotations polish

### DIFF
--- a/ui/src/reusable_ui/components/Button/index.tsx
+++ b/ui/src/reusable_ui/components/Button/index.tsx
@@ -23,6 +23,7 @@ interface Props {
   status?: ComponentStatus
   titleText?: string
   active?: boolean
+  tabIndex?: number
 }
 
 @ErrorHandling
@@ -36,7 +37,7 @@ class Button extends Component<Props> {
   }
 
   public render() {
-    const {onClick, text, titleText} = this.props
+    const {onClick, text, titleText, tabIndex} = this.props
 
     return (
       <button
@@ -44,6 +45,7 @@ class Button extends Component<Props> {
         disabled={this.disabled}
         onClick={onClick}
         title={titleText || text}
+        tabIndex={!!tabIndex ? tabIndex : 0}
       >
         {this.icon}
         {this.text}

--- a/ui/src/shared/components/AnnotationFilterControl.tsx
+++ b/ui/src/shared/components/AnnotationFilterControl.tsx
@@ -77,6 +77,7 @@ class AnnotationFilterControl extends PureComponent<Props, State> {
           status={ComponentStatus.Default}
           size={ComponentSize.ExtraSmall}
           onClick={this.toggleFilterType}
+          tabIndex={-1}
         />
         <div className="annotation-filter-control--tag-value">
           <AnnotationFilterControlInput


### PR DESCRIPTION
Some minor tweaks to the `AnnotationFilterControl` and related components:

- Tab should cycle through inputs in correct order
- Blurring inputs should dismiss the suggestions popup always
- Clicking an input should show all suggestions, even when that input is non-empty