### PR TITLE
Enable exporting a CSV for Flux queries in the CEO

### DIFF
--- a/ui/src/shared/components/TimeMachine/CSVExporter.tsx
+++ b/ui/src/shared/components/TimeMachine/CSVExporter.tsx
@@ -7,7 +7,10 @@ import {
   downloadFluxCSV,
 } from 'src/shared/utils/downloadTimeseriesCSV'
 import {notify} from 'src/shared/actions/notifications'
-import {csvExportFailed} from 'src/shared/copy/notifications'
+import {
+  csvExportFailed,
+  fluxResponseTruncatedError,
+} from 'src/shared/copy/notifications'
 
 import {Query, Template, Service} from 'src/types'
 
@@ -73,10 +76,16 @@ class CSVExporter extends PureComponent<Props, State> {
     return downloadInfluxQLCSV(queries, templates)
   }
 
-  private downloadFluxCSV = (): Promise<void> => {
-    const {service, script} = this.props
+  private downloadFluxCSV = async (): Promise<void> => {
+    const {service, script, onNotify} = this.props
 
-    return downloadFluxCSV(service, script)
+    const {didTruncate} = await downloadFluxCSV(service, script)
+
+    if (didTruncate) {
+      onNotify(fluxResponseTruncatedError())
+    }
+
+    return
   }
 }
 

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -219,7 +219,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {services, timeRange, templates, isInCEO} = this.props
+    const {services, timeRange, templates, isInCEO, script} = this.props
     const {useDynamicSource, autoRefreshDuration} = this.state
 
     const horizontalDivisions = [
@@ -256,6 +256,7 @@ class TimeMachine extends PureComponent<Props, State> {
           service={this.service}
           services={services}
           isFluxSource={this.isFluxSource}
+          script={script}
           sourceSupportsFlux={this.sourceSupportsFlux}
           toggleVisType={this.toggleVisType}
           autoRefreshDuration={autoRefreshDuration}

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -25,6 +25,7 @@ interface Props {
   sources: SourcesModels.SourceOption[]
   service: Service
   services: Service[]
+  script: string
   isDynamicSourceSelected: boolean
   onChangeService: (service: Service, source: SourcesModels.Source) => void
   autoRefreshDuration: number
@@ -40,6 +41,7 @@ interface Props {
 }
 
 const TimeMachineControls: SFC<Props> = ({
+  script,
   source,
   sources,
   service,
@@ -88,6 +90,9 @@ const TimeMachineControls: SFC<Props> = ({
         </div>
       )}
       <CSVExporter
+        script={script}
+        service={service}
+        isFluxSource={isFluxSource}
         queries={buildQueries(queries, timeRange)}
         templates={templates}
       />


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/49

When viewing a Flux query in the DE/CEO, clicking the “Export CSV” button will download the CSV for the query. The CSV is in the format returned by `fluxd`.

I also took the opportunity to refactor `ui/src/flux/apis/index.ts` a bit.