### PR TITLE
Fix Color dropdown

### DIFF
--- a/ui/src/dashboards/components/AxesOptions.tsx
+++ b/ui/src/dashboards/components/AxesOptions.tsx
@@ -19,6 +19,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 // Types
 import {Axes, CellType} from 'src/types'
 import {DecimalPlaces} from 'src/types/dashboards'
+import {ColorString} from 'src/types/colors'
 
 const {LINEAR, LOG, BASE_2, BASE_10} = AXES_SCALE_OPTIONS
 const getInputMin = scale => (scale === LOG ? '0' : null)
@@ -28,9 +29,11 @@ interface Props {
   axes: Axes
   staticLegend: boolean
   defaultYLabel: string
+  lineColors: ColorString[]
   decimalPlaces: DecimalPlaces
   onUpdateAxes: (axes: Axes) => void
   onToggleStaticLegend: (isStaticLegend: boolean) => void
+  onUpdateLineColors: (colors: ColorString[]) => void
   onUpdateDecimalPlaces: (decimalPlaces: DecimalPlaces) => void
 }
 
@@ -63,7 +66,9 @@ class AxesOptions extends PureComponent<Props> {
         y: {bounds, label, prefix, suffix, scale},
       },
       type,
+      lineColors,
       defaultYLabel,
+      onUpdateLineColors,
     } = this.props
 
     const [min, max] = bounds
@@ -84,7 +89,10 @@ class AxesOptions extends PureComponent<Props> {
                 customPlaceholder={defaultYLabel || 'y-axis title'}
               />
             </div>
-            <LineGraphColorSelector />
+            <LineGraphColorSelector
+              onUpdateLineColors={onUpdateLineColors}
+              lineColors={lineColors}
+            />
             <div className="form-group col-sm-6">
               <label htmlFor="min">Min</label>
               <OptIn

--- a/ui/src/dashboards/components/DisplayOptions.tsx
+++ b/ui/src/dashboards/components/DisplayOptions.tsx
@@ -26,6 +26,7 @@ import {
   updateNoteVisibility,
   updateThresholdsListColors,
   updateThresholdsListType,
+  updateLineColors,
 } from 'src/shared/actions/visualizations'
 
 // Constants
@@ -46,7 +47,7 @@ import {
 import {buildDefaultYLabel} from 'src/shared/presenters'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Axes, Cell, QueryConfig} from 'src/types'
-import {ColorNumber} from 'src/types/colors'
+import {ColorNumber, ColorString} from 'src/types/colors'
 import {VisualizationOptions} from 'src/shared/components/TimeMachine/TimeMachine'
 
 interface Props extends VisualizationOptions {
@@ -64,6 +65,7 @@ interface Props extends VisualizationOptions {
   onUpdateTimeFormat: typeof updateTimeFormat
   onUpdateVisType: typeof updateVisType
   onUpdateNote: typeof updateNote
+  onUpdateLineColors: typeof updateLineColors
   onUpdateNoteVisibility: typeof updateNoteVisibility
   onUpdateThresholdsListColors: typeof updateThresholdsListColors
   onUpdateThresholdsListType: typeof updateThresholdsListType
@@ -143,6 +145,7 @@ class DisplayOptions extends Component<Props, State> {
     const {
       type,
       decimalPlaces,
+      lineColors,
       gaugeColors,
       staticLegend,
       onToggleStaticLegend,
@@ -210,11 +213,13 @@ class DisplayOptions extends Component<Props, State> {
           <AxesOptions
             axes={this.axes}
             type={type}
+            lineColors={lineColors}
             staticLegend={staticLegend}
             defaultYLabel={defaultYLabel}
             decimalPlaces={decimalPlaces}
             onUpdateAxes={this.handleUpdateAxes}
             onToggleStaticLegend={onToggleStaticLegend}
+            onUpdateLineColors={this.handleUpdateLineColors}
             onUpdateDecimalPlaces={this.handleUpdateDecimalPlaces}
           />
         )
@@ -305,6 +310,12 @@ class DisplayOptions extends Component<Props, State> {
 
     onUpdateThresholdsListType(type, this.stateToUpdate)
   }
+
+  private handleUpdateLineColors = (colors: ColorString[]): void => {
+    const {onUpdateLineColors} = this.props
+
+    onUpdateLineColors(colors, this.stateToUpdate)
+  }
 }
 
 const mdtp = {
@@ -319,6 +330,7 @@ const mdtp = {
   onUpdateNoteVisibility: updateNoteVisibility,
   onUpdateThresholdsListColors: updateThresholdsListColors,
   onUpdateThresholdsListType: updateThresholdsListType,
+  onUpdateLineColors: updateLineColors,
 }
 
 export default connect(null, mdtp)(DisplayOptions)

--- a/ui/src/shared/components/ColorScaleDropdown.tsx
+++ b/ui/src/shared/components/ColorScaleDropdown.tsx
@@ -5,16 +5,16 @@ import classnames from 'classnames'
 import {ClickOutside} from 'src/shared/components/ClickOutside'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
-import {ColorNumber} from 'src/types/colors'
+import {ColorString} from 'src/types/colors'
 import {LINE_COLOR_SCALES} from 'src/shared/constants/graphColorPalettes'
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'src/shared/constants/index'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
-  onChoose: (colors: ColorNumber[]) => void
+  onChoose: (colors: ColorString[]) => void
   stretchToFit?: boolean
   disabled?: boolean
-  selected: ColorNumber[]
+  selected: ColorString[]
 }
 
 interface State {

--- a/ui/src/shared/components/LineGraphColorSelector.tsx
+++ b/ui/src/shared/components/LineGraphColorSelector.tsx
@@ -1,16 +1,13 @@
 import React, {Component} from 'react'
-import {connect} from 'react-redux'
-import {bindActionCreators} from 'redux'
 
 import ColorScaleDropdown from 'src/shared/components/ColorScaleDropdown'
 
-import {updateLineColors} from 'src/shared/actions/visualizations'
-import {ColorNumber} from 'src/types/colors'
+import {ColorString} from 'src/types/colors'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
-  lineColors: ColorNumber[]
-  handleUpdateLineColors: (colors: ColorNumber[]) => void
+  lineColors: ColorString[]
+  onUpdateLineColors: (colors: ColorString[]) => void
 }
 
 @ErrorHandling
@@ -31,21 +28,11 @@ class LineGraphColorSelector extends Component<Props> {
   }
 
   public handleSelectColors = (colorScale): void => {
-    const {handleUpdateLineColors} = this.props
+    const {onUpdateLineColors} = this.props
     const {colors} = colorScale
 
-    handleUpdateLineColors(colors)
+    onUpdateLineColors(colors)
   }
 }
 
-const mapStateToProps = ({cellEditorOverlay: {lineColors}}) => ({
-  lineColors,
-})
-
-const mapDispatchToProps = dispatch => ({
-  handleUpdateLineColors: bindActionCreators(updateLineColors, dispatch),
-})
-
-export default connect(mapStateToProps, mapDispatchToProps)(
-  LineGraphColorSelector
-)
+export default LineGraphColorSelector


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/68

_What was the problem?_
When all the children of display options were disconnected from redux and recieved their props from parent components, the dropdown component was missed so editing the line color dropdown did not modify the line graphs.

_What was the solution?_
Disconnect the selector from redux and pass down options and handlers from parents.

  - [x] Rebased/mergeable
  - [x] Tests pass