### PR TITLE
Fix query editor flickering on update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 1.  [#4392](https://github.com/influxdata/chronograf/pull/4392): Add log filters on left side
 
 1.  [#2265](https://github.com/influxdata/chronograf/pull/2265): Autofocus dashboard query editor
+1.  [#4423](https://github.com/influxdata/chronograf/pull/4423): Fix query editor flickering on update
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -33,6 +33,7 @@ interface State {
   isShowingTemplateValues: boolean
   filteredTemplates: Template[]
   isSubmitted: boolean
+  configID: string
 }
 
 interface Props {
@@ -59,12 +60,12 @@ class InfluxQLEditor extends Component<Props, State> {
 
     // stale prop values after recent submission cause flickering
     const isRecentlySubmitted = !isSubmitted || prevState.isSubmitted
+    const isQueryTextChanged = editedQueryText.trim() !== nextProps.query.trim()
+    const isQueryUpdated = !isRecentlySubmitted && isQueryTextChanged
 
-    if (
-      !isRecentlySubmitted &&
-      !isShowingTemplateValues &&
-      editedQueryText.trim() !== nextProps.query.trim()
-    ) {
+    const isQueryConfigChanged = nextProps.config.id !== prevState.configID
+
+    if ((isQueryUpdated && !isShowingTemplateValues) || isQueryConfigChanged) {
       return {
         ...BLURRED_EDITOR_STATE,
         selectedTemplate: {
@@ -73,6 +74,8 @@ class InfluxQLEditor extends Component<Props, State> {
         filteredTemplates: nextProps.templates,
         templatingQueryText: nextProps.query,
         editedQueryText: nextProps.query,
+        configID: nextProps.config.id,
+        focused: isQueryConfigChanged,
       }
     }
 
@@ -97,6 +100,7 @@ class InfluxQLEditor extends Component<Props, State> {
       templatingQueryText: props.query,
       editedQueryText: props.query,
       isSubmitted: true,
+      configID: props.config.id,
     }
   }
 

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -57,8 +57,11 @@ class InfluxQLEditor extends Component<Props, State> {
   public static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     const {isSubmitted, isShowingTemplateValues, editedQueryText} = prevState
 
+    // stale prop values after recent submission cause flickering
+    const isRecentlySubmitted = !isSubmitted || prevState.isSubmitted
+
     if (
-      isSubmitted &&
+      !isRecentlySubmitted &&
       !isShowingTemplateValues &&
       editedQueryText.trim() !== nextProps.query.trim()
     ) {


### PR DESCRIPTION
Closes #4412 

_What was the problem?_
Query editor would flicker a stale value after an update 
_What was the solution?_
Prevent updating immediately after the submission. It also focuses the query after the active editor tab changes. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass