### PR TITLE
Add generic dashboard selection icons

### DIFF
--- a/ui/src/reusable_ui/components/card_select/CardSelectCard.scss
+++ b/ui/src/reusable_ui/components/card_select/CardSelectCard.scss
@@ -38,15 +38,11 @@
 .card-select--image {
     justify-content: center;
     max-width: 60%;
-    .card-select--placeholder {
-        color: $ix-text-default;
-        transition: color .2s ease;
-    }
+    filter: grayscale(0.80) opacity(30%);
+    transition: filter .2s ease;
     img {
-        filter: grayscale(0.80);
         width: 100%;
         height: 100%;
-        transition: filter .2s ease;
         font-size: $ix-text-base;
     }
 }
@@ -55,12 +51,7 @@
 .card-select--active.card-select--checked {
     background-color: $g5-pepper;
     .card-select--image {
-        img {
-            filter: grayscale(0);
-        }
-    }
-    .card-select--placeholder {
-        color: $c-pool;
+        filter: grayscale(0) opacity(100%);
     }
 }
 

--- a/ui/src/reusable_ui/components/card_select/CardSelectCard.tsx
+++ b/ui/src/reusable_ui/components/card_select/CardSelectCard.tsx
@@ -2,6 +2,7 @@
 import React, {PureComponent} from 'react'
 import classnames from 'classnames'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import ProtoboardIcon from 'src/reusable_ui/components/card_select/ProtoboardIcon'
 
 interface Props {
   id: string
@@ -66,7 +67,7 @@ class CardSelectCard extends PureComponent<Props> {
       return <img src={image} alt={`${label} icon`} />
     }
 
-    return <span className="card-select--placeholder icon dash-j" />
+    return <ProtoboardIcon displayText={label} />
   }
 
   private handleClick = e => {

--- a/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
+++ b/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
@@ -1,6 +1,5 @@
 .protoboard-icon {
   position: relative;
-  display: inline-block;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
+++ b/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
@@ -1,0 +1,29 @@
+.protoboard-icon {
+  position: relative;
+  display: inline-block;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  svg {
+    width: 60%;
+  }
+
+  .protoboard-icon--shape {
+    fill: $c-pool;
+  }
+  
+  .protoboard-icon--text {
+    fill: $g1-raven;
+    font-family: $ix-text-font;
+    font-weight: 900;
+    font-size: 42px;
+  }
+}
+
+.card-select--active:hover,
+.card-select--active.card-select--checked {
+  .protoboard-icon--text {
+    fill: $g5-pepper;
+  }
+}

--- a/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
+++ b/ui/src/reusable_ui/components/card_select/ProtoboardIcon.scss
@@ -10,6 +10,14 @@
   }
 
   .protoboard-icon--shape {
+    stroke: $c-pool;
+    stroke-width: 2;
+    fill: transparent;
+  }
+
+  .protoboard-icon--text-shape {
+    stroke-width: 2;
+    stroke: $c-pool;
     fill: $c-pool;
   }
   

--- a/ui/src/reusable_ui/components/card_select/ProtoboardIcon.tsx
+++ b/ui/src/reusable_ui/components/card_select/ProtoboardIcon.tsx
@@ -18,47 +18,51 @@ class ProtoboardIcon extends PureComponent<Props> {
           id="protoboard_icon"
           x="0px"
           y="0px"
-          viewBox="0 0 80 64.8"
+          viewBox="0 0 80 65"
         >
-          <g>
-            <g>
-              <g>
-                <path
-                  className="protoboard-icon--shape"
-                  d="M31.3,5.8v27.4H2V5.8H31.3 M31.4,3.8H1.9C0.9,3.8,0,4.7,0,5.7v27.6c0,1.1,0.9,1.9,1.9,1.9h29.5
-				c1.1,0,1.9-0.9,1.9-1.9V5.7C33.3,4.7,32.5,3.8,31.4,3.8L31.4,3.8z"
-                />
-              </g>
-              <g>
-                <path
-                  className="protoboard-icon--shape"
-                  d="M31.3,43v16H2V43H31.3 M31.4,41H1.9C0.9,41,0,41.8,0,42.9V59C0,60.1,0.9,61,1.9,61h29.5
-				c1.1,0,1.9-0.9,1.9-1.9V42.9C33.3,41.8,32.5,41,31.4,41L31.4,41z"
-                />
-              </g>
-              <g>
-                <path
-                  className="protoboard-icon--shape"
-                  d="M41,61h37.1c1.1,0,1.9-0.9,1.9-1.9V21.9c0-1.1-0.9-1.9-1.9-1.9H41c-1.1,0-1.9,0.9-1.9,1.9V59
-				C39,60.1,39.9,61,41,61z"
-                />
-              </g>
-              <g>
-                <path
-                  className="protoboard-icon--shape"
-                  d="M78,5.8v6.5H41V5.8H78 M78.1,3.8H41c-1.1,0-1.9,0.9-1.9,1.9v6.7c0,1.1,0.9,1.9,1.9,1.9h37.1
-				c1.1,0,1.9-0.9,1.9-1.9V5.7C80,4.7,79.1,3.8,78.1,3.8L78.1,3.8z"
-                />
-              </g>
-            </g>
-            <text
-              transform="matrix(1 0 0 1 59.5 55.8103)"
-              textAnchor="middle"
-              className="protoboard-icon--text"
-            >
-              {this.displayInitial}
-            </text>
-          </g>
+          <rect
+            className="protoboard-icon--shape"
+            x="2"
+            y="6"
+            width="32"
+            height="28"
+            rx="2"
+            ry="2"
+          />
+          <rect
+            className="protoboard-icon--shape"
+            x="40"
+            y="6"
+            width="38"
+            height="9"
+            rx="2"
+            ry="2"
+          />
+          <rect
+            className="protoboard-icon--shape"
+            x="2"
+            y="41"
+            width="32"
+            height="21"
+            rx="2"
+            ry="2"
+          />
+          <rect
+            className="protoboard-icon--text-shape"
+            x="40"
+            y="22"
+            width="38"
+            height="40"
+            rx="2"
+            ry="2"
+          />
+          <text
+            transform="matrix(1 0 0 1 59 57)"
+            textAnchor="middle"
+            className="protoboard-icon--text"
+          >
+            {this.displayInitial}
+          </text>
         </svg>
       </div>
     )

--- a/ui/src/reusable_ui/components/card_select/ProtoboardIcon.tsx
+++ b/ui/src/reusable_ui/components/card_select/ProtoboardIcon.tsx
@@ -1,0 +1,73 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+interface Props {
+  displayText?: string
+}
+
+class ProtoboardIcon extends PureComponent<Props> {
+  public static defaultProps: Partial<Props> = {
+    displayText: '',
+  }
+
+  public render() {
+    return (
+      <div className="protoboard-icon">
+        <svg
+          version="1.1"
+          id="protoboard_icon"
+          x="0px"
+          y="0px"
+          viewBox="0 0 80 64.8"
+        >
+          <g>
+            <g>
+              <g>
+                <path
+                  className="protoboard-icon--shape"
+                  d="M31.3,5.8v27.4H2V5.8H31.3 M31.4,3.8H1.9C0.9,3.8,0,4.7,0,5.7v27.6c0,1.1,0.9,1.9,1.9,1.9h29.5
+				c1.1,0,1.9-0.9,1.9-1.9V5.7C33.3,4.7,32.5,3.8,31.4,3.8L31.4,3.8z"
+                />
+              </g>
+              <g>
+                <path
+                  className="protoboard-icon--shape"
+                  d="M31.3,43v16H2V43H31.3 M31.4,41H1.9C0.9,41,0,41.8,0,42.9V59C0,60.1,0.9,61,1.9,61h29.5
+				c1.1,0,1.9-0.9,1.9-1.9V42.9C33.3,41.8,32.5,41,31.4,41L31.4,41z"
+                />
+              </g>
+              <g>
+                <path
+                  className="protoboard-icon--shape"
+                  d="M41,61h37.1c1.1,0,1.9-0.9,1.9-1.9V21.9c0-1.1-0.9-1.9-1.9-1.9H41c-1.1,0-1.9,0.9-1.9,1.9V59
+				C39,60.1,39.9,61,41,61z"
+                />
+              </g>
+              <g>
+                <path
+                  className="protoboard-icon--shape"
+                  d="M78,5.8v6.5H41V5.8H78 M78.1,3.8H41c-1.1,0-1.9,0.9-1.9,1.9v6.7c0,1.1,0.9,1.9,1.9,1.9h37.1
+				c1.1,0,1.9-0.9,1.9-1.9V5.7C80,4.7,79.1,3.8,78.1,3.8L78.1,3.8z"
+                />
+              </g>
+            </g>
+            <text
+              transform="matrix(1 0 0 1 59.5 55.8103)"
+              textAnchor="middle"
+              className="protoboard-icon--text"
+            >
+              {this.displayInitial}
+            </text>
+          </g>
+        </svg>
+      </div>
+    )
+  }
+
+  private get displayInitial() {
+    const {displayText} = this.props
+    return displayText.substring(0, 1).toUpperCase()
+  }
+}
+
+export default ProtoboardIcon

--- a/ui/src/reusable_ui/components/card_select/test/__snapshots__/CardSelectCard.test.tsx.snap
+++ b/ui/src/reusable_ui/components/card_select/test/__snapshots__/CardSelectCard.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Card Select Card matches snapshot with minimal props 1`] = `
     className="card-select--container"
   >
     <input
-      checked={false}
+      defaultChecked={false}
       disabled={false}
       id="card_select_card_id"
       type="checkbox"
@@ -22,8 +22,8 @@ exports[`Card Select Card matches snapshot with minimal props 1`] = `
     <div
       className="card-select--image"
     >
-      <span
-        className="card-select--placeholder icon dash-j"
+      <ProtoboardIcon
+        displayText="Card Label"
       />
     </div>
     <span
@@ -45,7 +45,7 @@ exports[`Card Select Card with image matches snapshot when provided image source
     className="card-select--container"
   >
     <input
-      checked={false}
+      defaultChecked={false}
       disabled={false}
       id="card_select_card_id"
       type="checkbox"

--- a/ui/src/reusable_ui/components/card_select/test/__snapshots__/CardSelectCard.test.tsx.snap
+++ b/ui/src/reusable_ui/components/card_select/test/__snapshots__/CardSelectCard.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Card Select Card matches snapshot with minimal props 1`] = `
     className="card-select--container"
   >
     <input
-      defaultChecked={false}
+      checked={false}
       disabled={false}
       id="card_select_card_id"
       type="checkbox"
@@ -45,7 +45,7 @@ exports[`Card Select Card with image matches snapshot when provided image source
     className="card-select--container"
   >
     <input
-      defaultChecked={false}
+      checked={false}
       disabled={false}
       id="card_select_card_id"
       type="checkbox"

--- a/ui/src/reusable_ui/components/grid_sizer/GridSizer.tsx
+++ b/ui/src/reusable_ui/components/grid_sizer/GridSizer.tsx
@@ -17,7 +17,7 @@ interface State {
 @ErrorHandling
 class GridSizer extends PureComponent<Props, State> {
   public static defaultProps: Partial<Props> = {
-    cellWidth: 160,
+    cellWidth: 150,
     width: null,
   }
 

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -85,6 +85,7 @@
 @import '../reusable_ui/components/overlays/Overlay.scss';
 @import '../dashboards/components/import_dashboard_mappings/ImportDashboardMappings.scss';
 @import '../reusable_ui/components/card_select/CardSelectCard.scss';
+@import '../reusable_ui/components/card_select/ProtoboardIcon.scss';
 @import '../reusable_ui/components/grid_sizer/GridSizer.scss';
 @import '../reusable_ui/components/wizard/WizardController.scss';
 @import '../reusable_ui/components/wizard/WizardButtonBar.scss';


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Create generic icons for dashboards which are missing icons.

_What was the problem?_
Dashboards without icons in their metadata need to be displayed in the dashboard selection step.

_What was the solution?_
Create customizable icon with dashboard initial

  - [x] Rebased/mergeable
  - [x] Tests pass
