### PR TITLE
Update chunk size for logs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Features
 
 ### UI Improvements
+1.  [#4225](https://github.com/influxdata/chronograf/pull/4225): Make infinite scroll UX in Log Viewer more crisp by decreasing results queried for at a time
 
 ### Bug Fixes
 1.  [#4231](https://github.com/influxdata/chronograf/pull/4231): Fix notifying user to press ESC to exit presentation mode

--- a/ui/src/logs/utils/index.ts
+++ b/ui/src/logs/utils/index.ts
@@ -176,7 +176,7 @@ export function buildGeneralLogQuery(
   return `${select}${condition}${dimensions}${fillClause}`
 }
 
-export async function getQueryCountForBounds(
+export async function getQueryResultsCountForBounds(
   lower: string,
   upper: string,
   config: QueryConfig,
@@ -209,6 +209,9 @@ export async function getQueryCountForBounds(
   return getDeep<number>(result, 'results.0.series.0.values.0.1', 0)
 }
 
+// HOW_LOW_CAN_YOU_GO is the magical cut-off point for number of results where exponential backoff will stop
+const HOW_LOW_CAN_YOU_GO = 150
+
 export async function findOlderLowerTimeBounds(
   upper: string,
   config: QueryConfig,
@@ -227,7 +230,7 @@ export async function findOlderLowerTimeBounds(
       break
     }
 
-    const count = await getQueryCountForBounds(
+    const count = await getQueryResultsCountForBounds(
       currentLower.toISOString(),
       upper,
       config,
@@ -237,7 +240,7 @@ export async function findOlderLowerTimeBounds(
       namespace
     )
 
-    if (count >= 400) {
+    if (count >= HOW_LOW_CAN_YOU_GO) {
       break
     }
 
@@ -266,7 +269,7 @@ export async function findNewerUpperTimeBounds(
       break
     }
 
-    const count = await getQueryCountForBounds(
+    const count = await getQueryResultsCountForBounds(
       lower,
       currentUpper.toISOString(),
       config,
@@ -276,7 +279,7 @@ export async function findNewerUpperTimeBounds(
       namespace
     )
 
-    if (count >= 400) {
+    if (count >= HOW_LOW_CAN_YOU_GO) {
       break
     }
 


### PR DESCRIPTION
Closes #4188 

_What was the problem?_
The threshold for the number of results in the exponential back off for logs results was large enough that it slowed the user scrolling experience by issuing too many queries
_What was the solution?_
See how low we could go by doing the results count limbo.
![200w_d](https://user-images.githubusercontent.com/6403018/44173088-f761c900-a0ac-11e8-80b0-cfd6098983b0.gif)




  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Update CHANGELOG