### PR TITLE
Add hostname syncing between source url, and kapacitor

### DIFF
--- a/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
@@ -13,6 +13,7 @@ interface Props {
   isDisabled?: boolean
   onChange: (value: string) => void
   valueModifier?: (value: string) => string
+  submitAction?: (value: string) => void
   placeholder?: string
   autoFocus?: boolean
   type?: string
@@ -34,6 +35,7 @@ class WizardTextInput extends PureComponent<Props, State> {
     valueModifier: x => x,
     autoFocus: false,
     type: 'text',
+    submitAction: x => null,
   }
 
   constructor(props) {
@@ -53,6 +55,7 @@ class WizardTextInput extends PureComponent<Props, State> {
       autoFocus,
       label,
       type,
+      submitAction,
     } = this.props
 
     let inputClass = ''
@@ -105,8 +108,9 @@ class WizardTextInput extends PureComponent<Props, State> {
   }
 
   private submit = incomingValue => {
-    const {onChange, value, valueModifier} = this.props
+    const {onChange, value, valueModifier, submitAction} = this.props
     const newValue = valueModifier(incomingValue)
+    submitAction(newValue)
 
     if (value !== newValue) {
       onChange(newValue)

--- a/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardTextInput.tsx
@@ -13,7 +13,7 @@ interface Props {
   isDisabled?: boolean
   onChange: (value: string) => void
   valueModifier?: (value: string) => string
-  submitAction?: (value: string) => void
+  onSubmit?: (value: string) => void
   placeholder?: string
   autoFocus?: boolean
   type?: string
@@ -35,7 +35,7 @@ class WizardTextInput extends PureComponent<Props, State> {
     valueModifier: x => x,
     autoFocus: false,
     type: 'text',
-    submitAction: x => null,
+    onSubmit: () => null,
   }
 
   constructor(props) {
@@ -55,7 +55,6 @@ class WizardTextInput extends PureComponent<Props, State> {
       autoFocus,
       label,
       type,
-      submitAction,
     } = this.props
 
     let inputClass = ''
@@ -108,9 +107,9 @@ class WizardTextInput extends PureComponent<Props, State> {
   }
 
   private submit = incomingValue => {
-    const {onChange, value, valueModifier, submitAction} = this.props
+    const {onChange, value, valueModifier, onSubmit} = this.props
     const newValue = valueModifier(incomingValue)
-    submitAction(newValue)
+    onSubmit(newValue)
 
     if (value !== newValue) {
       onChange(newValue)

--- a/ui/src/sources/components/KapacitorStep.tsx
+++ b/ui/src/sources/components/KapacitorStep.tsx
@@ -57,6 +57,13 @@ const getActiveKapacitor = (source: Source, sources: Source[]): Kapacitor => {
   return activeKapacitor
 }
 
+const syncHostnames = (source: Source, kapacitor: Kapacitor) => {
+  const sourceURL = new URL(source.url)
+  const kapacitorURL = new URL(kapacitor.url)
+  kapacitorURL.hostname = sourceURL.hostname
+  return {...kapacitor, url: kapacitorURL.href}
+}
+
 @ErrorHandling
 class KapacitorStep extends Component<Props, State> {
   public static defaultProps: Partial<Props> = {
@@ -66,13 +73,15 @@ class KapacitorStep extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    const kapacitor = props.showNewKapacitor
-      ? DEFAULT_KAPACITOR
-      : getActiveKapacitor(props.source, props.sources) || DEFAULT_KAPACITOR
+    let kapacitor = getActiveKapacitor(props.source, props.sources)
 
-    this.state = {
-      kapacitor,
+    if (!kapacitor || props.showNewKapacitor) {
+      kapacitor = DEFAULT_KAPACITOR
     }
+
+    kapacitor = syncHostnames(props.source, kapacitor)
+
+    this.state = {kapacitor}
   }
 
   public next = async () => {

--- a/ui/src/sources/components/KapacitorStep.tsx
+++ b/ui/src/sources/components/KapacitorStep.tsx
@@ -58,10 +58,15 @@ const getActiveKapacitor = (source: Source, sources: Source[]): Kapacitor => {
 }
 
 const syncHostnames = (source: Source, kapacitor: Kapacitor) => {
-  const sourceURL = new URL(source.url)
-  const kapacitorURL = new URL(kapacitor.url)
-  kapacitorURL.hostname = sourceURL.hostname
-  return {...kapacitor, url: kapacitorURL.href}
+  if (source && source.url) {
+    const sourceURL = new URL(source.url)
+    const kapacitorURL = new URL(kapacitor.url)
+    if (sourceURL.hostname) {
+      kapacitorURL.hostname = sourceURL.hostname
+      return {...kapacitor, url: kapacitorURL.href}
+    }
+  }
+  return kapacitor
 }
 
 @ErrorHandling

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -209,11 +209,15 @@ class SourceStep extends PureComponent<Props, State> {
 
   private syncHostnames = (sourceURLstring: string) => {
     if (this.isEnterprise) {
-      const sourceURL = new URL(sourceURLstring)
-      const {source} = this.state
-      const metaserviceURL = new URL(source.metaUrl || DEFAULT_SOURCE.metaUrl)
-      metaserviceURL.hostname = sourceURL.hostname
-      this.onChangeInput('metaUrl')(metaserviceURL.href)
+      if (sourceURLstring) {
+        const sourceURL = new URL(sourceURLstring)
+        const {source} = this.state
+        const metaserviceURL = new URL(source.metaUrl || DEFAULT_SOURCE.metaUrl)
+        if (sourceURL.hostname) {
+          metaserviceURL.hostname = sourceURL.hostname
+          this.onChangeInput('metaUrl')(metaserviceURL.href)
+        }
+      }
     }
   }
 

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -107,7 +107,7 @@ class SourceStep extends PureComponent<Props, State> {
           label="Connection URL"
           onChange={this.onChangeInput('url')}
           valueModifier={this.URLModifier}
-          submitAction={this.syncHostnames}
+          onSubmit={this.syncHostnames}
         />
         <WizardTextInput
           value={source.name}

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -107,6 +107,7 @@ class SourceStep extends PureComponent<Props, State> {
           label="Connection URL"
           onChange={this.onChangeInput('url')}
           valueModifier={this.URLModifier}
+          submitAction={this.syncHostnames}
         />
         <WizardTextInput
           value={source.name}
@@ -204,6 +205,16 @@ class SourceStep extends PureComponent<Props, State> {
     const {setError} = this.props
     this.setState({source: {...source, [key]: value}})
     setError(false)
+  }
+
+  private syncHostnames = (sourceURLstring: string) => {
+    if (this.isEnterprise) {
+      const sourceURL = new URL(sourceURLstring)
+      const {source} = this.state
+      const metaserviceURL = new URL(source.metaUrl || DEFAULT_SOURCE.metaUrl)
+      metaserviceURL.hostname = sourceURL.hostname
+      this.onChangeInput('metaUrl')(metaserviceURL.href)
+    }
   }
 
   private get isNewSource(): boolean {


### PR DESCRIPTION
Closes #4198 

_Desired behavior_ 
On new source creation or when editing a source in the onboarding and connection wizards, when a user enters a url with hostname `http://hostname:port` for their influxdb source, we would like to automagically update their metaUrl hostname (on same wizard step), and their kapacitor hostname (on next wizard step) to match.

_What was the solution?_
Add an onSubmit action to WizardTextInput, which is called onBlur or on keyboarding `enter`, with the input field text.
Add onSubmit action to the `url` WizardTextInput of sourceStep, which edits the metaUrl hostname to match the source hostname. 
Add syncHostnames function to constructor of kapacitorStep which checks and syncs hostname to source. 



  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)