### PR TITLE
Add tooltip for dynamic source that does not support flux

### DIFF
--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -1,9 +1,10 @@
 // Libraries
 import React, {SFC} from 'react'
 
-// Componentes
+// Components
 import SourceDropdown from 'src/flux/components/SourceDropdown'
 import {Radio} from 'src/reusable_ui'
+import QuestionMarkTooltip from 'src/shared/components/QuestionMarkTooltip'
 
 // Types
 import * as QueriesModels from 'src/types/queries'
@@ -55,28 +56,36 @@ const SourceSelector: SFC<Props> = ({
         onChangeService={onChangeService}
         onSelectDynamicSource={onSelectDynamicSource}
       />
+      {isDynamicSourceSelected && (
+        <Radio>
+          <Radio.Button
+            id="flux-source"
+            titleText="Flux"
+            value="Flux"
+            onClick={toggleFlux}
+            active={isFluxSource}
+            disabled={!sourceSupportsFlux}
+          >
+            Flux
+          </Radio.Button>
+          <Radio.Button
+            id="influxql-source"
+            titleText="InfluxQL"
+            value="InfluxQL"
+            onClick={toggleFlux}
+            active={!isFluxSource}
+            disabled={!sourceSupportsFlux}
+          >
+            InfluxQL
+          </Radio.Button>
+        </Radio>
+      )}
       {isDynamicSourceSelected &&
-        sourceSupportsFlux && (
-          <Radio>
-            <Radio.Button
-              id="flux-source"
-              titleText="Flux"
-              value="Flux"
-              onClick={toggleFlux}
-              active={isFluxSource}
-            >
-              Flux
-            </Radio.Button>
-            <Radio.Button
-              id="influxql-source"
-              titleText="InfluxQL"
-              value="InfluxQL"
-              onClick={toggleFlux}
-              active={!isFluxSource}
-            >
-              InfluxQL
-            </Radio.Button>
-          </Radio>
+        !sourceSupportsFlux && (
+          <QuestionMarkTooltip
+            tipID="token"
+            tipContent={`<p>The current source does not support Flux.</p>`}
+          />
         )}
     </div>
   )

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -405,14 +405,13 @@ class TimeMachine extends PureComponent<Props, State> {
   private get source(): Source {
     const {source, sources, queryDrafts} = this.props
     const {selectedSource, useDynamicSource} = this.state
-
-    if (selectedSource) {
-      return selectedSource
-    }
-
     // return current source
     if (useDynamicSource) {
       return source
+    }
+
+    if (selectedSource) {
+      return selectedSource
     }
 
     const queryDraft = _.get(queryDrafts, 0)


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/9

_What was the problem?_
If the user selected "dynamic source," it was not clear whether or not a Flux service could be used.

_What was the solution?_
If the dynamic source being used does not support Flux, then the Radio button to toggle Flux/InfluxQL becomes disabled and a tooltip appears to alert the user that the source does not support Flux.

  - [x] Rebased/mergeable
  - [x] Tests pass