### PR TITLE
Save log wrap/truncate setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 1.  [#4410](https://github.com/influxdata/chronograf/pull/4410): Add ability to use line graph visualizations for flux query
 1.  [#4445](https://github.com/influxdata/chronograf/pull/4445): Allow flux dashboard cells to be exported
 1.  [#4449](https://github.com/influxdata/chronograf/pull/4449): Add ability to use single stat graph visualizations for flux query
+1.  [#4454](https://github.com/influxdata/chronograf/pull/4454): Save log line wrap/truncate preference
 
 
 ### UI Improvements

--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -344,6 +344,9 @@ export type Action =
   | SetNextTailLowerBoundAction
   | SetSearchStatusAction
 
+const getIsTruncated = (state: State): boolean =>
+  state.logs.logConfig.isTruncated
+
 const getForwardTableData = (state: State): TableData =>
   state.logs.tableInfiniteData.forward
 
@@ -975,11 +978,20 @@ export const getSourceAndPopulateNamespacesAsync = (sourceID: string) => async (
 }
 
 export const getLogConfigAsync = (url: string) => async (
-  dispatch: Dispatch<SetConfigAction>
+  dispatch: Dispatch<SetConfigAction>,
+  getState: GetState
 ): Promise<void> => {
+  const state = getState()
+  const isTruncated = getIsTruncated(state)
+
   try {
     const {data} = await getLogConfigAJAX(url)
-    const logConfig = logConfigServerToUI(data)
+
+    const logConfig = {
+      ...logConfigServerToUI(data),
+      isTruncated,
+    }
+
     await dispatch(setConfig(logConfig))
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
Closes #4293

_Briefly describe your proposed changes:_
Load `wrap` or `truncate` log config setting saved in local storage.
_What was the problem?_
Log viewer would not attempt to save a `truncate` or `wrap` preference and would default to `truncate` after page refresh.
_What was the solution?_
Restore the log viewer message truncation preference in local storage after fetching the log config from  the server.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass