### PR TITLE
Exclude '_start' and '_stop' columns from group key

### DIFF
--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -4,6 +4,8 @@ import uuid from 'uuid'
 
 import {FluxTable} from 'src/types'
 
+const GROUP_KEY_EXCLUSIONS = []
+
 export const parseResponseError = (response: string): FluxTable[] => {
   const data = Papa.parse(response.trim()).data as string[][]
 
@@ -72,7 +74,7 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
 
   // groupRow = ['#group', 'false', 'true', 'true', 'false']
   const groupKeyIndices = groupRow.reduce((acc, value, i) => {
-    if (value === 'true') {
+    if (value === 'true' && !GROUP_KEY_EXCLUSIONS.includes(headerRow[i])) {
       return [...acc, i]
     }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/69

Flux responses include `_start` and `_stop` in the group key. We don't use these columns anywhere, 
 but we do use the group key to give individual time series a name. This results in very long names such as
```
_value[_start=2018-09-17T17:58:21.265021Z][_stop=2018-09-17T17:59:21.265021Z][_field=active][_measurement=mem][host=bertrand.local]
```
This PR excludes `_start` and `_stop` keys from our parsed representation of the group key, so that the names are more reasonable:
```
_value[_field=active][_measurement=mem][host=bertrand.local]
```
