### PR TITLE
Fix query editor rejecting updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 1.  [#4392](https://github.com/influxdata/chronograf/pull/4392): Add log filters on left side
 
 1.  [#2265](https://github.com/influxdata/chronograf/pull/2265): Autofocus dashboard query editor
+1.  [#4429](https://github.com/influxdata/chronograf/pull/4429): Fix query editor flickering on update
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,6 @@
 1.  [#4392](https://github.com/influxdata/chronograf/pull/4392): Add log filters on left side
 
 1.  [#2265](https://github.com/influxdata/chronograf/pull/2265): Autofocus dashboard query editor
-1.  [#4423](https://github.com/influxdata/chronograf/pull/4423): Fix query editor flickering on update
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -276,7 +276,7 @@ class InfluxQLEditor extends Component<Props, State> {
       this.pendingUpdates = [...this.pendingUpdates, cancelableUpdate]
 
       try {
-        await cancelableUpdate
+        await cancelableUpdate.promise
         this.setState({isSubmitted: true})
       } catch (error) {
         if (!error.isCanceled) {

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -58,14 +58,13 @@ class InfluxQLEditor extends Component<Props, State> {
   public static getDerivedStateFromProps(nextProps: Props, prevState: State) {
     const {isSubmitted, isShowingTemplateValues, editedQueryText} = prevState
 
-    // stale prop values after recent submission cause flickering
-    const isRecentlySubmitted = !isSubmitted || prevState.isSubmitted
-    const isQueryTextChanged = editedQueryText.trim() !== nextProps.query.trim()
-    const isQueryUpdated = !isRecentlySubmitted && isQueryTextChanged
-
     const isQueryConfigChanged = nextProps.config.id !== prevState.configID
+    const isQueryTextChanged = editedQueryText.trim() !== nextProps.query.trim()
 
-    if ((isQueryUpdated && !isShowingTemplateValues) || isQueryConfigChanged) {
+    if (
+      (isSubmitted && isQueryTextChanged && !isShowingTemplateValues) ||
+      isQueryConfigChanged
+    ) {
       return {
         ...BLURRED_EDITOR_STATE,
         selectedTemplate: {

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -266,15 +266,20 @@ class InfluxQLEditor extends Component<Props, State> {
     const {onUpdate} = this.props
 
     if (!this.isDisabled && !this.state.isSubmitted) {
+      const {editedQueryText} = this.state
       this.cancelPendingUpdates()
-      const update = onUpdate(this.state.editedQueryText)
+      const update = onUpdate(editedQueryText)
       const cancelableUpdate = makeCancelable(update)
 
       this.pendingUpdates = [...this.pendingUpdates, cancelableUpdate]
 
       try {
         await cancelableUpdate.promise
-        this.setState({isSubmitted: true})
+
+        // prevent changing submitted status when edited while awaiting update
+        if (this.state.editedQueryText === editedQueryText) {
+          this.setState({isSubmitted: true})
+        }
       } catch (error) {
         if (!error.isCanceled) {
           console.error(error)

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -56,15 +56,12 @@ const TEMPLATE_VAR = /[:]\w+[:]/g
 @ErrorHandling
 class InfluxQLEditor extends Component<Props, State> {
   public static getDerivedStateFromProps(nextProps: Props, prevState: State) {
-    const {isSubmitted, isShowingTemplateValues, editedQueryText} = prevState
+    const {isSubmitted, editedQueryText} = prevState
 
     const isQueryConfigChanged = nextProps.config.id !== prevState.configID
     const isQueryTextChanged = editedQueryText.trim() !== nextProps.query.trim()
 
-    if (
-      (isSubmitted && isQueryTextChanged && !isShowingTemplateValues) ||
-      isQueryConfigChanged
-    ) {
+    if ((isSubmitted && isQueryTextChanged) || isQueryConfigChanged) {
       return {
         ...BLURRED_EDITOR_STATE,
         selectedTemplate: {


### PR DESCRIPTION
Closes #4427 
Closes #4412

_What was the problem?_
A bug in the `isSubmitted` logic for `getDerivedStateFromProps` in the InflxuQLEditor prevented query updates from generated statements that have the same query config id, but also, the `isSubmitted` status was changing to true before a submission had completed causing `getDerivedStateFromProps` to replace editor text with a stale props query causing a flicker of old text.

_What was the solution?_
Remove the bad `getDerivedStateFromProps`  condition and update query submission to await the `promise` of the wrapped `props.onUpdate`.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass