### PR TITLE
Refetch logs after source update

### DIFF
--- a/ui/src/logs/components/loading_status/LoadingStatus.tsx
+++ b/ui/src/logs/components/loading_status/LoadingStatus.tsx
@@ -53,6 +53,8 @@ class LoadingStatus extends PureComponent<Props> {
         return 'Searching time bounds'
       case SearchStatus.UpdatingSource:
         return 'Searching updated source'
+      case SearchStatus.UpdatingNamespace:
+        return 'Searching updated namespace'
       case SearchStatus.Loading:
       default:
         return 'Searching'

--- a/ui/src/logs/components/loading_status/LoadingStatus.tsx
+++ b/ui/src/logs/components/loading_status/LoadingStatus.tsx
@@ -46,11 +46,13 @@ class LoadingStatus extends PureComponent<Props> {
   private get loadingMessage(): string {
     switch (this.props.status) {
       case SearchStatus.UpdatingFilters:
-        return 'Updating Search Filters'
+        return 'Updating search filters'
       case SearchStatus.NoResults:
         return 'No logs found'
       case SearchStatus.UpdatingTimeBounds:
         return 'Searching time bounds'
+      case SearchStatus.UpdatingSource:
+        return 'Searching updated source'
       case SearchStatus.Loading:
       default:
         return 'Searching'

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -853,8 +853,9 @@ class LogsPage extends Component<Props, State> {
     this.updateTableData(SearchStatus.UpdatingSource)
   }
 
-  private handleChooseNamespace = (namespace: Namespace) => {
-    this.props.setNamespaceAsync(namespace)
+  private handleChooseNamespace = async (namespace: Namespace) => {
+    await this.props.setNamespaceAsync(namespace)
+    this.updateTableData(SearchStatus.UpdatingNamespace)
   }
 
   private updateTableData(searchStatus: SearchStatus) {

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -461,6 +461,18 @@ class LogsPage extends Component<Props, State> {
     }
   }
 
+  private cancelChunks() {
+    if (this.currentNewerChunksGenerator) {
+      this.currentNewerChunksGenerator.cancel()
+      this.currentNewerChunksGenerator = null
+    }
+
+    if (this.currentOlderChunksGenerator) {
+      this.currentOlderChunksGenerator.cancel()
+      this.currentOlderChunksGenerator = null
+    }
+  }
+
   private get tableScrollToRow() {
     if (this.isLiveUpdating === true) {
       return 0
@@ -836,16 +848,18 @@ class LogsPage extends Component<Props, State> {
     this.handleSetTimeBounds()
   }
 
-  private handleChooseSource = (sourceID: string) => {
-    this.props.getSourceAndPopulateNamespaces(sourceID)
+  private handleChooseSource = async (sourceID: string) => {
+    await this.props.getSourceAndPopulateNamespaces(sourceID)
+    this.updateTableData(SearchStatus.UpdatingSource)
   }
 
   private handleChooseNamespace = (namespace: Namespace) => {
     this.props.setNamespaceAsync(namespace)
   }
 
-  private updateTableData(searchStatus) {
+  private updateTableData(searchStatus: SearchStatus) {
     this.clearTailInterval()
+    this.cancelChunks()
     this.props.clearSearchData(searchStatus)
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -217,6 +217,7 @@ class LogsPage extends Component<Props, State> {
 
   public componentWillUnmount() {
     this.clearTailInterval()
+    this.cancelChunks()
   }
 
   public render() {

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -17,6 +17,7 @@ export enum SearchStatus {
   UpdatingTimeBounds = 'UpdatingTimeBounds',
   UpdatingFilters = 'UpdatingFilters',
   UpdatingSource = 'UpdatingSource',
+  UpdatingNamespace = 'UpdatingNamespace',
   Loaded = 'Loaded',
   Clearing = 'Clearing',
   Cleared = 'Cleared',

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -16,6 +16,7 @@ export enum SearchStatus {
   NoResults = 'NoResults',
   UpdatingTimeBounds = 'UpdatingTimeBounds',
   UpdatingFilters = 'UpdatingFilters',
+  UpdatingSource = 'UpdatingSource',
   Loaded = 'Loaded',
   Clearing = 'Clearing',
   Cleared = 'Cleared',


### PR DESCRIPTION
Closes #4425 

_What was the problem?_
Switching sources would not refetch data, namespace switching would not refetch data, and unmount would not stop searching
_What was the solution?_
Handle a source or namespace change and then refetch logs for the new source. Cancel all search chunks on unmount.

  - [x] Rebased/mergeable
  - [x] Tests pass