### PR TITLE
feat: protoboard api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1.  [#4068](https://github.com/influxdata/chronograf/pull/4068): Add ability to map sources when importing dashboard
 1.  [#4144](https://github.com/influxdata/chronograf/pull/4144): Create onboarding wizard for adding source and kapacitor connections
 1.  [#4208](https://github.com/influxdata/chronograf/pull/4208): Add a duration to the show series and tag values on host page
+1.  [#4217](https://github.com/influxdata/chronograf/pull/4217): Add filestore backed API for protodashboards
 
 ### UI Improvements
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -14,9 +14,11 @@ const (
 	ErrSourceNotFound                  = Error("source not found")
 	ErrServerNotFound                  = Error("server not found")
 	ErrLayoutNotFound                  = Error("layout not found")
+	ErrProtoboardNotFound              = Error("protoboard not found")
 	ErrDashboardNotFound               = Error("dashboard not found")
 	ErrUserNotFound                    = Error("user not found")
 	ErrLayoutInvalid                   = Error("layout is invalid")
+	ErrProtoboardInvalid               = Error("protoboard is invalid")
 	ErrDashboardInvalid                = Error("dashboard is invalid")
 	ErrSourceInvalid                   = Error("source is invalid")
 	ErrServerInvalid                   = Error("server is invalid")
@@ -700,6 +702,56 @@ type LayoutsStore interface {
 	Get(ctx context.Context, ID string) (Layout, error)
 	// Update the dashboard in the store.
 	Update(context.Context, Layout) error
+}
+
+// ProtoboardMeta is the metadata of a Protoboard
+type ProtoboardMeta struct {
+	Name             string `json:"name"`
+	Icon             string `json:"icon,omitempty"`
+	Version          string `json:"version"`
+	DashboardVersion string `json:"dashboardVersion"`
+	Description      string `json:"description,omitempty"`
+	Author           string `json:"author,omitempty"`
+	License          string `json:"license,omitempty"`
+	URL              string `json:"url,omitempty"`
+}
+
+// ProtoboardCell holds visual and query information for a cell
+type ProtoboardCell struct {
+	X             int32            `json:"x"`
+	Y             int32            `json:"y"`
+	W             int32            `json:"w"`
+	H             int32            `json:"h"`
+	Name          string           `json:"name"`
+	Queries       []DashboardQuery `json:"queries"`
+	Axes          map[string]Axis  `json:"axes"`
+	Type          string           `json:"type"`
+	CellColors    []CellColor      `json:"colors"`
+	Legend        Legend           `json:"legend"`
+	TableOptions  TableOptions     `json:"tableOptions,omitempty"`
+	FieldOptions  []RenamableField `json:"fieldOptions"`
+	TimeFormat    string           `json:"timeFormat"`
+	DecimalPlaces DecimalPlaces    `json:"decimalPlaces"`
+}
+
+// ProtoboardData is the data of a Protoboard that can be instantiated into a dashboard, including a collection of cells
+type ProtoboardData struct {
+	Cells []ProtoboardCell `json:"cells"`
+}
+
+// Protoboard is a prototype of a dashboard that can be instantiated
+type Protoboard struct {
+	ID   string         `json:"id"`
+	Meta ProtoboardMeta `json:"meta"`
+	Data ProtoboardData `json:"data"`
+}
+
+// ProtoboardsStore stores protoboards that can be instantiated into dashboards
+type ProtoboardsStore interface {
+	// All returns all protoboards in the store
+	All(context.Context) ([]Protoboard, error)
+	// Add creates a new protoboards in the ProtoboardsStore
+	Get(ctx context.Context, ID string) (Protoboard, error)
 }
 
 // MappingWildcard is the wildcard value for mappings

--- a/filestore/protoboards.go
+++ b/filestore/protoboards.go
@@ -1,0 +1,118 @@
+package filestore
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/influxdata/chronograf"
+)
+
+// ProtoboardExt is the the file extension searched for in the directory for protoboard files
+const ProtoboardExt = ".json"
+
+// Protoboards are instantiable JSON representation of dashbards.  Implements ProtoboardsStore.
+type Protoboards struct {
+	Dir     string                                      // Dir is the directory containing protoboard json definitions
+	Load    func(string) (chronograf.Protoboard, error) // Load receives filename, returns a Protoboard from json file
+	ReadDir func(dirname string) ([]os.FileInfo, error) // ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
+	IDs     chronograf.ID                               // ID generates unique ids for new protoboards
+	Logger  chronograf.Logger
+}
+
+// NewProtoboards constructs a protoboard store wrapping a file system directory
+func NewProtoboards(dir string, ids chronograf.ID, logger chronograf.Logger) chronograf.ProtoboardsStore {
+	return &Protoboards{
+		Dir:     dir,
+		Load:    protoboardLoadFile,
+		ReadDir: ioutil.ReadDir,
+		IDs:     ids,
+		Logger:  logger,
+	}
+}
+
+func protoboardLoadFile(name string) (chronograf.Protoboard, error) {
+	octets, err := ioutil.ReadFile(name)
+	if err != nil {
+		return chronograf.Protoboard{}, chronograf.ErrProtoboardNotFound
+	}
+	var protoboard chronograf.Protoboard
+	if err = json.Unmarshal(octets, &protoboard); err != nil {
+		return chronograf.Protoboard{}, chronograf.ErrProtoboardInvalid
+	}
+	return protoboard, nil
+}
+
+// All returns all protoboards from the directory
+func (a *Protoboards) All(ctx context.Context) ([]chronograf.Protoboard, error) {
+	files, err := a.ReadDir(a.Dir)
+	if err != nil {
+		return nil, err
+	}
+
+	protoboards := []chronograf.Protoboard{}
+	for _, file := range files {
+		if path.Ext(file.Name()) != ProtoboardExt {
+			continue
+		}
+		if protoboard, err := a.Load(path.Join(a.Dir, file.Name())); err != nil {
+			continue // We want to load all files we can.
+		} else {
+			protoboards = append(protoboards, protoboard)
+		}
+	}
+
+	return protoboards, nil
+}
+
+// Get returns a protoboard file from the protoboard directory
+func (a *Protoboards) Get(ctx context.Context, ID string) (chronograf.Protoboard, error) {
+	l, file, err := a.idToFile(ID)
+	if err != nil {
+		return chronograf.Protoboard{}, err
+	}
+
+	if err != nil {
+		if err == chronograf.ErrProtoboardNotFound {
+			a.Logger.
+				WithField("component", "protoboards").
+				WithField("name", file).
+				Error("Unable to read file")
+		} else if err == chronograf.ErrProtoboardInvalid {
+			a.Logger.
+				WithField("component", "protoboards").
+				WithField("name", file).
+				Error("File is not a protoboard")
+		}
+		return chronograf.Protoboard{}, err
+	}
+	return l, nil
+}
+
+// idToFile takes an id and finds the associated filename
+func (a *Protoboards) idToFile(ID string) (chronograf.Protoboard, string, error) {
+	// Find the name of the file through matching the ID in the protoboard
+	// content with the ID passed.
+	files, err := a.ReadDir(a.Dir)
+	if err != nil {
+		return chronograf.Protoboard{}, "", err
+	}
+
+	for _, f := range files {
+		if path.Ext(f.Name()) != ProtoboardExt {
+			continue
+		}
+		file := path.Join(a.Dir, f.Name())
+		protoboard, err := a.Load(file)
+		if err != nil {
+			return chronograf.Protoboard{}, "", err
+		}
+		if protoboard.ID == ID {
+			return protoboard, file, nil
+		}
+	}
+
+	return chronograf.Protoboard{}, "", chronograf.ErrProtoboardNotFound
+}

--- a/filestore/protoboards_test.go
+++ b/filestore/protoboards_test.go
@@ -1,0 +1,183 @@
+package filestore_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/filestore"
+	clog "github.com/influxdata/chronograf/log"
+)
+
+func Test_Protoboard_All(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		Existing []chronograf.Protoboard
+		Err      error
+	}{
+		{
+			Existing: []chronograf.Protoboard{
+				{ID: "1"},
+				{ID: "2"},
+			},
+			Err: nil,
+		},
+		{
+			Existing: []chronograf.Protoboard{},
+			Err:      nil,
+		},
+		{
+			Existing: nil,
+			Err:      errors.New("Error"),
+		},
+	}
+	for i, test := range tests {
+		fp, _ := MockProtoboards(test.Existing, test.Err)
+		protoboards, err := fp.All(context.Background())
+		if err != test.Err {
+			t.Errorf("Test %d: protoboards all error expected: %v; actual: %v", i, test.Err, err)
+		}
+		if !reflect.DeepEqual(protoboards, test.Existing) {
+			t.Errorf("Test %d: Protoboards should be equal; expected %v; actual %v", i, test.Existing, protoboards)
+		}
+	}
+}
+
+func Test_Protoboard_Get(t *testing.T) {
+	t.Parallel()
+	var tests = []struct {
+		Existing []chronograf.Protoboard
+		ID       string
+		Expected chronograf.Protoboard
+		Err      error
+	}{
+		{
+			Existing: []chronograf.Protoboard{
+				{ID: "1"},
+				{ID: "2"},
+			},
+			ID: "1",
+			Expected: chronograf.Protoboard{
+				ID: "1",
+			},
+			Err: nil,
+		},
+		{
+			Existing: []chronograf.Protoboard{},
+			ID:       "1",
+			Expected: chronograf.Protoboard{},
+			Err:      chronograf.ErrProtoboardNotFound,
+		},
+		{
+			Existing: nil,
+			ID:       "1",
+			Expected: chronograf.Protoboard{},
+			Err:      chronograf.ErrProtoboardNotFound,
+		},
+	}
+	for i, test := range tests {
+		fp, _ := MockProtoboards(test.Existing, test.Err)
+		protoboard, err := fp.Get(context.Background(), test.ID)
+		if err != test.Err {
+			t.Errorf("Test %d: Protoboards get error expected: %v; actual: %v", i, test.Err, err)
+		}
+		if !reflect.DeepEqual(protoboard, test.Expected) {
+			t.Errorf("Test %d: Protoboards should be equal; expected %v; actual %v", i, test.Expected, protoboard)
+		}
+	}
+}
+
+type Mock_Protoboard_FileInfo struct {
+	name string
+}
+
+func (m *Mock_Protoboard_FileInfo) Name() string {
+	return m.name
+}
+
+func (m *Mock_Protoboard_FileInfo) Size() int64 {
+	return 0
+}
+
+func (m *Mock_Protoboard_FileInfo) Mode() os.FileMode {
+	return 0666
+}
+
+func (m *Mock_Protoboard_FileInfo) ModTime() time.Time {
+	return time.Now()
+}
+
+func (m *Mock_Protoboard_FileInfo) IsDir() bool {
+	return false
+}
+
+func (m *Mock_Protoboard_FileInfo) Sys() interface{} {
+	return nil
+}
+
+type Mock_Protoboard_FileInfos []os.FileInfo
+
+func (m Mock_Protoboard_FileInfos) Len() int           { return len(m) }
+func (m Mock_Protoboard_FileInfos) Swap(i, j int)      { m[i], m[j] = m[j], m[i] }
+func (m Mock_Protoboard_FileInfos) Less(i, j int) bool { return m[i].Name() < m[j].Name() }
+
+type Mock_Protoboard_ID struct {
+	id int
+}
+
+func (m *Mock_Protoboard_ID) Generate() (string, error) {
+	m.id++
+	return strconv.Itoa(m.id), nil
+}
+
+func MockProtoboards(existing []chronograf.Protoboard, expected error) (filestore.Protoboards, *map[string]chronograf.Protoboard) {
+	protoboards := map[string]chronograf.Protoboard{}
+	fileName := func(dir string, protoboard chronograf.Protoboard) string {
+		return path.Join(dir, protoboard.ID+".json")
+	}
+	dir := "dir"
+	for _, l := range existing {
+		protoboards[fileName(dir, l)] = l
+	}
+	load := func(file string) (chronograf.Protoboard, error) {
+		if expected != nil {
+			return chronograf.Protoboard{}, expected
+		}
+
+		l, ok := protoboards[file]
+		if !ok {
+			return chronograf.Protoboard{}, chronograf.ErrProtoboardNotFound
+		}
+		return l, nil
+	}
+
+	readDir := func(dirname string) ([]os.FileInfo, error) {
+		if expected != nil {
+			return nil, expected
+		}
+		info := []os.FileInfo{}
+		for k := range protoboards {
+			info = append(info, &Mock_Protoboard_FileInfo{filepath.Base(k)})
+		}
+		sort.Sort(Mock_Protoboard_FileInfos(info))
+		return info, nil
+	}
+
+	return filestore.Protoboards{
+		Dir:     dir,
+		Load:    load,
+		ReadDir: readDir,
+		IDs: &Mock_Protoboard_ID{
+			id: len(existing),
+		},
+		Logger: clog.New(clog.ParseLevel("debug")),
+	}, &protoboards
+}

--- a/mocks/protoboards.go
+++ b/mocks/protoboards.go
@@ -1,0 +1,22 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/influxdata/chronograf"
+)
+
+var _ chronograf.ProtoboardsStore = &ProtoboardsStore{}
+
+type ProtoboardsStore struct {
+	AllF func(ctx context.Context) ([]chronograf.Protoboard, error)
+	GetF func(ctx context.Context, id string) (chronograf.Protoboard, error)
+}
+
+func (s *ProtoboardsStore) All(ctx context.Context) ([]chronograf.Protoboard, error) {
+	return s.AllF(ctx)
+}
+
+func (s *ProtoboardsStore) Get(ctx context.Context, id string) (chronograf.Protoboard, error) {
+	return s.GetF(ctx, id)
+}

--- a/mocks/store.go
+++ b/mocks/store.go
@@ -13,6 +13,7 @@ type Store struct {
 	MappingsStore           chronograf.MappingsStore
 	ServersStore            chronograf.ServersStore
 	LayoutsStore            chronograf.LayoutsStore
+	ProtoboardsStore        chronograf.ProtoboardsStore
 	UsersStore              chronograf.UsersStore
 	DashboardsStore         chronograf.DashboardsStore
 	OrganizationsStore      chronograf.OrganizationsStore
@@ -34,6 +35,10 @@ func (s *Store) Layouts(ctx context.Context) chronograf.LayoutsStore {
 	return s.LayoutsStore
 }
 
+func (s *Store) Protoboards(ctx context.Context) chronograf.ProtoboardsStore {
+	return s.ProtoboardsStore
+}
+
 func (s *Store) Users(ctx context.Context) chronograf.UsersStore {
 	return s.UsersStore
 }
@@ -41,6 +46,7 @@ func (s *Store) Users(ctx context.Context) chronograf.UsersStore {
 func (s *Store) Organizations(ctx context.Context) chronograf.OrganizationsStore {
 	return s.OrganizationsStore
 }
+
 func (s *Store) Mappings(ctx context.Context) chronograf.MappingsStore {
 	return s.MappingsStore
 }

--- a/server/mux.go
+++ b/server/mux.go
@@ -251,6 +251,10 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.GET("/chronograf/v1/layouts", EnsureViewer(service.Layouts))
 	router.GET("/chronograf/v1/layouts/:id", EnsureViewer(service.LayoutsID))
 
+	// Protoboards
+	router.GET("/chronograf/v1/protoboards", EnsureViewer(service.Protoboards))
+	router.GET("/chronograf/v1/protoboards/:id", EnsureViewer(service.ProtoboardsID))
+
 	// Users associated with Chronograf
 	router.GET("/chronograf/v1/me", service.Me)
 

--- a/server/protoboards.go
+++ b/server/protoboards.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/bouk/httprouter"
+	"github.com/influxdata/chronograf"
+)
+
+type protoboardLinks struct {
+	Self string `json:"self"`
+}
+
+type protoboardResponse struct {
+	chronograf.Protoboard
+	Links protoboardLinks `json:"links"`
+}
+
+func newProtoboardResponse(protoboard chronograf.Protoboard) protoboardResponse {
+	httpAPIProtoboards := "/chronograf/v1/protoboards"
+	selfLink := fmt.Sprintf("%s/%s", httpAPIProtoboards, protoboard.ID)
+
+	return protoboardResponse{
+		Protoboard: protoboard,
+		Links: protoboardLinks{
+			Self: selfLink,
+		},
+	}
+}
+
+type getProtoboardsResponse struct {
+	Protoboards []protoboardResponse `json:"protoboards"`
+}
+
+// Protoboards retrieves all protoboards from store
+func (s *Service) Protoboards(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+	protoboards, err := s.Store.Protoboards(ctx).All(ctx)
+	if err != nil {
+		Error(w, http.StatusInternalServerError, "Error loading protoboards", s.Logger)
+		return
+	}
+
+	res := getProtoboardsResponse{
+		Protoboards: []protoboardResponse{},
+	}
+
+	seen := make(map[string]bool)
+	for _, protoboard := range protoboards {
+		// remove duplicates
+		if seen[protoboard.ID] {
+			continue
+		}
+		seen[protoboard.ID] = true
+
+		res.Protoboards = append(res.Protoboards, newProtoboardResponse(protoboard))
+	}
+	encodeJSON(w, http.StatusOK, res, s.Logger)
+}
+
+// ProtoboardsID retrieves protoboard with ID from store
+func (s *Service) ProtoboardsID(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	id := httprouter.GetParamFromContext(ctx, "id")
+
+	protoboard, err := s.Store.Protoboards(ctx).Get(ctx, id)
+	if err != nil {
+		Error(w, http.StatusNotFound, fmt.Sprintf("ID %s not found", id), s.Logger)
+		return
+	}
+
+	res := newProtoboardResponse(protoboard)
+	encodeJSON(w, http.StatusOK, res, s.Logger)
+}

--- a/server/protoboards_test.go
+++ b/server/protoboards_test.go
@@ -1,0 +1,322 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/bouk/httprouter"
+	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/mocks"
+)
+
+func Test_Protoboards(t *testing.T) {
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+
+	tests := []struct {
+		name      string
+		wants     wants
+		arg       []chronograf.Protoboard
+		shouldErr bool
+	}{
+		{
+			name: "Empty protoboards",
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body:        `{"protoboards":[]}`,
+			},
+			arg:       []chronograf.Protoboard{},
+			shouldErr: false,
+		},
+		{
+			name: "Several protoboards",
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body:        `{"protoboards":[{"id":"1","meta":{"name":"protodashboard 1","icon":"http://example.com/icon.png","version":"1.2.3","dashboardVersion":"1.7.0","description":"this is great","author":"Chronogiraffe","license":"Apache-2.0","url":"http://example.com"},"data":{"cells":[{"x":0,"y":0,"w":0,"h":0,"name":"","queries":null,"axes":null,"type":"","colors":null,"legend":{},"tableOptions":{"verticalTimeAxis":false,"sortBy":{"internalName":"","displayName":"","visible":false},"wrapping":"","fixFirstColumn":false},"fieldOptions":null,"timeFormat":"","decimalPlaces":{"isEnforced":false,"digits":0}}]},"links":{"self":"/chronograf/v1/protoboards/1"}},{"id":"2","meta":{"name":"protodashboard 2","icon":"http://example.com/icon.png","version":"1.2.3","dashboardVersion":"1.7.0","description":"this is great","author":"Chronogiraffe","license":"Apache-2.0","url":"http://example.com"},"data":{"cells":[{"x":8,"y":0,"w":3,"h":5,"name":"Untitled Cell","queries":[{"query":"SELECT mean(\"usage_steal\") AS \"mean_usage_steal\", mean(\"usage_system\") AS \"mean_usage_system\" FROM \"telegraf\".\"autogen\".\"cpu\" WHERE time \u003e :dashboardTime: AND \"host\"='denizs-MacBook-Pro.local' GROUP BY time(:interval:) FILL(null)","queryConfig":{"database":"telegraf","measurement":"cpu","retentionPolicy":"autogen","fields":[{"value":"mean","type":"func","alias":"mean_usage_steal","args":[{"value":"usage_steal","type":"field","alias":""}]},{"value":"mean","type":"func","alias":"mean_usage_system","args":[{"value":"usage_steal","type":"field","alias":""}]}],"tags":{"host":["denizs-MacBook-Pro.local"]},"groupBy":{"time":"auto","tags":[]},"areTagsAccepted":true,"fill":"null","rawText":null,"range":null,"shifts":null},"source":""}],"axes":{"x":{"bounds":["",""],"label":"","prefix":"","suffix":"","base":"10","scale":"linear"},"y":{"bounds":["",""],"label":"","prefix":"","suffix":"","base":"10","scale":"linear"},"y2":{"bounds":["",""],"label":"","prefix":"","suffix":"","base":"10","scale":"linear"}},"type":"line","colors":[],"legend":{},"tableOptions":{"verticalTimeAxis":false,"sortBy":{"internalName":"","displayName":"","visible":false},"wrapping":"","fixFirstColumn":false},"fieldOptions":[],"timeFormat":"","decimalPlaces":{"isEnforced":true,"digits":2}}]},"links":{"self":"/chronograf/v1/protoboards/2"}}]}`}, arg: []chronograf.Protoboard{
+				chronograf.Protoboard{
+					ID: "1",
+					Meta: chronograf.ProtoboardMeta{
+						Name:             "protodashboard 1",
+						Icon:             "http://example.com/icon.png",
+						Version:          "1.2.3",
+						DashboardVersion: "1.7.0",
+						Description:      "this is great",
+						Author:           "Chronogiraffe",
+						License:          "Apache-2.0",
+						URL:              "http://example.com",
+					},
+					Data: chronograf.ProtoboardData{Cells: []chronograf.ProtoboardCell{chronograf.ProtoboardCell{}}}},
+				chronograf.Protoboard{
+					ID:   "2",
+					Meta: chronograf.ProtoboardMeta{Name: "protodashboard 2", Icon: "http://example.com/icon.png", Version: "1.2.3", DashboardVersion: "1.7.0", Description: "this is great", Author: "Chronogiraffe", License: "Apache-2.0", URL: "http://example.com"},
+					Data: chronograf.ProtoboardData{Cells: []chronograf.ProtoboardCell{chronograf.ProtoboardCell{
+						X:    8,
+						Y:    0,
+						W:    3,
+						H:    5,
+						Name: "Untitled Cell",
+						Axes: map[string]chronograf.Axis{
+							"x": chronograf.Axis{
+								Bounds: []string{"", ""},
+								Label:  "",
+								Prefix: "",
+								Suffix: "",
+								Base:   "10",
+								Scale:  "linear",
+							},
+							"y": chronograf.Axis{
+								Bounds: []string{"", ""},
+								Label:  "",
+								Prefix: "",
+								Suffix: "",
+								Base:   "10",
+								Scale:  "linear",
+							},
+							"y2": chronograf.Axis{
+								Bounds: []string{"", ""},
+								Label:  "",
+								Prefix: "",
+								Suffix: "",
+								Base:   "10",
+								Scale:  "linear",
+							},
+						},
+						Type:       "line",
+						CellColors: []chronograf.CellColor{},
+						Legend: chronograf.Legend{
+							Type:        "",
+							Orientation: "",
+						},
+						TableOptions: chronograf.TableOptions{
+							VerticalTimeAxis: false,
+							SortBy: chronograf.RenamableField{
+								InternalName: "",
+								DisplayName:  "",
+								Visible:      false,
+							},
+							Wrapping:       "",
+							FixFirstColumn: false,
+						},
+						FieldOptions: []chronograf.RenamableField{},
+						TimeFormat:   "",
+						DecimalPlaces: chronograf.DecimalPlaces{
+							IsEnforced: true,
+							Digits:     2,
+						},
+						Queries: []chronograf.DashboardQuery{
+							chronograf.DashboardQuery{
+								Command: "SELECT mean(\"usage_steal\") AS \"mean_usage_steal\", mean(\"usage_system\") AS \"mean_usage_system\" FROM \"telegraf\".\"autogen\".\"cpu\" WHERE time > :dashboardTime: AND \"host\"='denizs-MacBook-Pro.local' GROUP BY time(:interval:) FILL(null)",
+								Label:   "",
+								QueryConfig: chronograf.QueryConfig{
+									ID:              "",
+									Database:        "telegraf",
+									Measurement:     "cpu",
+									RetentionPolicy: "autogen",
+									Fields: []chronograf.Field{
+										chronograf.Field{
+											Value: "mean",
+											Type:  "func",
+											Alias: "mean_usage_steal",
+											Args: []chronograf.Field{
+												chronograf.Field{
+													Value: "usage_steal",
+													Type:  "field",
+													Alias: "",
+												},
+											},
+										},
+										chronograf.Field{
+											Value: "mean",
+											Type:  "func",
+											Alias: "mean_usage_system",
+											Args: []chronograf.Field{
+												chronograf.Field{
+													Value: "usage_steal",
+													Type:  "field",
+													Alias: "",
+												},
+											},
+										},
+									},
+									Tags: map[string][]string{
+										"host": []string{
+											"denizs-MacBook-Pro.local",
+										},
+									},
+									GroupBy: chronograf.GroupBy{
+										Time: "auto",
+										Tags: []string{},
+									},
+									AreTagsAccepted: true,
+									Fill:            "null",
+								},
+							},
+						},
+					}}},
+				}},
+			shouldErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// setup mock chronograf.Service and mock logger
+			lg := &mocks.TestLogger{}
+			svc := Service{
+				Store: &mocks.Store{ProtoboardsStore: &mocks.ProtoboardsStore{
+					AllF: func(ctx context.Context) ([]chronograf.Protoboard, error) {
+						return tt.arg, nil
+					},
+				},
+				},
+				Logger: lg,
+			}
+
+			// setup mock request and response
+			rr := httptest.NewRecorder()
+			reqURL := url.URL{
+				Path: "/chronograf/v1/protoboards",
+			}
+
+			req := httptest.NewRequest("GET", reqURL.RequestURI(), strings.NewReader(""))
+
+			svc.Protoboards(rr, req)
+
+			resp := rr.Result()
+			contentType := resp.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(resp.Body)
+			statusCode := resp.StatusCode
+
+			if statusCode != tt.wants.statusCode {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, statusCode, tt.wants.statusCode)
+			}
+			if contentType != tt.wants.contentType {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, contentType, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); !eq {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, string(body), tt.wants.body)
+			}
+
+		})
+	}
+}
+
+func Test_ProtoboardsID(t *testing.T) {
+	type wants struct {
+		statusCode  int
+		contentType string
+		body        string
+	}
+	type args struct {
+		id string
+	}
+
+	tests := []struct {
+		name      string
+		wants     wants
+		args      args
+		shouldErr bool
+	}{
+		{
+			name: "Get protoboard with id",
+			wants: wants{
+				statusCode:  http.StatusOK,
+				contentType: "application/json",
+				body:        `{"id":"1","meta":{"name":"","version":"","dashboardVersion":""},"data":{"cells":null},"links":{"self":"/chronograf/v1/protoboards/1"}}`,
+			},
+			args: args{
+				id: "1",
+			},
+			shouldErr: false,
+		},
+		{
+			name: "Not found",
+			wants: wants{
+				statusCode:  http.StatusNotFound,
+				contentType: "application/json",
+				body:        `{"code":404,"message":"ID 5 not found"}`,
+			},
+			args: args{
+				id: "5",
+			},
+			shouldErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			// setup mock chronograf.Service and mock logger
+			lg := &mocks.TestLogger{}
+			svc := Service{
+				Store: &mocks.Store{ProtoboardsStore: &mocks.ProtoboardsStore{
+					GetF: func(ctx context.Context, id string) (chronograf.Protoboard, error) {
+						switch id {
+						case "1":
+							return chronograf.Protoboard{
+								ID:   "1",
+								Meta: chronograf.ProtoboardMeta{},
+								Data: chronograf.ProtoboardData{},
+							}, nil
+						case "2":
+							return chronograf.Protoboard{
+								ID:   "2",
+								Meta: chronograf.ProtoboardMeta{},
+								Data: chronograf.ProtoboardData{},
+							}, nil
+						}
+						return chronograf.Protoboard{}, chronograf.ErrProtoboardNotFound
+					},
+				},
+				},
+				Logger: lg,
+			}
+
+			// setup mock request and response
+			rr := httptest.NewRecorder()
+			reqURL := url.URL{
+				Path: fmt.Sprintf("/chronograf/v1/protoboards/%s", tt.args.id),
+			}
+
+			req := httptest.NewRequest("GET", reqURL.RequestURI(), strings.NewReader(""))
+			req = req.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: tt.args.id,
+					},
+				}))
+
+			svc.ProtoboardsID(rr, req)
+
+			resp := rr.Result()
+			statusCode := resp.StatusCode
+			contentType := resp.Header.Get("Content-Type")
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			if statusCode != tt.wants.statusCode {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, statusCode, tt.wants.statusCode)
+			}
+			if contentType != tt.wants.contentType {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, contentType, tt.wants.contentType)
+			}
+			if eq, _ := jsonEqual(string(body), tt.wants.body); !eq {
+				t.Errorf("%q. Protoboards() = %v, want %v", tt.name, string(body), tt.wants.body)
+			}
+
+		})
+	}
+}

