### PR TITLE
Correct wizard step index for Kapacitor Step

### DIFF
--- a/ui/src/sources/components/KapacitorDropdown.tsx
+++ b/ui/src/sources/components/KapacitorDropdown.tsx
@@ -173,7 +173,7 @@ class KapacitorDropdown extends PureComponent<Props & WithRouterProps> {
   private launchWizard = () => {
     const {toggleWizard, source} = this.props
     if (toggleWizard) {
-      toggleWizard(true, source, 1, true)()
+      toggleWizard(true, source, 2, true)()
     }
   }
 }


### PR DESCRIPTION
Closes #4332 Add Kapacitor Connection opens wizard to Dashboards step

_Briefly describe your proposed changes:_
When the user clicks the Add new Kapacitor button it takes them to the correct wizard step.

_What was the problem?_
When the user clicks the Add new Kapacitor button it takes them to the dashboard wizard step. This is because the step index was not updated when the dashboard step was added.

_What was the solution?_
Correct the index from 1 to 2.

  - [x] Rebased/mergeable
  - [x] Tests pass