### PR TITLE
Check if source has been edited to decide where to redirect at wizard close. 

### DIFF
--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -137,7 +137,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           isErrored={false}
           onNext={this.handleCompletionNext}
           onPrevious={this.handleCompletionPrev}
-          nextLabel="View All Connections"
+          nextLabel="Finish"
           previousLabel="Go Back"
         >
           <CompletionStep
@@ -146,6 +146,9 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
         </WizardStep>
       </WizardOverlay>
     )
+  }
+  private get isSourceEdited() {
+    return !_.isEqual(this.state.source, this.props.source)
   }
 
   // SourceStep
@@ -214,7 +217,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
     const {router} = this.props
     const {source} = this.state
     this.resetWizardState()
-    if (source) {
+    if (this.isSourceEdited) {
       router.push(`/sources/${source.id}/manage-sources`)
     }
     return {error: false, payload: null}


### PR DESCRIPTION
Closes #4356 

_Briefly describe your proposed changes:_
_What was the problem?_
Wizard would redirect to source being edited even if user only manipulated kapacitor connection.
_What was the solution?_
Check whether source has been edited, by comparing source in props and in state. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)