### PR TITLE
Use bucket instead of db for flux queries

### DIFF
--- a/ui/src/flux/components/FilterTagListItem.tsx
+++ b/ui/src/flux/components/FilterTagListItem.tsx
@@ -247,7 +247,7 @@ export default class FilterTagListItem extends PureComponent<Props, State> {
     const {searchTerm, limit} = this.state
     const response = await fetchTagValues({
       service,
-      db,
+      bucket: db,
       filter,
       tagKey,
       limit,
@@ -283,7 +283,7 @@ export default class FilterTagListItem extends PureComponent<Props, State> {
     try {
       const response = await fetchTagValues({
         service,
-        db,
+        bucket: db,
         filter,
         tagKey,
         limit,

--- a/ui/src/flux/components/TagListItem.tsx
+++ b/ui/src/flux/components/TagListItem.tsx
@@ -223,7 +223,7 @@ export default class TagListItem extends PureComponent<Props, State> {
     const {searchTerm, limit} = this.state
     const response = await fetchTagValues({
       service,
-      db,
+      bucket: db,
       filter,
       tagKey,
       limit,
@@ -275,7 +275,7 @@ export default class TagListItem extends PureComponent<Props, State> {
     try {
       const response = await fetchTagValues({
         service,
-        db,
+        bucket: db,
         filter,
         tagKey,
         limit,

--- a/ui/src/flux/constants/builder.ts
+++ b/ui/src/flux/constants/builder.ts
@@ -1,2 +1,2 @@
-export const NEW_FROM = `from(db: "pick a db")\n\t|> filter(fn: (r) => r.tag == "value")\n\t|> range(start: -1m)`
+export const NEW_FROM = `from(bucket: "pick a bucket")\n\t|> filter(fn: (r) => r.tag == "value")\n\t|> range(start: -1m)`
 export const NEW_JOIN = `join(tables:{fil:fil, tele:tele}, on:["host"], fn:(tables) => tables.fil["_value"] + tables.tele["_value"])`

--- a/ui/src/flux/constants/editor.ts
+++ b/ui/src/flux/constants/editor.ts
@@ -60,4 +60,4 @@ export const EXCLUDED_KEYS = [
 ]
 
 export const DEFAULT_SCRIPT =
-  'from(db: "pick a db")\n\t|> filter(fn: (r) => r._measurement == "your value here")\n\t|> range(start: -1m)\n\t|> yield(name: "Results")\n\n'
+  'from(bucket: "pick a bucket")\n\t|> filter(fn: (r) => r._measurement == "your value here")\n\t|> range(start: -1m)\n\t|> yield(name: "Results")\n\n'

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -5,10 +5,10 @@ import {Service, SchemaFilter} from 'src/types'
 
 export const measurements = async (
   service: Service,
-  db: string
+  bucket: string
 ): Promise<any> => {
   const script = `
-    from(db:"${db}") 
+    from(bucket:"${bucket}") 
         |> range(start:-24h) 
         |> group(by:["_measurement"]) 
         |> distinct(column:"_measurement") 
@@ -20,7 +20,7 @@ export const measurements = async (
 
 export const tagKeys = async (
   service: Service,
-  db: string,
+  bucket: string,
   filter: SchemaFilter[]
 ): Promise<any> => {
   let tagKeyFilter = ''
@@ -32,8 +32,8 @@ export const tagKeys = async (
   }
 
   const script = `
-    from(db: "${db}")
-      |> range(start: -24h)
+    from(bucket: "${bucket}")
+      |> range(start: -30d)
       ${tagsetFilter(filter)}
      	|> group(none: true)
       |> keys(except:["_time", "_value", "_start", "_stop"])
@@ -46,7 +46,7 @@ export const tagKeys = async (
 
 interface TagValuesParams {
   service: Service
-  db: string
+  bucket: string
   tagKey: string
   limit: number
   filter?: SchemaFilter[]
@@ -55,7 +55,7 @@ interface TagValuesParams {
 }
 
 export const tagValues = async ({
-  db,
+  bucket,
   service,
   tagKey,
   limit,
@@ -73,7 +73,7 @@ export const tagValues = async ({
   const countFunc = count ? '|> count()' : ''
 
   const script = `
-    from(db:"${db}")
+    from(bucket:"${bucket}")
       |> range(start:-1h)
       ${regexFilter}
       ${tagsetFilter(filter)}
@@ -89,11 +89,11 @@ export const tagValues = async ({
 
 export const tagsFromMeasurement = async (
   service: Service,
-  db: string,
+  bucket: string,
   measurement: string
 ): Promise<any> => {
   const script = `
-    from(db:"${db}") 
+    from(bucket:"${bucket}") 
       |> range(start:-24h) 
       |> filter(fn:(r) => r._measurement == "${measurement}") 
       |> group() 

--- a/ui/test/flux/ast/complex.ts
+++ b/ui/test/flux/ast/complex.ts
@@ -10,7 +10,7 @@ export default {
       column: 91,
     },
     source:
-      'from(db: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
+      'from(bucket: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
   },
   body: [
     {
@@ -25,7 +25,7 @@ export default {
           column: 91,
         },
         source:
-          'from(db: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
+          'from(bucket: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
       },
       expression: {
         type: 'PipeExpression',
@@ -64,7 +64,7 @@ export default {
                 line: 1,
                 column: 21,
               },
-              source: 'from(db: "telegraf")',
+              source: 'from(bucket: "telegraf")',
             },
             callee: {
               type: 'Identifier',

--- a/ui/test/flux/ast/walker.test.ts
+++ b/ui/test/flux/ast/walker.test.ts
@@ -195,11 +195,11 @@ describe('Flux.AST.Walker', () => {
           {
             type: 'PipeExpression',
             source:
-              'from(db: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
+              'from(bucket: "telegraf") |> filter(fn: (r) => r["_measurement"] == "cpu") |> range(start: -1m)',
             funcs: [
               {
                 name: 'from',
-                source: 'from(db: "telegraf")',
+                source: 'from(bucket: "telegraf")',
                 args: [{key: 'db', value: 'telegraf'}],
               },
               {


### PR DESCRIPTION
Because changes in flux dbs are now referred to as buckets

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)