### PR TITLE
Improve Log Viewer Time Selection UX

### DIFF
--- a/ui/src/logs/components/LogsHeader.tsx
+++ b/ui/src/logs/components/LogsHeader.tsx
@@ -3,7 +3,6 @@ import React, {PureComponent} from 'react'
 import {Source, Namespace} from 'src/types'
 
 import Dropdown from 'src/shared/components/Dropdown'
-import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 import PageHeaderTitle from 'src/reusable_ui/components/page_layout/PageHeaderTitle'
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
@@ -24,10 +23,6 @@ interface Props {
   liveUpdating: boolean
   onChangeLiveUpdatingStatus: () => void
   onShowOptionsOverlay: () => void
-  customTime?: string
-  relativeTime?: number
-  onChooseCustomTime: (time: string) => void
-  onChooseRelativeTime: (time: number) => void
 }
 
 class LogsHeader extends PureComponent<Props> {
@@ -56,13 +51,7 @@ class LogsHeader extends PureComponent<Props> {
   }
 
   private get optionsComponents(): JSX.Element {
-    const {
-      onShowOptionsOverlay,
-      customTime,
-      relativeTime,
-      onChooseCustomTime,
-      onChooseRelativeTime,
-    } = this.props
+    const {onShowOptionsOverlay} = this.props
 
     return (
       <>
@@ -78,12 +67,6 @@ class LogsHeader extends PureComponent<Props> {
           items={this.namespaceDropDownItems}
           selected={this.selectedNamespace}
           onChoose={this.handleChooseNamespace}
-        />
-        <PointInTimeDropDown
-          customTime={customTime}
-          relativeTime={relativeTime}
-          onChooseCustomTime={onChooseCustomTime}
-          onChooseRelativeTime={onChooseRelativeTime}
         />
         <Authorized requiredRole={EDITOR_ROLE}>
           <button

--- a/ui/src/logs/components/LogsHeader.tsx
+++ b/ui/src/logs/components/LogsHeader.tsx
@@ -2,14 +2,11 @@ import _ from 'lodash'
 import React, {PureComponent} from 'react'
 import {Source, Namespace} from 'src/types'
 
-import {getDeep} from 'src/utils/wrappers'
 import Dropdown from 'src/shared/components/Dropdown'
 import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 import PageHeaderTitle from 'src/reusable_ui/components/page_layout/PageHeaderTitle'
-import TimeWindowDropdown from 'src/logs/components/TimeWindowDropdown'
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
-import {TimeRange, TimeWindow} from 'src/types/logs'
 import LiveUpdatingStatus from 'src/logs/components/LiveUpdatingStatus'
 
 interface SourceItem {
@@ -27,8 +24,6 @@ interface Props {
   liveUpdating: boolean
   onChangeLiveUpdatingStatus: () => void
   onShowOptionsOverlay: () => void
-  timeRange: TimeRange
-  onSetTimeWindow: (timeWindow: TimeWindow) => void
   customTime?: string
   relativeTime?: number
   onChooseCustomTime: (time: string) => void
@@ -63,20 +58,11 @@ class LogsHeader extends PureComponent<Props> {
   private get optionsComponents(): JSX.Element {
     const {
       onShowOptionsOverlay,
-      onSetTimeWindow,
       customTime,
       relativeTime,
       onChooseCustomTime,
       onChooseRelativeTime,
     } = this.props
-
-    const timeRange = getDeep(this.props, 'timeRange', {
-      upper: null,
-      lower: 'now() - 1m',
-      seconds: 60,
-      windowOption: '1m',
-      timeOption: 'now',
-    })
 
     return (
       <>
@@ -98,10 +84,6 @@ class LogsHeader extends PureComponent<Props> {
           relativeTime={relativeTime}
           onChooseCustomTime={onChooseCustomTime}
           onChooseRelativeTime={onChooseRelativeTime}
-        />
-        <TimeWindowDropdown
-          selectedTimeWindow={timeRange}
-          onSetTimeWindow={onSetTimeWindow}
         />
         <Authorized requiredRole={EDITOR_ROLE}>
           <button

--- a/ui/src/logs/components/LogsSearchBar.tsx
+++ b/ui/src/logs/components/LogsSearchBar.tsx
@@ -1,9 +1,14 @@
 import React, {PureComponent, ChangeEvent, KeyboardEvent} from 'react'
 
 import {Input, IconFont, Button, ComponentColor} from 'src/reusable_ui'
+import PointInTimeDropDown from 'src/logs/components/PointInTimeDropDown'
 
 interface Props {
   onSearch: (value: string) => void
+  customTime?: string
+  relativeTime?: number
+  onChooseCustomTime: (time: string) => void
+  onChooseRelativeTime: (time: number) => void
 }
 
 interface State {
@@ -21,6 +26,12 @@ class LogsSearchBar extends PureComponent<Props, State> {
 
   public render() {
     const {searchTerm} = this.state
+    const {
+      customTime,
+      relativeTime,
+      onChooseCustomTime,
+      onChooseRelativeTime,
+    } = this.props
 
     return (
       <div className="logs-viewer--search-bar">
@@ -33,6 +44,12 @@ class LogsSearchBar extends PureComponent<Props, State> {
             value={searchTerm}
           />
         </div>
+        <PointInTimeDropDown
+          customTime={customTime}
+          relativeTime={relativeTime}
+          onChooseCustomTime={onChooseCustomTime}
+          onChooseRelativeTime={onChooseRelativeTime}
+        />
         <Button
           text="Search"
           color={ComponentColor.Primary}

--- a/ui/src/logs/components/PointInTimeDropDown.tsx
+++ b/ui/src/logs/components/PointInTimeDropDown.tsx
@@ -40,7 +40,10 @@ class TimeRangeDropdown extends Component<Props, State> {
 
     return (
       <ClickOutside onClickOutside={this.handleClickOutside}>
-        <div className="time-range-dropdown" style={{display: 'inline'}}>
+        <div
+          className="time-range-dropdown logs-viewer--search-dropdown"
+          style={{display: 'inline'}}
+        >
           <div className={this.dropdownClassName}>
             <div
               className="btn btn-sm btn-default dropdown-toggle"

--- a/ui/src/logs/components/QueryResults.tsx
+++ b/ui/src/logs/components/QueryResults.tsx
@@ -3,11 +3,16 @@ import React, {PureComponent} from 'react'
 interface Props {
   count: number
   queryCount: number
+  isInsideHistogram?: boolean
 }
 
 class QueryResults extends PureComponent<Props> {
+  public static defaultProps: Partial<Props> = {
+    isInsideHistogram: false,
+  }
+
   public render() {
-    const {count} = this.props
+    const {count, isInsideHistogram} = this.props
 
     let contents = (
       <>
@@ -15,8 +20,20 @@ class QueryResults extends PureComponent<Props> {
       </>
     )
 
+    if (isInsideHistogram) {
+      contents = (
+        <>
+          Displaying <strong>{count} Events</strong> in Histogram
+        </>
+      )
+    }
+
     if (this.isPending) {
       contents = <>Querying...</>
+    }
+
+    if (this.isPending && isInsideHistogram) {
+      contents = <>Updating Histogram...</>
     }
 
     return <label className="logs-viewer--results-text">{contents}</label>

--- a/ui/src/logs/components/TimeWindowDropdown.tsx
+++ b/ui/src/logs/components/TimeWindowDropdown.tsx
@@ -12,7 +12,7 @@ class TimeWindowDropdown extends Component<Props> {
   public render() {
     return (
       <Dropdown
-        className="dropdown-90"
+        className="dropdown-120"
         selected={this.selected}
         onChoose={this.handleChoose}
         buttonSize="btn-sm"
@@ -28,10 +28,10 @@ class TimeWindowDropdown extends Component<Props> {
     } = this.props
 
     if (timeOption === 'now') {
-      return `- ${windowOption}`
+      return `Past ${windowOption}`
     }
 
-    return `+/- ${windowOption}`
+    return `${windowOption} Window`
   }
 
   private handleChoose = (dropdownItem): void => {

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -36,6 +36,7 @@ import {getSourcesAsync} from 'src/shared/actions/sources'
 import LogsHeader from 'src/logs/components/LogsHeader'
 import HistogramChart from 'src/shared/components/HistogramChart'
 import LogsGraphContainer from 'src/logs/components/LogsGraphContainer'
+import TimeWindowDropdown from 'src/logs/components/TimeWindowDropdown'
 import OptionsOverlay from 'src/logs/components/OptionsOverlay'
 import SearchBar from 'src/logs/components/LogsSearchBar'
 import FilterBar from 'src/logs/components/LogsFilterBar'
@@ -212,8 +213,10 @@ class LogsPage extends Component<Props, State> {
         <div className="page">
           {this.header}
           <div className="page-contents logs-viewer">
-            <QueryResults count={this.histogramTotal} queryCount={queryCount} />
-            <LogsGraphContainer>{this.chart}</LogsGraphContainer>
+            <LogsGraphContainer>
+              {this.chartControlBar}
+              {this.chart}
+            </LogsGraphContainer>
             <SearchBar onSearch={this.handleSubmitSearch} />
             <FilterBar
               filters={filters || []}
@@ -496,14 +499,11 @@ class LogsPage extends Component<Props, State> {
       currentSource,
       currentNamespaces,
       currentNamespace,
-      timeRange,
       tableTime,
     } = this.props
 
     return (
       <LogsHeader
-        timeRange={timeRange}
-        onSetTimeWindow={this.handleSetTimeWindow}
         liveUpdating={this.liveUpdatingStatus}
         availableSources={sources}
         onChooseSource={this.handleChooseSource}
@@ -518,6 +518,32 @@ class LogsPage extends Component<Props, State> {
         onChooseCustomTime={this.handleChooseCustomTime}
         onChooseRelativeTime={this.handleChooseRelativeTime}
       />
+    )
+  }
+
+  private get chartControlBar(): JSX.Element {
+    const {queryCount} = this.props
+
+    const timeRange = getDeep(this.props, 'timeRange', {
+      upper: null,
+      lower: 'now() - 1m',
+      seconds: 60,
+      windowOption: '1m',
+      timeOption: 'now',
+    })
+
+    return (
+      <div className="logs-viewer--graph-controls">
+        <QueryResults
+          count={this.histogramTotal}
+          queryCount={queryCount}
+          isInsideHistogram={true}
+        />
+        <TimeWindowDropdown
+          selectedTimeWindow={timeRange}
+          onSetTimeWindow={this.handleSetTimeWindow}
+        />
+      </div>
     )
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -396,93 +396,97 @@ class LogsPage extends Component<Props, State> {
     const {histogramColors} = this.state
 
     return (
-      <AutoSizer>
-        {({width, height}) => (
-          <HistogramChart
-            data={histogramData}
-            width={width}
-            height={height}
-            colorScale={colorForSeverity}
-            colors={histogramColors}
-            onBarClick={this.handleBarClick}
-            sortBarGroups={this.handleSortHistogramBarGroups}
-          >
-            {({xScale, adjustedHeight, margins}) => {
-              const x = xScale(new Date(timeOption).valueOf())
-              const y1 = margins.top
-              const y2 = margins.top + adjustedHeight
-              const textSize = 11
-              const markerSize = 5
-              const labelSize = 100
+      <div className="logs-viewer--graph">
+        <AutoSizer>
+          {({width, height}) => (
+            <HistogramChart
+              data={histogramData}
+              width={width}
+              height={height}
+              colorScale={colorForSeverity}
+              colors={histogramColors}
+              onBarClick={this.handleBarClick}
+              sortBarGroups={this.handleSortHistogramBarGroups}
+            >
+              {({xScale, adjustedHeight, margins}) => {
+                const x = xScale(new Date(timeOption).valueOf())
+                const y1 = margins.top
+                const y2 = margins.top + adjustedHeight
+                const textSize = 11
+                const markerSize = 5
+                const labelSize = 100
 
-              if (timeOption === 'now') {
-                return null
-              } else {
-                const lineContainerWidth = 3
-                const lineWidth = 1
+                if (timeOption === 'now') {
+                  return null
+                } else {
+                  const lineContainerWidth = 3
+                  const lineWidth = 1
 
-                return (
-                  <>
-                    <svg
-                      width={lineContainerWidth}
-                      height={height}
-                      style={{
-                        position: 'absolute',
-                        left: `${x}px`,
-                        top: '0px',
-                        transform: 'translateX(-50%)',
-                      }}
-                    >
-                      <line
-                        x1={(lineContainerWidth - lineWidth) / 2}
-                        x2={(lineContainerWidth - lineWidth) / 2}
-                        y1={y1 + markerSize / 2}
-                        y2={y2}
-                        stroke={Greys.White}
-                        strokeWidth={`${lineWidth}`}
-                      />
-                    </svg>
-                    <svg
-                      width={x}
-                      height={textSize + textSize / 2}
-                      style={{
-                        position: 'absolute',
-                        left: `${x - markerSize - labelSize}px`,
-                      }}
-                    >
-                      <text
-                        style={{fontSize: textSize, fontWeight: 600}}
-                        x={0}
-                        y={textSize}
-                        height={textSize}
-                        fill={Greys.Sidewalk}
+                  return (
+                    <>
+                      <svg
+                        width={lineContainerWidth}
+                        height={height}
+                        style={{
+                          position: 'absolute',
+                          left: `${x}px`,
+                          top: '0px',
+                          transform: 'translateX(-50%)',
+                        }}
                       >
-                        Current Timestamp
-                      </text>
-                      <ellipse
-                        cx={labelSize + markerSize - 0.5}
-                        cy={textSize / 2 + markerSize / 2}
-                        rx={markerSize / 2}
-                        ry={markerSize / 2}
-                        fill={Greys.White}
-                      />
-                      <text
-                        style={{fontSize: textSize, fontWeight: 600}}
-                        x={labelSize + markerSize / 2 + textSize}
-                        y={textSize}
-                        height={textSize}
-                        fill={Greys.Sidewalk}
+                        <line
+                          x1={(lineContainerWidth - lineWidth) / 2}
+                          x2={(lineContainerWidth - lineWidth) / 2}
+                          y1={y1 + markerSize / 2}
+                          y2={y2}
+                          stroke={Greys.White}
+                          strokeWidth={`${lineWidth}`}
+                        />
+                      </svg>
+                      <svg
+                        width={x}
+                        height={textSize + textSize / 2}
+                        style={{
+                          position: 'absolute',
+                          left: `${x - markerSize - labelSize}px`,
+                        }}
                       >
-                        {moment(timeOption).format('YYYY-MM-DD | HH:mm:ss.SSS')}
-                      </text>
-                    </svg>
-                  </>
-                )
-              }
-            }}
-          </HistogramChart>
-        )}
-      </AutoSizer>
+                        <text
+                          style={{fontSize: textSize, fontWeight: 600}}
+                          x={0}
+                          y={textSize}
+                          height={textSize}
+                          fill={Greys.Sidewalk}
+                        >
+                          Current Timestamp
+                        </text>
+                        <ellipse
+                          cx={labelSize + markerSize - 0.5}
+                          cy={textSize / 2 + markerSize / 2}
+                          rx={markerSize / 2}
+                          ry={markerSize / 2}
+                          fill={Greys.White}
+                        />
+                        <text
+                          style={{fontSize: textSize, fontWeight: 600}}
+                          x={labelSize + markerSize / 2 + textSize}
+                          y={textSize}
+                          height={textSize}
+                          fill={Greys.Sidewalk}
+                        >
+                          {moment(timeOption).format(
+                            'YYYY-MM-DD | HH:mm:ss.SSS'
+                          )}
+                        </text>
+                      </svg>
+                    </>
+                  )
+                }
+              }}
+            </HistogramChart>
+          )}
+        </AutoSizer>
+      </div>
     )
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -205,7 +205,7 @@ class LogsPage extends Component<Props, State> {
   }
 
   public render() {
-    const {filters, queryCount, timeRange, notify} = this.props
+    const {filters, queryCount, timeRange, notify, tableTime} = this.props
     const {searchStatus} = this.state
 
     return (
@@ -217,7 +217,13 @@ class LogsPage extends Component<Props, State> {
               {this.chartControlBar}
               {this.chart}
             </LogsGraphContainer>
-            <SearchBar onSearch={this.handleSubmitSearch} />
+            <SearchBar
+              onSearch={this.handleSubmitSearch}
+              customTime={tableTime.custom}
+              relativeTime={tableTime.relative}
+              onChooseCustomTime={this.handleChooseCustomTime}
+              onChooseRelativeTime={this.handleChooseRelativeTime}
+            />
             <FilterBar
               filters={filters || []}
               onDelete={this.handleFilterDelete}
@@ -503,7 +509,6 @@ class LogsPage extends Component<Props, State> {
       currentSource,
       currentNamespaces,
       currentNamespace,
-      tableTime,
     } = this.props
 
     return (
@@ -517,10 +522,6 @@ class LogsPage extends Component<Props, State> {
         currentNamespace={currentNamespace}
         onChangeLiveUpdatingStatus={this.handleChangeLiveUpdatingStatus}
         onShowOptionsOverlay={this.handleToggleOverlay}
-        customTime={tableTime.custom}
-        relativeTime={tableTime.relative}
-        onChooseCustomTime={this.handleChooseCustomTime}
-        onChooseRelativeTime={this.handleChooseRelativeTime}
       />
     )
   }

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -30,8 +30,11 @@ $logs-viewer-gutter: 60px;
   align-items: center;
   flex-wrap: nowrap;
   justify-content: space-between;
+  margin-bottom: $ix-marg-b;
+}
 
-
+.logs-viewer--graph {
+  flex: 1 0 calc(100% - 38px);
 }
 
 .logs-viewer--search-bar {

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -17,10 +17,21 @@ $logs-viewer-gutter: 60px;
 }
 
 .logs-viewer--graph-container {
-  padding: 22px $logs-viewer-gutter 10px $logs-viewer-gutter;
+  padding: $ix-marg-b $logs-viewer-gutter;
   height: $logs-viewer-graph-height;
   @include gradient-v($g2-kevlar, $g0-obsidian);
   display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.logs-viewer--graph-controls {
+  display: flex;
+  align-items: center;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+
+
 }
 
 .logs-viewer--search-bar {
@@ -61,9 +72,7 @@ $logs-viewer-gutter: 60px;
 
 .logs-viewer--results-text {
   margin: 0;
-  margin-top: 12px;
   margin-right: $logs-viewer-results-text-indent;
-  text-align: right;
   padding: 0;
   font-size: 13px;
   line-height: 13px;

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -58,8 +58,11 @@ $logs-viewer-gutter: 60px;
 // Search Bar
 .logs-viewer--search-input {
   flex: 1 0 0;
-  margin-right: 8px;
+  margin-right: $ix-marg-b;
   position: relative;
+}
+.logs-viewer--search-dropdown {
+  margin-right: $ix-marg-b;
 }
 
 // Filters Bar
@@ -70,7 +73,6 @@ $logs-viewer-gutter: 60px;
   padding: 0 $logs-viewer-gutter 0 ($logs-viewer-gutter + 185);
   height: $logs-viewer-filter-height;
   background-color: $g3-castle;
-  position: relative;
 }
 
 .logs-viewer--results-text {

--- a/ui/src/utils/extentBy.tsx
+++ b/ui/src/utils/extentBy.tsx
@@ -7,6 +7,10 @@ export default function extentBy<T>(
   let minItem
   let maxItem
 
+  if (collection.length === 0) {
+    return collection
+  }
+
   for (const item of collection) {
     const val = keyFn(item)
 


### PR DESCRIPTION
_Briefly describe your proposed changes:_
![screen shot 2018-08-27 at 4 01 59 pm](https://user-images.githubusercontent.com/2433762/44692451-cde35e80-aa17-11e8-80b9-df3a265d593d.png)

_What was the problem?_
Neighboring placement of the window & point time selectors suggests they both affect the whole page, which is not the case.

_What was the solution?_
Move the window time selection into the histogram to indicate its scope more clearly. Move the point in time selector next to the search button to indicate its scope.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass