### PR TITLE
Add default empty string to querySource

### DIFF
--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -366,7 +366,7 @@ class TimeMachine extends PureComponent<Props, State> {
     const {selectedService} = this.state
 
     const queryDraft = _.get(queryDrafts, 0)
-    const querySource = _.get(queryDraft, 'source')
+    const querySource = _.get(queryDraft, 'source', '')
 
     if (querySource.includes('service')) {
       const foundService = services.find(s => {


### PR DESCRIPTION
_What was the problem?_
Deleting every query from the data explorer caused the page to crash.

_What was the solution?_
Add a default of empty string to `querySource` so that calling `includes()` on `querySource` does not result in an error.


  - [x] Rebased/mergeable
  - [x] Tests pass