### PR TITLE
Toggle for Flux/InfluxQL for dynamic source in CEO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@
 1.  [#4390](https://github.com/influxdata/chronograf/pull/4390): Remove Flux Page
 1.  [4364](https://github.com/influxdata/chronograf/pull/4364): Add ability to save a Flux query to a cell
 1.  [4390](https://github.com/influxdata/chronograf/pull/4390): Remove Flux Page
-1. [#4389](https://github.com/influxdata/chronograf/pull/4389): Add regexp search for appname in log lines
+1.  [#4389](https://github.com/influxdata/chronograf/pull/4389): Add regexp search for appname in log lines
+1.  [#4403](https://github.com/influxdata/chronograf/pull/4403): Add ability to toggle between Flux/InfluxQL on dynamic source in CEO
 
 
 ### UI Improvements

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -125,7 +125,7 @@ class CellEditorOverlay extends Component<Props, State> {
       queryStatus,
     } = this.props
 
-    const {isStaticLegend} = this.state
+    const {isStaticLegend, currentService} = this.state
 
     return (
       <div
@@ -147,6 +147,7 @@ class CellEditorOverlay extends Component<Props, State> {
           onResetFocus={this.handleResetFocus}
           isInCEO={true}
           sources={sources}
+          service={currentService}
           services={services}
           updateQueryDrafts={updateQueryDrafts}
           onToggleStaticLegend={this.handleToggleStaticLegend}

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -16,6 +16,7 @@ interface Props {
   service: Service
   services: Service[]
   isFluxSource: boolean
+  sourceSupportsFlux: boolean
   queries: QueriesModels.QueryConfig[]
   isDynamicSourceSelected: boolean
   toggleFlux: () => void
@@ -32,6 +33,7 @@ const SourceSelector: SFC<Props> = ({
   toggleFlux,
   isFluxSource,
   onChangeService,
+  sourceSupportsFlux,
   isDynamicSourceSelected,
   onSelectDynamicSource,
 }) => {
@@ -53,28 +55,29 @@ const SourceSelector: SFC<Props> = ({
         onChangeService={onChangeService}
         onSelectDynamicSource={onSelectDynamicSource}
       />
-      {isDynamicSourceSelected && (
-        <Radio>
-          <Radio.Button
-            id="flux-source"
-            titleText="Flux"
-            value="Flux"
-            onClick={toggleFlux}
-            active={isFluxSource}
-          >
-            Flux
-          </Radio.Button>
-          <Radio.Button
-            id="influxql-source"
-            titleText="InfluxQL"
-            value="InfluxQL"
-            onClick={toggleFlux}
-            active={!isFluxSource}
-          >
-            InfluxQL
-          </Radio.Button>
-        </Radio>
-      )}
+      {isDynamicSourceSelected &&
+        sourceSupportsFlux && (
+          <Radio>
+            <Radio.Button
+              id="flux-source"
+              titleText="Flux"
+              value="Flux"
+              onClick={toggleFlux}
+              active={isFluxSource}
+            >
+              Flux
+            </Radio.Button>
+            <Radio.Button
+              id="influxql-source"
+              titleText="InfluxQL"
+              value="InfluxQL"
+              onClick={toggleFlux}
+              active={!isFluxSource}
+            >
+              InfluxQL
+            </Radio.Button>
+          </Radio>
+        )}
     </div>
   )
 }

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -18,6 +18,7 @@ interface Props {
   isFluxSource: boolean
   queries: QueriesModels.QueryConfig[]
   isDynamicSourceSelected: boolean
+  toggleFlux: () => void
   onSelectDynamicSource: () => void
   onChangeService: (service: Service, source: SourcesModels.Source) => void
 }
@@ -28,6 +29,7 @@ const SourceSelector: SFC<Props> = ({
   service,
   services,
   queries,
+  toggleFlux,
   isFluxSource,
   onChangeService,
   isDynamicSourceSelected,
@@ -57,6 +59,7 @@ const SourceSelector: SFC<Props> = ({
             id="flux-source"
             titleText="Flux"
             value="Flux"
+            onClick={toggleFlux}
             active={isFluxSource}
           >
             Flux
@@ -65,6 +68,7 @@ const SourceSelector: SFC<Props> = ({
             id="influxql-source"
             titleText="InfluxQL"
             value="InfluxQL"
+            onClick={toggleFlux}
             active={!isFluxSource}
           >
             InfluxQL

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -3,6 +3,7 @@ import React, {SFC} from 'react'
 
 // Componentes
 import SourceDropdown from 'src/flux/components/SourceDropdown'
+import {Radio} from 'src/reusable_ui'
 
 // Types
 import * as QueriesModels from 'src/types/queries'
@@ -14,6 +15,7 @@ interface Props {
   sources: SourcesModels.SourceOption[]
   service: Service
   services: Service[]
+  isFluxSource: boolean
   queries: QueriesModels.QueryConfig[]
   isDynamicSourceSelected: boolean
   onSelectDynamicSource: () => void
@@ -26,6 +28,7 @@ const SourceSelector: SFC<Props> = ({
   service,
   services,
   queries,
+  isFluxSource,
   onChangeService,
   isDynamicSourceSelected,
   onSelectDynamicSource,
@@ -48,6 +51,26 @@ const SourceSelector: SFC<Props> = ({
         onChangeService={onChangeService}
         onSelectDynamicSource={onSelectDynamicSource}
       />
+      {isDynamicSourceSelected && (
+        <Radio>
+          <Radio.Button
+            id="flux-source"
+            titleText="Flux"
+            value="Flux"
+            active={isFluxSource}
+          >
+            Flux
+          </Radio.Button>
+          <Radio.Button
+            id="influxql-source"
+            titleText="InfluxQL"
+            value="InfluxQL"
+            active={!isFluxSource}
+          >
+            InfluxQL
+          </Radio.Button>
+        </Radio>
+      )}
     </div>
   )
 }

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -1022,7 +1022,20 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private toggleFlux = (): void => {
-    console.log('toggling!')
+    const {services, updateService} = this.props
+
+    if (this.isFluxSource) {
+      this.setState({selectedService: null})
+      updateService(null)
+    } else {
+      const foundFluxForSource = services.find(service => {
+        return service.sourceID === this.source.id
+      })
+
+      if (foundFluxForSource) {
+        updateService(foundFluxForSource)
+      }
+    }
   }
 }
 

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -270,6 +270,7 @@ class TimeMachine extends PureComponent<Props, State> {
           templates={templates}
           visType={this.visType}
           source={this.source}
+          toggleFlux={this.toggleFlux}
           sources={this.formattedSources}
           service={this.service}
           services={services}
@@ -1005,6 +1006,10 @@ class TimeMachine extends PureComponent<Props, State> {
       this.state.visType === VisType.Graph ? VisType.Table : VisType.Graph
 
     this.setState({visType: newVisType})
+  }
+
+  private toggleFlux = (): void => {
+    console.log('toggling!')
   }
 }
 

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -275,6 +275,7 @@ class TimeMachine extends PureComponent<Props, State> {
           service={this.service}
           services={services}
           isFluxSource={this.isFluxSource}
+          sourceSupportsFlux={this.sourceSupportsFlux}
           toggleVisType={this.toggleVisType}
           autoRefreshDuration={autoRefreshDuration}
           onChangeAutoRefreshDuration={this.handleChangeAutoRefreshDuration}
@@ -462,6 +463,18 @@ class TimeMachine extends PureComponent<Props, State> {
   private get isFluxSource(): boolean {
     // TODO: Update once flux is no longer a separate service
     if (this.service) {
+      return true
+    }
+    return false
+  }
+
+  private get sourceSupportsFlux(): boolean {
+    const {services} = this.props
+    const foundFluxForSource = services.find(service => {
+      return service.sourceID === this.source.id
+    })
+
+    if (foundFluxForSource) {
       return true
     }
     return false

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -31,6 +31,7 @@ interface Props {
   onChangeAutoRefreshDuration: (newDuration: number) => void
   queries: QueriesModels.QueryConfig[]
   templates: Template[]
+  sourceSupportsFlux: boolean
   onSelectDynamicSource: () => void
   timeRange: QueriesModels.TimeRange
   updateEditorTimeRange: (timeRange: QueriesModels.TimeRange) => void
@@ -54,6 +55,7 @@ const TimeMachineControls: SFC<Props> = ({
   autoRefreshDuration,
   onChangeAutoRefreshDuration,
   onChangeService,
+  sourceSupportsFlux,
   onSelectDynamicSource,
   isDynamicSourceSelected,
   updateEditorTimeRange,
@@ -69,6 +71,7 @@ const TimeMachineControls: SFC<Props> = ({
         services={services}
         queries={queries}
         toggleFlux={toggleFlux}
+        sourceSupportsFlux={sourceSupportsFlux}
         isFluxSource={isFluxSource}
         onChangeService={onChangeService}
         isDynamicSourceSelected={isDynamicSourceSelected}

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -35,6 +35,7 @@ interface Props {
   timeRange: QueriesModels.TimeRange
   updateEditorTimeRange: (timeRange: QueriesModels.TimeRange) => void
   toggleVisType: () => void
+  toggleFlux: () => void
 }
 
 const TimeMachineControls: SFC<Props> = ({
@@ -47,6 +48,7 @@ const TimeMachineControls: SFC<Props> = ({
   isInCEO,
   services,
   timeRange,
+  toggleFlux,
   isFluxSource,
   toggleVisType,
   autoRefreshDuration,
@@ -66,6 +68,7 @@ const TimeMachineControls: SFC<Props> = ({
         service={service}
         services={services}
         queries={queries}
+        toggleFlux={toggleFlux}
         isFluxSource={isFluxSource}
         onChangeService={onChangeService}
         isDynamicSourceSelected={isDynamicSourceSelected}

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -66,6 +66,7 @@ const TimeMachineControls: SFC<Props> = ({
         service={service}
         services={services}
         queries={queries}
+        isFluxSource={isFluxSource}
         onChangeService={onChangeService}
         isDynamicSourceSelected={isDynamicSourceSelected}
         onSelectDynamicSource={onSelectDynamicSource}

--- a/ui/src/style/components/source-selector.scss
+++ b/ui/src/style/components/source-selector.scss
@@ -15,4 +15,12 @@
     color: $g13-mist;
     @include no-user-select();
   }
+
+  .dropdown {
+    margin: 5px;
+  }
+
+  .radio-buttons {
+    margin: 5px;
+  }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/45

_What was the problem?_
When "dynamic source" was selected in the CEO, the user could not switch between Flux and InfluxQL without switching sources in the dropdown.

_What was the solution?_
Add a toggle for Flux/InfluxQL that appears next to the `SourceDropdown` only if "dynamic source" is selected and the current source supports Flux. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass