### PR TITLE
Remove check for flux ping when adding and updating flux service

### DIFF
--- a/server/services.go
+++ b/server/services.go
@@ -123,15 +123,6 @@ func (s *Service) NewService(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if req.Type != nil && req.URL != nil && *req.Type == "flux" {
-		err := pingFlux(ctx, *req.URL, req.InsecureSkipVerify)
-		if err != nil {
-			msg := fmt.Sprintf("Unable to reach flux %s: %v", *req.URL, err)
-			Error(w, http.StatusGatewayTimeout, msg, s.Logger)
-			return
-		}
-	}
-
 	srv := chronograf.Server{
 		SrcID:              srcID,
 		Name:               *req.Name,
@@ -318,15 +309,6 @@ func (s *Service) UpdateService(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Metadata != nil {
 		srv.Metadata = *req.Metadata
-	}
-
-	if srv.Type == "flux" {
-		err := pingFlux(ctx, srv.URL, srv.InsecureSkipVerify)
-		if err != nil {
-			msg := fmt.Sprintf("Unable to reach flux %s: %v", srv.URL, err)
-			Error(w, http.StatusGatewayTimeout, msg, s.Logger)
-			return
-		}
 	}
 
 	if err := s.Store.Servers(ctx).Update(ctx, srv); err != nil {


### PR DESCRIPTION
_What was the problem?_
When adding or updating a flux service, regardless of whether your url was valid, it always returned a response saying it could not connect to the service, and therefore it could not get added.

_What was the solution?_
Remove the pingFlux check when adding and updating a flux service. This does mean that if you have an incorrect url, it will allow you to make a connection. This is ok for now since flux will not be a separate service and this step will not be necessary.

  - [x] Rebased/mergeable
  - [x] Tests pass