### PR TITLE
Flux in single stat graph types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1.  [#4422](https://github.com/influxdata/chronograf/pull/4422): Allow deep linking flux script in data explorer
 1.  [#4410](https://github.com/influxdata/chronograf/pull/4410): Add ability to use line graph visualizations for flux query
 1.  [#4445](https://github.com/influxdata/chronograf/pull/4445): Allow flux dashboard cells to be exported
+1.  [#4449](https://github.com/influxdata/chronograf/pull/4449): Add ability to use single stat graph visualizations for flux query
 
 
 ### UI Improvements

--- a/ui/src/shared/components/GaugeChart.tsx
+++ b/ui/src/shared/components/GaugeChart.tsx
@@ -1,6 +1,8 @@
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
 
+import {manager} from 'src/worker/JobManager'
+
 import getLastValues from 'src/shared/parsing/lastValues'
 import Gauge from 'src/shared/components/Gauge'
 
@@ -11,9 +13,12 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import {DecimalPlaces} from 'src/types/dashboards'
 import {ColorString} from 'src/types/colors'
 import {TimeSeriesServerResponse} from 'src/types/series'
+import {FluxTable} from 'src/types/flux'
+import {DataTypes} from 'src/shared/components/RefreshingGraph'
 
 interface Props {
-  data: TimeSeriesServerResponse[]
+  data: TimeSeriesServerResponse[] | FluxTable[]
+  dataType: DataTypes
   decimalPlaces: DecimalPlaces
   cellID: string
   cellHeight?: number
@@ -23,10 +28,44 @@ interface Props {
   resizerTopHeight?: number
 }
 
+interface State {
+  lastValues?: {
+    values: number[]
+    series: string[]
+  }
+}
+
 @ErrorHandling
-class GaugeChart extends PureComponent<Props> {
+class GaugeChart extends PureComponent<Props, State> {
   public static defaultProps: Partial<Props> = {
     colors: stringifyColorValues(DEFAULT_GAUGE_COLORS),
+  }
+
+  private isComponentMounted: boolean
+
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {}
+  }
+
+  public async componentDidMount() {
+    this.isComponentMounted = true
+    await this.dataToLastValues()
+  }
+
+  public async componentDidUpdate(prevProps: Props) {
+    const isDataChanged =
+      prevProps.dataType !== this.props.dataType ||
+      !_.isEqual(prevProps.data, this.props.data)
+
+    if (isDataChanged) {
+      await this.dataToLastValues()
+    }
+  }
+
+  public componentWillUnmount() {
+    this.isComponentMounted = false
   }
 
   public render() {
@@ -63,15 +102,35 @@ class GaugeChart extends PureComponent<Props> {
   }
 
   private get lastValueForGauge(): number {
-    const {data} = this.props
-    const {lastValues} = getLastValues(data)
-    const lastValue = _.get(lastValues, 0, 0)
+    const {lastValues} = this.state
+    const lastValue = _.get(lastValues, 'values.0', 0)
 
     if (!lastValue) {
       return 0
     }
 
     return lastValue
+  }
+
+  private async dataToLastValues() {
+    const {data, dataType} = this.props
+
+    try {
+      let lastValues
+      if (dataType === DataTypes.flux) {
+        lastValues = await manager.fluxTablesToSingleStat(data as FluxTable[])
+      } else if (dataType === DataTypes.influxQL) {
+        lastValues = getLastValues(data as TimeSeriesServerResponse[])
+      }
+
+      if (!this.isComponentMounted) {
+        return
+      }
+
+      this.setState({lastValues})
+    } catch (err) {
+      console.error(err)
+    }
   }
 }
 

--- a/ui/src/shared/parsing/flux/parseTablesByTime.ts
+++ b/ui/src/shared/parsing/flux/parseTablesByTime.ts
@@ -1,0 +1,83 @@
+import {FluxTable} from 'src/types'
+
+const COLUMN_BLACKLIST = new Set([
+  '_time',
+  'result',
+  'table',
+  '_start',
+  '_stop',
+  '',
+])
+
+const NUMERIC_DATATYPES = ['double', 'long', 'int', 'float']
+
+interface TableByTime {
+  [time: string]: {[columnName: string]: string}
+}
+interface ParseTablesByTimeResult {
+  tablesByTime: TableByTime[]
+  allColumnNames: string[]
+  nonNumericColumns: string[]
+}
+
+export const parseTablesByTime = (
+  tables: FluxTable[]
+): ParseTablesByTimeResult => {
+  const allColumnNames = []
+  const nonNumericColumns = []
+
+  const tablesByTime = tables.map(table => {
+    const header = table.data[0]
+    const columnNames: {[k: number]: string} = {}
+
+    for (let i = 0; i < header.length; i++) {
+      const columnName = header[i]
+      const dataType = table.dataTypes[columnName]
+
+      if (COLUMN_BLACKLIST.has(columnName)) {
+        continue
+      }
+
+      if (table.groupKey[columnName]) {
+        continue
+      }
+
+      if (!NUMERIC_DATATYPES.includes(dataType)) {
+        nonNumericColumns.push(columnName)
+        continue
+      }
+
+      const uniqueColumnName = Object.entries(table.groupKey).reduce(
+        (acc, [k, v]) => acc + `[${k}=${v}]`,
+        columnName
+      )
+
+      columnNames[i] = uniqueColumnName
+      allColumnNames.push(uniqueColumnName)
+    }
+
+    const timeIndex = header.indexOf('_time')
+
+    if (timeIndex < 0) {
+      throw new Error('Could not find time index in FluxTable')
+    }
+
+    const result = {}
+    for (let i = 1; i < table.data.length; i++) {
+      const row = table.data[i]
+      const time = row[timeIndex]
+
+      result[time] = Object.entries(columnNames).reduce(
+        (acc, [valueIndex, columnName]) => ({
+          ...acc,
+          [columnName]: row[valueIndex],
+        }),
+        {}
+      )
+    }
+
+    return result
+  })
+
+  return {nonNumericColumns, tablesByTime, allColumnNames}
+}

--- a/ui/src/shared/parsing/lastValues.ts
+++ b/ui/src/shared/parsing/lastValues.ts
@@ -2,14 +2,14 @@ import _ from 'lodash'
 import {Data} from 'src/types/dygraphs'
 import {TimeSeriesServerResponse} from 'src/types/series'
 
-interface Result {
-  lastValues: number[]
+interface LastValues {
+  values: number[]
   series: string[]
 }
 
 export default function(
   timeSeriesResponse: TimeSeriesServerResponse[] | Data | null
-): Result {
+): LastValues {
   const values = _.get(
     timeSeriesResponse,
     ['0', 'response', 'results', '0', 'series', '0', 'values'],
@@ -24,5 +24,5 @@ export default function(
 
   const lastValues = values[values.length - 1].slice(1) // remove time with slice 1
 
-  return {lastValues, series}
+  return {values: lastValues, series}
 }

--- a/ui/src/worker/JobManager.ts
+++ b/ui/src/worker/JobManager.ts
@@ -8,6 +8,7 @@ import {getBasepath} from 'src/utils/basepath'
 import {TimeSeriesToTableGraphReturnType} from 'src/worker/jobs/timeSeriesToTableGraph'
 import {TimeSeriesToDyGraphReturnType} from 'src/worker/jobs/timeSeriesToDygraph'
 import {FluxTablesToDygraphResult} from 'src/worker/jobs/fluxTablesToDygraph'
+import {LastValues} from 'src/worker/jobs/fluxTablesToSingleStat'
 
 interface DecodeFluxRespWithLimitResult {
   body: string
@@ -97,6 +98,10 @@ class JobManager {
     raw: FluxTable[]
   ): Promise<FluxTablesToDygraphResult> => {
     return this.publishDBJob('FLUXTODYGRAPH', {raw})
+  }
+
+  public fluxTablesToSingleStat = (raw: FluxTable[]): Promise<LastValues> => {
+    return this.publishDBJob('FLUXTOSINGLE', {raw})
   }
 
   public validateDygraphData = (ts: DygraphValue[][]) => {

--- a/ui/src/worker/jobs/fluxTablesToDygraph.ts
+++ b/ui/src/worker/jobs/fluxTablesToDygraph.ts
@@ -3,6 +3,7 @@ import _ from 'lodash'
 import {Message} from 'src/worker/types'
 import {fetchData} from 'src/worker/utils'
 import {FluxTable, DygraphValue} from 'src/types'
+import {parseTablesByTime} from 'src/shared/parsing/flux/parseTablesByTime'
 
 export interface FluxTablesToDygraphResult {
   labels: string[]
@@ -10,75 +11,12 @@ export interface FluxTablesToDygraphResult {
   nonNumericColumns: string[]
 }
 
-const COLUMN_BLACKLIST = new Set([
-  '_time',
-  'result',
-  'table',
-  '_start',
-  '_stop',
-  '',
-])
-
-const NUMERIC_DATATYPES = ['double', 'long', 'int', 'float']
-
 export const fluxTablesToDygraphWork = (
   tables: FluxTable[]
 ): FluxTablesToDygraphResult => {
-  const allColumnNames = []
-  const nonNumericColumns = []
-
-  const tablesByTime = tables.map(table => {
-    const header = table.data[0]
-    const columnNames: {[k: number]: string} = {}
-
-    for (let i = 0; i < header.length; i++) {
-      const columnName = header[i]
-      const dataType = table.dataTypes[columnName]
-
-      if (COLUMN_BLACKLIST.has(columnName)) {
-        continue
-      }
-
-      if (table.groupKey[columnName]) {
-        continue
-      }
-
-      if (!NUMERIC_DATATYPES.includes(dataType)) {
-        nonNumericColumns.push(columnName)
-        continue
-      }
-
-      const uniqueColmnName = Object.entries(table.groupKey).reduce(
-        (acc, [k, v]) => acc + `[${k}=${v}]`,
-        columnName
-      )
-
-      columnNames[i] = uniqueColmnName
-      allColumnNames.push(uniqueColmnName)
-    }
-
-    const timeIndex = header.indexOf('_time')
-
-    if (timeIndex < 0) {
-      throw new Error('Could not find time index in FluxTable')
-    }
-
-    const result = {}
-    for (let i = 1; i < table.data.length; i++) {
-      const row = table.data[i]
-      const time = row[timeIndex]
-
-      result[time] = Object.entries(columnNames).reduce(
-        (acc, [valueIndex, columnName]) => ({
-          ...acc,
-          [columnName]: row[valueIndex],
-        }),
-        {}
-      )
-    }
-
-    return result
-  })
+  const {tablesByTime, allColumnNames, nonNumericColumns} = parseTablesByTime(
+    tables
+  )
 
   const dygraphValuesByTime: {[k: string]: DygraphValue[]} = {}
   const DATE_INDEX = 0

--- a/ui/src/worker/jobs/fluxTablesToSingleStat.ts
+++ b/ui/src/worker/jobs/fluxTablesToSingleStat.ts
@@ -1,0 +1,36 @@
+import _ from 'lodash'
+import {Message} from 'src/worker/types'
+import {fetchData} from 'src/worker/utils'
+import {FluxTable} from 'src/types'
+import {parseTablesByTime} from 'src/shared/parsing/flux/parseTablesByTime'
+
+export interface LastValues {
+  values: number[]
+  series: string[]
+}
+
+export const fluxTablesToSingleStatWork = (tables: FluxTable[]): LastValues => {
+  const {tablesByTime} = parseTablesByTime(tables)
+
+  const lastValues = _.reduce(
+    tablesByTime,
+    (acc, table) => {
+      const lastTime = _.last(Object.keys(table))
+      const values = table[lastTime]
+      _.forEach(values, (value, series) => {
+        acc.series.push(series)
+        acc.values.push(value)
+      })
+      return acc
+    },
+    {values: [], series: []}
+  )
+
+  return lastValues
+}
+
+export default async (msg: Message): Promise<LastValues> => {
+  const {raw} = await fetchData(msg)
+
+  return fluxTablesToSingleStatWork(raw)
+}

--- a/ui/src/worker/worker.ts
+++ b/ui/src/worker/worker.ts
@@ -16,6 +16,7 @@ import validateDygraphData from 'src/worker/jobs/validateDygraphData'
 import postJSON from 'src/worker/jobs/postJSON'
 import fetchFluxData from 'src/worker/jobs/fetchFluxData'
 import fluxTablesToDygraph from 'src/worker/jobs/fluxTablesToDygraph'
+import fluxTablesToSingleStat from 'src/worker/jobs/fluxTablesToSingleStat'
 
 type Job = (msg: Message) => Promise<any>
 
@@ -29,6 +30,7 @@ const jobMapping: {[key: string]: Job} = {
   VALIDATEDYGRAPHDATA: validateDygraphData,
   FETCHFLUXDATA: fetchFluxData,
   FLUXTODYGRAPH: fluxTablesToDygraph,
+  FLUXTOSINGLE: fluxTablesToSingleStat,
 }
 
 const errorJob = async (data: Message) => {

--- a/ui/test/shared/components/GaugeChart.test.tsx
+++ b/ui/test/shared/components/GaugeChart.test.tsx
@@ -2,6 +2,7 @@ import {shallow} from 'enzyme'
 import React from 'react'
 import Gauge from 'src/shared/components/Gauge'
 import GaugeChart from 'src/shared/components/GaugeChart'
+import {DataTypes} from 'src/shared/components/RefreshingGraph'
 
 const data = [
   {
@@ -30,6 +31,7 @@ const defaultProps = {
     digits: 10,
     isEnforced: false,
   },
+  dataType: DataTypes.influxQL,
 }
 
 const setup = (overrides = {}) => {

--- a/ui/test/shared/parsing/lastValues.test.ts
+++ b/ui/test/shared/parsing/lastValues.test.ts
@@ -3,7 +3,7 @@ import lastValues from 'src/shared/parsing/lastValues'
 describe('lastValues', () => {
   it('returns the correct value when response is empty', () => {
     expect(lastValues([])).toEqual({
-      lastValues: [''],
+      values: [''],
       series: [''],
     })
   })


### PR DESCRIPTION
Closes #4114 

_Briefly describe your proposed changes:_
Support flux data in single stat, line graph + single stat, and gauge chart.
Update line graph to only take in one data prop instead of a type for each language.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass