### PR TITLE
Fix RuleGraphDygraph

### DIFF
--- a/ui/src/kapacitor/components/RuleGraphDygraph.tsx
+++ b/ui/src/kapacitor/components/RuleGraphDygraph.tsx
@@ -34,25 +34,36 @@ interface Props {
 }
 
 interface State {
-  timeSeriesToDygraphResult?: TimeSeriesToDyGraphReturnType
+  timeSeriesToDygraphResult: TimeSeriesToDyGraphReturnType | null
 }
 
 @ErrorHandling
 class RuleGraphDygraph extends Component<Props, State> {
-  public async componentWillReceiveProps(nextProps: Props) {
-    const {loading, timeSeries} = this.props
-    if (
-      loading !== nextProps.loading &&
-      nextProps.loading === RemoteDataState.Done
-    ) {
-      const result = await timeSeriesToDygraph(timeSeries, 'rule-builder')
-      this.setState({timeSeriesToDygraphResult: result})
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {timeSeriesToDygraphResult: null}
+  }
+
+  public componentDidMount() {
+    if (this.props.timeSeries) {
+      this.loadDygraphData()
+    }
+  }
+
+  public componentDidUpdate(prevProps) {
+    if (prevProps.timeSeries !== this.props.timeSeries) {
+      this.loadDygraphData()
     }
   }
 
   public render() {
     const {timeRange, rule} = this.props
     const {timeSeriesToDygraphResult} = this.state
+
+    if (!timeSeriesToDygraphResult) {
+      return null
+    }
 
     return (
       <Dygraph
@@ -71,6 +82,13 @@ class RuleGraphDygraph extends Component<Props, State> {
         handleSetHoverTime={this.props.setHoverTime}
       />
     )
+  }
+
+  private loadDygraphData = async () => {
+    const {timeSeries} = this.props
+    const result = await timeSeriesToDygraph(timeSeries, 'rule-builder')
+
+    this.setState({timeSeriesToDygraphResult: result})
   }
 
   private get containerStyle(): CSSProperties {


### PR DESCRIPTION
The rule graph on the _Alert Rule Builder_ page will not render. The following error is thrown in the console:

```
Uncaught TypeError: Cannot read property 'timeSeriesToDygraphResult' of null
    at Wrapped.render (eval at hmrApply (runtime.js:737), <anonymous>:155:56)
    at Wrapped.render (_task.js:85)
    at finishClassComponent (_add-to-unscopables.js:2)
    at updateClassComponent (_add-to-unscopables.js:2)
    at beginWork (es6.array.iterator.js:35)
    at performUnitOfWork (_meta.js:54)
    at workLoop (_meta.js:54)
    at HTMLUnknownElement.callCallback (_export.js:63)
    at Object.invokeGuardedCallbackDev (_export.js:63)
    at invokeGuardedCallback (_export.js:63)
```

The issue is some invalid property access in the `RuleGraphDygraph` component.

Solution: refactor lifecycle logic in the `RuleGraphDygraph` component.