### PR TITLE
Fix notifications and dashboard getting in send to dashboard. 

### DIFF
--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -524,6 +524,23 @@ export const addDashboardCellAsync = (
   }
 }
 
+export const sendDashboardCellAsync = (
+  dashboard: Dashboard,
+  cell: Partial<Cell>
+) => async (
+  dispatch: Dispatch<Action>
+): Promise<{success: boolean; dashboard: Dashboard}> => {
+  try {
+    const {data} = await addDashboardCellAJAX(dashboard, cell)
+    dispatch(addDashboardCell(dashboard, data))
+    return {success: true, dashboard}
+  } catch (error) {
+    console.error(error)
+    dispatch(errorThrown(error))
+    return {success: false, dashboard}
+  }
+}
+
 export const cloneDashboardCellAsync = (
   dashboard: Dashboard,
   cell: Cell

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -528,6 +528,31 @@ export const notifyCellAdded = (name: string): Notification => ({
   message: `Added "${name}" to dashboard.`,
 })
 
+export const notifyCellSent = (
+  cellName: string,
+  dashboardNum: number
+): Notification => {
+  const pluralizer = dashboardNum > 1 ? 's' : ''
+  return {
+    ...defaultSuccessNotification,
+    icon: 'dash-h',
+    duration: 1900,
+    message: `Added "${cellName}" to ${dashboardNum} dashboard${pluralizer}.`,
+  }
+}
+
+export const notifyCellSendFailed = (
+  cellName: string,
+  dashboardName: string
+): Notification => {
+  return {
+    ...defaultErrorNotification,
+    icon: 'dash-h',
+    duration: 1900,
+    message: `Could not add "${cellName}" to ${dashboardName}.`,
+  }
+}
+
 export const notifyCellDeleted = (name: string): Notification => ({
   ...defaultDeletionNotification,
   icon: 'dash-h',

--- a/ui/test/data_explorer/containers/DataExplorer.test.tsx
+++ b/ui/test/data_explorer/containers/DataExplorer.test.tsx
@@ -71,6 +71,7 @@ const setup = () => {
     fieldOptions: [],
     note: '',
     noteVisibility: null,
+    sendDashboardCell: jest.fn(() => Promise.resolve()),
   }
 
   const wrapper = shallow(<DataExplorer {...props} />)


### PR DESCRIPTION
Closes #4443 again!

_What was the problem?_
_What was the solution?_
Send to Dashboard queries for dashboards on didMount so that dashboards are up to date if new ones have been created. 
Successes will be displayed all together, and failures will be displayed one by one at resolution of sendcell promises. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)