### PR TITLE
Add password input text field to WizardTextInput

### DIFF
--- a/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
@@ -15,6 +15,7 @@ interface Props {
   valueModifier?: (value: string) => string
   placeholder?: string
   autoFocus?: boolean
+  type?: string
 }
 
 interface State {
@@ -32,6 +33,7 @@ class WizardTextInput extends PureComponent<Props, State> {
     }),
     valueModifier: x => x,
     autoFocus: false,
+    type: 'text',
   }
 
   constructor(props) {
@@ -50,6 +52,7 @@ class WizardTextInput extends PureComponent<Props, State> {
       value,
       autoFocus,
       label,
+      type,
     } = this.props
 
     let inputClass = ''
@@ -64,7 +67,7 @@ class WizardTextInput extends PureComponent<Props, State> {
       <div className="form-group col-xs-6">
         <label htmlFor={label}>{label}</label>
         <input
-          type="text"
+          type={type}
           id={label}
           className={`form-control input-sm ${inputClass}`}
           value={value}

--- a/ui/src/sources/components/KapacitorForm.tsx
+++ b/ui/src/sources/components/KapacitorForm.tsx
@@ -46,6 +46,7 @@ class KapacitorForm extends PureComponent<Props> {
         <WizardTextInput
           value={kapacitor.password}
           label="Password"
+          type="password"
           onChange={onChangeInput('password')}
         />
         {this.isHTTPS && (

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -122,6 +122,7 @@ class SourceStep extends PureComponent<Props, State> {
           value={source.password}
           label="Password"
           placeholder={this.passwordPlaceholder}
+          type="password"
           onChange={this.onChangeInput('password')}
         />
         <WizardTextInput


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
_What was the problem?_
There was no password type input field in wizard
_What was the solution?_
created a prop to make password type input fields 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)