### PR TITLE
Clear localStorage state upon every commit

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -9,8 +9,8 @@
     "url": "github:influxdata/chronograf"
   },
   "scripts": {
-    "start": "node parcel.js",
-    "build": "parcel build -d build --no-source-maps --public-url '' src/index.html",
+    "start": "GIT_SHA=$(git rev-parse HEAD) node parcel.js",
+    "build": "GIT_SHA=$(git rev-parse HEAD) parcel build -d build --no-source-maps --public-url '' src/index.html",
     "clean": "rm -rf ./build/* && rm -rf ./.cache",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -38,7 +38,7 @@ export const notifyNewVersion = (version: string): Notification => ({
   type: 'info',
   icon: 'cubo-uniform',
   duration: INFINITE,
-  message: `Welcome to the latest Chronograf${version}. Local settings cleared.`,
+  message: `Welcome to the latest Chronograf (${version}). Local settings cleared.`,
 })
 
 export const notifyLoadLocalSettingsFailed = (error: string): Notification => ({


### PR DESCRIPTION
_Problem:_

We store our redux app state in localStorage. Every commit potentially changes the schema of this stored state. If the schema changes, we can't use it to rehydrate the redux store reliably. 

_Solution:_

Clear localStorage every commit. We already clear localStorage (for the most part) every release, so this is for development and for users of the nightly release.

This is a step towards debugging https://github.com/influxdata/chronograf/issues/4340.

