### PR TITLE
Add attributes to log search

### DIFF
--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -131,12 +131,14 @@ export type RowHeightHandler = (index: Index) => number
 export interface Term {
   type: TermType
   term: string
+  attribute: string
 }
 
 export interface TokenLiteralMatch {
   literal: string
   nextText: string
   rule: TermRule
+  attribute: string
 }
 
 export interface TermRule {
@@ -153,10 +155,14 @@ export enum TermPart {
   EXCLUSION = '-',
   SINGLE_QUOTED = "'([^']+)'",
   DOUBLE_QUOTED = '"([^"]+)"',
+  ATTRIBUTE = '(\\w+(?=\\:))',
+  COLON = '(?::)',
   UNQUOTED_WORD = '([\\S]+)',
 }
 
 export enum Operator {
   NOT_LIKE = '!~',
   LIKE = '=~',
+  EQUAL = '==',
+  NOT_EQUAL = '!=',
 }

--- a/ui/test/logs/utils/logFilters.test.ts
+++ b/ui/test/logs/utils/logFilters.test.ts
@@ -7,14 +7,14 @@ describe('Logs.searchToFilters', () => {
   )
 
   it('can return like filters for terms', () => {
-    const text = 'seq_!@.#: TERMS /api/search'
+    const text = 'seq_!@.# TERMS /api/search'
     const actual = searchToFilters(text)
 
     const expected = [
       {
         id: isUUID,
         key: 'message',
-        value: 'seq_!@.#:',
+        value: 'seq_!@.#',
         operator: Operator.LIKE,
       },
       {
@@ -27,6 +27,40 @@ describe('Logs.searchToFilters', () => {
         id: isUUID,
         key: 'message',
         value: '/api/search',
+        operator: Operator.LIKE,
+      },
+    ]
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('can return filters for attribute terms', () => {
+    const text = 'severity:info :TERMS -host:del.local foo:'
+    const actual = searchToFilters(text)
+
+    const expected = [
+      {
+        id: isUUID,
+        key: 'severity',
+        value: 'info',
+        operator: Operator.EQUAL,
+      },
+      {
+        id: isUUID,
+        key: 'message',
+        value: ':TERMS',
+        operator: Operator.LIKE,
+      },
+      {
+        id: isUUID,
+        key: 'host',
+        value: 'del.local',
+        operator: Operator.NOT_EQUAL,
+      },
+      {
+        id: isUUID,
+        key: 'message',
+        value: 'foo:',
         operator: Operator.LIKE,
       },
     ]
@@ -107,15 +141,15 @@ describe('Logs.searchToFilters', () => {
   })
 
   it('can create filters for phrases and terms', () => {
-    const text = `status:4\d{2} -"NOT FOUND" 'some "quote"' -thing`
+    const text = `severity:4\\d{2} -"NOT FOUND" 'some "quote"' -thing`
     const actual = searchToFilters(text)
 
     const expected = [
       {
         id: isUUID,
-        key: 'message',
-        value: 'status:4d{2}',
-        operator: Operator.LIKE,
+        key: 'severity',
+        value: '4\\d{2}',
+        operator: Operator.EQUAL,
       },
       {
         id: isUUID,


### PR DESCRIPTION
_What was the problem?_
Users expected to be able to search logs using `attribute:value` syntax
_What was the solution?_
Extend search terms to include attribute filters

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass