### PR TITLE
Flux/send query to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1.  [#4217](https://github.com/influxdata/chronograf/pull/4217): Add filestore backed API for protodashboards
 1.  [#4220](https://github.com/influxdata/chronograf/pull/4220): Add ability to copy expanded/untruncated log message
 1.  [#4228](https://github.com/influxdata/chronograf/pull/4228): Add close button for logs pop over
+1.  [#4229](https://github.com/influxdata/chronograf/pull/4229): Add button on Data Explorer to send query to dashboard cell
 1.  [#4241](https://github.com/influxdata/chronograf/pull/4241): Add search attributes to log viewer
 1.  [#4254](https://github.com/influxdata/chronograf/pull/4254): Add Dynamic Source option to CEO source selector
 

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -1,0 +1,137 @@
+import React, {PureComponent} from 'react'
+
+import {getNewDashboardCell} from 'src/dashboards/utils/cellGetters'
+
+import {
+  OverlayContainer,
+  OverlayHeading,
+  OverlayBody,
+  Dropdown,
+} from 'src/reusable_ui'
+
+import {addDashboardCellAsync} from 'src/dashboards/actions'
+
+import {QueryConfig, Dashboard, Source} from 'src/types'
+
+interface Props {
+  queryConfig: QueryConfig
+  dashboards: Dashboard[]
+  source: Source
+  rawText: string
+  onCancel: () => void
+  addDashboardCell: typeof addDashboardCellAsync
+}
+
+interface State {
+  selected: string
+  hasQuery: boolean
+  name: string
+}
+
+class SendToDashboardOverlay extends PureComponent<Props, State> {
+  constructor(props) {
+    super(props)
+    const {queryConfig} = this.props
+
+    this.state = {
+      selected: this.props.dashboards[0].id.toString(),
+      hasQuery: queryConfig.fields.length !== 0,
+      name: '',
+    }
+  }
+
+  public handleChangeName = e => {
+    const name = e.target.value
+    this.setState({name})
+  }
+
+  public render() {
+    const {onCancel} = this.props
+    const {hasQuery, name} = this.state
+
+    return (
+      <OverlayContainer>
+        <OverlayHeading title="Send to Dashboard" />
+        <OverlayBody>
+          <div className="form-group">
+            <label htmlFor="New Cell Name"> New Cell Name </label>
+            <input
+              type="text"
+              id="New Cell Name"
+              className="form-control input-sm"
+              value={name}
+              onChange={this.handleChangeName}
+            />
+          </div>
+          <Dropdown
+            onChange={this.handleSelect}
+            selectedID={this.selectedID}
+            widthPixels={250}
+          >
+            {this.dropdownItems}
+          </Dropdown>
+          <button
+            className="button button-md button-default"
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button
+            className="button button-md button-success"
+            disabled={!hasQuery}
+            onClick={this.sendToDashboard}
+          >
+            Send to Dashboard
+          </button>
+        </OverlayBody>
+      </OverlayContainer>
+    )
+  }
+
+  private get dropdownItems(): JSX.Element[] {
+    const {dashboards} = this.props
+    return dashboards.map(dashboard => {
+      const stringID = dashboard.id.toString()
+      return (
+        <Dropdown.Item key={stringID} id={stringID} value={stringID}>
+          {dashboard.name}
+        </Dropdown.Item>
+      )
+    })
+    return []
+  }
+
+  private get selectedID(): string {
+    return this.state.selected
+  }
+
+  private get selectedDashboard(): Dashboard {
+    const {dashboards} = this.props
+
+    return dashboards.find(d => {
+      return d.id.toString() === this.selectedID
+    })
+  }
+
+  private handleSelect = choice => {
+    this.setState({selected: choice})
+  }
+
+  private sendToDashboard = async () => {
+    const {queryConfig, addDashboardCell, rawText, source} = this.props
+    const {hasQuery, name} = this.state
+
+    if (hasQuery) {
+      const dashboard = this.selectedDashboard
+      const emptyCell = getNewDashboardCell(dashboard)
+      const newCell = {
+        ...emptyCell,
+        name,
+        queries: [{queryConfig, query: rawText, source: source.links.self}],
+      }
+      await addDashboardCell(dashboard, newCell)
+    }
+  }
+}
+
+export default SendToDashboardOverlay

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -1,7 +1,10 @@
+// Libraries
 import React, {PureComponent} from 'react'
 
+// Utils
 import {getNewDashboardCell} from 'src/dashboards/utils/cellGetters'
 
+// Components
 import {
   OverlayContainer,
   OverlayHeading,
@@ -10,8 +13,10 @@ import {
   Form,
 } from 'src/reusable_ui'
 
+// Constants
 import {addDashboardCellAsync} from 'src/dashboards/actions'
 
+// Types
 import {QueryConfig, Dashboard, Source} from 'src/types'
 
 interface Props {
@@ -76,23 +81,19 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
               </MultiSelectDropdown>
             </Form.Element>
             <Form.Footer>
-              <div>
-                <button
-                  className="button button-md button-default"
-                  style={{margin: 5}}
-                  onClick={onCancel}
-                >
-                  Cancel
-                </button>
-                <button
-                  className="button button-md button-success"
-                  style={{margin: 5}}
-                  disabled={!hasQuery || selectedIDs.length === 0}
-                  onClick={this.sendToDashboard}
-                >
-                  {`Send to ${numberDashboards} Dashboard${pluralizer}`}
-                </button>
-              </div>
+              <button
+                className="button button-md button-default"
+                onClick={onCancel}
+              >
+                Cancel
+              </button>
+              <button
+                className="button button-md button-success"
+                disabled={!hasQuery || selectedIDs.length === 0}
+                onClick={this.sendToDashboard}
+              >
+                {`Send to ${numberDashboards} Dashboard${pluralizer}`}
+              </button>
             </Form.Footer>
           </Form>
         </OverlayBody>

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -7,6 +7,7 @@ import {
   OverlayHeading,
   OverlayBody,
   MultiSelectDropdown,
+  Form,
 } from 'src/reusable_ui'
 
 import {addDashboardCellAsync} from 'src/dashboards/actions'
@@ -53,35 +54,44 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       <OverlayContainer>
         <OverlayHeading title="Send to Dashboard" />
         <OverlayBody>
-          <div className="form-group">
-            <label htmlFor="New Cell Name"> New Cell Name </label>
-            <input
-              type="text"
-              id="New Cell Name"
-              className="form-control input-sm"
-              value={name}
-              onChange={this.handleChangeName}
-            />
-          </div>
-          <MultiSelectDropdown
-            onChange={this.handleSelect}
-            selectedIDs={this.state.selectedIDs}
-          >
-            {this.dropdownItems}
-          </MultiSelectDropdown>
-          <button
-            className="button button-md button-default"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
-          <button
-            className="button button-md button-success"
-            disabled={!hasQuery}
-            onClick={this.sendToDashboard}
-          >
-            Send to Dashboard
-          </button>
+          <Form>
+            <Form.Element label="New Cell Name">
+              <input
+                type="text"
+                id="New Cell Name"
+                className="form-control input-sm"
+                value={name}
+                onChange={this.handleChangeName}
+              />
+            </Form.Element>
+            <Form.Element>
+              <MultiSelectDropdown
+                onChange={this.handleSelect}
+                selectedIDs={this.state.selectedIDs}
+              >
+                {this.dropdownItems}
+              </MultiSelectDropdown>
+            </Form.Element>
+            <Form.Footer>
+              <div>
+                <button
+                  className="button button-md button-default"
+                  style={{margin: 5}}
+                  onClick={onCancel}
+                >
+                  Cancel
+                </button>
+                <button
+                  className="button button-md button-success"
+                  style={{margin: 5}}
+                  disabled={!hasQuery}
+                  onClick={this.sendToDashboard}
+                >
+                  Send to Dashboard
+                </button>
+              </div>
+            </Form.Footer>
+          </Form>
         </OverlayBody>
       </OverlayContainer>
     )

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -127,7 +127,13 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
   }
 
   private sendToDashboard = async () => {
-    const {queryConfig, addDashboardCell, rawText, source} = this.props
+    const {
+      queryConfig,
+      addDashboardCell,
+      rawText,
+      source,
+      onCancel,
+    } = this.props
     const {hasQuery, name} = this.state
 
     if (hasQuery) {
@@ -142,6 +148,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
           return addDashboardCell(dashboard, newCell)
         })
       )
+      onCancel()
     }
   }
 }

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -48,7 +48,10 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
 
   public render() {
     const {onCancel} = this.props
-    const {hasQuery, name} = this.state
+    const {hasQuery, name, selectedIDs} = this.state
+
+    const numberDashboards = selectedIDs.length > 1 ? selectedIDs.length : ''
+    const pluralizer = selectedIDs.length > 1 ? 's' : ''
 
     return (
       <OverlayContainer>
@@ -64,7 +67,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
                 onChange={this.handleChangeName}
               />
             </Form.Element>
-            <Form.Element>
+            <Form.Element label="Choose 1 or more Dashboards">
               <MultiSelectDropdown
                 onChange={this.handleSelect}
                 selectedIDs={this.state.selectedIDs}
@@ -84,10 +87,10 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
                 <button
                   className="button button-md button-success"
                   style={{margin: 5}}
-                  disabled={!hasQuery}
+                  disabled={!hasQuery || selectedIDs.length === 0}
                   onClick={this.sendToDashboard}
                 >
-                  Send to Dashboard
+                  {`Send to ${numberDashboards} Dashboard${pluralizer}`}
                 </button>
               </div>
             </Form.Footer>

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -112,13 +112,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
     const {selectedIDs} = this.state
 
     return dashboards.filter(d => {
-      let foundID = false
-      selectedIDs.forEach(id => {
-        if (d.id.toString() === id) {
-          foundID = true
-        }
-      })
-      return foundID
+      return selectedIDs.includes(d.id.toString())
     })
   }
 

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -11,6 +11,10 @@ import {
   OverlayBody,
   MultiSelectDropdown,
   Form,
+  Button,
+  ComponentColor,
+  ComponentStatus,
+  Input,
 } from 'src/reusable_ui'
 
 // Constants
@@ -53,47 +57,41 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
 
   public render() {
     const {onCancel} = this.props
-    const {hasQuery, name, selectedIDs} = this.state
+    const {name, selectedIDs} = this.state
 
     const numberDashboards = selectedIDs.length > 1 ? selectedIDs.length : ''
     const pluralizer = selectedIDs.length > 1 ? 's' : ''
 
     return (
       <OverlayContainer>
-        <OverlayHeading title="Send to Dashboard" />
+        <OverlayHeading title="Send to Dashboard" onDismiss={onCancel} />
         <OverlayBody>
           <Form>
-            <Form.Element label="New Cell Name">
-              <input
-                type="text"
-                id="New Cell Name"
-                className="form-control input-sm"
+            <Form.Element label="Cell Name">
+              <Input
                 value={name}
                 onChange={this.handleChangeName}
+                placeholder={'Name this new cell'}
               />
             </Form.Element>
-            <Form.Element label="Choose 1 or more Dashboards">
+            <Form.Element label="Target Dashboard(s)">
               <MultiSelectDropdown
                 onChange={this.handleSelect}
                 selectedIDs={this.state.selectedIDs}
+                emptyText="Choose at least 1 dashboard"
               >
                 {this.dropdownItems}
               </MultiSelectDropdown>
             </Form.Element>
             <Form.Footer>
-              <button
-                className="button button-md button-default"
-                onClick={onCancel}
-              >
-                Cancel
-              </button>
-              <button
-                className="button button-md button-success"
-                disabled={!hasQuery || selectedIDs.length === 0}
+              <Button
+                color={ComponentColor.Success}
+                text={`Send to ${numberDashboards} Dashboard${pluralizer}`}
+                titleText="Must choose at least 1 dashboard and set a name"
+                status={this.submitButtonStatus}
                 onClick={this.sendToDashboard}
-              >
-                {`Send to ${numberDashboards} Dashboard${pluralizer}`}
-              </button>
+              />
+              <Button text="Cancel" onClick={onCancel} />
             </Form.Footer>
           </Form>
         </OverlayBody>
@@ -128,6 +126,16 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
     return dashboards.filter(d => {
       return selectedIDs.includes(d.id.toString())
     })
+  }
+
+  private get submitButtonStatus(): ComponentStatus {
+    const {hasQuery, name, selectedIDs} = this.state
+
+    if (!hasQuery || selectedIDs.length === 0 || name.trim().length === 0) {
+      return ComponentStatus.Disabled
+    }
+
+    return ComponentStatus.Default
   }
 
   private handleSelect = (updatedSelection: string[]) => {

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -73,7 +73,9 @@ export class DataExplorer extends PureComponent<Props, State> {
   public async componentDidMount() {
     const {source, autoRefresh, handleGetDashboards} = this.props
     const {query} = qs.parse(location.search, {ignoreQueryPrefix: true})
-    await handleGetDashboards()
+    if (!this.props.dashboards.length) {
+      await handleGetDashboards()
+    }
 
     AutoRefresh.poll(autoRefresh)
 

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -1,14 +1,16 @@
+// Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
 import {bindActionCreators} from 'redux'
 import {withRouter, InjectedRouter} from 'react-router'
 import {Location} from 'history'
 import qs from 'qs'
-
 import _ from 'lodash'
 
+// Utils
 import {stripPrefix} from 'src/utils/basepath'
 
+// Components
 import QueryMaker from 'src/data_explorer/components/QueryMaker'
 import Visualization from 'src/data_explorer/components/Visualization'
 import WriteDataForm from 'src/data_explorer/components/WriteDataForm'
@@ -21,7 +23,9 @@ import GraphTips from 'src/shared/components/GraphTips'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 import AutoRefresh from 'src/utils/AutoRefresh'
 import SendToDashboardOverlay from 'src/data_explorer/components/SendToDashboardOverlay'
+import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
 
+// Constants
 import {VIS_VIEWS, AUTO_GROUP_BY, TEMPLATES} from 'src/shared/constants'
 import {MINIMUM_HEIGHTS, INITIAL_HEIGHTS} from 'src/data_explorer/constants'
 import {errorThrown} from 'src/shared/actions/errors'
@@ -32,6 +36,7 @@ import {writeLineProtocolAsync} from 'src/data_explorer/actions/view/write'
 import {buildRawText} from 'src/utils/influxql'
 import defaultQueryConfig from 'src/utils/defaultQueryConfig'
 
+// Types
 import {Source, QueryConfig, TimeRange, Dashboard} from 'src/types'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -141,16 +146,18 @@ export class DataExplorer extends PureComponent<Props, State> {
             writeLineProtocol={writeLineProtocol}
           />
         </OverlayTechnology>
-        <OverlayTechnology visible={isSendToDashboardVisible}>
-          <SendToDashboardOverlay
-            onCancel={this.toggleSendToDashboard}
-            queryConfig={this.activeQuery}
-            source={source}
-            rawText={this.rawText}
-            dashboards={dashboards}
-            addDashboardCell={addDashboardCell}
-          />
-        </OverlayTechnology>
+        <Authorized requiredRole={EDITOR_ROLE}>
+          <OverlayTechnology visible={isSendToDashboardVisible}>
+            <SendToDashboardOverlay
+              onCancel={this.toggleSendToDashboard}
+              queryConfig={this.activeQuery}
+              source={source}
+              rawText={this.rawText}
+              dashboards={dashboards}
+              addDashboardCell={addDashboardCell}
+            />
+          </OverlayTechnology>
+        </Authorized>
         <PageHeader
           titleText="Explore"
           fullWidth={true}
@@ -238,12 +245,14 @@ export class DataExplorer extends PureComponent<Props, State> {
         >
           Write Data
         </button>
-        <button
-          onClick={this.toggleSendToDashboard}
-          className="button button-sm button-success"
-        >
-          Send to Dashboard
-        </button>
+        <Authorized requiredRole={EDITOR_ROLE}>
+          <button
+            onClick={this.toggleSendToDashboard}
+            className="button button-sm button-success"
+          >
+            Send to Dashboard
+          </button>
+        </Authorized>
         <GraphTips />
         <AutoRefreshDropdown
           selected={autoRefresh}

--- a/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/MultiSelectDropdown.tsx
@@ -49,7 +49,6 @@ class MultiSelectDropdown extends Component<Props, State> {
     buttonColor: ComponentColor.Default,
     buttonSize: ComponentSize.Small,
     status: ComponentStatus.Default,
-    widthPixels: 120,
     wrapText: false,
     maxMenuHeight: 250,
     menuColor: DropdownMenuColors.Sapphire,
@@ -70,13 +69,11 @@ class MultiSelectDropdown extends Component<Props, State> {
   }
 
   public render() {
-    const width = `${this.props.widthPixels}px`
-
     this.validateChildCount()
 
     return (
       <ClickOutside onClickOutside={this.collapseMenu}>
-        <div className={this.containerClassName} style={{width}}>
+        <div className={this.containerClassName} style={this.containerStyle}>
           {this.button}
           {this.menuItems}
         </div>
@@ -92,7 +89,20 @@ class MultiSelectDropdown extends Component<Props, State> {
     const {onCollapse} = this.props
 
     this.setState({expanded: false})
-    onCollapse()
+
+    if (onCollapse) {
+      onCollapse()
+    }
+  }
+
+  private get containerStyle(): CSSProperties {
+    const {widthPixels} = this.props
+
+    if (widthPixels) {
+      return {width: `${widthPixels}px`}
+    }
+
+    return {width: '100%'}
   }
 
   private get containerClassName(): string {
@@ -211,14 +221,20 @@ class MultiSelectDropdown extends Component<Props, State> {
   private get menuStyle(): CSSProperties {
     const {wrapText, widthPixels} = this.props
 
-    if (wrapText) {
+    let containerWidth = '100%'
+
+    if (widthPixels) {
+      containerWidth = `${widthPixels}px`
+    }
+
+    if (wrapText && widthPixels) {
       return {
-        width: `${widthPixels}px`,
+        width: containerWidth,
       }
     }
 
     return {
-      minWidth: `${widthPixels}px`,
+      minWidth: containerWidth,
     }
   }
 

--- a/ui/src/reusable_ui/components/dropdowns/test/__snapshots__/MultiSelectDropdown.test.tsx.snap
+++ b/ui/src/reusable_ui/components/dropdowns/test/__snapshots__/MultiSelectDropdown.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`MultiSelectDropdown matches snapshot with minimal props 1`] = `
     className="dropdown dropdown-sm dropdown-default"
     style={
       Object {
-        "width": "120px",
+        "width": "100%",
       }
     }
   >
@@ -33,7 +33,7 @@ exports[`MultiSelectDropdown with menu expanded matches snapshot 1`] = `
     className="dropdown dropdown-sm dropdown-default"
     style={
       Object {
-        "width": "120px",
+        "width": "100%",
       }
     }
   >
@@ -50,7 +50,7 @@ exports[`MultiSelectDropdown with menu expanded matches snapshot 1`] = `
       className="dropdown--menu-container dropdown--sapphire"
       style={
         Object {
-          "minWidth": "120px",
+          "minWidth": "100%",
         }
       }
     >

--- a/ui/src/reusable_ui/components/form_layout/Form.scss
+++ b/ui/src/reusable_ui/components/form_layout/Form.scss
@@ -99,7 +99,13 @@ $grid--form-gutter: 6px;
   ------------------------------------------------------------------------------
 */
 .form--submit {
+  flex-direction: row;
+  justify-content: center;
   align-items: center;
   margin-top: $form-sm-height - $ix-marg-b;
   margin-bottom: 0;
+
+  > .button {
+    margin: 0 $ix-marg-a;
+  }
 }

--- a/ui/test/data_explorer/containers/DataExplorer.test.tsx
+++ b/ui/test/data_explorer/containers/DataExplorer.test.tsx
@@ -33,15 +33,15 @@ const setup = () => {
     queryConfigActions,
     autoRefresh: 1000,
     handleChooseAutoRefresh: () => {},
-    timeRange,
     setTimeRange: () => {},
-    dataExplorer: {
-      queryIDs: [query.id],
-    },
-    writeLineProtocol: () => {},
-    errorThrownAction: () => {},
-    onManualRefresh: () => {},
+    timeRange,
     manualRefresh: 0,
+    dashboards: [],
+    onManualRefresh: () => {},
+    errorThrownAction: () => {},
+    writeLineProtocol: () => {},
+    handleGetDashboards: () => [],
+    addDashboardCell: jest.fn(() => Promise.resolve()),
   }
 
   const wrapper = shallow(<DataExplorer {...props} />)


### PR DESCRIPTION
Closes #4142

_What was the problem?_
The user experience of the Data Explorer and the Cell Editor Overlay was similar but not consistent, so that users were using the Data Explorer to create queries but then had to switch to the Dashboards page in order to put that query into a cell.

_What was the solution?_
These changes allow the user to create a query and press a button to create a cell with that query in one or more dashboards.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] CHANGELOG.md updated
  