### PR TITLE
refactor: rename LogViewerHeader to LogsHeader for consistency

### DIFF
--- a/ui/src/logs/components/LogsHeader.tsx
+++ b/ui/src/logs/components/LogsHeader.tsx
@@ -35,7 +35,7 @@ interface Props {
   onChooseRelativeTime: (time: number) => void
 }
 
-class LogViewerHeader extends PureComponent<Props> {
+class LogsHeader extends PureComponent<Props> {
   public render(): JSX.Element {
     return (
       <PageHeader
@@ -173,4 +173,4 @@ class LogViewerHeader extends PureComponent<Props> {
   }
 }
 
-export default LogViewerHeader
+export default LogsHeader

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -33,7 +33,7 @@ import {
   updateLogConfigAsync,
 } from 'src/logs/actions'
 import {getSourcesAsync} from 'src/shared/actions/sources'
-import LogViewerHeader from 'src/logs/components/LogViewerHeader'
+import LogsHeader from 'src/logs/components/LogsHeader'
 import HistogramChart from 'src/shared/components/HistogramChart'
 import LogsGraphContainer from 'src/logs/components/LogsGraphContainer'
 import OptionsOverlay from 'src/logs/components/OptionsOverlay'
@@ -501,7 +501,7 @@ class LogsPage extends Component<Props, State> {
     } = this.props
 
     return (
-      <LogViewerHeader
+      <LogsHeader
         timeRange={timeRange}
         onSetTimeWindow={this.handleSetTimeWindow}
         liveUpdating={this.liveUpdatingStatus}


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_
Inconsistent component name for LogViewerHeader, whereas all other components are prefixed with Logs, made it confusing to search for.

_What was the solution?_
Rename component and file.
