### PR TITLE
Add source creation to onSubmit on SourceStep

### DIFF
--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -128,7 +128,7 @@ export const notifyUnableToGetApps = (): Notification => ({
 
 //  InfluxDB Sources Notifications
 //  ----------------------------------------------------------------------------
-export const notifySourceCreationSucceeded = (
+export const notifySourceConnectionSucceeded = (
   sourceName: string
 ): Notification => ({
   ...defaultSuccessNotification,
@@ -145,13 +145,7 @@ export const notifySourceCreationFailed = (
   message: `Unable to connect to InfluxDB ${sourceName}: ${errorMessage}`,
 })
 
-export const notifySourceUdpated = (sourceName: string): Notification => ({
-  ...defaultSuccessNotification,
-  icon: 'server2',
-  message: `Updated InfluxDB ${sourceName} Connection successfully.`,
-})
-
-export const notifySourceUdpateFailed = (
+export const notifySourceUpdateFailed = (
   sourceName: string,
   errorMessage: string
 ): Notification => ({


### PR DESCRIPTION
Closes #4197 

_Briefly describe your proposed changes:_
_What was the problem?_ 
The onboarding and connection wizards need to be able to display a metaUrl field -which is displayed if a source isEnterprise- before user clicks next on the sourceStep

_What was the solution?_
Add to the onSubmit function of the url text field in sourceStep, so that when the url field is blurred the source is created or updated without alerting the user. The source returned from server has information on whether it isEnterprise, and if it is, the metaUrl field is displayed. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)