### PR TITLE
Add No Results Message For Histogram

### DIFF
--- a/ui/src/logs/components/HistogramResults.tsx
+++ b/ui/src/logs/components/HistogramResults.tsx
@@ -1,11 +1,11 @@
 import React, {PureComponent} from 'react'
-import {SearchStatus} from 'src/types/logs'
+import {SearchStatus, TimeRange} from 'src/types/logs'
 
 interface Props {
   count: number
   queryCount: number
   searchStatus: SearchStatus
-  windowOption: string
+  selectedTimeWindow: TimeRange
 }
 
 class HistogramResults extends PureComponent<Props> {
@@ -41,9 +41,19 @@ class HistogramResults extends PureComponent<Props> {
   private get noResultsContent(): JSX.Element {
     return (
       <>
-        No results in past <strong>{this.props.windowOption}</strong>
+        No results in <strong>{this.window}</strong>
       </>
     )
+  }
+
+  private get window(): string {
+    const {timeOption, windowOption} = this.props.selectedTimeWindow
+
+    if (timeOption === 'now') {
+      return `Past ${windowOption}`
+    }
+
+    return `${windowOption} Window`
   }
 }
 

--- a/ui/src/logs/components/HistogramResults.tsx
+++ b/ui/src/logs/components/HistogramResults.tsx
@@ -5,6 +5,7 @@ interface Props {
   count: number
   queryCount: number
   searchStatus: SearchStatus
+  windowOption: string
 }
 
 class HistogramResults extends PureComponent<Props> {
@@ -19,7 +20,7 @@ class HistogramResults extends PureComponent<Props> {
       case SearchStatus.Loaded:
         return this.completedContents
       default:
-        return <>Updating Histogram...</>
+        return <>Updating histogram...</>
     }
   }
 
@@ -32,13 +33,17 @@ class HistogramResults extends PureComponent<Props> {
 
     return (
       <>
-        Displaying <strong> {count} Events</strong> in Histogram
+        Displaying <strong> {count} events</strong> in histogram
       </>
     )
   }
 
   private get noResultsContent(): JSX.Element {
-    return <>No Histogram results. Try adjusting the window.</>
+    return (
+      <>
+        No results in past <strong>{this.props.windowOption}</strong>
+      </>
+    )
   }
 }
 

--- a/ui/src/logs/components/HistogramResults.tsx
+++ b/ui/src/logs/components/HistogramResults.tsx
@@ -9,27 +9,36 @@ interface Props {
 
 class HistogramResults extends PureComponent<Props> {
   public render() {
-    return (
-      <label className="logs-viewer--results-text">
-        {this.isPending ? this.pendingContents : this.completedContents}
-      </label>
-    )
+    return <label className="logs-viewer--results-text">{this.contents}</label>
   }
 
-  private get isPending(): boolean {
-    return this.props.searchStatus !== SearchStatus.Loaded
-  }
-
-  private get pendingContents(): JSX.Element {
-    return <>Updating Histogram...</>
+  private get contents() {
+    switch (this.props.searchStatus) {
+      case SearchStatus.NoResults:
+        return this.noResultsContent
+      case SearchStatus.Loaded:
+        return this.completedContents
+      default:
+        return <>Updating Histogram...</>
+    }
   }
 
   private get completedContents(): JSX.Element {
+    const {count} = this.props
+
+    if (count === 0) {
+      return this.noResultsContent
+    }
+
     return (
       <>
-        Displaying <strong> {this.props.count} Events</strong> in Histogram
+        Displaying <strong> {count} Events</strong> in Histogram
       </>
     )
+  }
+
+  private get noResultsContent(): JSX.Element {
+    return <>No Histogram results. Try adjusting the window.</>
   }
 }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -754,6 +754,7 @@ class LogsPage extends Component<Props, State> {
           count={this.histogramTotal}
           queryCount={queryCount}
           searchStatus={searchStatus}
+          windowOption={timeRange.windowOption}
         />
         <TimeWindowDropdown
           selectedTimeWindow={timeRange}

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -754,7 +754,7 @@ class LogsPage extends Component<Props, State> {
           count={this.histogramTotal}
           queryCount={queryCount}
           searchStatus={searchStatus}
-          windowOption={timeRange.windowOption}
+          selectedTimeWindow={timeRange}
         />
         <TimeWindowDropdown
           selectedTimeWindow={timeRange}


### PR DESCRIPTION
_What was the problem?_
Histogram continues to say 'updating' when search status is NoResults
_What was the solution?_
Adds a switch/case for the Histogram that includes a No Results message

  - [x] Rebased/mergeable
  - [ ] Tests pass