### PR TITLE
fix(server): pass pprof enabled option down to NewMux properly

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -375,6 +375,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		Basepath:      s.Basepath,
 		StatusFeedURL: s.StatusFeedURL,
 		CustomLinks:   s.CustomLinks,
+		PprofEnabled:  s.PprofEnabled,
 	}, service)
 
 	// Add chronograf's version header to all requests


### PR DESCRIPTION
_What was the problem?_
The `--pprof-enabled` flag was not being passed down to the mux.

_What was the solution?_
Pass the flag to the mux.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)