### PR TITLE
Render null data point values in Alerts Table as mdashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 1.  [#4272](https://github.com/influxdata/chronograf/pull/4272): Fix logs loading description not displaying
 1.  [#4363](https://github.com/influxdata/chronograf/pull/4363): Position expanded log messages above logs table
 1.  [#4388](https://github.com/influxdata/chronograf/pull/4388): Fix logs to progressively load results and provide feedback on search
+1.  [#4408](https://github.com/influxdata/chronograf/pull/4408): Render null data point values in Alerts Table as mdashes
 
 ## v1.6.2 [2018-09-06]
 

--- a/ui/src/alerts/components/AlertsTable.tsx
+++ b/ui/src/alerts/components/AlertsTable.tsx
@@ -1,10 +1,10 @@
 import React, {PureComponent} from 'react'
 
 import _ from 'lodash'
-import classnames from 'classnames'
-import {Link} from 'react-router'
 import uuid from 'uuid'
+import {Link} from 'react-router'
 
+import AlertsTableRow from 'src/alerts/components/AlertsTableRow'
 import InfiniteScroll from 'src/shared/components/InfiniteScroll'
 import SearchBar from 'src/alerts/components/SearchBar'
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -192,50 +192,11 @@ class AlertsTable extends PureComponent<Props, State> {
         <InfiniteScroll
           className="alert-history-table--tbody"
           itemHeight={25}
-          items={alerts.map(({name, level, time, host, value}) => {
-            return (
-              <div className="alert-history-table--tr" key={uuid.v4()}>
-                <div
-                  className="alert-history-table--td"
-                  style={{width: colName}}
-                >
-                  {name}
-                </div>
-                <div
-                  className={`alert-history-table--td alert-level-${level.toLowerCase()}`}
-                  style={{width: colLevel}}
-                >
-                  <span
-                    className={classnames(
-                      'table-dot',
-                      {'dot-critical': level === 'CRITICAL'},
-                      {'dot-success': level === 'OK'}
-                    )}
-                  />
-                </div>
-                <div
-                  className="alert-history-table--td"
-                  style={{width: colTime}}
-                >
-                  {new Date(Number(time)).toISOString()}
-                </div>
-                <div
-                  className="alert-history-table--td alert-history-table--host"
-                  style={{width: colHost}}
-                >
-                  <Link to={`/sources/${id}/hosts/${host}`} title={host}>
-                    {host}
-                  </Link>
-                </div>
-                <div
-                  className="alert-history-table--td"
-                  style={{width: colValue}}
-                >
-                  {value}
-                </div>
-              </div>
-            )
-          })}
+          items={alerts.map(alert => (
+            <div className="alert-history-table--tr" key={uuid.v4()}>
+              <AlertsTableRow sourceID={id} {...alert} />
+            </div>
+          ))}
         />
       </div>
     ) : (

--- a/ui/src/alerts/components/AlertsTableRow.tsx
+++ b/ui/src/alerts/components/AlertsTableRow.tsx
@@ -32,8 +32,12 @@ class AlertsTableRow extends PureComponent<Props> {
     const {name} = this.props
 
     return (
-      <div className="alert-history-table--td" style={{width: colName}}>
-        {name === null ? '–' : name}
+      <div
+        className="alert-history-table--td"
+        style={{width: colName}}
+        data-test="nameCell"
+      >
+        {name === null ? <span>{'–'}</span> : <span>{name}</span>}
       </div>
     )
   }
@@ -47,9 +51,10 @@ class AlertsTableRow extends PureComponent<Props> {
           level === null ? 'null' : level.toLowerCase()
         }`}
         style={{width: colLevel}}
+        data-test="levelCell"
       >
         {level === null ? (
-          '–'
+          <span>{'–'}</span>
         ) : (
           <span
             className={classnames(
@@ -67,8 +72,16 @@ class AlertsTableRow extends PureComponent<Props> {
     const {time} = this.props
 
     return (
-      <div className="alert-history-table--td" style={{width: colTime}}>
-        {time === null ? '–' : new Date(Number(time)).toISOString()}
+      <div
+        className="alert-history-table--td"
+        style={{width: colTime}}
+        data-test="timeCell"
+      >
+        {time === null ? (
+          <span>{'–'}</span>
+        ) : (
+          <span>{new Date(Number(time)).toISOString()}</span>
+        )}
       </div>
     )
   }
@@ -80,9 +93,10 @@ class AlertsTableRow extends PureComponent<Props> {
       <div
         className="alert-history-table--td alert-history-table--host"
         style={{width: colHost}}
+        data-test="hostCell"
       >
         {host === null ? (
-          '–'
+          <span>{'–'}</span>
         ) : (
           <Link to={`/sources/${sourceID}/hosts/${host}`} title={host}>
             {host}
@@ -96,8 +110,12 @@ class AlertsTableRow extends PureComponent<Props> {
     const {value} = this.props
 
     return (
-      <div className="alert-history-table--td" style={{width: colValue}}>
-        {value === null ? '–' : value}
+      <div
+        className="alert-history-table--td"
+        style={{width: colValue}}
+        data-test="valueCell"
+      >
+        {value === null ? <span>{'–'}</span> : <span>{value}</span>}
       </div>
     )
   }

--- a/ui/src/alerts/components/AlertsTableRow.tsx
+++ b/ui/src/alerts/components/AlertsTableRow.tsx
@@ -1,0 +1,106 @@
+import React, {PureComponent} from 'react'
+import {Link} from 'react-router'
+
+import classnames from 'classnames'
+
+import {ALERTS_TABLE} from 'src/alerts/constants/tableSizing'
+
+interface Props {
+  sourceID: string
+  name: string | null
+  level: string | null
+  time: string | null
+  host: string | null
+  value: string | null
+}
+
+const {colName, colLevel, colTime, colHost, colValue} = ALERTS_TABLE
+
+class AlertsTableRow extends PureComponent<Props> {
+  public render() {
+    return (
+      <>
+        {this.nameCell}
+        {this.levelCell}
+        {this.timeCell}
+        {this.hostCell}
+        {this.valueCell}
+      </>
+    )
+  }
+  private get nameCell(): JSX.Element {
+    const {name} = this.props
+
+    return (
+      <div className="alert-history-table--td" style={{width: colName}}>
+        {name === null ? '–' : name}
+      </div>
+    )
+  }
+
+  private get levelCell(): JSX.Element {
+    const {level} = this.props
+
+    return (
+      <div
+        className={`alert-history-table--td alert-level-${
+          level === null ? 'null' : level.toLowerCase()
+        }`}
+        style={{width: colLevel}}
+      >
+        {level === null ? (
+          '–'
+        ) : (
+          <span
+            className={classnames(
+              'table-dot',
+              {'dot-critical': level === 'CRITICAL'},
+              {'dot-success': level === 'OK'}
+            )}
+          />
+        )}
+      </div>
+    )
+  }
+
+  private get timeCell(): JSX.Element {
+    const {time} = this.props
+
+    return (
+      <div className="alert-history-table--td" style={{width: colTime}}>
+        {time === null ? '–' : new Date(Number(time)).toISOString()}
+      </div>
+    )
+  }
+
+  private get hostCell(): JSX.Element {
+    const {sourceID, host} = this.props
+
+    return (
+      <div
+        className="alert-history-table--td alert-history-table--host"
+        style={{width: colHost}}
+      >
+        {host === null ? (
+          '–'
+        ) : (
+          <Link to={`/sources/${sourceID}/hosts/${host}`} title={host}>
+            {host}
+          </Link>
+        )}
+      </div>
+    )
+  }
+
+  private get valueCell(): JSX.Element {
+    const {value} = this.props
+
+    return (
+      <div className="alert-history-table--td" style={{width: colValue}}>
+        {value === null ? '–' : value}
+      </div>
+    )
+  }
+}
+
+export default AlertsTableRow

--- a/ui/test/alerts/components/AlertsTableRow.test.tsx
+++ b/ui/test/alerts/components/AlertsTableRow.test.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import AlertsTableRow from 'src/alerts/components/AlertsTableRow'
+import {Link} from 'react-router'
+
+import {shallow} from 'enzyme'
+
+const alertsTableRowProps = {
+  sourceID: '3',
+  name: 'No Dog Can Be',
+  level: 'OK',
+  time: Date.now().toString(),
+  host: 'Ada Island',
+  value: '1337',
+}
+
+const setup = (override = {}) => {
+  const props = {
+    ...alertsTableRowProps,
+    ...override,
+  }
+  const wrapper = shallow(<AlertsTableRow {...props} />)
+  return {
+    props,
+    wrapper,
+  }
+}
+
+describe('Components.Shared.ProvidersTableRowNew', () => {
+  it('should render all valid data with the passed in data', () => {
+    const time = Date.now().toString()
+
+    const {wrapper} = setup({time})
+
+    const nameCell = wrapper.find({'data-test': 'nameCell'})
+    const levelCell = wrapper.find({'data-test': 'levelCell'})
+    const timeCell = wrapper.find({'data-test': 'timeCell'})
+    const hostCell = wrapper.find({'data-test': 'hostCell'})
+    const valueCell = wrapper.find({'data-test': 'valueCell'})
+
+    expect(nameCell.text()).toBe('No Dog Can Be')
+    expect(levelCell.text()).toBe('')
+    expect(timeCell.text()).toBe(new Date(Number(time)).toISOString())
+    expect(hostCell.find(Link).exists()).toBe(true)
+    expect(valueCell.text()).toBe('1337')
+  })
+
+  it('should render any invalid data as an mdash', () => {
+    const props = {
+      sourceID: '3',
+      name: null,
+      level: null,
+      time: null,
+      host: null,
+      value: null,
+    }
+    const {wrapper} = setup(props)
+
+    const nameCell = wrapper.find({'data-test': 'nameCell'})
+    const levelCell = wrapper.find({'data-test': 'levelCell'})
+    const timeCell = wrapper.find({'data-test': 'timeCell'})
+    const hostCell = wrapper.find({'data-test': 'hostCell'})
+    const valueCell = wrapper.find({'data-test': 'valueCell'})
+
+    expect(nameCell.text()).toBe('–')
+    expect(levelCell.text()).toBe('–')
+    expect(timeCell.text()).toBe('–')
+    expect(hostCell.find(Link).exists()).toBe(false)
+    expect(valueCell.text()).toBe('–')
+  })
+})


### PR DESCRIPTION
Closes #4342 

_What was the problem?_
Invalid data from InfluxDB (such as if `level` was `null`), would cause the Alerts Table on the Status Page to error out.

_What was the solution?_
- Check for `null` on any data point values passed to Alerts Table and render an mdash (`–`) if so.
- Refactor AlertsTable rows into AlertsTableRow component for clarity and ease of testing.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
