### PR TITLE
Fix log viewer hanging 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 ### Bug Fixes
 
 1. [#4272](https://github.com/influxdata/chronograf/pull/4272): Fix logs loading description not displaying
+1. [#4279](https://github.com/influxdata/chronograf/pull/4279): Fix log search hanging when query is specific
+
 
 ## v1.6.2 [unreleased]
 

--- a/ui/src/logs/utils/index.ts
+++ b/ui/src/logs/utils/index.ts
@@ -211,6 +211,7 @@ export async function getQueryResultsCountForBounds(
 
 // HOW_LOW_CAN_YOU_GO is the magical cut-off point for number of results where exponential backoff will stop
 const HOW_LOW_CAN_YOU_GO = 150
+const SUPER_LOW = 10 // For very specific queries w/ few results
 
 export async function findOlderLowerTimeBounds(
   upper: string,
@@ -240,7 +241,7 @@ export async function findOlderLowerTimeBounds(
       namespace
     )
 
-    if (count >= HOW_LOW_CAN_YOU_GO) {
+    if (count >= HOW_LOW_CAN_YOU_GO || (count > 0 && count <= SUPER_LOW)) {
       break
     }
 
@@ -279,7 +280,7 @@ export async function findNewerUpperTimeBounds(
       namespace
     )
 
-    if (count >= HOW_LOW_CAN_YOU_GO) {
+    if (count >= HOW_LOW_CAN_YOU_GO || (count > 0 && count <= SUPER_LOW)) {
       break
     }
 


### PR DESCRIPTION
_What was the problem?_
Currently a search for a specific message phrase causes the log viewer to hang
_What was the solution?_
Add a condition to stop searching if matching message count is super low.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass