### PR TITLE
View flux editor in the CEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1.  [#4254](https://github.com/influxdata/chronograf/pull/4254): Add Dynamic Source option to CEO source selector
 1.  [#4257](https://github.com/influxdata/chronograf/pull/4257): Introduce cell notes & note cells
 1.  [#4287](https://github.com/influxdata/chronograf/pull/4287): Add time selector dropdown to CEO
+1.  [#4311](https://github.com/influxdata/chronograf/pull/4311): Add Flux query editor to the Cell Editor Overlay
 
 ### UI Improvements
 1.  [#4227](https://github.com/influxdata/chronograf/pull/4227): Redesign Cell Editor Overlay for reuse in other parts of application

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -45,7 +45,7 @@ interface QueryStatus {
 }
 
 interface Props {
-  links: Links
+  fluxLinks: Links
   script: string
   sources: SourcesModels.Source[]
   services: Service[]
@@ -101,7 +101,7 @@ class CellEditorOverlay extends Component<Props, State> {
 
   public render() {
     const {
-      links,
+      fluxLinks,
       script,
       notify,
       services,
@@ -132,7 +132,7 @@ class CellEditorOverlay extends Component<Props, State> {
         ref={this.onRef}
       >
         <TimeMachine
-          links={links}
+          fluxLinks={fluxLinks}
           notify={notify}
           script={script}
           queryDrafts={queryDrafts}

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -23,7 +23,7 @@ import * as ColorsModels from 'src/types/colors'
 import * as DashboardsModels from 'src/types/dashboards'
 import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
-import {Service, TimeRange} from 'src/types'
+import {Service, TimeRange, NotificationAction} from 'src/types'
 import {Template} from 'src/types/tempVars'
 import {NewDefaultCell} from 'src/types/dashboards'
 import {
@@ -31,6 +31,8 @@ import {
   addQueryAsync,
   deleteQueryAsync,
 } from 'src/dashboards/actions/cellEditorOverlay'
+import {UpdateScript} from 'src/flux/actions'
+import {Links} from 'src/types/flux'
 
 const staticLegend: DashboardsModels.Legend = {
   type: 'static',
@@ -43,8 +45,11 @@ interface QueryStatus {
 }
 
 interface Props {
+  links: Links
+  script: string
   sources: SourcesModels.Source[]
   services: Service[]
+  notify: NotificationAction
   editQueryStatus: typeof editCellQueryStatus
   onCancel: () => void
   onSave: (cell: DashboardsModels.Cell | NewDefaultCell) => void
@@ -66,6 +71,7 @@ interface Props {
   addQuery: typeof addQueryAsync
   deleteQuery: typeof deleteQueryAsync
   updateEditorTimeRange: (timeRange: TimeRange) => void
+  updateScript: UpdateScript
 }
 
 interface State {
@@ -95,6 +101,9 @@ class CellEditorOverlay extends Component<Props, State> {
 
   public render() {
     const {
+      links,
+      script,
+      notify,
       services,
       onCancel,
       templates,
@@ -110,6 +119,7 @@ class CellEditorOverlay extends Component<Props, State> {
       addQuery,
       deleteQuery,
       updateEditorTimeRange,
+      updateScript,
     } = this.props
 
     const {isStaticLegend} = this.state
@@ -122,7 +132,11 @@ class CellEditorOverlay extends Component<Props, State> {
         ref={this.onRef}
       >
         <TimeMachine
+          links={links}
+          notify={notify}
+          script={script}
           queryDrafts={queryDrafts}
+          updateScript={updateScript}
           editQueryStatus={editQueryStatus}
           templates={templates}
           timeRange={timeRange}

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -40,7 +40,7 @@ const SourceSelector: SFC<Props> = ({
         sources={sources}
         allowInfluxQL={true}
         // TODO: when flux is added into CEO/DE, change to true
-        allowFlux={false}
+        allowFlux={process.env.NODE_ENV === 'development' ? true : false}
         allowDynamicSource={true}
         isDynamicSourceSelected={isDynamicSourceSelected}
         onChangeService={onChangeService}

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -73,7 +73,7 @@ import {Links} from 'src/types/flux'
 import {UpdateScript} from 'src/flux/actions'
 
 interface Props extends ManualRefreshProps, WithRouterProps {
-  links: Links
+  fluxLinks: Links
   script: string
   updateScript: UpdateScript
   source: SourcesModels.Source
@@ -235,9 +235,9 @@ class DashboardPage extends Component<Props, State> {
 
   public render() {
     const {
-      links,
       script,
       notify,
+      fluxLinks,
       updateScript,
       isUsingAuth,
       meRole,
@@ -326,7 +326,7 @@ class DashboardPage extends Component<Props, State> {
             source={source}
             sources={sources}
             notify={notify}
-            links={links}
+            fluxLinks={fluxLinks}
             script={script}
             services={this.services}
             cell={selectedCell}
@@ -720,7 +720,7 @@ const mstp = (state, {params: {dashboardID}}) => {
     services,
     meRole,
     dashboard,
-    links: links.flux,
+    fluxLinks: links.flux,
     dashboardID: Number(dashboardID),
     timeRange,
     zoomedTimeRange,

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -30,6 +30,7 @@ import {
   fetchAllFluxServicesAsync,
   FetchAllFluxServicesAsync,
 } from 'src/shared/actions/services'
+import {updateScript as updateScriptAction} from 'src/flux/actions'
 
 // Utils
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
@@ -64,13 +65,17 @@ import * as ErrorsActions from 'src/types/actions/errors'
 import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import * as TempVarsModels from 'src/types/tempVars'
-import * as NotificationsActions from 'src/types/actions/notifications'
 import {NewDefaultCell} from 'src/types/dashboards'
-import {Service} from 'src/types'
+import {Service, NotificationAction} from 'src/types'
 import {QueryConfigActions} from 'src/dashboards/actions/cellEditorOverlay'
 import {AnnotationsDisplaySetting} from 'src/types/annotations'
+import {Links} from 'src/types/flux'
+import {UpdateScript} from 'src/flux/actions'
 
 interface Props extends ManualRefreshProps, WithRouterProps {
+  links: Links
+  script: string
+  updateScript: UpdateScript
   source: SourcesModels.Source
   sources: SourcesModels.Source[]
   params: {
@@ -100,7 +105,7 @@ interface Props extends ManualRefreshProps, WithRouterProps {
   meRole: string
   isUsingAuth: boolean
   router: InjectedRouter
-  notify: NotificationsActions.PublishNotificationActionCreator
+  notify: NotificationAction
   annotationsDisplaySetting: AnnotationsDisplaySetting
   onGetAnnotationsAsync: typeof getAnnotationsAsync
   handleLoadCEO: typeof cellEditorOverlayActions.loadCEO
@@ -230,6 +235,10 @@ class DashboardPage extends Component<Props, State> {
 
   public render() {
     const {
+      links,
+      script,
+      notify,
+      updateScript,
       isUsingAuth,
       meRole,
       source,
@@ -316,6 +325,9 @@ class DashboardPage extends Component<Props, State> {
           <CellEditorOverlay
             source={source}
             sources={sources}
+            notify={notify}
+            links={links}
+            script={script}
             services={this.services}
             cell={selectedCell}
             queryDrafts={queryDrafts}
@@ -337,6 +349,7 @@ class DashboardPage extends Component<Props, State> {
             queryConfigActions={this.queryConfigActions}
             addQuery={addQuery}
             deleteQuery={deleteQuery}
+            updateScript={updateScript}
           />
         </OverlayTechnology>
         <DashboardHeader
@@ -669,6 +682,8 @@ const mstp = (state, {params: {dashboardID}}) => {
       ephemeral: {inPresentationMode},
       persisted: {autoRefresh, showTemplateVariableControlBar},
     },
+    script,
+    links,
     annotations: {displaySetting},
     dashboardUI: {dashboards, cellQueryStatus, zoomedTimeRange},
     sources,
@@ -700,10 +715,12 @@ const mstp = (state, {params: {dashboardID}}) => {
   const selectedCell = cell
 
   return {
+    script,
     sources,
     services,
     meRole,
     dashboard,
+    links: links.flux,
     dashboardID: Number(dashboardID),
     timeRange,
     zoomedTimeRange,
@@ -724,6 +741,7 @@ const mstp = (state, {params: {dashboardID}}) => {
 }
 
 const mdtp = {
+  updateScript: updateScriptAction,
   setDashTimeV1: dashboardActions.setDashTimeV1,
   setZoomedTimeRange: dashboardActions.setZoomedTimeRange,
   updateDashboard: dashboardActions.updateDashboard,

--- a/ui/src/flux/components/BodyBuilder.tsx
+++ b/ui/src/flux/components/BodyBuilder.tsx
@@ -9,11 +9,12 @@ import BodyDelete from 'src/flux/components/BodyDelete'
 import {funcNames} from 'src/flux/constants'
 
 import {Service} from 'src/types'
-import {Body, Suggestion} from 'src/types/flux'
+import {Body, Suggestion, Context} from 'src/types/flux'
 
 interface Props {
-  service: Service
   body: Body[]
+  service: Service
+  context: Context
   suggestions: Suggestion[]
   onAppendFrom: () => void
   onAppendJoin: () => void
@@ -22,7 +23,7 @@ interface Props {
 
 class BodyBuilder extends PureComponent<Props> {
   public render() {
-    const {body, onDeleteBody} = this.props
+    const {body, onDeleteBody, context} = this.props
 
     const bodybuilder = body.map((b, i) => {
       if (b.declarations.length) {
@@ -38,12 +39,13 @@ class BodyBuilder extends PureComponent<Props> {
                 </div>
                 <ExpressionNode
                   bodyID={b.id}
+                  funcs={d.funcs}
+                  context={context}
                   declarationID={d.id}
                   funcNames={this.funcNames}
-                  funcs={d.funcs}
-                  declarationsFromBody={this.declarationsFromBody}
-                  isLastBody={this.isLastBody(i)}
                   onDeleteBody={onDeleteBody}
+                  isLastBody={this.isLastBody(i)}
+                  declarationsFromBody={this.declarationsFromBody}
                 />
               </div>
             )
@@ -71,10 +73,11 @@ class BodyBuilder extends PureComponent<Props> {
           <ExpressionNode
             bodyID={b.id}
             funcs={b.funcs}
+            context={context}
             funcNames={this.funcNames}
-            declarationsFromBody={this.declarationsFromBody}
-            isLastBody={this.isLastBody(i)}
             onDeleteBody={onDeleteBody}
+            isLastBody={this.isLastBody(i)}
+            declarationsFromBody={this.declarationsFromBody}
           />
         </div>
       )

--- a/ui/src/flux/components/BodyBuilder.tsx
+++ b/ui/src/flux/components/BodyBuilder.tsx
@@ -9,12 +9,11 @@ import BodyDelete from 'src/flux/components/BodyDelete'
 import {funcNames} from 'src/flux/constants'
 
 import {Service} from 'src/types'
-import {Body, Suggestion, Context} from 'src/types/flux'
+import {Body, Suggestion} from 'src/types/flux'
 
 interface Props {
   body: Body[]
   service: Service
-  context: Context
   suggestions: Suggestion[]
   onAppendFrom: () => void
   onAppendJoin: () => void
@@ -23,7 +22,7 @@ interface Props {
 
 class BodyBuilder extends PureComponent<Props> {
   public render() {
-    const {body, onDeleteBody, context} = this.props
+    const {body, onDeleteBody} = this.props
 
     const bodybuilder = body.map((b, i) => {
       if (b.declarations.length) {
@@ -40,7 +39,6 @@ class BodyBuilder extends PureComponent<Props> {
                 <ExpressionNode
                   bodyID={b.id}
                   funcs={d.funcs}
-                  context={context}
                   declarationID={d.id}
                   funcNames={this.funcNames}
                   onDeleteBody={onDeleteBody}
@@ -73,7 +71,6 @@ class BodyBuilder extends PureComponent<Props> {
           <ExpressionNode
             bodyID={b.id}
             funcs={b.funcs}
-            context={context}
             funcNames={this.funcNames}
             onDeleteBody={onDeleteBody}
             isLastBody={this.isLastBody(i)}

--- a/ui/src/flux/components/DatabaseList.tsx
+++ b/ui/src/flux/components/DatabaseList.tsx
@@ -1,16 +1,16 @@
 import React, {PureComponent} from 'react'
 
-import {NotificationContext} from 'src/flux/containers/CheckServices'
 import DatabaseListItem from 'src/flux/components/DatabaseListItem'
 
 import {showDatabases} from 'src/shared/apis/metaQuery'
 import showDatabasesParser from 'src/shared/parsing/showDatabases'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Service} from 'src/types'
+import {Service, NotificationAction} from 'src/types'
 
 interface Props {
   service: Service
+  notify: NotificationAction
 }
 
 interface State {
@@ -47,15 +47,11 @@ class DatabaseList extends PureComponent<Props, State> {
 
   public render() {
     const {databases} = this.state
-    const {service} = this.props
+    const {service, notify} = this.props
 
     return databases.map(db => {
       return (
-        <NotificationContext.Consumer key={db}>
-          {({notify}) => (
-            <DatabaseListItem db={db} service={service} notify={notify} />
-          )}
-        </NotificationContext.Consumer>
+        <DatabaseListItem key={db} db={db} service={service} notify={notify} />
       )
     })
   }

--- a/ui/src/flux/components/DatabaseListItem.tsx
+++ b/ui/src/flux/components/DatabaseListItem.tsx
@@ -82,7 +82,7 @@ class DatabaseListItem extends PureComponent<Props, State> {
   }
 
   private get filterAndTagList(): JSX.Element {
-    const {db, service} = this.props
+    const {db, service, notify} = this.props
     const {isOpen, searchTerm} = this.state
 
     return (
@@ -99,7 +99,13 @@ class DatabaseListItem extends PureComponent<Props, State> {
             onChange={this.onSearch}
           />
         </div>
-        <TagList db={db} service={service} tags={this.tags} filter={[]} />
+        <TagList
+          db={db}
+          service={service}
+          tags={this.tags}
+          filter={[]}
+          notify={notify}
+        />
       </div>
     )
   }

--- a/ui/src/flux/components/ExpressionNode.tsx
+++ b/ui/src/flux/components/ExpressionNode.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent, Fragment} from 'react'
 
-import {FluxContext} from 'src/flux/containers/FluxPage'
 import FuncSelector from 'src/flux/components/FuncSelector'
 import FuncNode from 'src/flux/components/FuncNode'
 import YieldFuncNode from 'src/flux/components/YieldFuncNode'
@@ -9,12 +8,13 @@ import {getDeep} from 'src/utils/wrappers'
 import {Func, Context} from 'src/types/flux'
 
 interface Props {
-  funcNames: any[]
-  bodyID: string
   funcs: Func[]
+  bodyID: string
+  context: Context
+  funcNames: any[]
+  isLastBody: boolean
   declarationID?: string
   declarationsFromBody: string[]
-  isLastBody: boolean
   onDeleteBody: (bodyID: string) => void
 }
 
@@ -36,6 +36,7 @@ class ExpressionNode extends PureComponent<Props, State> {
 
   public render() {
     const {
+      context,
       declarationID,
       bodyID,
       funcNames,
@@ -45,105 +46,97 @@ class ExpressionNode extends PureComponent<Props, State> {
     } = this.props
 
     const {nonYieldableIndexesToggled} = this.state
+    const {
+      onDeleteFuncNode,
+      onAddNode,
+      onChangeArg,
+      onGenerateScript,
+      onToggleYield,
+      service,
+      data,
+      scriptUpToYield,
+    } = context
+
+    let isAfterRange = false
+    let isAfterFilter = false
 
     return (
-      <FluxContext.Consumer>
-        {({
-          onDeleteFuncNode,
-          onAddNode,
-          onChangeArg,
-          onGenerateScript,
-          onToggleYield,
-          service,
-          data,
-          scriptUpToYield,
-        }: Context) => {
-          let isAfterRange = false
-          let isAfterFilter = false
+      <>
+        {funcs.map((func, i) => {
+          if (func.name === 'yield') {
+            return null
+          }
 
-          return (
-            <>
-              {funcs.map((func, i) => {
-                if (func.name === 'yield') {
-                  return null
-                }
+          if (func.name === 'range') {
+            isAfterRange = true
+          }
 
-                if (func.name === 'range') {
-                  isAfterRange = true
-                }
+          if (func.name === 'filter') {
+            isAfterFilter = true
+          }
+          const isYieldable = isAfterFilter && isAfterRange
 
-                if (func.name === 'filter') {
-                  isAfterFilter = true
-                }
-                const isYieldable = isAfterFilter && isAfterRange
-
-                const funcNode = (
-                  <FuncNode
-                    key={i}
-                    index={i}
-                    func={func}
-                    funcs={funcs}
-                    bodyID={bodyID}
-                    service={service}
-                    onChangeArg={onChangeArg}
-                    onDelete={onDeleteFuncNode}
-                    onToggleYield={onToggleYield}
-                    isYieldable={isYieldable}
-                    isYielding={this.isBeforeYielding(i)}
-                    isYieldedInScript={this.isYieldNodeIndex(i + 1)}
-                    declarationID={declarationID}
-                    onGenerateScript={onGenerateScript}
-                    declarationsFromBody={declarationsFromBody}
-                    onToggleYieldWithLast={this.handleToggleYieldWithLast}
-                    onDeleteBody={onDeleteBody}
-                  />
-                )
-
-                if (
-                  nonYieldableIndexesToggled[i] ||
-                  this.isYieldNodeIndex(i + 1)
-                ) {
-                  const script: string = scriptUpToYield(
-                    bodyID,
-                    declarationID,
-                    i,
-                    isYieldable
-                  )
-
-                  let yieldFunc = func
-
-                  if (this.isYieldNodeIndex(i + 1)) {
-                    yieldFunc = funcs[i + 1]
-                  }
-
-                  return (
-                    <Fragment key={`${i}-notInScript`}>
-                      {funcNode}
-                      <YieldFuncNode
-                        index={i}
-                        func={yieldFunc}
-                        data={data}
-                        script={script}
-                        bodyID={bodyID}
-                        service={service}
-                        declarationID={declarationID}
-                      />
-                    </Fragment>
-                  )
-                }
-
-                return funcNode
-              })}
-              <FuncSelector
-                bodyID={bodyID}
-                funcs={funcNames}
-                onAddNode={onAddNode}
-                declarationID={declarationID}
-              />
-            </>
+          const funcNode = (
+            <FuncNode
+              key={i}
+              index={i}
+              func={func}
+              funcs={funcs}
+              bodyID={bodyID}
+              service={service}
+              onChangeArg={onChangeArg}
+              onDelete={onDeleteFuncNode}
+              onToggleYield={onToggleYield}
+              isYieldable={isYieldable}
+              isYielding={this.isBeforeYielding(i)}
+              isYieldedInScript={this.isYieldNodeIndex(i + 1)}
+              declarationID={declarationID}
+              onGenerateScript={onGenerateScript}
+              declarationsFromBody={declarationsFromBody}
+              onToggleYieldWithLast={this.handleToggleYieldWithLast}
+              onDeleteBody={onDeleteBody}
+            />
           )
-        }}
-      </FluxContext.Consumer>
+
+          if (nonYieldableIndexesToggled[i] || this.isYieldNodeIndex(i + 1)) {
+            const script: string = scriptUpToYield(
+              bodyID,
+              declarationID,
+              i,
+              isYieldable
+            )
+
+            let yieldFunc = func
+
+            if (this.isYieldNodeIndex(i + 1)) {
+              yieldFunc = funcs[i + 1]
+            }
+
+            return (
+              <Fragment key={`${i}-notInScript`}>
+                {funcNode}
+                <YieldFuncNode
+                  index={i}
+                  func={yieldFunc}
+                  data={data}
+                  script={script}
+                  bodyID={bodyID}
+                  service={service}
+                  declarationID={declarationID}
+                />
+              </Fragment>
+            )
+          }
+
+          return funcNode
+        })}
+        <FuncSelector
+          bodyID={bodyID}
+          funcs={funcNames}
+          onAddNode={onAddNode}
+          declarationID={declarationID}
+        />
+      </>
     )
   }
 

--- a/ui/src/flux/components/FluxQueryBuilder.tsx
+++ b/ui/src/flux/components/FluxQueryBuilder.tsx
@@ -1,14 +1,18 @@
+// Libraries
 import React, {SFC} from 'react'
 
+// Components
 import SchemaExplorer from 'src/flux/components/SchemaExplorer'
 import BodyBuilder from 'src/flux/components/BodyBuilder'
-import TimeMachineVis from 'src/flux/components/TimeMachineVis'
 import TimeMachineEditor from 'src/flux/components/TimeMachineEditor'
 import Threesizer from 'src/shared/components/threesizer/Threesizer'
 
-import {HANDLE_VERTICAL, HANDLE_HORIZONTAL} from 'src/shared/constants'
+// Constants
+import {HANDLE_VERTICAL} from 'src/shared/constants'
 
+// Types
 import {
+  Context,
   Suggestion,
   OnChangeScript,
   OnSubmitScript,
@@ -16,16 +20,18 @@ import {
   FlatBody,
   ScriptStatus,
 } from 'src/types/flux'
-import {Service} from 'src/types'
+import {Service, NotificationAction} from 'src/types'
 
 interface Props {
-  service: Service
-  script: string
   body: Body[]
+  script: string
+  context: Context
+  service: Service
   status: ScriptStatus
   suggestions: Suggestion[]
-  onChangeScript: OnChangeScript
   onDeleteBody: OnDeleteBody
+  notify: NotificationAction
+  onChangeScript: OnChangeScript
   onSubmitScript: OnSubmitScript
   onAppendFrom: () => void
   onAppendJoin: () => void
@@ -36,10 +42,12 @@ interface Body extends FlatBody {
   id: string
 }
 
-const TimeMachine: SFC<Props> = props => {
+const FluxQueryBuilder: SFC<Props> = props => {
   const {
     body,
+    notify,
     service,
+    context,
     suggestions,
     onAppendFrom,
     onDeleteBody,
@@ -83,6 +91,7 @@ const TimeMachine: SFC<Props> = props => {
       render: () => (
         <BodyBuilder
           body={body}
+          context={context}
           service={service}
           suggestions={suggestions}
           onDeleteBody={onDeleteBody}
@@ -95,41 +104,18 @@ const TimeMachine: SFC<Props> = props => {
       name: 'Explore',
       headerButtons: [],
       menuOptions: [],
-      render: () => <SchemaExplorer service={service} />,
+      render: () => <SchemaExplorer service={service} notify={notify} />,
       headerOrientation: HANDLE_VERTICAL,
-    },
-  ]
-
-  const horizontalDivisions = [
-    {
-      name: '',
-      handleDisplay: 'none',
-      headerButtons: [],
-      menuOptions: [],
-      render: () => <TimeMachineVis service={service} script={script} />,
-      headerOrientation: HANDLE_HORIZONTAL,
-    },
-    {
-      name: '',
-      headerButtons: [],
-      menuOptions: [],
-      render: () => (
-        <Threesizer
-          orientation={HANDLE_VERTICAL}
-          divisions={verticalDivisions}
-        />
-      ),
-      headerOrientation: HANDLE_HORIZONTAL,
     },
   ]
 
   return (
     <Threesizer
-      orientation={HANDLE_HORIZONTAL}
-      divisions={horizontalDivisions}
+      orientation={HANDLE_VERTICAL}
+      divisions={verticalDivisions}
       containerClass="page-contents"
     />
   )
 }
 
-export default TimeMachine
+export default FluxQueryBuilder

--- a/ui/src/flux/components/FluxQueryBuilder.tsx
+++ b/ui/src/flux/components/FluxQueryBuilder.tsx
@@ -12,7 +12,6 @@ import {HANDLE_VERTICAL} from 'src/shared/constants'
 
 // Types
 import {
-  Context,
   Suggestion,
   OnChangeScript,
   OnSubmitScript,
@@ -25,7 +24,6 @@ import {Service, NotificationAction} from 'src/types'
 interface Props {
   body: Body[]
   script: string
-  context: Context
   service: Service
   status: ScriptStatus
   suggestions: Suggestion[]
@@ -47,7 +45,6 @@ const FluxQueryBuilder: SFC<Props> = props => {
     body,
     notify,
     service,
-    context,
     suggestions,
     onAppendFrom,
     onDeleteBody,
@@ -91,7 +88,6 @@ const FluxQueryBuilder: SFC<Props> = props => {
       render: () => (
         <BodyBuilder
           body={body}
-          context={context}
           service={service}
           suggestions={suggestions}
           onDeleteBody={onDeleteBody}

--- a/ui/src/flux/components/SchemaExplorer.tsx
+++ b/ui/src/flux/components/SchemaExplorer.tsx
@@ -2,19 +2,20 @@ import React, {PureComponent} from 'react'
 
 import DatabaseList from 'src/flux/components/DatabaseList'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
-import {Service} from 'src/types'
+import {Service, NotificationAction} from 'src/types'
 
 interface Props {
   service: Service
+  notify: NotificationAction
 }
 
 class SchemaExplorer extends PureComponent<Props> {
   public render() {
-    const {service} = this.props
+    const {service, notify} = this.props
     return (
       <div className="flux-schema-explorer">
         <FancyScrollbar>
-          <DatabaseList service={service} />
+          <DatabaseList service={service} notify={notify} />
         </FancyScrollbar>
       </div>
     )

--- a/ui/src/flux/components/TagList.tsx
+++ b/ui/src/flux/components/TagList.tsx
@@ -1,36 +1,33 @@
 import React, {PureComponent, MouseEvent} from 'react'
 
 import TagListItem from 'src/flux/components/TagListItem'
-import {NotificationContext} from 'src/flux/containers/CheckServices'
 
-import {SchemaFilter, Service} from 'src/types'
+import {SchemaFilter, Service, NotificationAction} from 'src/types'
 
 interface Props {
   db: string
   service: Service
   tags: string[]
   filter: SchemaFilter[]
+  notify: NotificationAction
 }
 
 export default class TagList extends PureComponent<Props> {
   public render() {
-    const {db, service, tags, filter} = this.props
+    const {db, service, tags, filter, notify} = this.props
 
     if (tags.length) {
       return (
         <>
           {tags.map(t => (
-            <NotificationContext.Consumer key={t}>
-              {({notify}) => (
-                <TagListItem
-                  db={db}
-                  tagKey={t}
-                  service={service}
-                  filter={filter}
-                  notify={notify}
-                />
-              )}
-            </NotificationContext.Consumer>
+            <TagListItem
+              db={db}
+              key={t}
+              tagKey={t}
+              service={service}
+              filter={filter}
+              notify={notify}
+            />
           ))}
         </>
       )

--- a/ui/src/flux/components/TagListItem.tsx
+++ b/ui/src/flux/components/TagListItem.tsx
@@ -65,7 +65,7 @@ export default class TagListItem extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {tagKey, db, service, filter} = this.props
+    const {tagKey, db, service, filter, notify} = this.props
     const {
       tagValues,
       searchTerm,
@@ -110,6 +110,7 @@ export default class TagListItem extends PureComponent<Props, State> {
           {!this.isLoading && (
             <TagValueList
               db={db}
+              notify={notify}
               service={service}
               values={tagValues}
               tagKey={tagKey}

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -2,26 +2,27 @@ import React, {PureComponent, MouseEvent} from 'react'
 
 import TagValueListItem from 'src/flux/components/TagValueListItem'
 import LoadingSpinner from 'src/flux/components/LoadingSpinner'
-import {NotificationContext} from 'src/flux/containers/CheckServices'
 
-import {Service, SchemaFilter} from 'src/types'
+import {Service, SchemaFilter, NotificationAction} from 'src/types'
 
 interface Props {
-  service: Service
   db: string
   tagKey: string
   values: string[]
+  service: Service
+  loadMoreCount: number
   filter: SchemaFilter[]
+  notify: NotificationAction
   isLoadingMoreValues: boolean
   onLoadMoreValues: () => void
   shouldShowMoreValues: boolean
-  loadMoreCount: number
 }
 
 export default class TagValueList extends PureComponent<Props> {
   public render() {
     const {
       db,
+      notify,
       service,
       values,
       tagKey,
@@ -32,19 +33,15 @@ export default class TagValueList extends PureComponent<Props> {
     return (
       <>
         {values.map((v, i) => (
-          <NotificationContext.Consumer key={v}>
-            {({notify}) => (
-              <TagValueListItem
-                key={i}
-                db={db}
-                value={v}
-                tagKey={tagKey}
-                service={service}
-                filter={filter}
-                notify={notify}
-              />
-            )}
-          </NotificationContext.Consumer>
+          <TagValueListItem
+            key={i}
+            db={db}
+            value={v}
+            tagKey={tagKey}
+            service={service}
+            filter={filter}
+            notify={notify}
+          />
         ))}
         {shouldShowMoreValues && (
           <div className="flux-schema-tree flux-schema--child">

--- a/ui/src/flux/components/TagValueListItem.tsx
+++ b/ui/src/flux/components/TagValueListItem.tsx
@@ -47,7 +47,7 @@ class TagValueListItem extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {db, service, value} = this.props
+    const {db, service, value, notify} = this.props
     const {searchTerm, isOpen} = this.state
 
     return (
@@ -85,6 +85,7 @@ class TagValueListItem extends PureComponent<Props, State> {
               )}
               <TagList
                 db={db}
+                notify={notify}
                 service={service}
                 tags={this.tags}
                 filter={this.filter}

--- a/ui/src/flux/containers/FluxPage.tsx
+++ b/ui/src/flux/containers/FluxPage.tsx
@@ -205,7 +205,6 @@ export class FluxPage extends PureComponent<Props, State> {
         script={script}
         status={status}
         service={service}
-        context={this.getContext}
         suggestions={suggestions}
         onValidate={this.handleValidate}
         onAppendFrom={this.handleAppendFrom}

--- a/ui/src/flux/helpers/scriptBuilder.ts
+++ b/ui/src/flux/helpers/scriptBuilder.ts
@@ -1,0 +1,387 @@
+// Libraries
+import _ from 'lodash'
+
+// Constants
+import {builder, argTypes} from 'src/flux/constants'
+
+// Types
+import {FlatBody, InputArg, Func, DeleteFuncNodeArgs} from 'src/types/flux'
+
+interface Body extends FlatBody {
+  id: string
+}
+
+interface Status {
+  type: string
+  text: string
+}
+
+export const changeArg = (
+  {key, value, funcID, declarationID = '', bodyID}: InputArg,
+  bodies: Body[]
+) => {
+  return bodies.map(b => {
+    if (b.id !== bodyID) {
+      return b
+    }
+
+    if (declarationID) {
+      const declarations = b.declarations.map(d => {
+        if (d.id !== declarationID) {
+          return d
+        }
+
+        const functions = editFuncArgs({
+          funcs: d.funcs,
+          funcID,
+          key,
+          value,
+        })
+
+        return {...d, funcs: functions}
+      })
+
+      return {...b, declarations}
+    }
+
+    const funcs = editFuncArgs({
+      funcs: b.funcs,
+      funcID,
+      key,
+      value,
+    })
+
+    return {...b, funcs}
+  })
+}
+
+export const editFuncArgs = ({funcs, funcID, key, value}): Func[] => {
+  return funcs.map(f => {
+    if (f.id !== funcID) {
+      return f
+    }
+
+    const args = f.args.map(a => {
+      if (a.key === key) {
+        return {...a, value}
+      }
+
+      return a
+    })
+
+    return {...f, args}
+  })
+}
+
+export const getBodyToScript = (body: Body[]): string => {
+  return body.reduce((acc, b) => {
+    if (b.declarations.length) {
+      const declaration = _.get(b, 'declarations.0', false)
+      if (!declaration) {
+        return acc
+      }
+
+      if (!declaration.funcs) {
+        return `${acc}${b.source}`
+      }
+
+      return `${acc}${declaration.name} = ${funcsToScript(
+        declaration.funcs
+      )}\n\n`
+    }
+
+    return `${acc}${funcsToScript(b.funcs)}\n\n`
+  }, '')
+}
+
+export const funcsToScript = (funcs): string => {
+  return funcs
+    .map(func => `${func.name}(${argsToScript(func.args)})`)
+    .join('\n\t|> ')
+}
+
+export const argsToScript = (args): string => {
+  const withValues = args.filter(arg => arg.value || arg.value === false)
+
+  return withValues
+    .map(({key, value, type}) => {
+      if (type === argTypes.STRING) {
+        return `${key}: "${value}"`
+      }
+
+      if (type === argTypes.ARRAY) {
+        return `${key}: ["${value}"]`
+      }
+
+      if (type === argTypes.OBJECT) {
+        const valueString = _.map(value, (v, k) => k + ':' + v).join(',')
+        return `${key}: {${valueString}}`
+      }
+
+      return `${key}: ${value}`
+    })
+    .join(', ')
+}
+
+export const appendJoin = (script: string): string => {
+  return `${script.trim()}\n\n${builder.NEW_JOIN}\n\n`
+}
+
+export const appendFrom = (script: string): string => {
+  return `${script.trim()}\n\n${builder.NEW_FROM}\n\n`
+}
+
+export const addNode = (
+  name: string,
+  bodyID: string,
+  declarationID: string,
+  bodies: Body[]
+): string => {
+  return bodies.reduce((acc, body) => {
+    const {id, source, funcs} = body
+
+    if (id === bodyID) {
+      const declaration = body.declarations.find(d => d.id === declarationID)
+      if (declaration) {
+        return `${acc}${declaration.name} = ${appendFunc(
+          declaration.funcs,
+          name
+        )}`
+      }
+
+      return `${acc}${appendFunc(funcs, name)}`
+    }
+
+    return `${acc}${formatSource(source)}`
+  }, '')
+}
+
+export const appendFunc = (funcs: Func[], name: string): string => {
+  return `${funcsToScript(funcs)}\n\t|> ${name}()\n\n`
+}
+
+export const deleteBody = (bodyID: string, bodies: Body[]) => {
+  const newBody = bodies.filter(b => b.id !== bodyID)
+  return getBodyToScript(newBody)
+}
+
+// funcsToSource takes a list of funtion nodes and returns an flux script
+export const funcsToSource = (funcs): string => {
+  return funcs.reduce((acc, f, i) => {
+    if (i === 0) {
+      return `${f.source}`
+    }
+    return `${acc}\n\t${f.source}`
+  }, '')
+}
+
+export const formatSource = (source: string): string => {
+  // currently a bug in the AST which does not add newlines to literal variable assignment bodies
+  if (!source.match(/\n\n/)) {
+    return `${source}\n\n`
+  }
+
+  return `${source}`
+}
+
+// formats the last line of a body string to include two new lines
+export const formatLastSource = (source: string, isLast: boolean): string => {
+  if (isLast) {
+    return `${source}`
+  }
+
+  // currently a bug in the AST which does not add newlines to literal variable assignment bodies
+  if (!source.match(/\n\n/)) {
+    return `${source}\n\n`
+  }
+
+  return `${source}\n\n`
+}
+
+export const deleteFuncNode = (
+  ids: DeleteFuncNodeArgs,
+  bodies: Body[]
+): string => {
+  const {funcID, declarationID = '', bodyID, yieldNodeID = ''} = ids
+  return bodies
+    .map((body, bodyIndex) => {
+      if (body.id !== bodyID) {
+        return formatSource(body.source)
+      }
+      const isLast = bodyIndex === bodies.length - 1
+      if (declarationID) {
+        const declaration = body.declarations.find(d => d.id === declarationID)
+        if (!declaration) {
+          return
+        }
+        const functions = declaration.funcs.filter(
+          f => f.id !== funcID && f.id !== yieldNodeID
+        )
+        const s = funcsToSource(functions)
+        return `${declaration.name} = ${formatLastSource(s, isLast)}`
+      }
+      const funcs = body.funcs.filter(
+        f => f.id !== funcID && f.id !== yieldNodeID
+      )
+      const source = funcsToSource(funcs)
+      return formatLastSource(source, isLast)
+    })
+    .join('')
+}
+
+export const getNextYieldName = (bodies: Body[]): string => {
+  const yieldNamePrefix = 'results_'
+  const yieldNamePattern = `${yieldNamePrefix}(\\d+)`
+  const regex = new RegExp(yieldNamePattern)
+  const MIN = -1
+  const yieldsMaxResultNumber = bodies.reduce((scriptMax, body) => {
+    const {funcs: bodyFuncs, declarations} = body
+    let funcs = bodyFuncs
+    if (!_.isEmpty(declarations)) {
+      funcs = _.flatMap(declarations, d => _.get(d, 'funcs', []))
+    }
+    const yields = funcs.filter(f => f.name === 'yield')
+    const bodyMax = yields.reduce((max, y) => {
+      const yieldArg = _.get(y, 'args.0.value')
+      if (!yieldArg) {
+        return max
+      }
+      const yieldNumberString = _.get(yieldArg.match(regex), '1', `${MIN}`)
+      const yieldNumber = parseInt(yieldNumberString, 10)
+      return Math.max(yieldNumber, max)
+    }, scriptMax)
+    return Math.max(scriptMax, bodyMax)
+  }, MIN)
+  return `${yieldNamePrefix}${yieldsMaxResultNumber + 1}`
+}
+
+export const insertYieldFunc = (
+  funcs: Func[],
+  index: number,
+  bodies: Body[]
+): string => {
+  const funcsBefore = funcs.slice(0, index + 1)
+  const funcsBeforeScript = funcsToScript(funcsBefore)
+  const funcsAfter = funcs.slice(index + 1)
+  const funcsAfterScript = funcsToScript(funcsAfter)
+  const funcSeparator = '\n\t|> '
+  if (funcsAfterScript) {
+    return `${funcsBeforeScript}${funcSeparator}yield(name: "${getNextYieldName(
+      bodies
+    )}")${funcSeparator}${funcsAfterScript}\n\n`
+  }
+  return `${funcsBeforeScript}${funcSeparator}yield(name: "${getNextYieldName(
+    bodies
+  )}")\n\n`
+}
+
+export const removeYieldFunc = (funcs: Func[], funcAfterNode: Func): string => {
+  const filteredFuncs = funcs.filter(f => f.id !== funcAfterNode.id)
+  return `${funcsToScript(filteredFuncs)}\n\n`
+}
+
+export const addOrRemoveYieldFunc = (
+  funcs: Func[],
+  funcNodeIndex: number,
+  bodies: Body[]
+): string => {
+  if (funcNodeIndex < funcs.length - 1) {
+    const funcAfterNode = funcs[funcNodeIndex + 1]
+    if (funcAfterNode.name === 'yield') {
+      return removeYieldFunc(funcs, funcAfterNode)
+    }
+  }
+  return insertYieldFunc(funcs, funcNodeIndex, bodies)
+}
+
+export const toggleYield = (
+  bodyID: string,
+  declarationID: string,
+  funcNodeIndex: number,
+  bodies: Body[]
+): string => {
+  return bodies.reduce((acc, body) => {
+    const {id, source, funcs} = body
+    if (id === bodyID) {
+      const declaration = body.declarations.find(d => d.id === declarationID)
+      if (declaration) {
+        return `${acc}${declaration.name} = ${addOrRemoveYieldFunc(
+          declaration.funcs,
+          funcNodeIndex,
+          bodies
+        )}`
+      }
+      return `${acc}${addOrRemoveYieldFunc(funcs, funcNodeIndex, bodies)}`
+    }
+    return `${acc}${formatSource(source)}`
+  }, '')
+}
+
+export const prepBodyForYield = (
+  body: Body,
+  declarationID: string,
+  yieldNodeIndex: number
+) => {
+  const funcs = getFuncs(body, declarationID)
+  const funcsUpToYield = funcs.slice(0, yieldNodeIndex)
+  const yieldNode = funcs[yieldNodeIndex]
+  const funcsWithoutYields = funcsUpToYield.filter(f => f.name !== 'yield')
+  const funcsForBody = [...funcsWithoutYields, yieldNode]
+  if (declarationID) {
+    const declaration = body.declarations.find(d => d.id === declarationID)
+    const declarations = [{...declaration, funcs: funcsForBody}]
+    return {...body, declarations}
+  }
+  return {...body, funcs: funcsForBody}
+}
+
+export const scriptUpToYield = (
+  bodyID: string,
+  declarationID: string,
+  funcNodeIndex: number,
+  isYieldable: boolean,
+  bodies: Body[]
+) => {
+  const bodyIndex = bodies.findIndex(b => b.id === bodyID)
+  const bodiesBeforeYield = bodies
+    .slice(0, bodyIndex)
+    .map(b => removeYieldFuncFromBody(b))
+  const body = prepBodyForYield(bodies[bodyIndex], declarationID, funcNodeIndex)
+  const bodiesForScript = [...bodiesBeforeYield, body]
+  let script = getBodyToScript(bodiesForScript)
+  if (!isYieldable) {
+    const regex: RegExp = /\n{2}$/
+    script = script.replace(regex, '\n\t|> last()\n\t|> yield()$&')
+    return script
+  }
+  return script
+}
+
+export const getFuncs = (body: Body, declarationID: string): Func[] => {
+  const declaration = body.declarations.find(d => d.id === declarationID)
+  if (declaration) {
+    return _.get(declaration, 'funcs', [])
+  }
+  return _.get(body, 'funcs', [])
+}
+
+export const removeYieldFuncFromBody = (body: Body): Body => {
+  const declarationID = _.get(body, 'declarations.0.id')
+  const funcs = getFuncs(body, declarationID)
+  if (_.isEmpty(funcs)) {
+    return body
+  }
+  const funcsWithoutYields = funcs.filter(f => f.name !== 'yield')
+  if (declarationID) {
+    const declaration = _.get(body, 'declarations.0')
+    const declarations = [{...declaration, funcs: funcsWithoutYields}]
+    return {...body, declarations}
+  }
+  return {...body, funcs: funcsWithoutYields}
+}
+
+export const parseError = (error): Status => {
+  const s = error.data.slice(0, -5) // There is a 'null\n' at the end of these responses
+  const data = JSON.parse(s)
+  return {type: 'error', text: `${data.message}`}
+}

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -359,7 +359,6 @@ class TimeMachine extends PureComponent<Props, State> {
             script={script}
             status={status}
             notify={notify}
-            context={this.getContext}
             service={this.service}
             suggestions={suggestions}
             onValidate={this.handleValidate}

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -73,7 +73,7 @@ import {
 import {UpdateScript} from 'src/flux/actions'
 
 interface Props {
-  links: Links
+  fluxLinks: Links
   source: Source
   script: string
   sources: Source[]
@@ -155,7 +155,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    const {links, script} = this.props
+    const {fluxLinks, script} = this.props
 
     try {
       this.debouncedASTResponse(script)
@@ -164,7 +164,7 @@ class TimeMachine extends PureComponent<Props, State> {
     }
 
     try {
-      const suggestions = await getSuggestions(links.suggestions)
+      const suggestions = await getSuggestions(fluxLinks.suggestions)
       this.setState({suggestions})
     } catch (error) {
       console.error('Could not get function suggestions: ', error)
@@ -596,7 +596,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private getASTResponse = async (script: string, update: boolean = true) => {
-    const {links} = this.props
+    const {fluxLinks} = this.props
 
     if (!script) {
       this.props.updateScript(script)
@@ -604,7 +604,7 @@ class TimeMachine extends PureComponent<Props, State> {
     }
 
     try {
-      const ast = await getAST({url: links.ast, body: script})
+      const ast = await getAST({url: fluxLinks.ast, body: script})
 
       if (update) {
         this.props.updateScript(script)
@@ -620,12 +620,12 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private getTimeSeries = async () => {
-    const {script, links, notify} = this.props
+    const {script, fluxLinks, notify} = this.props
     if (!script) {
       return
     }
     try {
-      await getAST({url: links.ast, body: script})
+      await getAST({url: fluxLinks.ast, body: script})
     } catch (error) {
       this.setState({status: parseError(error)})
       return console.error('Could not parse AST', error)
@@ -801,10 +801,10 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private handleValidate = async () => {
-    const {links, notify, script} = this.props
+    const {fluxLinks, notify, script} = this.props
 
     try {
-      const ast = await getAST({url: links.ast, body: script})
+      const ast = await getAST({url: fluxLinks.ast, body: script})
       const body = bodyNodes(ast, this.state.suggestions)
       const status = {type: 'success', text: ''}
       notify(validateSuccess())

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -3,24 +3,45 @@ import React, {PureComponent} from 'react'
 import _ from 'lodash'
 
 // Components
+import TimeMachineVis from 'src/flux/components/TimeMachineVis'
 import Threesizer from 'src/shared/components/threesizer/Threesizer'
 import Visualization from 'src/dashboards/components/Visualization'
 import InfluxQLQueryMaker from 'src/shared/components/TimeMachine/InfluxQLQueryMaker'
 import DisplayOptions from 'src/dashboards/components/DisplayOptions'
 import TimeMachineBottom from 'src/shared/components/TimeMachine/TimeMachineBottom'
 import TimeMachineControls from 'src/shared/components/TimeMachine/TimeMachineControls'
+import KeyboardShortcuts from 'src/shared/components/KeyboardShortcuts'
+import FluxQueryBuilder from 'src/flux/components/FluxQueryBuilder'
 
 // Utils
 import {getConfig} from 'src/dashboards/utils/cellGetters'
 import {getDeep} from 'src/utils/wrappers'
+import {bodyNodes} from 'src/flux/helpers'
+import {
+  addNode,
+  parseError,
+  deleteBody,
+  appendJoin,
+  toggleYield,
+  deleteFuncNode,
+  getBodyToScript,
+  scriptUpToYield,
+} from 'src/flux/helpers/scriptBuilder'
 
 // Actions
 import {editCellQueryStatus} from 'src/dashboards/actions'
+import {
+  validateSuccess,
+  fluxTimeSeriesError,
+  fluxResponseTruncatedError,
+} from 'src/shared/copy/notifications'
+import {getSuggestions, getAST, getTimeSeries} from 'src/flux/apis'
 
 // Constants
 import {HANDLE_HORIZONTAL} from 'src/shared/constants'
 import {AUTO_GROUP_BY, PREDEFINED_TEMP_VARS} from 'src/shared/constants'
 import {CEOTabs} from 'src/dashboards/constants'
+import {builder, emptyAST} from 'src/flux/constants'
 
 // Types
 import {
@@ -35,11 +56,26 @@ import {
   Source,
   Service,
   CellQuery,
+  NotificationAction,
+  FluxTable,
 } from 'src/types'
 import {SourceOption} from 'src/types/sources'
+import {
+  Suggestion,
+  FlatBody,
+  Links,
+  InputArg,
+  Context,
+  DeleteFuncNodeArgs,
+  Func,
+  ScriptStatus,
+} from 'src/types/flux'
+import {UpdateScript} from 'src/flux/actions'
 
 interface Props {
+  links: Links
   source: Source
+  script: string
   sources: Source[]
   isInCEO: boolean
   services: Service[]
@@ -47,30 +83,48 @@ interface Props {
   timeRange: TimeRange
   templates: Template[]
   isStaticLegend: boolean
-  queryConfigActions: QueryConfigActions
-  onResetFocus: () => void
   queryDrafts: CellQuery[]
+  onResetFocus: () => void
+  updateScript: UpdateScript
+  addQuery: typeof addQueryAsync
+  deleteQuery: typeof deleteQueryAsync
+  queryConfigActions: QueryConfigActions
+  notify: NotificationAction
   editQueryStatus: typeof editCellQueryStatus
   updateQueryDrafts: (queryDrafts: CellQuery[]) => void
+  updateEditorTimeRange: (timeRange: TimeRange) => void
   onToggleStaticLegend: (isStaticLegend: boolean) => void
   children: (
     activeEditorTab: CEOTabs,
     onSetActiveEditorTab: (activeEditorTab: CEOTabs) => void
   ) => JSX.Element
-  addQuery: typeof addQueryAsync
-  deleteQuery: typeof deleteQueryAsync
-  updateEditorTimeRange: (timeRange: TimeRange) => void
+}
+
+interface Body extends FlatBody {
+  id: string
 }
 
 interface State {
+  body: Body[]
+  script: string
+  ast: object
+  data: FluxTable[]
+  status: ScriptStatus
+  selectedSource: Source
   activeQueryIndex: number
   activeEditorTab: CEOTabs
-  selectedSource: Source
   selectedService: Service
   useDynamicSource: boolean
+  suggestions: Suggestion[]
 }
 
+type ScriptFunc = (script: string) => void
+
+export const FluxContext = React.createContext(undefined)
+
 class TimeMachine extends PureComponent<Props, State> {
+  private debouncedASTResponse: ScriptFunc
+
   constructor(props: Props) {
     super(props)
 
@@ -84,6 +138,39 @@ class TimeMachine extends PureComponent<Props, State> {
       selectedService: null,
       selectedSource: null,
       useDynamicSource,
+      data: [],
+      body: [],
+      ast: null,
+      suggestions: [],
+      status: {
+        type: 'none',
+        text: '',
+      },
+      script: '',
+    }
+
+    this.debouncedASTResponse = _.debounce(script => {
+      this.getASTResponse(script, false)
+    }, 250)
+  }
+
+  public async componentDidMount() {
+    const {links, script} = this.props
+
+    try {
+      this.debouncedASTResponse(script)
+    } catch (error) {
+      console.error('Could not retrieve AST for script', error)
+    }
+
+    try {
+      const suggestions = await getSuggestions(links.suggestions)
+      this.setState({suggestions})
+    } catch (error) {
+      console.error('Could not get function suggestions: ', error)
+    }
+    if (this.isFluxSource) {
+      this.getTimeSeries()
     }
   }
 
@@ -138,6 +225,7 @@ class TimeMachine extends PureComponent<Props, State> {
 
   private get visualization() {
     const {
+      script,
       timeRange,
       templates,
       autoRefresh,
@@ -147,6 +235,10 @@ class TimeMachine extends PureComponent<Props, State> {
       isStaticLegend,
     } = this.props
 
+    if (this.isFluxSource) {
+      const service = this.service
+      return <TimeMachineVis service={service} script={script} />
+    }
     return (
       <div className="deceo--top">
         <Visualization
@@ -168,30 +260,14 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private get editorTab() {
-    const {
-      templates,
-      timeRange,
-      isStaticLegend,
-      onToggleStaticLegend,
-    } = this.props
-    const {activeQueryIndex, activeEditorTab} = this.state
+    const {isStaticLegend, onToggleStaticLegend} = this.props
+    const {activeEditorTab} = this.state
 
     if (activeEditorTab === CEOTabs.Queries) {
-      return (
-        <InfluxQLQueryMaker
-          source={this.source}
-          templates={templates}
-          queries={this.queriesWorkingDraft}
-          actions={this.queryConfigActions}
-          timeRange={timeRange}
-          onDeleteQuery={this.handleDeleteQuery}
-          onAddQuery={this.handleAddQuery}
-          activeQueryIndex={activeQueryIndex}
-          activeQuery={this.getActiveQuery()}
-          setActiveQueryIndex={this.handleSetActiveQueryIndex}
-          initialGroupByTime={AUTO_GROUP_BY}
-        />
-      )
+      if (this.isFluxSource) {
+        return this.fluxBuilder
+      }
+      return this.influxQLBuilder
     }
 
     return (
@@ -260,6 +336,63 @@ class TimeMachine extends PureComponent<Props, State> {
       ...s,
       text: `${s.name} @ ${s.url}`,
     }))
+  }
+
+  private get isFluxSource(): boolean {
+    // TODO: Update once flux is no longer a separate service
+    const {selectedService} = this.state
+    if (selectedService) {
+      return true
+    }
+    return false
+  }
+
+  private get fluxBuilder(): JSX.Element {
+    const {suggestions, body, status} = this.state
+    const {script, notify} = this.props
+
+    return (
+      <FluxContext.Provider value={this.getContext}>
+        <KeyboardShortcuts onControlEnter={this.getTimeSeries}>
+          <FluxQueryBuilder
+            body={body}
+            script={script}
+            status={status}
+            notify={notify}
+            context={this.getContext}
+            service={this.service}
+            suggestions={suggestions}
+            onValidate={this.handleValidate}
+            onAppendFrom={this.handleAppendFrom}
+            onAppendJoin={this.handleAppendJoin}
+            onChangeScript={this.handleChangeScript}
+            onSubmitScript={this.handleSubmitScript}
+            onDeleteBody={this.handleDeleteBody}
+          />
+        </KeyboardShortcuts>
+      </FluxContext.Provider>
+    )
+  }
+
+  private get influxQLBuilder(): JSX.Element {
+    const {templates, timeRange} = this.props
+    const {activeQueryIndex} = this.state
+
+    return (
+      <InfluxQLQueryMaker
+        source={this.source}
+        templates={templates}
+        queries={this.queriesWorkingDraft}
+        actions={this.queryConfigActions}
+        timeRange={timeRange}
+        onDeleteQuery={this.handleDeleteQuery}
+        onAddQuery={this.handleAddQuery}
+        activeQueryIndex={activeQueryIndex}
+        activeQuery={this.getActiveQuery()}
+        setActiveQueryIndex={this.handleSetActiveQueryIndex}
+        initialGroupByTime={AUTO_GROUP_BY}
+      />
+    )
   }
 
   private getActiveQuery = (): QueryConfig => {
@@ -444,6 +577,243 @@ class TimeMachine extends PureComponent<Props, State> {
 
   private handleSetActiveEditorTab = (tabName: CEOTabs): void => {
     this.setState({activeEditorTab: tabName})
+  }
+
+  // --------------- FLUX ----------------
+  private get getContext(): Context {
+    return {
+      onAddNode: this.handleAddNode,
+      onChangeArg: this.handleChangeArg,
+      onSubmitScript: this.handleSubmitScript,
+      onChangeScript: this.handleChangeScript,
+      onDeleteFuncNode: this.handleDeleteFuncNode,
+      onGenerateScript: this.handleGenerateScript,
+      onToggleYield: this.handleToggleYield,
+      service: this.service,
+      data: this.state.data,
+      scriptUpToYield: this.handleScriptUpToYield,
+    }
+  }
+
+  private getASTResponse = async (script: string, update: boolean = true) => {
+    const {links} = this.props
+
+    if (!script) {
+      this.props.updateScript(script)
+      return this.setState({ast: emptyAST, body: []})
+    }
+
+    try {
+      const ast = await getAST({url: links.ast, body: script})
+
+      if (update) {
+        this.props.updateScript(script)
+      }
+
+      const body = bodyNodes(ast, this.state.suggestions)
+      const status = {type: 'success', text: ''}
+      this.setState({ast, body, status})
+    } catch (error) {
+      this.setState({status: parseError(error)})
+      return console.error('Could not parse AST', error)
+    }
+  }
+
+  private getTimeSeries = async () => {
+    const {script, links, notify} = this.props
+    if (!script) {
+      return
+    }
+    try {
+      await getAST({url: links.ast, body: script})
+    } catch (error) {
+      this.setState({status: parseError(error)})
+      return console.error('Could not parse AST', error)
+    }
+    try {
+      const {tables, didTruncate} = await getTimeSeries(this.service, script)
+      this.setState({data: tables})
+      if (didTruncate) {
+        notify(fluxResponseTruncatedError())
+      }
+    } catch (error) {
+      this.setState({data: []})
+      notify(fluxTimeSeriesError(error))
+      console.error('Could not get timeSeries', error)
+    }
+    this.getASTResponse(script)
+  }
+
+  private handleSubmitScript = () => {
+    this.getASTResponse(this.props.script)
+  }
+
+  private handleGenerateScript = (): void => {
+    this.getASTResponse(this.bodyToScript)
+  }
+
+  private handleChangeArg = ({
+    key,
+    value,
+    generate,
+    funcID,
+    declarationID = '',
+    bodyID,
+  }: InputArg): void => {
+    const body = this.state.body.map(b => {
+      if (b.id !== bodyID) {
+        return b
+      }
+
+      if (declarationID) {
+        const declarations = b.declarations.map(d => {
+          if (d.id !== declarationID) {
+            return d
+          }
+
+          const functions = this.editFuncArgs({
+            funcs: d.funcs,
+            funcID,
+            key,
+            value,
+          })
+
+          return {...d, funcs: functions}
+        })
+
+        return {...b, declarations}
+      }
+
+      const funcs = this.editFuncArgs({
+        funcs: b.funcs,
+        funcID,
+        key,
+        value,
+      })
+
+      return {...b, funcs}
+    })
+
+    this.setState({body}, () => {
+      if (generate) {
+        this.handleGenerateScript()
+      }
+    })
+  }
+
+  private editFuncArgs = ({funcs, funcID, key, value}): Func[] => {
+    return funcs.map(f => {
+      if (f.id !== funcID) {
+        return f
+      }
+
+      const args = f.args.map(a => {
+        if (a.key === key) {
+          return {...a, value}
+        }
+
+        return a
+      })
+
+      return {...f, args}
+    })
+  }
+
+  private get bodyToScript(): string {
+    return getBodyToScript(this.state.body)
+  }
+
+  private handleAppendFrom = (): void => {
+    const {script} = this.props
+    let newScript = script.trim()
+    const from = builder.NEW_FROM
+
+    if (!newScript) {
+      this.getASTResponse(from)
+      return
+    }
+
+    newScript = `${script.trim()}\n\n${from}\n\n`
+    this.getASTResponse(newScript)
+  }
+
+  private handleAppendJoin = (): void => {
+    const {script} = this.props
+    const newScript = appendJoin(script)
+
+    this.getASTResponse(newScript)
+  }
+
+  private handleChangeScript = (script: string): void => {
+    this.debouncedASTResponse(script)
+    this.props.updateScript(script)
+  }
+
+  private handleAddNode = (
+    name: string,
+    bodyID: string,
+    declarationID: string
+  ): void => {
+    const script = addNode(name, bodyID, declarationID, this.state.body)
+
+    this.getASTResponse(script)
+  }
+
+  private handleDeleteBody = (bodyID: string): void => {
+    const script = deleteBody(bodyID, this.state.body)
+    this.getASTResponse(script)
+  }
+
+  private handleScriptUpToYield = (
+    bodyID: string,
+    declarationID: string,
+    funcNodeIndex: number,
+    isYieldable: boolean
+  ): string => {
+    return scriptUpToYield(
+      bodyID,
+      declarationID,
+      funcNodeIndex,
+      isYieldable,
+      this.state.body
+    )
+  }
+
+  private handleToggleYield = (
+    bodyID: string,
+    declarationID: string,
+    funcNodeIndex: number
+  ): void => {
+    const script = toggleYield(
+      bodyID,
+      declarationID,
+      funcNodeIndex,
+      this.state.body
+    )
+
+    this.getASTResponse(script)
+  }
+
+  private handleDeleteFuncNode = (ids: DeleteFuncNodeArgs): void => {
+    const script = deleteFuncNode(ids, this.state.body)
+
+    this.getASTResponse(script)
+  }
+
+  private handleValidate = async () => {
+    const {links, notify, script} = this.props
+
+    try {
+      const ast = await getAST({url: links.ast, body: script})
+      const body = bodyNodes(ast, this.state.suggestions)
+      const status = {type: 'success', text: ''}
+      notify(validateSuccess())
+
+      this.setState({ast, body, status})
+    } catch (error) {
+      this.setState({status: parseError(error)})
+      return console.error('Could not parse AST', error)
+    }
   }
 }
 

--- a/ui/test/flux/components/FluxQueryBuilder.test.tsx
+++ b/ui/test/flux/components/FluxQueryBuilder.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
-import TimeMachine from 'src/flux/components/TimeMachine'
+import FluxQueryBuilder from 'src/flux/components/FluxQueryBuilder'
 import {service} from 'test/resources'
 
 const setup = () => {
@@ -19,14 +19,14 @@ const setup = () => {
     status: {type: '', text: ''},
   }
 
-  const wrapper = shallow(<TimeMachine {...props} />)
+  const wrapper = shallow(<FluxQueryBuilder {...props} />)
 
   return {
     wrapper,
   }
 }
 
-describe('Flux.Components.TimeMachine', () => {
+describe('Flux.Components.FluxQueryBuilder', () => {
   describe('rendering', () => {
     it('renders', () => {
       const {wrapper} = setup()

--- a/ui/test/flux/components/FluxQueryBuilder.test.tsx
+++ b/ui/test/flux/components/FluxQueryBuilder.test.tsx
@@ -10,6 +10,7 @@ const setup = () => {
     data: [],
     service,
     suggestions: [],
+    notify: () => {},
     onSubmitScript: () => {},
     onChangeScript: () => {},
     onValidate: () => {},

--- a/ui/test/flux/containers/FluxPage.test.tsx
+++ b/ui/test/flux/containers/FluxPage.test.tsx
@@ -2,9 +2,9 @@ import React from 'react'
 import {shallow} from 'enzyme'
 
 import {FluxPage} from 'src/flux/containers/FluxPage'
-import TimeMachine from 'src/flux/components/TimeMachine'
 import {ActionTypes} from 'src/flux/actions'
 import {source} from 'test/resources'
+import Threesizer from 'src/shared/components/threesizer/Threesizer'
 
 jest.mock('src/flux/apis', () => require('mocks/flux/apis'))
 
@@ -55,12 +55,12 @@ describe('Flux.Containers.FluxPage', () => {
       expect(wrapper.exists()).toBe(true)
     })
 
-    it('renders the <TimeMachine/>', () => {
+    it('renders the <Threesizer/>', () => {
       const {wrapper} = setup()
 
-      const timeMachine = wrapper.find(TimeMachine)
+      const threesizer = wrapper.find(Threesizer)
 
-      expect(timeMachine.exists()).toBe(true)
+      expect(threesizer.exists()).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/3 and https://github.com/influxdata/applications-team-issues/issues/4

_What was the problem?_
Only InfluxQL queries could be created from the Cell Editor Overlay. Furthermore, there was some repetitiveness with shared/TimeMachine and flux/TimeMachine.

_What was the solution?_
* Replace flux/TimeMachine with FluxQueryBuilder and use FluxQueryBuilder component in CEO
* Move helper functions to a utils files that can be used for both FluxPage and CEO
* Replace NotificationContext and FluxContext with passing props down

- [x] CHANGELOG.md updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [ ] Tests pass