### PR TITLE
Add check for undefined cell to LayoutCellNote

### DIFF
--- a/ui/src/shared/components/LayoutCellNote.tsx
+++ b/ui/src/shared/components/LayoutCellNote.tsx
@@ -26,6 +26,7 @@ class LayoutCellNote extends Component<Props> {
 
     if (
       note === '' ||
+      note === undefined ||
       cellType === CellType.Note ||
       visibility === CellNoteVisibility.ShowWhenNoData
     ) {


### PR DESCRIPTION
Closes #4276

_What was the problem?_
Layouts were not loading in the Host List page.

_What was the solution?_
Add a check and return if the cell is undefined in `LayoutCellNote`.

  - [x] Rebased/mergeable
  - [x] Tests pass