### PR TITLE
Clear logs after search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### UI Improvements
 1.  [#4227](https://github.com/influxdata/chronograf/pull/4227): Redesign Cell Editor Overlay for reuse in other parts of application
+1. [#4268](https://github.com/influxdata/chronograf/pull/4268): Clear logs after searching
 
 ### Bug Fixes
 

--- a/ui/src/logs/components/LogsSearchBar.tsx
+++ b/ui/src/logs/components/LogsSearchBar.tsx
@@ -1,5 +1,7 @@
 import React, {PureComponent, ChangeEvent, KeyboardEvent} from 'react'
 
+import {Input, IconFont, Button, ComponentColor} from 'src/reusable_ui'
+
 interface Props {
   onSearch: (value: string) => void
 }
@@ -23,21 +25,19 @@ class LogsSearchBar extends PureComponent<Props, State> {
     return (
       <div className="logs-viewer--search-bar">
         <div className="logs-viewer--search-input">
-          <input
-            type="text"
+          <Input
+            icon={IconFont.Search}
             placeholder="Search logs using keywords or regular expressions..."
-            value={searchTerm}
             onChange={this.handleChange}
             onKeyDown={this.handleInputKeyDown}
-            className="form-control input-sm"
-            spellCheck={false}
-            autoComplete="off"
+            value={searchTerm}
           />
-          <span className="icon search" />
         </div>
-        <button className="btn btn-sm btn-default" onClick={this.handleSearch}>
-          Search
-        </button>
+        <Button
+          text="Search"
+          color={ComponentColor.Primary}
+          onClick={this.handleSearch}
+        />
       </div>
     )
   }

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -8,6 +8,7 @@ import {color} from 'd3-color'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import ExpandableMessage from 'src/logs/components/expandable_message/ExpandableMessage'
 import LogsMessage from 'src/logs/components/logs_message/LogsMessage'
+import LoadingStatus from 'src/logs/components/loading_status/LoadingStatus'
 import {getDeep} from 'src/utils/wrappers'
 
 import {colorForSeverity} from 'src/logs/utils/colors'
@@ -168,7 +169,9 @@ class LogsTable extends Component<Props, State> {
   }
 
   public componentDidUpdate() {
-    if (this.isTableEmpty) {
+    const {searchStatus} = this.props
+
+    if (searchStatus === SearchStatus.NoResults) {
       return
     }
 
@@ -199,12 +202,8 @@ class LogsTable extends Component<Props, State> {
   public render() {
     const columnCount = Math.max(getColumnsFromData(this.props.data).length, 0)
 
-    if (this.isTableEmpty) {
-      return this.emptyTable
-    }
-
-    if (this.isLoading) {
-      return this.loadingTable
+    if (this.isLoadingTableData) {
+      return this.loadingStatus
     }
 
     return (
@@ -684,65 +683,19 @@ class LogsTable extends Component<Props, State> {
     this.setState({currentRow: -1})
   }
 
-  private get emptyTable(): JSX.Element {
-    return (
-      <div className="logs-viewer--table-container generic-empty-state">
-        <h4>No logs to display</h4>
-        <p>
-          Try changing the <strong>time range</strong> or{' '}
-          <strong>removing filters</strong>
-        </p>
-      </div>
-    )
+  private get loadingStatus(): JSX.Element {
+    return <LoadingStatus status={this.props.searchStatus} />
   }
 
-  private get loadingTable(): JSX.Element {
-    return (
-      <div className="logs-viewer--table-container generic-empty-state">
-        <h4 className="logs-viewer--loading-message">
-          {this.loadingMessage}...
-        </h4>
-        <p>{this.randomLoadingMessage()}</p>
-      </div>
-    )
-  }
-
-  private randomLoadingMessage = (): string => {
-    const messages = [
-      'Looking for logs in all the wrong places',
-      'I have the best logs',
-      'Rolling like a log',
-      '100% natural logs',
-      'Chopping wood',
-    ]
-
-    return _.sample(messages)
-  }
-
-  private get loadingMessage(): string {
-    switch (this.props.searchStatus) {
-      case SearchStatus.Loading:
-        return 'Searching'
-      case SearchStatus.UpdatingFilters:
-        return 'Updating Search Filters'
-    }
-  }
-  private get isLoading(): boolean {
+  private get isLoadingTableData(): boolean {
     const {searchStatus} = this.props
 
     switch (searchStatus) {
-      case SearchStatus.Loading:
-      case SearchStatus.UpdatingFilters:
-        return true
-      default:
+      case SearchStatus.Loaded:
         return false
+      default:
+        return true
     }
-  }
-
-  private get isTableEmpty(): boolean {
-    const rowCount = getDeep(this.props, 'data.values.length', 0)
-
-    return rowCount === 0
   }
 }
 

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -39,6 +39,7 @@ import {
   SeverityFormat,
   SeverityLevelColor,
   RowHeightHandler,
+  SearchStatus,
 } from 'src/types/logs'
 import {INITIAL_LIMIT} from 'src/logs/actions'
 
@@ -66,6 +67,7 @@ interface Props {
   onExpandMessage: () => void
   onChooseCustomTime: (time: string) => void
   notify: NotificationAction
+  searchStatus: SearchStatus
 }
 
 interface State {
@@ -199,6 +201,10 @@ class LogsTable extends Component<Props, State> {
 
     if (this.isTableEmpty) {
       return this.emptyTable
+    }
+
+    if (this.isLoading) {
+      return this.loadingTable
     }
 
     return (
@@ -688,6 +694,49 @@ class LogsTable extends Component<Props, State> {
         </p>
       </div>
     )
+  }
+
+  private get loadingTable(): JSX.Element {
+    return (
+      <div className="logs-viewer--table-container generic-empty-state">
+        <h4 className="logs-viewer--loading-message">
+          {this.loadingMessage}...
+        </h4>
+        <p>{this.randomLoadingMessage()}</p>
+      </div>
+    )
+  }
+
+  private randomLoadingMessage = (): string => {
+    const messages = [
+      'Looking for logs in all the wrong places',
+      'I have the best logs',
+      'Rolling like a log',
+      '100% natural logs',
+      'Chopping wood',
+    ]
+
+    return _.sample(messages)
+  }
+
+  private get loadingMessage(): string {
+    switch (this.props.searchStatus) {
+      case SearchStatus.Loading:
+        return 'Searching'
+      case SearchStatus.UpdatingFilters:
+        return 'Updating Search Filters'
+    }
+  }
+  private get isLoading(): boolean {
+    const {searchStatus} = this.props
+
+    switch (searchStatus) {
+      case SearchStatus.Loading:
+      case SearchStatus.UpdatingFilters:
+        return true
+      default:
+        return false
+    }
   }
 
   private get isTableEmpty(): boolean {

--- a/ui/src/logs/components/loading_status/LoadingStatus.tsx
+++ b/ui/src/logs/components/loading_status/LoadingStatus.tsx
@@ -1,4 +1,6 @@
 import React, {PureComponent} from 'react'
+import _ from 'lodash'
+
 import {SearchStatus} from 'src/types/logs'
 import {LoadingMessages} from 'src/logs/constants'
 
@@ -42,6 +44,8 @@ class LoadingStatus extends PureComponent<Props> {
         return 'Updating Search Filters'
       case SearchStatus.NoResults:
         return 'No logs to display'
+      case SearchStatus.UpdatingTimeBounds:
+        return 'Searching time bounds'
     }
   }
 }

--- a/ui/src/logs/components/loading_status/LoadingStatus.tsx
+++ b/ui/src/logs/components/loading_status/LoadingStatus.tsx
@@ -1,0 +1,49 @@
+import React, {PureComponent} from 'react'
+import {SearchStatus} from 'src/types/logs'
+import {LoadingMessages} from 'src/logs/constants'
+
+interface Props {
+  status: SearchStatus
+}
+
+class LoadingStatus extends PureComponent<Props> {
+  public render() {
+    return (
+      <div className="logs-viewer--table-container generic-empty-state">
+        <h4>{this.loadingMessage}...</h4>
+        <p>{this.description}</p>
+      </div>
+    )
+  }
+
+  private randomLoadingDescription = (): string => {
+    return _.sample(LoadingMessages)
+  }
+
+  private get description(): JSX.Element {
+    switch (this.props.status) {
+      case SearchStatus.NoResults:
+        return (
+          <>
+            Try changing the <strong>time range</strong> or
+            <strong>removing filters</strong>
+          </>
+        )
+      default:
+        return <>{this.randomLoadingDescription}</>
+    }
+  }
+
+  private get loadingMessage(): string {
+    switch (this.props.status) {
+      case SearchStatus.Loading:
+        return 'Searching'
+      case SearchStatus.UpdatingFilters:
+        return 'Updating Search Filters'
+      case SearchStatus.NoResults:
+        return 'No logs to display'
+    }
+  }
+}
+
+export default LoadingStatus

--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -204,3 +204,11 @@ export const HISTOGRAM_CENTRAL_REGION = 3 / 5
 export const HISTOGRAM_SHIFT = 1 / 5
 
 export const SECONDS_TO_MS = 1000
+
+export const LoadingMessages = [
+  'Looking for logs in all the wrong places',
+  'I have the best logs',
+  'Rolling like a log',
+  '100% natural logs',
+  'Chopping wood',
+]

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -65,7 +65,10 @@ import {
   TimeBounds,
   SearchStatus,
 } from 'src/types/logs'
-import {applyChangesToTableData} from 'src/logs/utils/table'
+import {
+  applyChangesToTableData,
+  isEmptyInfiniteData,
+} from 'src/logs/utils/table'
 import extentBy from 'src/utils/extentBy'
 import {computeTimeBounds} from 'src/logs/utils/timeBounds'
 
@@ -121,7 +124,9 @@ interface State {
 }
 
 class LogsPage extends Component<Props, State> {
-  public static getDerivedStateFromProps(props: Props) {
+  public static getDerivedStateFromProps(props: Props, state: State) {
+    const {tableInfiniteData} = props
+
     const severityLevelColors: SeverityLevelColor[] = _.get(
       props.logConfig,
       'severityLevelColors',
@@ -131,7 +136,16 @@ class LogsPage extends Component<Props, State> {
       group: lc.level,
       color: lc.color,
     }))
-    return {histogramColors}
+
+    let {searchStatus} = state
+
+    if (isEmptyInfiniteData(tableInfiniteData)) {
+      searchStatus = SearchStatus.NoResults
+    } else if (searchStatus === SearchStatus.None) {
+      searchStatus = SearchStatus.Loaded
+    }
+
+    return {histogramColors, searchStatus}
   }
 
   private interval: NodeJS.Timer

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -550,23 +550,13 @@ class LogsPage extends Component<Props, State> {
       this.props.addFilter(filter)
     })
 
-    try {
-      this.setState({searchStatus: SearchStatus.Loading})
-      await this.fetchNewDataset()
-    } finally {
-      this.setState({searchStatus: SearchStatus.Loaded})
-    }
+    this.fetchSearchDataset(SearchStatus.Loading)
   }
 
-  private handleFilterDelete = async (id: string): Promise<void> => {
+  private handleFilterDelete = (id: string): void => {
     this.props.removeFilter(id)
 
-    try {
-      this.setState({searchStatus: SearchStatus.UpdatingFilters})
-      await this.fetchNewDataset()
-    } finally {
-      this.setState({searchStatus: SearchStatus.Loaded})
-    }
+    this.fetchSearchDataset(SearchStatus.UpdatingFilters)
   }
 
   private handleFilterChange = async (
@@ -575,12 +565,6 @@ class LogsPage extends Component<Props, State> {
     value: string
   ): Promise<void> => {
     this.props.changeFilter(id, operator, value)
-    try {
-      this.setState({searchStatus: SearchStatus.UpdatingFilters})
-      await this.fetchNewDataset()
-    } finally {
-      this.setState({searchStatus: SearchStatus.Loaded})
-    }
   }
 
   private handleBarClick = (time: string): void => {
@@ -613,7 +597,7 @@ class LogsPage extends Component<Props, State> {
 
     this.props.setTimeRangeAsync(this.props.timeRange)
 
-    this.fetchNewDataset()
+    this.fetchSearchDataset(SearchStatus.UpdatingTimeBounds)
   }
 
   private handleSetTimeWindow = async (timeWindow: TimeWindow) => {
@@ -627,6 +611,17 @@ class LogsPage extends Component<Props, State> {
 
   private handleChooseNamespace = (namespace: Namespace) => {
     this.props.setNamespaceAsync(namespace)
+  }
+
+  private fetchSearchDataset = async (
+    searchStatus: SearchStatus
+  ): Promise<void> => {
+    try {
+      this.setState({searchStatus})
+      await this.fetchNewDataset()
+    } finally {
+      this.setState({searchStatus: SearchStatus.Loaded})
+    }
   }
 
   private fetchNewDataset() {

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -157,3 +157,14 @@ export const applyChangesToTableData = (
     values: updatedValues,
   }
 }
+
+export const isEmptyInfiniteData = (data: {
+  forward: TableData
+  backward: TableData
+}) => {
+  return isEmptyTableData(data.forward) && isEmptyTableData(data.backward)
+}
+
+const isEmptyTableData = (data: TableData): boolean => {
+  return getDeep(data, 'values.length', 0) === 0
+}

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -46,24 +46,6 @@ $logs-viewer-gutter: 60px;
   flex: 1 0 0;
   margin-right: 8px;
   position: relative;
-
-  > span.icon.search {
-    font-size: 14px;
-    position: absolute;
-    top: 50%;
-    left: 12px;
-    transform: translateY(-50%);
-    color: $g8-storm;
-    transition: color 0.25s ease;
-  }
-
-  > input.form-control.input-sm {
-    padding-left: 30px;
-  }
-
-  > input.form-control.input-sm:focus + span.icon.search {
-    color: $c-pool;
-  }
 }
 
 // Filters Bar
@@ -95,6 +77,7 @@ $logs-viewer-gutter: 60px;
     font-weight: 900;
   }
 }
+
 
 @keyframes resultsSpinner {
   0% {

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -14,6 +14,7 @@ export enum SearchStatus {
   None = 'None',
   Loading = 'Loading',
   NoResults = 'NoResults',
+  UpdatingTimeBounds = 'UpdatingTimeBounds',
   UpdatingFilters = 'UpdatingFilters',
   Loaded = 'Loaded',
 }

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -13,6 +13,7 @@ import {TimeRange} from 'src/types/logs'
 export enum SearchStatus {
   None = 'None',
   Loading = 'Loading',
+  NoResults = 'NoResults',
   UpdatingFilters = 'UpdatingFilters',
   Loaded = 'Loaded',
 }

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -10,6 +10,13 @@ import {FieldOption} from 'src/types/dashboards'
 import {TimeSeriesValue} from 'src/types/series'
 import {TimeRange} from 'src/types/logs'
 
+export enum SearchStatus {
+  None = 'None',
+  Loading = 'Loading',
+  UpdatingFilters = 'UpdatingFilters',
+  Loaded = 'Loaded',
+}
+
 export interface Filter {
   id: string
   key: string


### PR DESCRIPTION
Closes #4246 

_What was the problem?_
It was unclear when the logs table was awaiting search results after a search filter was added. Table rows might appear to be stale.
_What was the solution?_
Add a search status that is updated when a search is performed and render a corresponding loading message for no results, loading, or loaded table data.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [x] Tests pass