### PR TITLE
Add manualRefresh prop to TimeSeries component to fix refresh bug

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -73,7 +73,10 @@ class RefreshingGraph extends PureComponent<Props> {
   private timeSeries: React.RefObject<TimeSeries> = React.createRef()
 
   public componentDidUpdate() {
-    if (this.props.isInCEO && this.props.type !== CellType.Note) {
+    if (!this.timeSeries.current) {
+      return
+    }
+    if (this.props.isInCEO) {
       this.timeSeries.current.forceUpdate()
     }
   }
@@ -87,6 +90,7 @@ class RefreshingGraph extends PureComponent<Props> {
       cellNote,
       timeRange,
       templates,
+      manualRefresh,
       editQueryStatus,
       cellNoteVisibility,
       grabDataForDownload,
@@ -107,6 +111,7 @@ class RefreshingGraph extends PureComponent<Props> {
     return (
       <TimeSeries
         ref={this.timeSeries}
+        manualRefresh={manualRefresh}
         source={source}
         cellType={type}
         inView={inView}

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -35,6 +35,7 @@ interface RenderProps {
 interface Props {
   source: Source
   cellType?: CellType
+  manualRefresh?: number
   queries: Query[]
   timeRange: TimeRange
   children: (r: RenderProps) => JSX.Element
@@ -104,6 +105,7 @@ class TimeSeries extends Component<Props, State> {
       'inView',
       'templates',
       'cellType',
+      'manualRefresh',
     ]
 
     return (
@@ -265,13 +267,14 @@ class TimeSeries extends Component<Props, State> {
     return null
   }
 
-  private isPropsDifferent(nextProps: Props) {
-    const isSourceDifferent = !_.isEqual(this.props.source, nextProps.source)
+  private isPropsDifferent(prevProps: Props) {
+    const isSourceDifferent = !_.isEqual(this.props.source, prevProps.source)
 
     return (
-      this.props.inView !== nextProps.inView ||
-      !!this.queryDifference(this.props.queries, nextProps.queries).length ||
-      !_.isEqual(this.props.templates, nextProps.templates) ||
+      this.props.manualRefresh !== prevProps.manualRefresh ||
+      this.props.inView !== prevProps.inView ||
+      !!this.queryDifference(this.props.queries, prevProps.queries).length ||
+      !_.isEqual(this.props.templates, prevProps.templates) ||
       isSourceDifferent
     )
   }


### PR DESCRIPTION
Closes #4252

_What was the problem?_
When autorefresh was paused, hitting the "refresh" button didn't do anything. 

_What was the solution?_
Passing a `manualRefresh` prop to the `TimeSeries` component from `RefreshingGraph` and calling a force update if this prop changes.

  - [x] Rebased/mergeable
  - [x] Tests pass