### PR TITLE
Improve source/namespace switching experience

### DIFF
--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -586,6 +586,7 @@ export const clearSearchData = (
   searchStatus: SearchStatus
 ) => async dispatch => {
   await dispatch(setSearchStatus(SearchStatus.Clearing))
+  dispatch(setHistogramData([]))
   dispatch(clearAllTimeBounds())
   dispatch(clearTableData())
   await dispatch(setSearchStatus(SearchStatus.Cleared))

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -846,11 +846,13 @@ class LogsPage extends Component<Props, State> {
   }
 
   private handleChooseSource = async (sourceID: string) => {
+    this.updateTableData(SearchStatus.Cleared)
     await this.props.getSourceAndPopulateNamespaces(sourceID)
     this.updateTableData(SearchStatus.UpdatingSource)
   }
 
   private handleChooseNamespace = async (namespace: Namespace) => {
+    this.updateTableData(SearchStatus.Cleared)
     await this.props.setNamespaceAsync(namespace)
     this.updateTableData(SearchStatus.UpdatingNamespace)
   }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Clear results before fetching source
_What was the problem?_
The histogram data was not being cleared when a new search was submitted
_What was the solution?_
Clear the histogram data when clearing old search data to improve responsiveness. Clear old histogram data before awaiting new source/namespace.

  - [x] Rebased/mergeable
  - [x] Tests pass