### PR TITLE
fix: notify user to press esc upon entering presentation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### UI Improvements
 
 ### Bug Fixes
+1.  [#4231](https://github.com/influxdata/chronograf/pull/4231): Fix notifying user to press ESC to exit presentation mode
 
 ## v1.6.1 [2018-08-02]
 

--- a/ui/src/shared/actions/app.ts
+++ b/ui/src/shared/actions/app.ts
@@ -29,7 +29,7 @@ export const delayEnablePresentationMode: DelayEnablePresentationModeDispatcher 
 ): Promise<NodeJS.Timer> =>
   setTimeout(() => {
     dispatch(enablePresentationMode())
-    notify(notifyPresentationMode())
+    dispatch(notify(notifyPresentationMode()))
   }, PRESENTATION_MODE_ANIMATION_DELAY)
 
 // persistent state action creators


### PR DESCRIPTION
Closes #4161 

_What was the problem?_
Notification to user to `Press ESC to exit presentation mode` was not showing anymore.

_What was the solution?_
Dispatch the `notify` action that generates the notification. This was probably lost in the notifications refactor.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass