### PR TITLE
Properly update tablegraph when in editor

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -76,11 +76,12 @@ class RefreshingGraph extends PureComponent<Props> {
 
   private timeSeries: React.RefObject<TimeSeries> = React.createRef()
 
-  public componentDidUpdate() {
+  public componentDidUpdate(prevProps) {
     if (!this.timeSeries.current) {
       return
     }
-    if (this.props.editorLocation) {
+
+    if (this.props.editorLocation && this.haveVisOptionsChanged(prevProps)) {
       this.timeSeries.current.forceUpdate()
     }
   }
@@ -143,6 +144,21 @@ class RefreshingGraph extends PureComponent<Props> {
         }}
       </TimeSeries>
     )
+  }
+
+  private haveVisOptionsChanged(prevProps: Props): boolean {
+    const visProps: string[] = [
+      'axes',
+      'colors',
+      'tableOptions',
+      'fieldOptions',
+      'decimalPlaces',
+      'timeFormat',
+    ]
+
+    const prevVisValues = _.pick(prevProps, visProps)
+    const curVisValues = _.pick(this.props, visProps)
+    return !_.isEqual(prevVisValues, curVisValues)
   }
 
   private singleStat = (data): JSX.Element => {

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -248,7 +248,8 @@ class TableGraph extends Component<Props, State> {
     const {sort} = this.state
 
     let result = {}
-    if (this.hasDataChanged(nextProps.data)) {
+    const hasDataChanged = this.hasDataChanged(nextProps.data)
+    if (hasDataChanged) {
       result = await timeSeriesToTableGraph(nextProps.data)
     }
     const data = _.get(result, 'data', this.state.data)
@@ -265,7 +266,7 @@ class TableGraph extends Component<Props, State> {
     const sortedLabels = _.get(result, 'sortedLabels', this.state.sortedLabels)
     const computedFieldOptions = computeFieldOptions(fieldOptions, sortedLabels)
 
-    if (this.hasDataChanged(nextProps.data)) {
+    if (hasDataChanged) {
       this.handleUpdateFieldOptions(computedFieldOptions)
     }
 
@@ -279,7 +280,7 @@ class TableGraph extends Component<Props, State> {
     }
 
     if (
-      this.hasDataChanged(nextProps.data) ||
+      hasDataChanged ||
       _.includes(updatedProps, 'tableOptions') ||
       _.includes(updatedProps, 'fieldOptions') ||
       _.includes(updatedProps, 'timeFormat')
@@ -338,7 +339,7 @@ class TableGraph extends Component<Props, State> {
     const newUUID = _.get(data, '0.response.uuid', null)
     const oldUUID = _.get(this.props.data, '0.response.uuid', null)
 
-    return newUUID !== oldUUID
+    return newUUID !== oldUUID || !!this.props.editorLocation
   }
 
   private get fixFirstColumn(): boolean {


### PR DESCRIPTION
Co-authored-by: Brandon Farmer <bthesorceror@gmail.com>

Closes #4320 

_What was the problem?_
There was a race condition when updating table graph in an editor. 

_What was the solution?_
Refreshing graph will only force update TimeSeries if visualization options have changed and not just any time its in the editor. TableGraph will update any time its in the editor and not just if data is different. 

  - [x] Rebased/mergeable
  - [x] Tests pass