### PR TITLE
Improve asset loading performance on low power devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 1.  [#4449](https://github.com/influxdata/chronograf/pull/4449): Add ability to use single stat graph visualizations for flux query
 1.  [#4454](https://github.com/influxdata/chronograf/pull/4454): Save log line wrap/truncate preference
 1.  [#4461](https://github.com/influxdata/chronograf/pull/4461): Add ability to use table graph visualizations for flux query
+1.  [#4470](https://github.com/influxdata/chronograf/pull/4470): Add option to disable gzip compression
 
 
 ### UI Improvements

--- a/server/server.go
+++ b/server/server.go
@@ -38,8 +38,9 @@ func init() {
 
 // Server for the chronograf API
 type Server struct {
-	Host string `long:"host" description:"The IP to listen on" default:"0.0.0.0" env:"HOST"`
-	Port int    `long:"port" description:"The port to listen on for insecure connections, defaults to a random value" default:"8888" env:"PORT"`
+	Host        string `long:"host" description:"The IP to listen on" default:"0.0.0.0" env:"HOST"`
+	Port        int    `long:"port" description:"The port to listen on for insecure connections, defaults to a random value" default:"8888" env:"PORT"`
+	DisableGZip bool   `long:"disable-gzip" description:"Disables gzip compression, even if client requests it. Useful if running on a low-cpu device" env:"DISABLE_GZIP"`
 
 	PprofEnabled bool `long:"pprof-enabled" description:"Enable the /debug/pprof/* HTTP routes" env:"PPROF_ENABLED"`
 
@@ -376,6 +377,7 @@ func (s *Server) Serve(ctx context.Context) error {
 		StatusFeedURL: s.StatusFeedURL,
 		CustomLinks:   s.CustomLinks,
 		PprofEnabled:  s.PprofEnabled,
+		DisableGZip:   s.DisableGZip,
 	}, service)
 
 	// Add chronograf's version header to all requests


### PR DESCRIPTION
This PR improves the loading performance of static assets on devices
with low CPU, such as a Raspberry Pi or another embedded devices.

_What was the problem?_

Loading Chronograf (as in the home page), is painfully slow on a Raspberry Pi or Pi-zero. It takes minutes just to load several static assets.

_What was the solution?_

This PR does two things:

  (1) Adds an option to explicitly disable gzip compression of requested
assets. Aside from having little CPU resources, these devices often don't have the intrinsics available that are used in compression schemes. This can make compression very expensive on these CPUs.
  (2) Avoids the very expensive URL prefix Handler wrapper if no base
path has been set, which was making many redundant reads and textual searches on the assets that were being served.


##### Performance

Before any changes, on my Pi it takes around **2 minutes** for Chronograf to load, as you can see in the following screenshot:

![](https://ucaae9fa0845b08ddd6b3fbfa99d.previews.dropboxusercontent.com/p/thumb/AAOJSqQ_NIx6gbOYDNr0FyU6RzyzCLpkvfcA-owQC6p2xC0Zx_Q0dfWpLXvdTfma3hDHBff20_IjeqOt2sZM3ikTxQHewVXEN-hh77UufHh51_G3cWM2FjO7UGoWFFzioyasbJaxgNm-RoLiKKo84Md8g1ByZsnItbfcDTRwThs8kwdLVhU-ap4M9aOMcugUvb-g4ji7quER8P57BMtQ-9B_4m-UWCRT1xcq5WssaJMYOQ/p.png?size=2048x1536&size_mode=3)

After the changes, and explicitly disabling gzip compression, Chonograf now loads on my Pi in around **10 seconds**, which is a 12X speedup.

![](https://ucc45c6616a2c55a6a914d37c9b1.previews.dropboxusercontent.com/p/thumb/AAMmezw8tWZiubFFbUwYbEDDLK5JHzPUaUyj3GRIlJAKX4YYZZkcDALyO7GAQ9r3sqzIDrOE-fmv99SmIBfEGsm7IWRU8n4Byd95P5SAD7o-oa8wf9kz9W6NWbiQ-G6JA_fVOFpVcehe6LHdkO4HgCIKVk_1Dln6c8UamyUihYnSuuNU87MQptaBquKSIS6aAC6CPK0KGXnL1b0b5ml7qW-aqZ4tqWbUpHWIdy3Yxefb4Q/p.png?size=2048x1536&size_mode=3)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)