### PR TITLE
Guard against nonexistent note

### DIFF
--- a/ui/src/shared/components/LayoutCellNote.tsx
+++ b/ui/src/shared/components/LayoutCellNote.tsx
@@ -25,6 +25,7 @@ class LayoutCellNote extends Component<Props> {
     const {note, cellType, visibility} = this.props
 
     if (
+      !note ||
       note === '' ||
       cellType === CellType.Note ||
       visibility === CellNoteVisibility.ShowWhenNoData


### PR DESCRIPTION
This most likely is not a big issue, because restarting the chronograf server prevents this from happening, but just in case this PR adds a guard against nonexistent cell notes. 

  - [x] Rebased/mergeable
  - [x] Tests pass