### PR TITLE
Rewrite Worker script paths according to basepath

### DIFF
--- a/server/url_prefixer.go
+++ b/server/url_prefixer.go
@@ -186,6 +186,8 @@ func NewDefaultURLPrefixer(prefix string, next http.Handler, lg chronograf.Logge
 			[]byte(`src="`),
 			[]byte(`href="`),
 			[]byte(`url(`),
+			[]byte(`new Worker("`),
+			[]byte(`new Worker('`),
 			[]byte(`data-basepath="`), // for forwarding basepath to frontend
 		},
 	}

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "start": "node parcel.js",
-    "build": "parcel build -d build --no-source-maps --public-url '' src/index.html src/worker/worker.ts",
+    "build": "parcel build -d build --no-source-maps --public-url '' src/index.html",
     "clean": "rm -rf ./build/* && rm -rf ./.cache",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/ui/parcel.js
+++ b/ui/parcel.js
@@ -1,23 +1,31 @@
+/* eslint no-console: 0 */
 const proxy = require('http-proxy-middleware')
 const Bundler = require('parcel')
 const express = require('express')
 
-const port = Number(process.env.PORT || 8080)
+const handleProxyError = err => {
+  if (err.code === 'ECONNREFUSED') {
+    console.log(
+      'Cannot reach Chronograf server at localhost:8888. Is it running?'
+    )
+  } else {
+    console.log(`Error: ${err.code}`)
+  }
+}
 
-console.log(`Serving on http://localhost:${port}`) // eslint-disable-line no-console
-
-const app = express()
-const bundler = new Bundler(['src/index.html', 'src/worker/worker.ts'], {
-  outDir: './build/',
+const proxyMiddleware = proxy('/chronograf/v1', {
+  target: 'http://localhost:8888',
+  logLevel: 'silent',
+  changeOrigin: true,
+  onError: handleProxyError,
 })
 
-app.use(
-  proxy('/chronograf/v1', {
-    target: 'http://localhost:8888',
-    logLevel: 'warn',
-    changeOrigin: true,
-  })
-)
+const bundler = new Bundler('src/index.html', {outDir: './build/'})
+const port = Number(process.env.PORT || 8080)
+const app = express()
 
+console.log(`Serving on http://localhost:${port}`)
+
+app.use(proxyMiddleware)
 app.use(bundler.middleware())
 app.listen(port)

--- a/ui/src/worker/JobManager.ts
+++ b/ui/src/worker/JobManager.ts
@@ -10,10 +10,6 @@ import {TimeSeriesToDyGraphReturnType} from 'src/worker/jobs/timeSeriesToDygraph
 
 const workerCount = navigator.hardwareConcurrency - 1
 
-// HACK: work around parcel picking up workers and trying to inline them.
-//       This is need to allow for basepaths
-const WorkerClass = Worker
-
 class JobManager {
   private currentIndex: number = 0
   private workers: Worker[] = []
@@ -21,9 +17,7 @@ class JobManager {
 
   constructor() {
     _.times(workerCount, () => {
-      const worker = new WorkerClass(
-        [getBasepath(), 'worker', 'worker.js'].join('/')
-      )
+      const worker = new Worker('./worker.ts')
 
       worker.onmessage = this.handleMessage
       worker.onerror = this.handleError


### PR DESCRIPTION
- Rewrites `new Worker('./my/path')` paths server side to handle base path config (like other assets)
- This enables us to develop on `localhost:8080` again
- Displays a more friendly error when proxying to `localhost:8888` fails