--- a/server/stores.go
+++ b/server/stores.go
@@ -87,6 +87,7 @@ type DataStore interface {
 	Sources(ctx context.Context) chronograf.SourcesStore
 	Servers(ctx context.Context) chronograf.ServersStore
 	Layouts(ctx context.Context) chronograf.LayoutsStore
+	Protoboards(ctx context.Context) chronograf.ProtoboardsStore
 	Users(ctx context.Context) chronograf.UsersStore
 	Organizations(ctx context.Context) chronograf.OrganizationsStore
 	Mappings(ctx context.Context) chronograf.MappingsStore
@@ -105,6 +106,7 @@ type Store struct {
 	SourcesStore            chronograf.SourcesStore
 	ServersStore            chronograf.ServersStore
 	LayoutsStore            chronograf.LayoutsStore
+	ProtoboardsStore        chronograf.ProtoboardsStore
 	UsersStore              chronograf.UsersStore
 	DashboardsStore         chronograf.DashboardsStore
 	MappingsStore           chronograf.MappingsStore
@@ -144,6 +146,11 @@ func (s *Store) Servers(ctx context.Context) chronograf.ServersStore {
 // Layouts returns all layouts in the underlying layouts store.
 func (s *Store) Layouts(ctx context.Context) chronograf.LayoutsStore {
 	return s.LayoutsStore
+}
+
+// Protoboards returns all protoboards in the underlying protoboards store.
+func (s *Store) Protoboards(ctx context.Context) chronograf.ProtoboardsStore {
+	return s.ProtoboardsStore
 }
 
 // Users returns a chronograf.UsersStore.


### PR DESCRIPTION
Closes #4080 
_Briefly describe your proposed changes:_
_What was the problem?_
The user needed a way to instantiate dashboards from a template like structure during for example the onboarding wizard process. 

_What was the solution?_
We implemented a API that can serve protoboards from .json files on the filesystem, in the /protoboards directory. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
