### PR TITLE
Fix adding additional where clauses on queries not supported by schema explorer

### DIFF
--- a/ui/src/utils/buildQueriesForLayouts.ts
+++ b/ui/src/utils/buildQueriesForLayouts.ts
@@ -90,7 +90,7 @@ export const buildQueriesForLayouts = (
   return cell.queries.map(query => {
     let queryText: string
     // Canned dashboards use an different a schema different from queryConfig.
-    if (_.get(query, 'queryConfig.database')) {
+    if (query.queryConfig) {
       const {
         queryConfig: {database, measurement, fields, shifts, rawText, range},
       } = query


### PR DESCRIPTION
Closes #4368 

_What was the problem?_
Queries that were not supported by the schema explorer (such as those with non-negative derivatives in the query) were getting additional where clauses added to the end of them.
This was caused by a change that was made to the way layouts buildingQueriesForLayouts. Instead of checking for the presence of a queryconfig, it was checking to see if queryConfig.db was empty.

_What was the solution?_
Change that check back to just checking for queryconfig.

  - [x] Rebased/mergeable
  - [x] Tests pass