### PR TITLE
Shrink CEO Overlay Mask

### DIFF
--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -378,8 +378,8 @@ div.dropdown.dropdown-stretch > button.dropdown-toggle {
 .deceo--overlay {
   margin: 0 auto;
   position: relative;
-  width: calc(100% - 120px);
-  height: calc(100% - 60px);
+  width: calc(100% - 60px);
+  height: calc(100% - 30px);
   overflow: hidden;
   border-radius: 0 0 $radius $radius;
   outline: none;


### PR DESCRIPTION
CEO overlay mask is now 30px instead of 60px

![screen shot 2018-08-28 at 3 22 39 pm](https://user-images.githubusercontent.com/2433762/44754322-3db81e80-aad6-11e8-88c4-4a3cb32ce2e0.png)

  - [ ] Rebased/mergeable
  - [ ] Tests pass