### PR TITLE
Update service in CEO when Time Machine renders

### DIFF
--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -201,7 +201,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    const {fluxLinks, script} = this.props
+    const {fluxLinks, script, updateService, isInCEO} = this.props
     const {autoRefresher, autoRefreshDuration} = this.state
 
     autoRefresher.poll(autoRefreshDuration)
@@ -216,6 +216,9 @@ class TimeMachine extends PureComponent<Props, State> {
     if (this.isFluxSource) {
       try {
         this.debouncedASTResponse(script)
+        if (isInCEO) {
+          updateService(this.service)
+        }
       } catch (error) {
         console.error('Could not retrieve AST for script', error)
       }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/58

_What was the problem?_
When opening an existing cell w/ a Flux query in the CEO, the save button was disabled.

_What was the solution?_
Set the `currentService` in the CEO when TimeMachine mounts.

  - [x] Rebased/mergeable
  - [x] Tests pass