### PR TITLE
Add timeSelectorDropdown to timeMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1.  [#4241](https://github.com/influxdata/chronograf/pull/4241): Add search attributes to log viewer
 1.  [#4254](https://github.com/influxdata/chronograf/pull/4254): Add Dynamic Source option to CEO source selector
 1.  [#4257](https://github.com/influxdata/chronograf/pull/4257): Introduce cell notes & note cells
+1.  [#4287](https://github.com/influxdata/chronograf/pull/4287): Add time selector dropdown to CEO
 
 ### UI Improvements
 1.  [#4227](https://github.com/influxdata/chronograf/pull/4227): Redesign Cell Editor Overlay for reuse in other parts of application

--- a/ui/src/dashboards/actions/cellEditorOverlay.ts
+++ b/ui/src/dashboards/actions/cellEditorOverlay.ts
@@ -40,6 +40,7 @@ import {
   Tag,
   TimeShift,
   ApplyFuncsToFieldArgs,
+  TimeRange,
 } from 'src/types'
 import {CEOInitialState} from 'src/dashboards/reducers/cellEditorOverlay'
 
@@ -50,8 +51,8 @@ interface State {
 type GetState = () => State
 
 export enum ActionType {
-  LoadCellForCEO = 'LOAD_CELL_FOR_CEO',
-  ClearCellFromCEO = 'CLEAR_CELL_FROM_CEO',
+  LoadCEO = 'LOAD_CEO',
+  ClearCEO = 'CLEAR_CEO',
   ChangeCellType = 'CHANGE_CELL_TYPE',
   RenameCell = 'RENAME_CELL',
   UpdateThresholdsListColors = 'UPDATE_THRESHOLDS_LIST_COLORS',
@@ -67,11 +68,12 @@ export enum ActionType {
   UpdateQueryDraft = 'UPDATE_QUERY_DRAFT',
   UpdateCellNote = 'UPDATE_CELL_NOTE',
   UpdateCellNoteVisibility = 'UPDATE_CELL_NOTE_VISIBILITY',
+  UpdateEditorTimeRange = 'UPDATE_EDITOR_TIME_RANGE',
 }
 
 export type Action =
-  | LoadCellForCEOAction
-  | ClearCellFromCEOAction
+  | LoadCEOAction
+  | ClearCEOAction
   | ChangeCellTypeAction
   | RenameCellAction
   | UpdateThresholdsListColorsAction
@@ -86,16 +88,18 @@ export type Action =
   | UpdateQueryDraftsAction
   | UpdateCellNoteAction
   | UpdateCellNoteVisibilityAction
+  | UpdateEditorTimeRangeAction
 
-export interface LoadCellForCEOAction {
-  type: ActionType.LoadCellForCEO
+export interface LoadCEOAction {
+  type: ActionType.LoadCEO
   payload: {
     cell: Cell | NewDefaultCell
+    timeRange: TimeRange
   }
 }
 
-export interface ClearCellFromCEOAction {
-  type: ActionType.ClearCellFromCEO
+export interface ClearCEOAction {
+  type: ActionType.ClearCEO
 }
 
 export interface ChangeCellTypeAction {
@@ -203,17 +207,26 @@ export interface UpdateCellNoteVisibilityAction {
   }
 }
 
-export const loadCellForCEO = (
-  cell: Cell | NewDefaultCell
-): LoadCellForCEOAction => ({
-  type: ActionType.LoadCellForCEO,
+export interface UpdateEditorTimeRangeAction {
+  type: ActionType.UpdateEditorTimeRange
+  payload: {
+    timeRange: TimeRange
+  }
+}
+
+export const loadCEO = (
+  cell: Cell | NewDefaultCell,
+  timeRange: TimeRange
+): LoadCEOAction => ({
+  type: ActionType.LoadCEO,
   payload: {
     cell,
+    timeRange,
   },
 })
 
-export const clearCellFromCEO = (): ClearCellFromCEOAction => ({
-  type: ActionType.ClearCellFromCEO,
+export const clearCEO = (): ClearCEOAction => ({
+  type: ActionType.ClearCEO,
 })
 
 export const changeCellType = (cellType: CellType): ChangeCellTypeAction => ({
@@ -322,6 +335,15 @@ export const updateFieldOptions = (
   type: ActionType.UpdateFieldOptions,
   payload: {
     fieldOptions,
+  },
+})
+
+export const updateEditorTimeRange = (
+  timeRange: TimeRange
+): UpdateEditorTimeRangeAction => ({
+  type: ActionType.UpdateEditorTimeRange,
+  payload: {
+    timeRange,
   },
 })
 

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -23,7 +23,7 @@ import * as ColorsModels from 'src/types/colors'
 import * as DashboardsModels from 'src/types/dashboards'
 import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
-import {Service} from 'src/types'
+import {Service, TimeRange} from 'src/types'
 import {Template} from 'src/types/tempVars'
 import {NewDefaultCell} from 'src/types/dashboards'
 import {
@@ -65,6 +65,7 @@ interface Props {
   queryConfigActions: QueryConfigActions
   addQuery: typeof addQueryAsync
   deleteQuery: typeof deleteQueryAsync
+  updateEditorTimeRange: (timeRange: TimeRange) => void
 }
 
 interface State {
@@ -108,6 +109,7 @@ class CellEditorOverlay extends Component<Props, State> {
       renameCell,
       addQuery,
       deleteQuery,
+      updateEditorTimeRange,
     } = this.props
 
     const {isStaticLegend} = this.state
@@ -136,6 +138,7 @@ class CellEditorOverlay extends Component<Props, State> {
           queryConfigActions={this.props.queryConfigActions}
           addQuery={addQuery}
           deleteQuery={deleteQuery}
+          updateEditorTimeRange={updateEditorTimeRange}
         >
           {(activeEditorTab, onSetActiveEditorTab) => (
             <CEOHeader

--- a/ui/src/dashboards/components/Visualization.tsx
+++ b/ui/src/dashboards/components/Visualization.tsx
@@ -89,6 +89,7 @@ const DashVisualization: SFC<Props> = ({
           isInCEO={isInCEO}
           cellNote={note}
           cellNoteVisibility={noteVisibility}
+          timeRange={timeRange}
         />
       </div>
     </div>

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -103,11 +103,12 @@ interface Props extends ManualRefreshProps, WithRouterProps {
   notify: NotificationsActions.PublishNotificationActionCreator
   annotationsDisplaySetting: AnnotationsDisplaySetting
   onGetAnnotationsAsync: typeof getAnnotationsAsync
-  handleLoadCellForCEO: typeof cellEditorOverlayActions.loadCellForCEO
-  handleClearCellFromCEO: typeof cellEditorOverlayActions.clearCellFromCEO
+  handleLoadCEO: typeof cellEditorOverlayActions.loadCEO
+  handleClearCEO: typeof cellEditorOverlayActions.clearCEO
   handleDismissEditingAnnotation: typeof dismissEditingAnnotation
   selectedCell: DashboardsModels.Cell
   queryDrafts: DashboardsModels.CellQuery[]
+  editorTimeRange: QueriesModels.TimeRange
   updateQueryDrafts: (queryDrafts: DashboardsModels.CellQuery[]) => void
   thresholdsListType: string
   thresholdsListColors: ColorsModels.ColorNumber[]
@@ -143,6 +144,7 @@ interface Props extends ManualRefreshProps, WithRouterProps {
   chooseMeasurement: typeof queryConfigActions.chooseMeasurement
   applyFuncsToField: typeof queryConfigActions.applyFuncsToField
   toggleTagAcceptance: typeof queryConfigActions.toggleTagAcceptance
+  updateEditorTimeRange: typeof cellEditorOverlayActions.updateEditorTimeRange
 }
 
 interface State {
@@ -236,6 +238,7 @@ class DashboardPage extends Component<Props, State> {
       deleteQuery,
       timeRange,
       timeRange: {lower, upper},
+      editorTimeRange,
       renameCell,
       zoomedTimeRange,
       zoomedTimeRange: {lower: zoomedLower, upper: zoomedUpper},
@@ -257,6 +260,7 @@ class DashboardPage extends Component<Props, State> {
       handleChooseAutoRefresh,
       handleClickPresentationButton,
       toggleTemplateVariableControlBar,
+      updateEditorTimeRange,
     } = this.props
 
     const low = zoomedLower || lower
@@ -315,7 +319,8 @@ class DashboardPage extends Component<Props, State> {
             services={this.services}
             cell={selectedCell}
             queryDrafts={queryDrafts}
-            timeRange={timeRange}
+            timeRange={editorTimeRange}
+            updateEditorTimeRange={updateEditorTimeRange}
             autoRefresh={autoRefresh}
             dashboardID={dashboardID}
             queryStatus={cellQueryStatus}
@@ -511,18 +516,18 @@ class DashboardPage extends Component<Props, State> {
   private handleShowCellEditorOverlay = (
     cell: DashboardsModels.Cell | DashboardsModels.NewDefaultCell
   ): void => {
-    const {handleLoadCellForCEO} = this.props
-    handleLoadCellForCEO(cell)
+    const {handleLoadCEO, timeRange} = this.props
+    handleLoadCEO(cell, timeRange)
     this.setState({showCellEditorOverlay: true})
   }
 
   private handleHideCellEditorOverlay = () => {
-    const {handleClearCellFromCEO} = this.props
+    const {handleClearCEO} = this.props
     const WAIT_FOR_ANIMATION = 400
 
     this.setState({showCellEditorOverlay: false})
     window.setTimeout(() => {
-      handleClearCellFromCEO()
+      handleClearCEO()
     }, WAIT_FOR_ANIMATION)
   }
 
@@ -677,6 +682,7 @@ const mstp = (state, {params: {dashboardID}}) => {
       thresholdsListColors,
       gaugeColors,
       lineColors,
+      timeRange: editorTimeRange,
     },
   } = state
 
@@ -707,6 +713,7 @@ const mstp = (state, {params: {dashboardID}}) => {
     inPresentationMode,
     selectedCell,
     queryDrafts,
+    editorTimeRange,
     thresholdsListType,
     thresholdsListColors,
     gaugeColors,
@@ -739,8 +746,8 @@ const mdtp = {
   handleClickPresentationButton: appActions.delayEnablePresentationMode,
   errorThrown: errorActions.errorThrown,
   notify: notifyActions.notify,
-  handleLoadCellForCEO: cellEditorOverlayActions.loadCellForCEO,
-  handleClearCellFromCEO: cellEditorOverlayActions.clearCellFromCEO,
+  handleLoadCEO: cellEditorOverlayActions.loadCEO,
+  handleClearCEO: cellEditorOverlayActions.clearCEO,
   onGetAnnotationsAsync: getAnnotationsAsync,
   handleDismissEditingAnnotation: dismissEditingAnnotation,
   updateQueryDraft: cellEditorOverlayActions.updateQueryDraft,
@@ -761,6 +768,7 @@ const mdtp = {
   chooseMeasurement: queryConfigActions.chooseMeasurement,
   applyFuncsToField: queryConfigActions.applyFuncsToField,
   toggleTagAcceptance: queryConfigActions.toggleTagAcceptance,
+  updateEditorTimeRange: cellEditorOverlayActions.updateEditorTimeRange,
 }
 
 export default connect(mstp, mdtp)(

--- a/ui/src/dashboards/reducers/cellEditorOverlay.ts
+++ b/ui/src/dashboards/reducers/cellEditorOverlay.ts
@@ -24,7 +24,7 @@ import {
 import {initializeOptions} from 'src/dashboards/constants/cellEditor'
 
 // types
-import {CellType, Cell} from 'src/types'
+import {CellType, Cell, TimeRange} from 'src/types'
 import {CellQuery, ThresholdType, TableOptions} from 'src/types/dashboards'
 import {ThresholdColor, GaugeColor, LineColor} from 'src/types/colors'
 import {NewDefaultCell} from 'src/types/dashboards'
@@ -36,6 +36,7 @@ export interface CEOInitialState {
   gaugeColors: GaugeColor[]
   lineColors: LineColor[]
   queryDrafts: CellQuery[]
+  timeRange: TimeRange
 }
 
 export const initialState = {
@@ -45,12 +46,13 @@ export const initialState = {
   gaugeColors: DEFAULT_GAUGE_COLORS,
   lineColors: DEFAULT_LINE_COLORS,
   queryDrafts: null,
+  timeRange: null,
 }
 
 export default (state = initialState, action: Action): CEOInitialState => {
   switch (action.type) {
-    case ActionType.LoadCellForCEO: {
-      const {cell} = action.payload
+    case ActionType.LoadCEO: {
+      const {cell, timeRange} = action.payload
 
       const tableOptions = getDeep<TableOptions>(
         cell,
@@ -98,19 +100,22 @@ export default (state = initialState, action: Action): CEOInitialState => {
           gaugeColors,
           lineColors,
           queryDrafts,
+          timeRange,
         }
       }
       return {
         ...state,
         cell: {...cell, tableOptions},
         queryDrafts,
+        timeRange,
       }
     }
 
-    case ActionType.ClearCellFromCEO: {
+    case ActionType.ClearCEO: {
       const cell = null
+      const timeRange = null
 
-      return {...state, cell}
+      return {...state, cell, timeRange}
     }
 
     case ActionType.ChangeCellType: {
@@ -209,6 +214,12 @@ export default (state = initialState, action: Action): CEOInitialState => {
       const {queryDrafts} = action.payload
 
       return {...state, queryDrafts}
+    }
+
+    case ActionType.UpdateEditorTimeRange: {
+      const {timeRange} = action.payload
+
+      return {...state, timeRange}
     }
   }
 

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -59,6 +59,7 @@ interface Props {
   ) => JSX.Element
   addQuery: typeof addQueryAsync
   deleteQuery: typeof deleteQueryAsync
+  updateEditorTimeRange: (timeRange: TimeRange) => void
 }
 
 interface State {
@@ -87,7 +88,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {services} = this.props
+    const {services, timeRange, updateEditorTimeRange} = this.props
     const {useDynamicSource} = this.state
     const horizontalDivisions = [
       {
@@ -121,6 +122,8 @@ class TimeMachine extends PureComponent<Props, State> {
           onChangeService={this.handleChangeService}
           onSelectDynamicSource={this.handleSelectDynamicSource}
           isDynamicSourceSelected={useDynamicSource}
+          timeRange={timeRange}
+          updateEditorTimeRange={updateEditorTimeRange}
         />
         <div className="deceo--container">
           <Threesizer

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -1,7 +1,11 @@
+// Libraries
 import React, {SFC} from 'react'
 
+// Components
 import SourceSelector from 'src/dashboards/components/SourceSelector'
+import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 
+// Types
 import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import {Service} from 'src/types'
@@ -15,6 +19,8 @@ interface Props {
   onChangeService: (service: Service, source: SourcesModels.Source) => void
   queries: QueriesModels.QueryConfig[]
   onSelectDynamicSource: () => void
+  timeRange: QueriesModels.TimeRange
+  updateEditorTimeRange: (timeRange: QueriesModels.TimeRange) => void
 }
 
 const TimeMachineControls: SFC<Props> = ({
@@ -23,9 +29,11 @@ const TimeMachineControls: SFC<Props> = ({
   service,
   queries,
   services,
+  timeRange,
   onChangeService,
-  isDynamicSourceSelected,
   onSelectDynamicSource,
+  isDynamicSourceSelected,
+  updateEditorTimeRange,
 }) => {
   return (
     <div className="deceo--controls">
@@ -38,6 +46,10 @@ const TimeMachineControls: SFC<Props> = ({
         onChangeService={onChangeService}
         isDynamicSourceSelected={isDynamicSourceSelected}
         onSelectDynamicSource={onSelectDynamicSource}
+      />
+      <TimeRangeDropdown
+        onChooseTimeRange={updateEditorTimeRange}
+        selected={timeRange}
       />
     </div>
   )

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -411,6 +411,7 @@ div.dropdown.dropdown-stretch > button.dropdown-toggle {
   height: 60px;
   padding: 0 60px;
   background-color: $g3-castle;
+  align-items: center;
 }
 
 .deceo--visualization {

--- a/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
+++ b/ui/test/dashboards/reducers/cellEditorOverlay.test.ts
@@ -1,8 +1,8 @@
 import reducer, {initialState} from 'src/dashboards/reducers/cellEditorOverlay'
 
 import {
-  loadCellForCEO,
-  clearCellFromCEO,
+  loadCEO,
+  clearCEO,
   changeCellType,
   renameCell,
   updateThresholdsListColors,
@@ -21,7 +21,7 @@ import {
 } from 'src/shared/constants/thresholds'
 import {validateLineColors} from 'src/shared/constants/graphColorPalettes'
 
-import {cell, axes} from 'test/fixtures'
+import {cell, axes, timeRange} from 'test/fixtures'
 
 const defaultCell = {
   ...cell,
@@ -37,26 +37,29 @@ const defaultLineColors = validateLineColors(defaultCell.colors)
 
 describe('Dashboards.Reducers.cellEditorOverlay', () => {
   it('should show cell editor overlay', () => {
-    const actual = reducer(initialState, loadCellForCEO(defaultCell))
+    const actual = reducer(initialState, loadCEO(defaultCell, timeRange))
     const expected = {
       cell: defaultCell,
       gaugeColors: defaultGaugeColors,
       thresholdsListColors: defaultThresholdsListColors,
       thresholdsListType: defaultThresholdsListType,
       tableOptions: DEFAULT_TABLE_OPTIONS,
+      timeRange,
     }
 
     expect(actual.cell).toEqual(expected.cell)
     expect(actual.gaugeColors).toBe(expected.gaugeColors)
     expect(actual.thresholdsListColors).toBe(expected.thresholdsListColors)
     expect(actual.thresholdsListType).toBe(expected.thresholdsListType)
+    expect(actual.timeRange).toBe(expected.timeRange)
   })
 
   it('should hide cell editor overlay', () => {
-    const actual = reducer(initialState, clearCellFromCEO())
+    const actual = reducer(initialState, clearCEO())
     const expected = null
 
     expect(actual.cell).toBe(expected)
+    expect(actual.timeRange).toBe(expected)
   })
 
   it('should change the cell editor visualization type', () => {


### PR DESCRIPTION
Closes #4141 

_Briefly describe your proposed changes:_
Add time selector dropdown into time machine. Store state in redux.
The time selector will default to the time set for the dashboard. This time selector does not update the time for the entire dashboard.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass