### PR TITLE
Update add filters to add to the left

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 1.  [#4268](https://github.com/influxdata/chronograf/pull/4268): Clear logs after searching
 1.  [#4253](https://github.com/influxdata/chronograf/pull/4253): Add search expression highlighting to log lines
 1.  [#4363](https://github.com/influxdata/chronograf/pull/4363): Move log message truncation controls into logs filter bar
+1.  [#4392](https://github.com/influxdata/chronograf/pull/4392): Add log filters on left side
 
 
 ### UI Improvements

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -587,9 +587,11 @@ class LogsPage extends Component<Props, State> {
   }
 
   private handleSubmitSearch = async (value: string): Promise<void> => {
-    searchToFilters(value).forEach(filter => {
-      this.props.addFilter(filter)
-    })
+    searchToFilters(value)
+      .reverse()
+      .forEach(filter => {
+        this.props.addFilter(filter)
+      })
 
     this.fetchSearchDataset(SearchStatus.Loading)
   }

--- a/ui/src/logs/reducers/index.ts
+++ b/ui/src/logs/reducers/index.ts
@@ -77,7 +77,7 @@ const removeFilter = (
 const addFilter = (state: LogsState, action: AddFilterAction): LogsState => {
   const {filter} = action.payload
 
-  return {...state, filters: [..._.get(state, 'filters', []), filter]}
+  return {...state, filters: [filter, ..._.get(state, 'filters', [])]}
 }
 
 const clearFilters = (state: LogsState): LogsState => {


### PR DESCRIPTION
Closes #4335 

_Briefly describe your proposed changes:_
Update log search filters to add on the left rather than the right
_What was the problem?_
Logs filters would be pushed on to the end of the logs filters list making it hard to find and correct a typo.
_What was the solution?_
Add search filters to the left.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass