### PR TITLE
Fix InfluxQL source saving

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -275,11 +275,8 @@ class CellEditorOverlay extends Component<Props, State> {
           null
         )
         const timeRange = getTimeRange(queryConfig)
-        const source = getDeep<string | null>(
-          queryConfig,
-          'source.links.self',
-          null
-        )
+        const source = getDeep<string | null>(q, 'source', null)
+
         return {
           ...q,
           query:


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/55

_What was the problem?_
When an influxQL source was selected before a query was written in the CEO, the source did not get saved to the cell. Instead, the CEO would open to "dynamic source" for that cell.

_What was the solution?_
Using the source link from the query rather than the queryConfig object. 

  - [x] Rebased/mergeable
  - [x] Tests pass