### PR TITLE
Update TimeMachineTables to use table name as id instead of uuid

### DIFF
--- a/ui/src/flux/components/TableSidebarItem.tsx
+++ b/ui/src/flux/components/TableSidebarItem.tsx
@@ -51,6 +51,6 @@ export default class TableSidebarItem extends PureComponent<Props> {
   }
 
   private handleClick = (): void => {
-    this.props.onSelect(this.props.id)
+    this.props.onSelect(this.props.name)
   }
 }

--- a/ui/src/flux/components/TimeMachineTables.tsx
+++ b/ui/src/flux/components/TimeMachineTables.tsx
@@ -146,7 +146,7 @@ class TimeMachineTables extends PureComponent<Props, State> {
     const {data} = this.props
 
     if (data.length && !!data[0]) {
-      return data[0].id
+      return data[0].name
     }
 
     return null
@@ -155,7 +155,7 @@ class TimeMachineTables extends PureComponent<Props, State> {
   private get selectedResult(): FluxTable {
     const filteredTables = filteredTablesMemoized(this.props.data)
 
-    return filteredTables.find(d => d.id === this.state.selectedResultID)
+    return filteredTables.find(d => d.name === this.state.selectedResultID)
   }
 }
 


### PR DESCRIPTION
Co-authored-by: Chris Henn <chris@chrishenn.net>

Closes https://github.com/influxdata/applications-team-issues/issues/83

_What was the problem?_
Tablegraph was getting remounted on every refresh.
_What was the solution?_
Use a more stable name for tables rather than uuid.

  - [x] Rebased/mergeable
  - [ ] Tests pass