### PR TITLE
Add query results to table

### DIFF
--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -546,7 +546,6 @@ class LogsPage extends Component<Props, State> {
   ) => {
     this.props.changeFilter(id, operator, value)
     this.fetchNewDataset()
-    this.props.executeQueriesAsync()
   }
 
   private handleBarClick = (time: string): void => {

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -121,6 +121,11 @@ $logs-viewer-gutter: 60px;
   }
 }
 
+.logs-viewer--table-count {
+  position: absolute;
+  top: -30px;
+}
+
 .logs-viewer--filters {
   flex: 1 0 0;
   display: flex;


### PR DESCRIPTION
Closes #4176

_Briefly describe your proposed changes:_
_What was the problem?_
It was unclear when the logs table was loading results
_What was the solution?_
Add a logs row count and query results spinner to the logs table.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass