### PR TITLE
Remove logs table query stats

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -10,7 +10,6 @@ import ExpandableMessage from 'src/logs/components/expandable_message/Expandable
 import LogsMessage from 'src/logs/components/logs_message/LogsMessage'
 import LoadingStatus from 'src/logs/components/loading_status/LoadingStatus'
 import {getDeep} from 'src/utils/wrappers'
-import QueryResults from 'src/logs/components/QueryResults'
 
 import {colorForSeverity} from 'src/logs/utils/colors'
 import {
@@ -63,7 +62,6 @@ interface Props {
   hasScrolled: boolean
   count: number
   timeRange: TimeRange
-  queryCount: number
   tableColumns: LogsTableColumn[]
   severityFormat: SeverityFormat
   severityLevelColors: SeverityLevelColor[]
@@ -208,8 +206,6 @@ class LogsTable extends Component<Props, State> {
   }
 
   public render() {
-    const {queryCount, upper, lower, searchStatus} = this.props
-    const {infiniteLoaderQueryCount} = this.state
     const columnCount = Math.max(getColumnsFromData(this.props.data).length, 0)
 
     if (this.isLoadingTableData) {
@@ -221,15 +217,6 @@ class LogsTable extends Component<Props, State> {
         className="logs-viewer--table-container"
         onMouseOut={this.handleMouseOut}
       >
-        <div className="logs-viewer--table-count">
-          <QueryResults
-            count={this.rowCount()}
-            queryCount={infiniteLoaderQueryCount + queryCount}
-            searchStatus={searchStatus}
-            upper={upper}
-            lower={lower}
-          />
-        </div>
         <AutoSizer>
           {({width}) => (
             <Grid

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -222,7 +222,6 @@ class LogsPage extends Component<Props, State> {
   public render() {
     const {
       filters,
-      queryCount,
       timeRange,
       notify,
       nextOlderUpperBound,
@@ -259,7 +258,6 @@ class LogsPage extends Component<Props, State> {
             />
             <LogsTable
               count={this.histogramTotal}
-              queryCount={queryCount}
               data={this.tableData}
               onScrollVertical={this.handleVerticalScroll}
               onScrolledToTop={this.handleScrollToTop}

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -5,7 +5,7 @@
 
 $logs-viewer-graph-height: 170px;
 $logs-viewer-search-height: 46px; 
-$logs-viewer-filter-height: 60px;
+$logs-viewer-filter-height: 40px;
 $logs-viewer-results-text-indent: 33px;
 $logs-viewer-gutter: 60px;
 
@@ -70,7 +70,7 @@ $logs-viewer-gutter: 60px;
   display: flex;
   align-items: center;
   @include no-user-select();
-  padding: 0 $logs-viewer-gutter 0 ($logs-viewer-gutter + 190);
+  padding: 0 $logs-viewer-gutter 0 ($logs-viewer-gutter);
   height: $logs-viewer-filter-height;
   background-color: $g3-castle;
 }


### PR DESCRIPTION
_What was the problem?_
QueryResults stats from the top left of logs table were more noisy than helpful
_What was the solution?_
Remove the query results stats from the logs table

  - [x] Rebased/mergeable
  - [x] Tests pass