### PR TITLE
Send cell from DE to a new dashboard

### DIFF
--- a/ui/src/dashboards/constants/index.ts
+++ b/ui/src/dashboards/constants/index.ts
@@ -109,9 +109,15 @@ type NewDefaultDashboard = Pick<
   }
 >
 export const DEFAULT_DASHBOARD_NAME = 'Name This Dashboard'
+
 export const NEW_DASHBOARD: NewDefaultDashboard = {
   name: DEFAULT_DASHBOARD_NAME,
   cells: [NEW_DEFAULT_DASHBOARD_CELL],
+}
+
+export const NEW_EMPTY_DASHBOARD: NewDefaultDashboard = {
+  name: DEFAULT_DASHBOARD_NAME,
+  cells: [],
 }
 
 export const TYPE_QUERY_CONFIG: string = 'queryConfig'

--- a/ui/src/dashboards/utils/notes.ts
+++ b/ui/src/dashboards/utils/notes.ts
@@ -1,3 +1,6 @@
 export const humanizeNote = (text: string): string => {
-  return text.replace(/&gt;/g, '>').replace(/&#39;/g, "'")
+  if (text) {
+    return text.replace(/&gt;/g, '>').replace(/&#39;/g, "'")
+  }
+  return ''
 }

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -148,7 +148,13 @@ export class DataExplorer extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    const {loadDE, timeRange, autoRefresh, queryDrafts} = this.props
+    const {
+      loadDE,
+      timeRange,
+      autoRefresh,
+      queryDrafts,
+      handleGetDashboards,
+    } = this.props
     const {query, script} = this.queryString
 
     GlobalAutoRefresher.poll(autoRefresh)
@@ -173,7 +179,7 @@ export class DataExplorer extends PureComponent<Props, State> {
       await this.createNewQueryDraft()
     }
 
-    await this.getDashboards()
+    await handleGetDashboards()
 
     this.fetchFluxServices()
   }
@@ -500,14 +506,6 @@ export class DataExplorer extends PureComponent<Props, State> {
     )
     const queryDraft = {query, queryConfig, source: source.links.self}
     loadDE([queryDraft], timeRange)
-  }
-
-  private async getDashboards() {
-    const {dashboards, handleGetDashboards} = this.props
-
-    if (!_.isEmpty(dashboards)) {
-      await handleGetDashboards()
-    }
   }
 
   private get activeScript(): string {


### PR DESCRIPTION
Closes #4443 

_Briefly describe your proposed changes:_
_What was the problem?_
Send to dashboard dropdown in data explorer was breaking when there were no dashboards to send to. 
_What was the solution?_
Added a "send to new dashboard" option to dropdown which creates a new dashboard to send cell to. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)