### PR TITLE
Fix subpixel height of Radio Buttons

### DIFF
--- a/ui/src/reusable_ui/components/radio_buttons/RadioButtons.scss
+++ b/ui/src/reusable_ui/components/radio_buttons/RadioButtons.scss
@@ -4,30 +4,34 @@
 */
 
 .radio-buttons {
-  @include no-user-select();
   display: inline-flex;
   align-items: stretch;
-  border: $ix-border solid $g5-pepper;
-  background-color: $g5-pepper;
-  border-radius: $ix-radius;
-  overflow: hidden;
 }
 
 .radio-button {
+  @include no-user-select();
   font-family: $ix-text-font;
   font-weight: 600;
-  margin-right: $ix-border;
   transition: background-color 0.25s ease, color 0.25s ease;
   background-color: $g2-kevlar;
   color: $g11-sidewalk;
   text-transform: capitalize;
   outline: none;
-  border: 0;
+  border: $ix-border solid $g5-pepper;
+  border-right-width: 0;
   text-align: center;
   white-space: nowrap;
+  overflow: hidden;
+
+  &:first-child {
+    border-top-left-radius: $ix-radius;
+    border-bottom-left-radius: $ix-radius;
+  }
 
   &:last-child {
-    margin-right: 0;
+    border-top-right-radius: $ix-radius;
+    border-bottom-right-radius: $ix-radius;
+    border-right-width: $ix-border;
   }
 
   &:hover {
@@ -51,10 +55,9 @@
 /*  Size Modifiers */
 @mixin radioButtonSizeModifier($fontSize, $padding, $height) {
   height: $height;
-  line-height: $height - ($ix-border * 2);
 
   .radio-button {
-    line-height: $height - ($ix-border * 2);
+    height: $height;
     padding: 0 $padding;
     font-size: $fontSize;
   }
@@ -109,19 +112,19 @@
 /* Shape Modifiers */
 .radio-buttons.radio-buttons--square {
   &.radio-buttons--xs .radio-button {
-    width: $form-xs-height - ($ix-border * 2);
+    width: $form-xs-height;
   }
   
   &.radio-buttons--sm .radio-button {
-    width: $form-sm-height - ($ix-border * 2);
+    width: $form-sm-height;
   }
   
   &.radio-buttons--md .radio-button {
-    width: $form-md-height - ($ix-border * 2);
+    width: $form-md-height;
   }
 
   &.radio-buttons--lg .radio-button {
-    width: $form-lg-height - ($ix-border * 2);
+    width: $form-lg-height;
   }
 
   .radio-button {


### PR DESCRIPTION
_What was the problem?_
![screen shot 2018-09-04 at 11 47 46 am](https://user-images.githubusercontent.com/2433762/45051370-c552df80-b038-11e8-971f-f6d817572a9a.png)
Radio buttons rendering at 28.97 pixels causing a weird extra thick border on the bottom

_What was the solution?_
![screen shot 2018-09-04 at 11 47 59 am](https://user-images.githubusercontent.com/2433762/45051399-d56abf00-b038-11e8-9e92-3d217fa8169f.png)
Use a simpler way to handle borders on the buttons which ensures proper sizing

  - [x] Rebased/mergeable
  - [x] Tests pass