### PR TITLE
Fix annotation filter control undefined bug

### DIFF
--- a/ui/src/shared/components/AnnotationFilterControlInput.tsx
+++ b/ui/src/shared/components/AnnotationFilterControlInput.tsx
@@ -131,8 +131,10 @@ class AnnotationFilterControlInput extends PureComponent<Props, State> {
 
     if (key === 'Enter') {
       const {selectionIndex, filteredSuggestions} = this.state
+      const newValue =
+        filteredSuggestions[selectionIndex] || this.input.current.value
 
-      this.handleSelect(filteredSuggestions[selectionIndex])
+      this.handleSelect(newValue)
     } else if (
       key === 'ArrowDown' ||
       (ctrlKey && (key === 'j' || key === 'n')) // emacs and vim bindings


### PR DESCRIPTION
Closes #4251

These changes fix the following bug:

1. Type text into an `AnnotationFilterControl` that does not match any suggestions in the dropdown
2. Press enter
3. The string "undefined" gets selected

The fix is to fallback to exactly what text the user entered when selecting if no suggestion is available.