### PR TITLE
Add auto refresh control to CEO

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -56,7 +56,6 @@ interface Props {
   source: SourcesModels.Source
   dashboardID: number
   queryStatus: QueryStatus
-  autoRefresh: number
   templates: Template[]
   timeRange: QueriesModels.TimeRange
   thresholdsListType: string
@@ -108,7 +107,6 @@ class CellEditorOverlay extends Component<Props, State> {
       onCancel,
       templates,
       timeRange,
-      autoRefresh,
       editQueryStatus,
       cell,
       queryDrafts,
@@ -140,7 +138,6 @@ class CellEditorOverlay extends Component<Props, State> {
           editQueryStatus={editQueryStatus}
           templates={templates}
           timeRange={timeRange}
-          autoRefresh={autoRefresh}
           source={source}
           onResetFocus={this.handleResetFocus}
           isInCEO={true}

--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -12,7 +12,6 @@ const Dashboard = ({
   onZoom,
   dashboard,
   timeRange,
-  autoRefresh,
   manualRefresh,
   onDeleteCell,
   onCloneCell,
@@ -52,7 +51,6 @@ const Dashboard = ({
             sources={sources}
             isEditable={true}
             timeRange={timeRange}
-            autoRefresh={autoRefresh}
             manualRefresh={manualRefresh}
             onDeleteCell={onDeleteCell}
             onCloneCell={onCloneCell}
@@ -103,7 +101,6 @@ Dashboard.propTypes = {
     }).isRequired,
   }).isRequired,
   sources: arrayOf(shape({})).isRequired,
-  autoRefresh: number.isRequired,
   manualRefresh: number,
   timeRange: shape({}).isRequired,
   onZoom: func,

--- a/ui/src/dashboards/components/Visualization.tsx
+++ b/ui/src/dashboards/components/Visualization.tsx
@@ -20,7 +20,6 @@ interface Props {
   axes: Axes
   type: CellType
   source: Source
-  autoRefresh: number
   templates: Template[]
   timeRange: TimeRange
   queryConfigs: QueryConfig[]
@@ -49,7 +48,6 @@ const DashVisualization: SFC<Props> = ({
   timeRange,
   lineColors,
   timeFormat,
-  autoRefresh,
   gaugeColors,
   fieldOptions,
   queryConfigs,
@@ -79,7 +77,6 @@ const DashVisualization: SFC<Props> = ({
           tableOptions={tableOptions}
           queries={buildQueries(queryConfigs, timeRange)}
           templates={templates}
-          autoRefresh={autoRefresh}
           editQueryStatus={editQueryStatus}
           resizerTopHeight={resizerTopHeight}
           staticLegend={staticLegend}

--- a/ui/src/dashboards/components/Visualization.tsx
+++ b/ui/src/dashboards/components/Visualization.tsx
@@ -2,7 +2,9 @@ import React, {SFC} from 'react'
 import {connect} from 'react-redux'
 
 import RefreshingGraph from 'src/shared/components/RefreshingGraph'
+
 import buildQueries from 'src/utils/buildQueriesForGraphs'
+import {AutoRefresher} from 'src/utils/AutoRefresher'
 
 import {getCellTypeColors} from 'src/dashboards/constants/cellEditor'
 
@@ -22,6 +24,7 @@ interface Props {
   source: Source
   templates: Template[]
   timeRange: TimeRange
+  autoRefresher: AutoRefresher
   queryConfigs: QueryConfig[]
   editQueryStatus: () => void
   tableOptions: TableOptions
@@ -54,6 +57,7 @@ const DashVisualization: SFC<Props> = ({
   staticLegend,
   tableOptions,
   decimalPlaces,
+  autoRefresher,
   noteVisibility,
   editQueryStatus,
   resizerTopHeight,
@@ -75,6 +79,7 @@ const DashVisualization: SFC<Props> = ({
           axes={axes}
           type={type}
           tableOptions={tableOptions}
+          autoRefresher={autoRefresher}
           queries={buildQueries(queryConfigs, timeRange)}
           templates={templates}
           editQueryStatus={editQueryStatus}

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -333,7 +333,6 @@ class DashboardPage extends Component<Props, State> {
             queryDrafts={queryDrafts}
             timeRange={editorTimeRange}
             updateEditorTimeRange={updateEditorTimeRange}
-            autoRefresh={autoRefresh}
             dashboardID={dashboardID}
             queryStatus={cellQueryStatus}
             onSave={this.handleSaveEditedCell}
@@ -398,7 +397,6 @@ class DashboardPage extends Component<Props, State> {
             inView={this.inView}
             dashboard={dashboard}
             timeRange={timeRange}
-            autoRefresh={autoRefresh}
             manualRefresh={manualRefresh}
             onZoom={this.handleZoomedTimeRange}
             inPresentationMode={inPresentationMode}

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -37,7 +37,7 @@ import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
 import {updateDashboardLinks} from 'src/dashboards/utils/dashboardSwitcherLinks'
-import AutoRefresh from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
 
 // APIs
 import {loadDashboardLinks} from 'src/dashboards/apis'
@@ -179,8 +179,8 @@ class DashboardPage extends Component<Props, State> {
   public async componentDidMount() {
     const {autoRefresh} = this.props
 
-    AutoRefresh.poll(autoRefresh)
-    AutoRefresh.subscribe(this.fetchAnnotations)
+    GlobalAutoRefresh.poll(autoRefresh)
+    GlobalAutoRefresh.subscribe(this.fetchAnnotations)
 
     window.addEventListener('resize', this.handleWindowResize, true)
 
@@ -214,7 +214,7 @@ class DashboardPage extends Component<Props, State> {
     }
 
     if (autoRefresh !== prevProps.autoRefresh) {
-      AutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresh.poll(autoRefresh)
     }
 
     if (
@@ -226,8 +226,8 @@ class DashboardPage extends Component<Props, State> {
   }
 
   public componentWillUnmount() {
-    AutoRefresh.stopPolling()
-    AutoRefresh.unsubscribe(this.fetchAnnotations)
+    GlobalAutoRefresh.stopPolling()
+    GlobalAutoRefresh.unsubscribe(this.fetchAnnotations)
 
     window.removeEventListener('resize', this.handleWindowResize, true)
     this.props.handleDismissEditingAnnotation()

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -37,7 +37,7 @@ import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {millisecondTimeRange} from 'src/dashboards/utils/time'
 import {getDeep} from 'src/utils/wrappers'
 import {updateDashboardLinks} from 'src/dashboards/utils/dashboardSwitcherLinks'
-import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 
 // APIs
 import {loadDashboardLinks} from 'src/dashboards/apis'
@@ -179,8 +179,8 @@ class DashboardPage extends Component<Props, State> {
   public async componentDidMount() {
     const {autoRefresh} = this.props
 
-    GlobalAutoRefresh.poll(autoRefresh)
-    GlobalAutoRefresh.subscribe(this.fetchAnnotations)
+    GlobalAutoRefresher.poll(autoRefresh)
+    GlobalAutoRefresher.subscribe(this.fetchAnnotations)
 
     window.addEventListener('resize', this.handleWindowResize, true)
 
@@ -214,7 +214,7 @@ class DashboardPage extends Component<Props, State> {
     }
 
     if (autoRefresh !== prevProps.autoRefresh) {
-      GlobalAutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresher.poll(autoRefresh)
     }
 
     if (
@@ -226,8 +226,8 @@ class DashboardPage extends Component<Props, State> {
   }
 
   public componentWillUnmount() {
-    GlobalAutoRefresh.stopPolling()
-    GlobalAutoRefresh.unsubscribe(this.fetchAnnotations)
+    GlobalAutoRefresher.stopPolling()
+    GlobalAutoRefresher.unsubscribe(this.fetchAnnotations)
 
     window.removeEventListener('resize', this.handleWindowResize, true)
     this.props.handleDismissEditingAnnotation()

--- a/ui/src/data_explorer/components/VisView.tsx
+++ b/ui/src/data_explorer/components/VisView.tsx
@@ -24,7 +24,6 @@ const DataExplorerVisView: SFC<Props> = ({
   source,
   queries,
   templates,
-  autoRefresh,
   manualRefresh,
   editQueryStatus,
 }) => {
@@ -53,7 +52,6 @@ const DataExplorerVisView: SFC<Props> = ({
       queries={queries}
       type={CellType.Line}
       templates={templates}
-      autoRefresh={autoRefresh}
       colors={DEFAULT_LINE_COLORS}
       manualRefresh={manualRefresh}
       editQueryStatus={editQueryStatus}

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -9,6 +9,7 @@ import _ from 'lodash'
 
 // Utils
 import {stripPrefix} from 'src/utils/basepath'
+import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
 
 // Components
 import QueryMaker from 'src/data_explorer/components/QueryMaker'
@@ -21,7 +22,6 @@ import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/Aut
 import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 import GraphTips from 'src/shared/components/GraphTips'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
-import AutoRefresh from 'src/utils/AutoRefresh'
 import SendToDashboardOverlay from 'src/data_explorer/components/SendToDashboardOverlay'
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
 
@@ -82,7 +82,7 @@ export class DataExplorer extends PureComponent<Props, State> {
       await handleGetDashboards()
     }
 
-    AutoRefresh.poll(autoRefresh)
+    GlobalAutoRefresh.poll(autoRefresh)
 
     if (query && query.length) {
       const qc = this.props.queryConfigs[0]
@@ -97,7 +97,7 @@ export class DataExplorer extends PureComponent<Props, State> {
   public componentDidUpdate(prevProps: Props) {
     const {autoRefresh} = this.props
     if (autoRefresh !== prevProps.autoRefresh) {
-      AutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresh.poll(autoRefresh)
     }
   }
 
@@ -116,7 +116,7 @@ export class DataExplorer extends PureComponent<Props, State> {
   }
 
   public componentWillUnmount() {
-    AutoRefresh.stopPolling()
+    GlobalAutoRefresh.stopPolling()
   }
 
   public render() {

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -9,7 +9,7 @@ import _ from 'lodash'
 
 // Utils
 import {stripPrefix} from 'src/utils/basepath'
-import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 
 // Components
 import QueryMaker from 'src/data_explorer/components/QueryMaker'
@@ -82,7 +82,7 @@ export class DataExplorer extends PureComponent<Props, State> {
       await handleGetDashboards()
     }
 
-    GlobalAutoRefresh.poll(autoRefresh)
+    GlobalAutoRefresher.poll(autoRefresh)
 
     if (query && query.length) {
       const qc = this.props.queryConfigs[0]
@@ -97,7 +97,7 @@ export class DataExplorer extends PureComponent<Props, State> {
   public componentDidUpdate(prevProps: Props) {
     const {autoRefresh} = this.props
     if (autoRefresh !== prevProps.autoRefresh) {
-      GlobalAutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresher.poll(autoRefresh)
     }
   }
 
@@ -116,7 +116,7 @@ export class DataExplorer extends PureComponent<Props, State> {
   }
 
   public componentWillUnmount() {
-    GlobalAutoRefresh.stopPolling()
+    GlobalAutoRefresher.stopPolling()
   }
 
   public render() {

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -20,7 +20,7 @@ import {EMPTY_LINKS} from 'src/dashboards/constants/dashboardHeader'
 
 import {setAutoRefresh, delayEnablePresentationMode} from 'shared/actions/app'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 
 @ErrorHandling
 class HostPage extends Component {
@@ -55,7 +55,7 @@ class HostPage extends Component {
     } = await getLayouts()
     const {location, autoRefresh} = this.props
 
-    GlobalAutoRefresh.poll(autoRefresh)
+    GlobalAutoRefresher.poll(autoRefresh)
 
     // fetching layouts and mappings can be done at the same time
     const {host, measurements} = await this.fetchHostsAndMeasurements(layouts)
@@ -82,12 +82,12 @@ class HostPage extends Component {
   componentDidUpdate(prevProps) {
     const {autoRefresh} = this.props
     if (prevProps.autoRefresh !== autoRefresh) {
-      GlobalAutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresher.poll(autoRefresh)
     }
   }
 
   componentWillUnmount() {
-    GlobalAutoRefresh.stopPolling()
+    GlobalAutoRefresher.stopPolling()
   }
 
   handleChooseTimeRange = ({lower, upper}) => {

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -106,7 +106,7 @@ class HostPage extends Component {
       return ''
     }
 
-    const {source, autoRefresh, manualRefresh} = this.props
+    const {source, manualRefresh} = this.props
 
     const autoflowLayouts = layouts.filter(layout => !!layout.autoflow)
 
@@ -162,7 +162,6 @@ class HostPage extends Component {
         cells={layoutCells}
         templates={tempVars}
         timeRange={timeRange}
-        autoRefresh={autoRefresh}
         manualRefresh={manualRefresh}
         host={this.props.params.hostID}
       />

--- a/ui/src/hosts/containers/HostPage.js
+++ b/ui/src/hosts/containers/HostPage.js
@@ -20,7 +20,7 @@ import {EMPTY_LINKS} from 'src/dashboards/constants/dashboardHeader'
 
 import {setAutoRefresh, delayEnablePresentationMode} from 'shared/actions/app'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import AutoRefresh from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresh} from 'src/utils/AutoRefresh'
 
 @ErrorHandling
 class HostPage extends Component {
@@ -55,7 +55,7 @@ class HostPage extends Component {
     } = await getLayouts()
     const {location, autoRefresh} = this.props
 
-    AutoRefresh.poll(autoRefresh)
+    GlobalAutoRefresh.poll(autoRefresh)
 
     // fetching layouts and mappings can be done at the same time
     const {host, measurements} = await this.fetchHostsAndMeasurements(layouts)
@@ -82,12 +82,12 @@ class HostPage extends Component {
   componentDidUpdate(prevProps) {
     const {autoRefresh} = this.props
     if (prevProps.autoRefresh !== autoRefresh) {
-      AutoRefresh.poll(autoRefresh)
+      GlobalAutoRefresh.poll(autoRefresh)
     }
   }
 
   componentWillUnmount() {
-    AutoRefresh.stopPolling()
+    GlobalAutoRefresh.stopPolling()
   }
 
   handleChooseTimeRange = ({lower, upper}) => {

--- a/ui/src/shared/components/Layout.tsx
+++ b/ui/src/shared/components/Layout.tsx
@@ -26,7 +26,6 @@ interface Props {
   source: Source
   sources: Source[]
   host: string
-  autoRefresh: number
   isEditable: boolean
   manualRefresh: number
   onZoom: () => void
@@ -49,7 +48,6 @@ class Layout extends Component<Props> {
       sources,
       onZoom,
       timeRange,
-      autoRefresh,
       manualRefresh,
       templates,
       isEditable,
@@ -84,7 +82,6 @@ class Layout extends Component<Props> {
             decimalPlaces={cell.decimalPlaces}
             timeRange={timeRange}
             templates={templates}
-            autoRefresh={autoRefresh}
             manualRefresh={manualRefresh}
             staticLegend={IS_STATIC_LEGEND(cell.legend)}
             grabDataForDownload={this.grabDataForDownload}

--- a/ui/src/shared/components/LayoutRenderer.tsx
+++ b/ui/src/shared/components/LayoutRenderer.tsx
@@ -32,7 +32,6 @@ interface Props {
   templates: Template[]
   sources: Source[]
   host: string
-  autoRefresh: number
   manualRefresh: number
   isStatusPage: boolean
   isEditable: boolean
@@ -67,7 +66,6 @@ class LayoutRenderer extends Component<Props, State> {
       templates,
       timeRange,
       isEditable,
-      autoRefresh,
       manualRefresh,
       onDeleteCell,
       onCloneCell,
@@ -116,7 +114,6 @@ class LayoutRenderer extends Component<Props, State> {
                   templates={templates}
                   timeRange={timeRange}
                   isEditable={isEditable}
-                  autoRefresh={autoRefresh}
                   onDeleteCell={onDeleteCell}
                   onCloneCell={onCloneCell}
                   manualRefresh={manualRefresh}

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -48,7 +48,6 @@ interface Props {
   isInCEO: boolean
   timeFormat: string
   cellHeight: number
-  autoRefresh: number
   staticLegend: boolean
   manualRefresh: number
   resizerTopHeight: number

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -18,6 +18,9 @@ import {
   DEFAULT_DECIMAL_PLACES,
 } from 'src/dashboards/constants'
 
+// Utils
+import {AutoRefresher} from 'src/utils/AutoRefresher'
+
 // Actions
 import {setHoverTime} from 'src/dashboards/actions'
 
@@ -49,6 +52,7 @@ interface Props {
   timeFormat: string
   cellHeight: number
   staticLegend: boolean
+  autoRefresher: AutoRefresher
   manualRefresh: number
   resizerTopHeight: number
   onZoom: () => void
@@ -90,6 +94,7 @@ class RefreshingGraph extends PureComponent<Props> {
       timeRange,
       templates,
       manualRefresh,
+      autoRefresher,
       editQueryStatus,
       cellNoteVisibility,
       grabDataForDownload,
@@ -110,6 +115,7 @@ class RefreshingGraph extends PureComponent<Props> {
     return (
       <TimeSeries
         ref={this.timeSeries}
+        autoRefresher={autoRefresher}
         manualRefresh={manualRefresh}
         source={source}
         cellType={type}

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -79,7 +79,6 @@ interface Props {
   sources: Source[]
   isInCEO: boolean
   services: Service[]
-  autoRefresh: number
   timeRange: TimeRange
   templates: Template[]
   isStaticLegend: boolean
@@ -228,7 +227,6 @@ class TimeMachine extends PureComponent<Props, State> {
       script,
       timeRange,
       templates,
-      autoRefresh,
       editQueryStatus,
       isInCEO,
       source,
@@ -245,7 +243,6 @@ class TimeMachine extends PureComponent<Props, State> {
           source={source}
           timeRange={timeRange}
           templates={templates}
-          autoRefresh={autoRefresh}
           queryConfigs={this.queriesWorkingDraft}
           editQueryStatus={editQueryStatus}
           staticLegend={isStaticLegend}

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -5,6 +5,7 @@ import React, {SFC} from 'react'
 import SourceSelector from 'src/dashboards/components/SourceSelector'
 import TimeRangeDropdown from 'src/shared/components/TimeRangeDropdown'
 import CSVExporter from 'src/shared/components/TimeMachine/CSVExporter'
+import AutoRefreshDropdown from 'src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown'
 
 // Utils
 import buildQueries from 'src/utils/buildQueriesForGraphs'
@@ -21,6 +22,8 @@ interface Props {
   services: Service[]
   isDynamicSourceSelected: boolean
   onChangeService: (service: Service, source: SourcesModels.Source) => void
+  autoRefreshDuration: number
+  onChangeAutoRefreshDuration: (newDuration: number) => void
   queries: QueriesModels.QueryConfig[]
   templates: Template[]
   onSelectDynamicSource: () => void
@@ -36,6 +39,8 @@ const TimeMachineControls: SFC<Props> = ({
   templates,
   services,
   timeRange,
+  autoRefreshDuration,
+  onChangeAutoRefreshDuration,
   onChangeService,
   onSelectDynamicSource,
   isDynamicSourceSelected,
@@ -56,6 +61,11 @@ const TimeMachineControls: SFC<Props> = ({
       <CSVExporter
         queries={buildQueries(queries, timeRange)}
         templates={templates}
+      />
+      <AutoRefreshDropdown
+        selected={autoRefreshDuration}
+        onChoose={onChangeAutoRefreshDuration}
+        showManualRefresh={false}
       />
       <TimeRangeDropdown
         onChooseTimeRange={updateEditorTimeRange}

--- a/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -16,13 +16,19 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface Props {
   selected: number
   onChoose: (milliseconds: number) => void
-  onManualRefresh: () => void
+  showManualRefresh?: boolean
+  onManualRefresh?: () => void
 }
 
 @ErrorHandling
 class AutoRefreshDropdown extends Component<Props> {
+  public static defaultProps: Partial<Props> = {
+    showManualRefresh: true,
+  }
+
   constructor(props) {
     super(props)
+
     this.state = {
       isOpen: false,
     }
@@ -105,7 +111,11 @@ class AutoRefreshDropdown extends Component<Props> {
   }
 
   private get manualRefreshButton(): JSX.Element {
-    const {onManualRefresh} = this.props
+    const {showManualRefresh, onManualRefresh} = this.props
+
+    if (!showManualRefresh) {
+      return
+    }
 
     if (this.isPaused) {
       return (

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -19,7 +19,7 @@ import {TimeSeriesServerResponse, TimeSeriesResponse} from 'src/types/series'
 import {GrabDataForDownloadHandler} from 'src/types/layout'
 
 // Utils
-import {GlobalAutoRefresh, AutoRefresh} from 'src/utils/AutoRefresh'
+import {GlobalAutoRefresher, AutoRefresher} from 'src/utils/AutoRefresher'
 import {CellNoteVisibility} from 'src/types/dashboards'
 
 // Components
@@ -39,7 +39,7 @@ interface Props {
   queries: Query[]
   timeRange: TimeRange
   children: (r: RenderProps) => JSX.Element
-  autoRefresh?: AutoRefresh
+  autoRefresher?: AutoRefresher
   inView?: boolean
   templates?: Template[]
   editQueryStatus?: () => void
@@ -67,7 +67,7 @@ class TimeSeries extends Component<Props, State> {
   public static defaultProps = {
     inView: true,
     templates: [],
-    autoRefresh: GlobalAutoRefresh,
+    autoRefresher: GlobalAutoRefresher,
   }
 
   public static getDerivedStateFromProps(props: Props, state: State) {
@@ -119,24 +119,24 @@ class TimeSeries extends Component<Props, State> {
   }
 
   public async componentDidMount() {
-    const {autoRefresh} = this.props
+    const {autoRefresher} = this.props
 
     this.isComponentMounted = true
     this.executeQueries()
-    autoRefresh.subscribe(this.executeQueries)
+    autoRefresher.subscribe(this.executeQueries)
   }
 
   public componentWillUnmount() {
-    const {autoRefresh} = this.props
+    const {autoRefresher} = this.props
 
     this.isComponentMounted = false
-    autoRefresh.unsubscribe(this.executeQueries)
+    autoRefresher.unsubscribe(this.executeQueries)
   }
 
   public async componentDidUpdate(prevProps: Props) {
-    if (this.props.autoRefresh !== prevProps.autoRefresh) {
-      prevProps.autoRefresh.unsubscribe(this.executeQueries)
-      this.props.autoRefresh.subscribe(this.executeQueries)
+    if (this.props.autoRefresher !== prevProps.autoRefresher) {
+      prevProps.autoRefresher.unsubscribe(this.executeQueries)
+      this.props.autoRefresher.subscribe(this.executeQueries)
     }
 
     if (!this.isPropsDifferent(prevProps)) {

--- a/ui/src/status/containers/StatusPage.tsx
+++ b/ui/src/status/containers/StatusPage.tsx
@@ -7,7 +7,6 @@ import LayoutRenderer from 'src/shared/components/LayoutRenderer'
 import PageHeader from 'src/reusable_ui/components/page_layout/PageHeader'
 
 // Constants
-import {AUTOREFRESH_DEFAULT} from 'src/shared/constants'
 import {STATUS_PAGE_TIME_RANGE} from 'src/shared/data/timeRanges'
 import {fixtureStatusPageCells} from 'src/status/fixtures'
 import {
@@ -34,7 +33,6 @@ interface Props {
   source: Source
 }
 
-const autoRefresh = AUTOREFRESH_DEFAULT
 const timeRange = STATUS_PAGE_TIME_RANGE
 
 @ErrorHandling
@@ -71,7 +69,6 @@ class StatusPage extends Component<Props, State> {
                 isStatusPage={true}
                 timeRange={timeRange}
                 templates={this.templates}
-                autoRefresh={autoRefresh}
               />
             ) : (
               <span>Loading Status Page...</span>

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -414,8 +414,12 @@ div.dropdown.dropdown-stretch > button.dropdown-toggle {
   background-color: $g3-castle;
   align-items: center;
 
-  .csv-export {
+  .csv-export, .autorefresh-dropdown {
     margin-right: 5px;
+  }
+
+  .autorefresh-dropdown.paused .dropdown {
+    margin-right: 0;
   }
 }
 

--- a/ui/src/utils/AutoRefresh.ts
+++ b/ui/src/utils/AutoRefresh.ts
@@ -1,6 +1,6 @@
 type func = (...args: any[]) => any
 
-class AutoRefresh {
+export class AutoRefresh {
   public subscribers: func[] = []
 
   private intervalID: NodeJS.Timer
@@ -39,4 +39,7 @@ class AutoRefresh {
   }
 }
 
-export default new AutoRefresh()
+// A global singleton, intended to be configured (via `AutoRefresh#poll`) at a
+// page level and consumed arbitrarily deep within the page's render tree
+// (usually in a `TimeSeries` component)
+export const GlobalAutoRefresh = new AutoRefresh()

--- a/ui/src/utils/AutoRefresher.ts
+++ b/ui/src/utils/AutoRefresher.ts
@@ -1,6 +1,6 @@
 type func = (...args: any[]) => any
 
-export class AutoRefresh {
+export class AutoRefresher {
   public subscribers: func[] = []
 
   private intervalID: NodeJS.Timer
@@ -39,7 +39,7 @@ export class AutoRefresh {
   }
 }
 
-// A global singleton, intended to be configured (via `AutoRefresh#poll`) at a
-// page level and consumed arbitrarily deep within the page's render tree
+// A global singleton, intended to be configured (via `AutoRefresher#poll`) at
+// a page level and consumed arbitrarily deep within the page's render tree
 // (usually in a `TimeSeries` component)
-export const GlobalAutoRefresh = new AutoRefresh()
+export const GlobalAutoRefresher = new AutoRefresher()


### PR DESCRIPTION
Closes #4140

Adds a control for the auto refresh interval to the CEO:

![screen shot 2018-08-29 at 2 13 02 pm](https://user-images.githubusercontent.com/638955/44816018-e37e9280-ab95-11e8-917d-97f2e7b3a726.png)

I did some refactoring here. It's probably easiest to review commit by commit.
