### PR TITLE
Add loading and error states to DashboardsPage

### DIFF
--- a/ui/src/dashboards/components/DashboardsPageContents.tsx
+++ b/ui/src/dashboards/components/DashboardsPageContents.tsx
@@ -9,13 +9,14 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
 import {Button, ComponentColor, IconFont} from 'src/reusable_ui'
 
-import {Dashboard, Source} from 'src/types'
+import {Dashboard, Source, RemoteDataState} from 'src/types'
 import {Notification} from 'src/types/notifications'
 
 interface Props {
   source: Source
   sources: Source[]
   dashboards: Dashboard[]
+  dashboardsStatus: RemoteDataState
   onDeleteDashboard: (dashboard: Dashboard) => () => void
   onCreateDashboard: () => void
   onCloneDashboard: (
@@ -50,14 +51,16 @@ class DashboardsPageContents extends Component<Props, State> {
       onCloneDashboard,
       onExportDashboard,
       dashboardLink,
+      dashboardsStatus,
     } = this.props
 
     return (
-      <div className="panel">
+      <div className="panel dashboards-page-panel">
         {this.renderPanelHeading}
         <div className="panel-body">
           <DashboardsTable
             dashboards={this.filteredDashboards}
+            dashboardsStatus={dashboardsStatus}
             onDeleteDashboard={onDeleteDashboard}
             onCreateDashboard={onCreateDashboard}
             onCloneDashboard={onCloneDashboard}

--- a/ui/src/dashboards/components/DashboardsTable.tsx
+++ b/ui/src/dashboards/components/DashboardsTable.tsx
@@ -7,10 +7,11 @@ import ConfirmButton from 'src/shared/components/ConfirmButton'
 
 import {getDeep} from 'src/utils/wrappers'
 
-import {Dashboard, Template} from 'src/types'
+import {Dashboard, Template, RemoteDataState} from 'src/types'
 
 interface Props {
   dashboards: Dashboard[]
+  dashboardsStatus: RemoteDataState
   onDeleteDashboard: (dashboard: Dashboard) => () => void
   onCreateDashboard: () => void
   onCloneDashboard: (
@@ -24,14 +25,26 @@ class DashboardsTable extends PureComponent<Props> {
   public render() {
     const {
       dashboards,
+      dashboardsStatus,
       dashboardLink,
       onCloneDashboard,
       onDeleteDashboard,
       onExportDashboard,
     } = this.props
 
+    if (
+      dashboardsStatus === RemoteDataState.Loading ||
+      dashboardsStatus === RemoteDataState.NotStarted
+    ) {
+      return this.renderLoadingState()
+    }
+
+    if (dashboardsStatus === RemoteDataState.Error) {
+      return this.renderErrorState()
+    }
+
     if (!dashboards.length) {
-      return this.emptyStateDashboard
+      return this.renderEmptyState()
     }
 
     return (
@@ -109,22 +122,36 @@ class DashboardsTable extends PureComponent<Props> {
     return <span className="empty-string">None</span>
   }
 
-  private get emptyStateDashboard(): JSX.Element {
+  private renderLoadingState(): JSX.Element {
+    return (
+      <div className="generic-empty-state">
+        <h4>Loading dashboards...</h4>
+      </div>
+    )
+  }
+
+  private renderErrorState(): JSX.Element {
+    return (
+      <div className="generic-empty-state">
+        <h4>Unable to load dashboards</h4>
+      </div>
+    )
+  }
+
+  private renderEmptyState(): JSX.Element {
     const {onCreateDashboard} = this.props
+
     return (
       <Authorized
         requiredRole={EDITOR_ROLE}
         replaceWithIfNotAuthorized={this.unauthorizedEmptyState}
       >
         <div className="generic-empty-state">
-          <h4 style={{marginTop: '90px'}}>
-            Looks like you don’t have any dashboards
-          </h4>
+          <h4>Looks like you don’t have any dashboards</h4>
           <br />
           <button
             className="btn btn-sm btn-primary"
             onClick={onCreateDashboard}
-            style={{marginBottom: '90px'}}
           >
             <span className="icon plus" /> Create Dashboard
           </button>

--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -33,11 +33,11 @@ import {Source, Dashboard, RemoteDataState} from 'src/types'
 import {Notification} from 'src/types/notifications'
 import {DashboardFile, Cell} from 'src/types/dashboards'
 
-interface Props {
+export interface Props {
   source: Source
   sources: Source[]
   router: InjectedRouter
-  handleGetDashboards: () => Dashboard[]
+  handleGetDashboards: () => Promise<Dashboard[]>
   handleGetChronografVersion: () => string
   handleDeleteDashboard: (dashboard: Dashboard) => void
   handleImportDashboard: (dashboard: Dashboard) => void
@@ -51,7 +51,7 @@ interface State {
 }
 
 @ErrorHandling
-class DashboardsPage extends PureComponent<Props, State> {
+export class DashboardsPage extends PureComponent<Props, State> {
   constructor(props: Props) {
     super(props)
 

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -59,6 +59,10 @@ $dash-graph-options-arrow: 8px;
   }
 }
 
+.dashboards-page-panel .generic-empty-state {
+  margin: 90px 0;
+}
+
 /*
   Default Dashboard Mode
   ------------------------------------------------------

--- a/ui/test/dashboards/components/DashboardsPage.test.tsx
+++ b/ui/test/dashboards/components/DashboardsPage.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+
+import {DashboardsPage, Props} from 'src/dashboards/containers/DashboardsPage'
+import DashboardsTable from 'src/dashboards/components/DashboardsTable'
+import DashboardsContents from 'src/dashboards/components/DashboardsPageContents'
+import {Page} from 'src/reusable_ui'
+
+import {source} from 'test/resources'
+
+describe('DashboadsPage', () => {
+  test('it displays a loading state initially', () => {
+    const props = {
+      dashboards: [],
+      handleGetDashboards: () => new Promise(() => {}),
+      source,
+      sources: [source],
+    } as Props
+
+    const wrapper = shallow(<DashboardsPage {...props} />)
+
+    const text = wrapper
+      .find(Page)
+      .dive()
+      .find(Page.Contents)
+      .dive()
+      .find(DashboardsContents)
+      .dive()
+      .find(DashboardsTable)
+      .dive()
+      .find('.generic-empty-state h4')
+      .text()
+
+    expect(text).toEqual('Loading dashboards...')
+  })
+})


### PR DESCRIPTION
Closes #4185

Adds a few more possible states to the dashboards page UI.

Loading:

![screen shot 2018-09-04 at 2 24 50 pm](https://user-images.githubusercontent.com/638955/45058837-becf6280-b04e-11e8-8180-856ff4d7e189.png)

Error: 

![screen shot 2018-09-04 at 2 24 31 pm](https://user-images.githubusercontent.com/638955/45058843-c2fb8000-b04e-11e8-81dd-8670afc98d61.png)

Previously the empty state showed in both these cases:

![screen shot 2018-09-04 at 2 23 39 pm](https://user-images.githubusercontent.com/638955/45058853-c8f16100-b04e-11e8-84fd-d70287025004.png)
