### PR TITLE
Remove redundant button from empty queries state

### DIFF
--- a/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
@@ -45,6 +45,14 @@ const QueryMaker: SFC<Props> = ({
   initialGroupByTime,
   setActiveQueryIndex,
 }) => {
+  if (!activeQuery || !activeQuery.id) {
+    return (
+      <div className="query-maker">
+        <EmptyQuery onAddQuery={onAddQuery} />
+      </div>
+    )
+  }
+
   return (
     <div className="query-maker">
       <QueryTabList
@@ -55,29 +63,25 @@ const QueryMaker: SFC<Props> = ({
         activeQueryIndex={activeQueryIndex}
         setActiveQueryIndex={setActiveQueryIndex}
       />
-      {activeQuery && activeQuery.id ? (
-        <div className="query-maker--tab-contents">
-          <InfluxQLEditor
-            query={buildText(activeQuery)}
-            config={activeQuery}
-            onUpdate={actions.editRawTextAsync}
-            templates={templates}
-          />
-          <SchemaExplorer
-            source={source}
-            actions={actions}
-            query={activeQuery}
-            initialGroupByTime={initialGroupByTime}
-            isQuerySupportedByExplorer={_.get(
-              activeQuery,
-              'isQuerySupportedByExplorer',
-              true
-            )}
-          />
-        </div>
-      ) : (
-        <EmptyQuery onAddQuery={onAddQuery} />
-      )}
+      <div className="query-maker--tab-contents">
+        <InfluxQLEditor
+          query={buildText(activeQuery)}
+          config={activeQuery}
+          onUpdate={actions.editRawTextAsync}
+          templates={templates}
+        />
+        <SchemaExplorer
+          source={source}
+          actions={actions}
+          query={activeQuery}
+          initialGroupByTime={initialGroupByTime}
+          isQuerySupportedByExplorer={_.get(
+            activeQuery,
+            'isQuerySupportedByExplorer',
+            true
+          )}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
Just something tiny I noticed. Before:

![before](https://user-images.githubusercontent.com/638955/44863354-bed7f880-ac31-11e8-8492-46932520bf1d.gif)

After:

![after](https://user-images.githubusercontent.com/638955/44863360-c26b7f80-ac31-11e8-868f-b283d281a85b.gif)
