### PR TITLE
fix: pass correct fields to /queries to fix de submit query button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Bug Fixes
 1.  [#4231](https://github.com/influxdata/chronograf/pull/4231): Fix notifying user to press ESC to exit presentation mode
 1.  [#4234](https://github.com/influxdata/chronograf/pull/4234): Fix persisting whether or not template variable control bar is open
+1.  [#4235](https://github.com/influxdata/chronograf/pull/4235): Fix Submit Query button in Data Explorer to correctly return results
 
 ## v1.6.1 [2018-08-02]
 

--- a/ui/src/data_explorer/actions/view/index.ts
+++ b/ui/src/data_explorer/actions/view/index.ts
@@ -395,9 +395,8 @@ export const editRawTextAsync = (
   try {
     const queries = await getQueryConfigAndStatus(url, [
       {
-        text,
         id,
-        queryConfig: {tags: {}, areTagsAccepted: true},
+        query: text,
       },
     ])
     const config = queries.find(q => q.id === id)


### PR DESCRIPTION
Closes #4199

_Briefly describe your proposed changes:_
_What was the problem?_
Upon hitting `Submit Query` in the Data Explorer, no queries were successful, whether for regular or metaqueries.

_What was the solution?_
Fix the faulty shape of the object sent to the `/queries` endpoint to match what's expected.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass