### PR TITLE
Introduce Multi-Select Dropdown Component

### DIFF
--- a/ui/src/dashboards/components/DashboardsPageContents.tsx
+++ b/ui/src/dashboards/components/DashboardsPageContents.tsx
@@ -8,13 +8,7 @@ import SearchBar from 'src/hosts/components/SearchBar'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
-import {
-  Button,
-  ComponentColor,
-  IconFont,
-  MultiSelectDropdown,
-  DropdownMenuColors,
-} from 'src/reusable_ui'
+import {Button, ComponentColor, IconFont} from 'src/reusable_ui'
 
 import {Dashboard, Source} from 'src/types'
 import {Notification} from 'src/types/notifications'
@@ -37,7 +31,6 @@ interface Props {
 interface State {
   searchTerm: string
   isOverlayVisible: boolean
-  selectedItemIDs: string[]
 }
 
 @ErrorHandling
@@ -48,7 +41,6 @@ class DashboardsPageContents extends Component<Props, State> {
     this.state = {
       searchTerm: '',
       isOverlayVisible: false,
-      selectedItemIDs: [],
     }
   }
 
@@ -78,56 +70,12 @@ class DashboardsPageContents extends Component<Props, State> {
                     dashboardLink={dashboardLink}
                   />
                 </div>
-                <div className="panel-body">{this.dropdown}</div>
               </div>
             </div>
           </div>
         </div>
       </FancyScrollbar>
     )
-  }
-
-  private get dropdown(): JSX.Element {
-    const {selectedItemIDs} = this.state
-
-    const items = [
-      {
-        id: 'ms-i-1',
-        text: 'FROOT',
-      },
-      {
-        id: 'ms-i-2',
-        text: 'FRUIT',
-      },
-      {
-        id: 'ms-i-3',
-        text: 'FR00T',
-      },
-      {
-        id: 'ms-i-4',
-        text: 'FRUUUT',
-      },
-    ]
-
-    return (
-      <MultiSelectDropdown
-        onChange={this.handleMSClick}
-        selectedIDs={selectedItemIDs}
-        widthPixels={300}
-        menuColor={DropdownMenuColors.Onyx}
-        separatorText=" "
-      >
-        {items.map(item => (
-          <MultiSelectDropdown.Item key={item.id} id={item.id} value={item}>
-            {item.text}
-          </MultiSelectDropdown.Item>
-        ))}
-      </MultiSelectDropdown>
-    )
-  }
-
-  private handleMSClick = updatedSelection => {
-    this.setState({selectedItemIDs: updatedSelection})
   }
 
   private get renderPanelHeading(): JSX.Element {

--- a/ui/src/dashboards/components/DashboardsPageContents.tsx
+++ b/ui/src/dashboards/components/DashboardsPageContents.tsx
@@ -8,7 +8,13 @@ import SearchBar from 'src/hosts/components/SearchBar'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
-import {Button, ComponentColor, IconFont} from 'src/reusable_ui'
+import {
+  Button,
+  ComponentColor,
+  IconFont,
+  MultiSelectDropdown,
+  DropdownMenuColors,
+} from 'src/reusable_ui'
 
 import {Dashboard, Source} from 'src/types'
 import {Notification} from 'src/types/notifications'
@@ -31,6 +37,7 @@ interface Props {
 interface State {
   searchTerm: string
   isOverlayVisible: boolean
+  selectedItemIDs: string[]
 }
 
 @ErrorHandling
@@ -41,6 +48,7 @@ class DashboardsPageContents extends Component<Props, State> {
     this.state = {
       searchTerm: '',
       isOverlayVisible: false,
+      selectedItemIDs: [],
     }
   }
 
@@ -70,12 +78,56 @@ class DashboardsPageContents extends Component<Props, State> {
                     dashboardLink={dashboardLink}
                   />
                 </div>
+                <div className="panel-body">{this.dropdown}</div>
               </div>
             </div>
           </div>
         </div>
       </FancyScrollbar>
     )
+  }
+
+  private get dropdown(): JSX.Element {
+    const {selectedItemIDs} = this.state
+
+    const items = [
+      {
+        id: 'ms-i-1',
+        text: 'FROOT',
+      },
+      {
+        id: 'ms-i-2',
+        text: 'FRUIT',
+      },
+      {
+        id: 'ms-i-3',
+        text: 'FR00T',
+      },
+      {
+        id: 'ms-i-4',
+        text: 'FRUUUT',
+      },
+    ]
+
+    return (
+      <MultiSelectDropdown
+        onChange={this.handleMSClick}
+        selectedIDs={selectedItemIDs}
+        widthPixels={300}
+        menuColor={DropdownMenuColors.Onyx}
+        separatorText=" "
+      >
+        {items.map(item => (
+          <MultiSelectDropdown.Item key={item.id} id={item.id} value={item}>
+            {item.text}
+          </MultiSelectDropdown.Item>
+        ))}
+      </MultiSelectDropdown>
+    )
+  }
+
+  private handleMSClick = updatedSelection => {
+    this.setState({selectedItemIDs: updatedSelection})
   }
 
   private get renderPanelHeading(): JSX.Element {

--- a/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
@@ -173,7 +173,7 @@ class MultiSelectDropdown extends Component<Props, State> {
             autoHeight={true}
             maxHeight={maxMenuHeight}
           >
-            <div className="dropdown--menu">
+            <div className="dropdown--menu" data-test="dropdown-menu">
               {React.Children.map(children, (child: JSX.Element) => {
                 if (this.childTypeIsValid(child)) {
                   if (child.type === DropdownItem) {

--- a/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
@@ -125,7 +125,7 @@ class MultiSelectDropdown extends Component<Props, State> {
       _.includes(selectedIDs, child.props.id)
     )
 
-    let label
+    let label: string | Array<string | JSX.Element>
 
     if (selectedChildren.length) {
       label = selectedChildren.map((sc, i) => {

--- a/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
@@ -1,0 +1,252 @@
+// Libraries
+import React, {Component, CSSProperties, Fragment} from 'react'
+import classnames from 'classnames'
+import _ from 'lodash'
+
+// Components
+import {ClickOutside} from 'src/shared/components/ClickOutside'
+import DropdownDivider from 'src/reusable_ui/components/dropdowns/DropdownDivider'
+import DropdownItem from 'src/reusable_ui/components/dropdowns/DropdownItem'
+import DropdownButton from 'src/reusable_ui/components/dropdowns/DropdownButton'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+
+// Types
+import {
+  DropdownMenuColors,
+  ComponentStatus,
+  ComponentColor,
+  ComponentSize,
+  IconFont,
+} from 'src/reusable_ui/types'
+
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  children: JSX.Element[]
+  onChange: (selectedIDs: string[], value: any) => void
+  onCollapse?: () => void
+  selectedIDs: string[]
+  buttonColor?: ComponentColor
+  buttonSize?: ComponentSize
+  menuColor?: DropdownMenuColors
+  status?: ComponentStatus
+  widthPixels?: number
+  icon?: IconFont
+  wrapText?: boolean
+  customClass?: string
+  maxMenuHeight?: number
+  emptyText?: string
+  separatorText?: string
+}
+
+interface State {
+  expanded: boolean
+}
+
+@ErrorHandling
+class MultiSelectDropdown extends Component<Props, State> {
+  public static defaultProps: Partial<Props> = {
+    buttonColor: ComponentColor.Default,
+    buttonSize: ComponentSize.Small,
+    status: ComponentStatus.Default,
+    widthPixels: 120,
+    wrapText: false,
+    maxMenuHeight: 250,
+    menuColor: DropdownMenuColors.Sapphire,
+    emptyText: 'Choose an item',
+    separatorText: ', ',
+  }
+
+  public static Button = DropdownButton
+  public static Item = DropdownItem
+  public static Divider = DropdownDivider
+
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {
+      expanded: false,
+    }
+  }
+
+  public render() {
+    const width = `${this.props.widthPixels}px`
+
+    this.validateChildCount()
+
+    return (
+      <ClickOutside onClickOutside={this.collapseMenu}>
+        <div className={this.containerClassName} style={{width}}>
+          {this.button}
+          {this.menuItems}
+        </div>
+      </ClickOutside>
+    )
+  }
+
+  private toggleMenu = (): void => {
+    this.setState({expanded: !this.state.expanded})
+  }
+
+  private collapseMenu = (): void => {
+    const {onCollapse} = this.props
+
+    this.setState({expanded: false})
+    onCollapse()
+  }
+
+  private get containerClassName(): string {
+    const {buttonColor, buttonSize, status, wrapText, customClass} = this.props
+
+    return classnames(
+      `dropdown dropdown-${buttonSize} dropdown-${buttonColor}`,
+      {
+        disabled: status === ComponentStatus.Disabled,
+        'dropdown-wrap': wrapText,
+        [customClass]: customClass,
+      }
+    )
+  }
+
+  private get button(): JSX.Element {
+    const {
+      selectedIDs,
+      status,
+      buttonColor,
+      buttonSize,
+      icon,
+      children,
+      emptyText,
+      separatorText,
+    } = this.props
+    const {expanded} = this.state
+
+    const selectedChildren = children.filter(child =>
+      _.includes(selectedIDs, child.props.id)
+    )
+
+    let label
+
+    if (selectedChildren.length) {
+      label = selectedChildren.map((sc, i) => {
+        if (i < selectedChildren.length - 1) {
+          return (
+            <Fragment key={sc.props.id}>
+              {sc.props.children}
+              {separatorText}
+            </Fragment>
+          )
+        }
+
+        return sc.props.children
+      })
+    } else {
+      label = emptyText
+    }
+
+    return (
+      <DropdownButton
+        active={expanded}
+        color={buttonColor}
+        size={buttonSize}
+        icon={icon}
+        onClick={this.toggleMenu}
+        status={status}
+      >
+        {label}
+      </DropdownButton>
+    )
+  }
+
+  private get menuItems(): JSX.Element {
+    const {selectedIDs, maxMenuHeight, menuColor, children} = this.props
+    const {expanded} = this.state
+
+    if (expanded) {
+      return (
+        <div
+          className={`dropdown--menu-container dropdown--${menuColor}`}
+          style={this.menuStyle}
+        >
+          <FancyScrollbar
+            autoHide={false}
+            autoHeight={true}
+            maxHeight={maxMenuHeight}
+          >
+            <div className="dropdown--menu">
+              {React.Children.map(children, (child: JSX.Element) => {
+                if (this.childTypeIsValid(child)) {
+                  if (child.type === DropdownItem) {
+                    return (
+                      <DropdownItem
+                        {...child.props}
+                        key={child.props.id}
+                        checkbox={true}
+                        selected={_.includes(selectedIDs, child.props.id)}
+                        onClick={this.handleItemClick}
+                      >
+                        {child.props.children}
+                      </DropdownItem>
+                    )
+                  }
+
+                  return (
+                    <DropdownDivider {...child.props} key={child.props.id} />
+                  )
+                } else {
+                  throw new Error(
+                    'Expected children of type <Dropdown.Item /> or <Dropdown.Divider />'
+                  )
+                }
+              })}
+            </div>
+          </FancyScrollbar>
+        </div>
+      )
+    }
+
+    return null
+  }
+
+  private get menuStyle(): CSSProperties {
+    const {wrapText, widthPixels} = this.props
+
+    if (wrapText) {
+      return {
+        width: `${widthPixels}px`,
+      }
+    }
+
+    return {
+      minWidth: `${widthPixels}px`,
+    }
+  }
+
+  private handleItemClick = (value: any): void => {
+    const {onChange, selectedIDs} = this.props
+    let updatedSelection
+
+    if (_.includes(selectedIDs, value.id)) {
+      updatedSelection = selectedIDs.filter(id => id !== value.id)
+    } else {
+      updatedSelection = [...selectedIDs, value.id]
+    }
+
+    onChange(updatedSelection, value)
+  }
+
+  private validateChildCount = (): void => {
+    const {children} = this.props
+
+    if (React.Children.count(children) === 0) {
+      throw new Error(
+        'Dropdowns require at least 1 child element. We recommend using Dropdown.Item and/or Dropdown.Divider.'
+      )
+    }
+  }
+
+  private childTypeIsValid = (child: JSX.Element): boolean =>
+    child.type === DropdownItem || child.type === DropdownDivider
+}
+
+export default MultiSelectDropdown

--- a/ui/src/reusable_ui/components/dropdowns/test/MultiSelectDropdown.test.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/test/MultiSelectDropdown.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+
+import MultiSelectDropdown from 'src/reusable_ui/components/dropdowns/MultiSelectDropdown'
+import DropdownButton from 'src/reusable_ui/components/dropdowns/DropdownButton'
+
+describe('MultiSelectDropdown', () => {
+  let wrapper
+
+  const wrapperSetup = (override = {}) => {
+    const items = [
+      {
+        id: 'item-a',
+        text: 'A',
+      },
+      {
+        id: 'item-b',
+        text: 'B',
+      },
+      {
+        id: 'item-c',
+        text: 'C',
+      },
+    ]
+
+    const selectedIDs = [items[0].id]
+
+    const children = items.map(item => (
+      <MultiSelectDropdown.Item id={item.id} key={item.id} value={item}>
+        {item.text}
+      </MultiSelectDropdown.Item>
+    ))
+
+    const props = {
+      children,
+      selectedIDs,
+      onChange: () => {},
+      ...override,
+    }
+
+    return shallow(<MultiSelectDropdown {...props} />)
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    wrapper = wrapperSetup()
+  })
+
+  it('mounts without exploding', () => {
+    expect(wrapper).toHaveLength(1)
+  })
+
+  it('matches snapshot with minimal props', () => {
+    expect(wrapper).toMatchSnapshot()
+  })
+
+  describe('with menu expanded', () => {
+    it('renders a dropdown menu', () => {
+      const button = wrapper.find(DropdownButton)
+
+      button.simulate('click')
+
+      expect(wrapper.find('[data-test="dropdown-menu"]')).toHaveLength(1)
+    })
+
+    it('matches snapshot', () => {
+      const button = wrapper.find(DropdownButton)
+
+      button.simulate('click')
+
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+})

--- a/ui/src/reusable_ui/components/dropdowns/test/__snapshots__/MultiSelectDropdown.test.tsx.snap
+++ b/ui/src/reusable_ui/components/dropdowns/test/__snapshots__/MultiSelectDropdown.test.tsx.snap
@@ -1,0 +1,118 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MultiSelectDropdown matches snapshot with minimal props 1`] = `
+<ClickOutside
+  onClickOutside={[Function]}
+>
+  <div
+    className="dropdown dropdown-sm dropdown-default"
+    style={
+      Object {
+        "width": "120px",
+      }
+    }
+  >
+    <DropdownButton
+      active={false}
+      color="default"
+      onClick={[Function]}
+      size="sm"
+      status="default"
+    >
+      A
+    </DropdownButton>
+  </div>
+</ClickOutside>
+`;
+
+exports[`MultiSelectDropdown with menu expanded matches snapshot 1`] = `
+<ClickOutside
+  onClickOutside={[Function]}
+>
+  <div
+    className="dropdown dropdown-sm dropdown-default"
+    style={
+      Object {
+        "width": "120px",
+      }
+    }
+  >
+    <DropdownButton
+      active={true}
+      color="default"
+      onClick={[Function]}
+      size="sm"
+      status="default"
+    >
+      A
+    </DropdownButton>
+    <div
+      className="dropdown--menu-container dropdown--sapphire"
+      style={
+        Object {
+          "minWidth": "120px",
+        }
+      }
+    >
+      <FancyScrollbar
+        autoHeight={true}
+        autoHide={false}
+        maxHeight={250}
+        setScrollTop={[Function]}
+        style={Object {}}
+      >
+        <div
+          className="dropdown--menu"
+          data-test="dropdown-menu"
+        >
+          <DropdownItem
+            checkbox={true}
+            id="item-a"
+            key=".$item-a"
+            onClick={[Function]}
+            selected={true}
+            value={
+              Object {
+                "id": "item-a",
+                "text": "A",
+              }
+            }
+          >
+            A
+          </DropdownItem>
+          <DropdownItem
+            checkbox={true}
+            id="item-b"
+            key=".$item-b"
+            onClick={[Function]}
+            selected={false}
+            value={
+              Object {
+                "id": "item-b",
+                "text": "B",
+              }
+            }
+          >
+            B
+          </DropdownItem>
+          <DropdownItem
+            checkbox={true}
+            id="item-c"
+            key=".$item-c"
+            onClick={[Function]}
+            selected={false}
+            value={
+              Object {
+                "id": "item-c",
+                "text": "C",
+              }
+            }
+          >
+            C
+          </DropdownItem>
+        </div>
+      </FancyScrollbar>
+    </div>
+  </div>
+</ClickOutside>
+`;

--- a/ui/src/reusable_ui/index.ts
+++ b/ui/src/reusable_ui/index.ts
@@ -1,6 +1,7 @@
 // Import Components
 import Button from './components/Button'
 import Dropdown from './components/dropdowns/Dropdown'
+import MultiSelectDropdown from './components/dropdowns/MultiSelectDropdown'
 import Form from './components/form_layout/Form'
 import Input, {InputType} from './components/inputs/Input'
 import OverlayTechnology from './components/overlays/OverlayTechnology'
@@ -30,6 +31,7 @@ import {
 export {
   Button,
   Dropdown,
+  MultiSelectDropdown,
   Form,
   Input,
   InputType,


### PR DESCRIPTION
This PR is a subset of the work described in https://github.com/influxdata/chronograf/issues/3946

### How to use

`MultiSelectDropdown` works like the standard `Dropdown` component but with some modified and extended functionality.

You will need state to store the `selectedIDs` for the component
```
interface State {
  selectedDropdownIDs: string[]
}

this.state = {
  selectedDropdownIDs: [],
}
```
Then define your list of dropdown items as you would with the standard `Dropdown` component:
```
interface sampleItem {
  id: string
  text: string
}

const dropdownItems: sampleItem[] = [
  {
    id: 'sample-item-1',
    text: 'Apple',
  },
  {
    id: 'sample-item-2',
    text: 'Banana',
  },
  {
    id: 'sample-item-3',
    text: 'Pineapple',
  },
]
```
Now you need to write a handler function for the `onChange` prop. Unlike the standard `Dropdown` component, `MultiSelectDropdown` passes 2 arguments into the `onChange` function: the updated array of IDs, and the clicked item `value`
```
private handleDropdownChange = (updatedSelection: sampleItem[], clickedItem: any) => {
  this.setState({selectedDropdownIDs: updatedSelection})
}
```
Additionally the `MultiSelectDropdown` offers a `onCollapse` callback which is useful when you only want to send updated data to the server after the dropdown has been collapsed (instead of on every click when open)

### Composable API

```
<MultiSelectDropdown
  onChange={this.handleDropdownChange}
  onCollapse={this.handleDropdownCollapse}
  selectedIDs={this.state.selectedDropdownIDs}
>
  {dropdownItems.map(item => <MultiSelectDropdown.Item id={item.id} key={item.key} value={item}>{item.text}</MultiSelectDropdown.Item>)}
</MultiSelectDropdown>
```
You can pass in children of type `<MultiSelectDropdown.Item>` and `<MultiSelectDropdown.Divider>`

### Customization

There are a number of optional props with reasonable defaults, here's a list:

| Prop | Type | Description | Default |
|---------------|--------------------|-------------------------------------------------------------------------------------------------|-------------------------------|
| widthPixels | number | Sets width in pixels of the entire dropdown | `120` |
| buttonColor | ComponentColor | Sets the coloration of the button | `ComponentColor.Default` |
| buttonSize | ComponentSize | Sets the size of the button | `ComponentColor.Small` |
| menuColor | DropdownMenuColors | Sets the color scheme of the dropdown menu | `DropdownMenuColors.Sapphire` |
| icon | IconFont | Choose an icon to display in the button |  |
| wrapText | boolean | If set to `true` the menu width will match the button width and the items will wrap text to fit | `false` |
| customClass | string | Add a classname to the dropdown |  |
| maxMenuHeight | number | Height after which the dropdown menu will overflow scroll | `250` |
| emptyText | string | What to display in the button when no items are selected | `'Choose an item'` |
| separatorText | string | What characters to use when separating selected items in the button | `', '` |

## Examples

![multi-select-basic](https://user-images.githubusercontent.com/2433762/44063269-c55a07d6-9f14-11e8-9514-4e092b354b0a.gif)
![multi-select-emoji](https://user-images.githubusercontent.com/2433762/44063387-182fb078-9f15-11e8-8c96-a467d44934db.gif)
![multi-select-separators](https://user-images.githubusercontent.com/2433762/44063473-748c97a0-9f15-11e8-8fe5-8e97abca547f.gif)
![multi-select-children](https://user-images.githubusercontent.com/2433762/44063649-4ac12d68-9f16-11e8-803d-2a7c977eb446.gif)


## Checklist

  - [x] Rebased/mergeable
  - [x] Tests pass