### PR TITLE
Add default for data explorer script in local storage

### DIFF
--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -5,6 +5,8 @@ import {
   notifyLoadLocalSettingsFailed,
 } from 'src/shared/copy/notifications'
 
+import {editor} from 'src/flux/constants'
+
 import {LocalStorage} from 'src/types/localStorage'
 
 const VERSION = process.env.npm_package_version
@@ -83,6 +85,7 @@ export const saveToLocalStorage = ({
               timeRange: dataExplorer.timeRange || {},
               sourceLink: dataExplorer.sourceLink || '',
               queryStatus: dataExplorer.queryStatus || {},
+              script: dataExplorer.script || editor.DEFAULT_SCRIPT,
             },
             script,
             logs: {


### PR DESCRIPTION

_Briefly describe your proposed changes:_
_What was the problem?_
Script in data explorer didnt have a default value.
_What was the solution?_
Give script a default value when pulling out of local storage.

  - [x] Rebased/mergeable
  - [ ] Tests pass
