### PR TITLE
Autofocus dashboard query editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@
 1.  [#4363](https://github.com/influxdata/chronograf/pull/4363): Move log message truncation controls into logs filter bar
 1.  [#4391](https://github.com/influxdata/chronograf/pull/4391): Colorize entire Single Stat cell
 1.  [#4392](https://github.com/influxdata/chronograf/pull/4392): Add log filters on left side
+
+1.  [#2265](https://github.com/influxdata/chronograf/pull/2265): Autofocus dashboard query editor
+
+### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows
 1.  [#4330](https://github.com/influxdata/chronograf/pull/4330): Position cloned cells adjacent to target cell
 

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -101,6 +101,10 @@ class InfluxQLEditor extends Component<Props, State> {
     this.cancelPendingUpdates()
   }
 
+  public componentDidMount() {
+    this.handleFocusEditor()
+  }
+
   public render() {
     const {config, templates} = this.props
 
@@ -185,6 +189,7 @@ class InfluxQLEditor extends Component<Props, State> {
   }
 
   private handleBlurEditor = (): void => {
+    this.setState({focused: false})
     this.handleUpdate()
   }
 

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -189,7 +189,7 @@ class InfluxQLEditor extends Component<Props, State> {
   }
 
   private handleBlurEditor = (): void => {
-    this.setState({focused: false})
+    this.setState({focused: false, isShowingTemplateValues: false})
     this.handleUpdate()
   }
 

--- a/ui/src/dashboards/components/ReactCodeMirror.tsx
+++ b/ui/src/dashboards/components/ReactCodeMirror.tsx
@@ -109,6 +109,10 @@ class ReactCodeMirror extends PureComponent<Props, State> {
         this.hideTemplateValues()
       }
     }
+
+    if (this.props.focused && this.editor && !this.editor.hasFocus()) {
+      this.focusEditor()
+    }
   }
 
   public handleTemplateReplace = (
@@ -143,6 +147,11 @@ class ReactCodeMirror extends PureComponent<Props, State> {
     if (this.editor) {
       this.editor.setSelection(selection.end, selection.start)
     }
+  }
+
+  private focusEditor() {
+    this.props.onFocus()
+    this.editor.focus()
   }
 
   private handleMountEditor = (editor: CMEditor) => {


### PR DESCRIPTION
Closes #2265 

_Briefly describe your proposed changes:_
Focuses dashboard query editor on mount 
_What was the problem?_
Query editor props would be out of sync with codemirror editor
_What was the solution?_
Check when focus prop was different from editor.hasFocus and then focus the editor

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass