### PR TITLE
Refactor Dygraph component

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -109,6 +109,7 @@
     "level-js": "^3.0.0",
     "levelup": "^3.1.1",
     "lodash": "^4.3.0",
+    "memoize-one": "^4.0.2",
     "moment": "^2.13.0",
     "nano-date": "^2.0.1",
     "papaparse": "^4.4.0",

--- a/ui/src/shared/graphs/helpers.ts
+++ b/ui/src/shared/graphs/helpers.ts
@@ -161,17 +161,6 @@ export const removeMeasurement = (label = '') => {
   return label.replace(measurement, '')
 }
 
-export const OPTIONS = {
-  rightGap: 0,
-  axisLineWidth: 2,
-  gridLineWidth: 1,
-  animatedZooms: true,
-  labelsSeparateLines: false,
-  hideOverlayOnMouseOut: false,
-  highlightSeriesBackgroundAlpha: 1.0,
-  highlightSeriesBackgroundColor: 'rgb(41, 41, 51)',
-}
-
 export const hasherino = (str, len) =>
   str
     .split('')

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5442,6 +5442,10 @@ mem@^1.1.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+memoize-one@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-4.0.2.tgz#3fb8db695aa14ab9c0f1644e1585a8806adc1aee"
+
 memoizerific@^1.11.2:
   version "1.11.3"
   resolved "https://registry.yarnpkg.com/memoizerific/-/memoizerific-1.11.3.tgz#7c87a4646444c32d75438570905f2dbd1b1a805a"


### PR DESCRIPTION
Closes #4337

This PR makes a number of changes to the `Dygraph` component to avoid unnecessary rerenders.

- Only call `updateOptions` on the dygraph instance when options have changed, since updating the options triggers a redraw.
- Don't call `Dygraph#resize` on `Dygraph#componentDidUpdate`. Redrawing in response to a legitimate resize is already handled by the `ReactResizeDetector` child of a `Dygraph`. 
- Don't call dygraph private instance methods `resizeElements_` and `predraw_` in the resize method. They are expensive and also redudant since `resize` is called on the dygraph instance in `Dygraph#resize` as well.
- Memoize calls to `src/shared/parsing/getRangeForDygraph`, which can be expensive since it must traverse the entire time series.
- Extract the logic of what options to pass to Dygraphs on initial render and rerenders to a `Dygraph#collectDygraphOptions` method. This reduces confusing duplication in the `Dygraph` component and fixes a potential bug where the `options` supplied in the props don't override the options computed in `Dygraph#componentDidUpdate` (even though they do in `Dygraph#componentDidMount`).
- Remove unused `setResolution` prop
- Group together ES5 getters and instance property methods (style change)
