### PR TITLE
Display placeholder to indicate password set in server

### DIFF
--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -121,6 +121,7 @@ class SourceStep extends PureComponent<Props, State> {
         <WizardTextInput
           value={source.password}
           label="Password"
+          placeholder={this.passwordPlaceholder}
           onChange={this.onChangeInput('password')}
         />
         <WizardTextInput
@@ -157,6 +158,14 @@ class SourceStep extends PureComponent<Props, State> {
         )}
       </>
     )
+  }
+
+  private get passwordPlaceholder() {
+    const {source} = this.props
+    if (source.authentication === 'basic') {
+      return 'Value saved in server'
+    }
+    return null
   }
 
   private get authIndicator(): JSX.Element {


### PR DESCRIPTION
Closes #4174 

_Briefly describe your proposed changes:_
Display placeholder to indicate password set in server

_What was the problem?_
The user had no indication of whether or not the entered password was successfully saved on the server.

_What was the solution?_
Add placeholder in password field if authentication type is 'basic'

  - [ ] Rebased/mergeable
  - [ ] Tests pass