### PR TITLE
Add onKeyDown method to create new tag in annotation editor on enter

### DIFF
--- a/ui/src/shared/components/AnnotationEditorForm.tsx
+++ b/ui/src/shared/components/AnnotationEditorForm.tsx
@@ -37,7 +37,12 @@ interface State {
   text: string
   startTime: number
   endTime: number
-  tags: Array<{id: string; tagKey: string; tagValue: string}>
+  tags: Array<{
+    id: string
+    tagKey: string
+    tagValue: string
+    shouldAutoFocus: boolean
+  }>
   startTimeInput: string
   endTimeInput: string
   textError: string | null
@@ -61,6 +66,7 @@ class AnnotationEditorForm extends PureComponent<Props, State> {
       id: uuid.v4(),
       tagKey: k,
       tagValue: v,
+      shouldAutoFocus: false,
     }))
 
     this.state = {
@@ -87,7 +93,6 @@ class AnnotationEditorForm extends PureComponent<Props, State> {
     const {
       type,
       text,
-      tags,
       startTimeInput,
       endTimeInput,
       textError,
@@ -161,15 +166,7 @@ class AnnotationEditorForm extends PureComponent<Props, State> {
               {tagsError && <div className="error">{tagsError}</div>}
             </label>
             <div className="annotation-tag-editor">
-              {tags.map(({id, tagKey, tagValue}) => (
-                <AnnotationTagEditorLi
-                  key={id}
-                  tagKey={tagKey}
-                  tagValue={tagValue}
-                  onUpdate={this.handleUpdateTag(id)}
-                  onDelete={this.handleDeleteTag(id)}
-                />
-              ))}
+              {this.tagEditorListItems}
               <button
                 className="btn btn-sm btn-primary annotation-tag-editor--add"
                 onClick={this.handleAddTag}
@@ -190,6 +187,30 @@ class AnnotationEditorForm extends PureComponent<Props, State> {
         </div>
       </div>
     )
+  }
+
+  private get tagEditorListItems(): JSX.Element[] {
+    const {tags} = this.state
+
+    return tags.map(({id, tagKey, tagValue, shouldAutoFocus}) => (
+      <AnnotationTagEditorLi
+        key={id}
+        tagKey={tagKey}
+        tagValue={tagValue}
+        onUpdate={this.handleUpdateTag(id)}
+        onDelete={this.handleDeleteTag(id)}
+        onKeyDown={this.onKeyDown}
+        shouldAutoFocus={shouldAutoFocus}
+      />
+    ))
+  }
+
+  private onKeyDown = (e: string): void => {
+    switch (e) {
+      case 'Enter':
+        this.handleAddTag()
+        return
+    }
   }
 
   private handleTextChange = ({
@@ -298,9 +319,18 @@ class AnnotationEditorForm extends PureComponent<Props, State> {
   }
 
   private handleAddTag = (): void => {
-    const newTag = {id: uuid.v4(), tagKey: '', tagValue: ''}
+    const newTag = {
+      id: uuid.v4(),
+      tagKey: '',
+      tagValue: '',
+      shouldAutoFocus: true,
+    }
 
-    this.setState({tags: [...this.state.tags, newTag]}, this.setDraftAnnotation)
+    const oldTags = this.state.tags.map(tag => {
+      return {...tag, shouldAutoFocus: false}
+    })
+
+    this.setState({tags: [...oldTags, newTag]}, this.setDraftAnnotation)
   }
 
   private handleUpdateTag = (id: string) => (

--- a/ui/src/shared/components/AnnotationTagEditorLi.tsx
+++ b/ui/src/shared/components/AnnotationTagEditorLi.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, ChangeEvent} from 'react'
+import React, {PureComponent, ChangeEvent, KeyboardEvent} from 'react'
 
 import {
   Button,
@@ -11,13 +11,15 @@ import {
 interface Props {
   tagKey: string
   tagValue: string
+  shouldAutoFocus: boolean
   onUpdate: (tagKey: string, tagValue: string) => void
   onDelete: () => void
+  onKeyDown: (e: string) => void
 }
 
 class AnnotationTagEditorLi extends PureComponent<Props> {
   public render() {
-    const {tagKey, tagValue, onDelete} = this.props
+    const {tagKey, tagValue, onDelete, shouldAutoFocus} = this.props
 
     return (
       <div className="tag-control">
@@ -25,6 +27,7 @@ class AnnotationTagEditorLi extends PureComponent<Props> {
           className="form-control input-sm tag-control--key"
           value={tagKey}
           onChange={this.handleChangeTagKey}
+          autoFocus={shouldAutoFocus}
         />
         <div className="tag-control--arrow">
           <span />
@@ -33,6 +36,7 @@ class AnnotationTagEditorLi extends PureComponent<Props> {
           className="form-control input-sm tag-control--value"
           value={tagValue}
           onChange={this.handleChangeTagValue}
+          onKeyDown={this.handleKeyDown}
         />
         <Button
           onClick={onDelete}
@@ -43,6 +47,12 @@ class AnnotationTagEditorLi extends PureComponent<Props> {
         />
       </div>
     )
+  }
+
+  private handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    const {onKeyDown} = this.props
+
+    onKeyDown(e.key)
   }
 
   private handleChangeTagKey = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
Closes #4135

_What was the problem?_
While in the `AnnotationEditorForm` the user would have to manually click the "add tag" button to create a new tag. 

_What was the solution?_
Add an onKeyDown method so that when the user hits the "enter" key when they have finished adding the value for a tag, a new tag will be automatically created and the focus will be shifted to the tag key input. Empty tag key/value pairs are automatically filtered out before saving. 

  - [x] Rebased/mergeable
  - [x] Tests pass