### PR TITLE
Fix meta query table

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -13,7 +13,7 @@ import {
   TableOptions,
   DecimalPlaces,
 } from 'src/types/dashboards'
-import {TimeSeriesValue} from 'src/types/series'
+import {TimeSeriesValue, InfluxQLQueryType} from 'src/types/series'
 import {DataType} from 'src/shared/constants'
 
 const calculateSize = (message: string): number => {
@@ -123,11 +123,19 @@ export const getDefaultTimeField = (dataType: DataType): FieldOption => {
 export const computeFieldOptions = (
   existingFieldOptions: FieldOption[],
   sortedLabels: SortedLabel[],
-  dataType: DataType
+  dataType: DataType,
+  influxQLQueryType: InfluxQLQueryType
 ): FieldOption[] => {
   const defaultTimeField = getDefaultTimeField(dataType)
 
-  let astNames = dataType === DataType.influxQL ? [defaultTimeField] : []
+  let astNames = []
+  if (
+    dataType === DataType.influxQL &&
+    influxQLQueryType === InfluxQLQueryType.DataQuery
+  ) {
+    astNames = [defaultTimeField]
+  }
+
   sortedLabels.forEach(({label}) => {
     const field: FieldOption = {
       internalName: label,

--- a/ui/src/shared/components/InvalidData.tsx
+++ b/ui/src/shared/components/InvalidData.tsx
@@ -1,14 +1,24 @@
 import React, {PureComponent} from 'react'
 
-class InvalidData extends PureComponent<{error?: Error}> {
+interface Props {
+  message?: string
+}
+
+class InvalidData extends PureComponent<Props> {
   public render() {
+    return <div className="graph-empty">{this.errorMessage}</div>
+  }
+
+  private get errorMessage(): JSX.Element {
+    if (this.props.message) {
+      return <p>{this.props.message}</p>
+    }
+
     return (
-      <div className="graph-empty">
-        <p>
-          The data returned from the query can't be visualized with this graph
-          type.<br />Try updating the query or selecting a different graph type.
-        </p>
-      </div>
+      <p>
+        The data returned from the query can't be visualized with this graph
+        type.<br />Try updating the query or selecting a different graph type.
+      </p>
     )
   }
 }

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -467,8 +467,24 @@ class TableGraph extends PureComponent<Props, State> {
   }
 
   private get fixFirstColumn(): boolean {
-    const {tableOptions} = this.props
+    const {tableOptions, fieldOptions} = this.props
     const {fixFirstColumn = DEFAULT_FIX_FIRST_COLUMN} = tableOptions
+
+    if (fieldOptions.length === 1) {
+      return false
+    }
+
+    const visibleFields = fieldOptions.reduce((acc, f) => {
+      if (f.visible) {
+        acc += 1
+      }
+      return acc
+    }, 0)
+
+    if (visibleFields === 1) {
+      return false
+    }
+
     return fixFirstColumn
   }
 

--- a/ui/src/types/series.ts
+++ b/ui/src/types/series.ts
@@ -39,3 +39,15 @@ export enum InfluxQLQueryType {
   DataQuery = 'DataQuery',
   ComboQuery = 'CombinationQuery',
 }
+
+export interface Label {
+  label: string
+  seriesIndex: number
+  responseIndex: number
+}
+
+export interface TimeSeriesToTableGraphReturnType {
+  data: TimeSeriesValue[][]
+  sortedLabels: Label[]
+  influxQLQueryType: InfluxQLQueryType
+}

--- a/ui/src/types/series.ts
+++ b/ui/src/types/series.ts
@@ -33,3 +33,9 @@ export interface TimeSeries {
   time: TimeSeriesValue
   values: TimeSeriesValue[]
 }
+
+export enum InfluxQLQueryType {
+  MetaQuery = 'MetaQuery',
+  DataQuery = 'DataQuery',
+  ComboQuery = 'CombinationQuery',
+}

--- a/ui/src/utils/timeSeriesTransformers.ts
+++ b/ui/src/utils/timeSeriesTransformers.ts
@@ -1,24 +1,16 @@
 import {fastMap} from 'src/utils/fast'
 import {manager} from 'src/worker/JobManager'
 
-import {TimeSeriesServerResponse, TimeSeriesValue} from 'src/types/series'
+import {
+  TimeSeriesServerResponse,
+  TimeSeriesToTableGraphReturnType,
+} from 'src/types/series'
 import {DygraphSeries, DygraphValue} from 'src/types'
-
-interface Label {
-  label: string
-  seriesIndex: number
-  responseIndex: number
-}
 
 export interface TimeSeriesToDyGraphReturnType {
   labels: string[]
   timeSeries: DygraphValue[][]
   dygraphSeries: DygraphSeries
-}
-
-interface TimeSeriesToTableGraphReturnType {
-  data: TimeSeriesValue[][]
-  sortedLabels: Label[]
 }
 
 export const timeSeriesToDygraph = async (

--- a/ui/src/worker/JobManager.ts
+++ b/ui/src/worker/JobManager.ts
@@ -2,10 +2,12 @@ import _ from 'lodash'
 import idGenerator from 'uuid'
 import Deferred from 'src/worker/Deferred'
 import DB from './Database'
-import {TimeSeriesServerResponse} from 'src/types/series'
+import {
+  TimeSeriesServerResponse,
+  TimeSeriesToTableGraphReturnType,
+} from 'src/types/series'
 import {DygraphValue, FluxTable} from 'src/types'
 import {getBasepath} from 'src/utils/basepath'
-import {TimeSeriesToTableGraphReturnType} from 'src/worker/jobs/timeSeriesToTableGraph'
 import {TimeSeriesToDyGraphReturnType} from 'src/worker/jobs/timeSeriesToDygraph'
 import {FluxTablesToDygraphResult} from 'src/worker/jobs/fluxTablesToDygraph'
 import {LastValues} from 'src/worker/jobs/fluxTablesToSingleStat'

--- a/ui/src/worker/jobs/timeSeriesToTableGraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToTableGraph.ts
@@ -5,19 +5,10 @@ import {
   TimeSeries,
   TimeSeriesValue,
   InfluxQLQueryType,
+  TimeSeriesToTableGraphReturnType,
+  Label,
 } from 'src/types/series'
 import {fetchData} from 'src/worker/utils'
-
-interface Label {
-  label: string
-  seriesIndex: number
-  responseIndex: number
-}
-
-export interface TimeSeriesToTableGraphReturnType {
-  data: TimeSeriesValue[][]
-  sortedLabels: Label[]
-}
 
 const timeSeriesToTableData = (
   timeSeries: TimeSeries[],
@@ -61,10 +52,13 @@ export const timeSeriesToTableGraphWork = (
   return {
     data,
     sortedLabels,
+    influxQLQueryType: queryType,
   }
 }
 
-const timeSeriesToTableGraph = async msg => {
+const timeSeriesToTableGraph = async (
+  msg
+): Promise<TimeSeriesToTableGraphReturnType> => {
   const {raw} = await fetchData(msg)
   return timeSeriesToTableGraphWork(raw)
 }

--- a/ui/src/worker/jobs/timeSeriesToTableGraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToTableGraph.ts
@@ -4,6 +4,7 @@ import {
   TimeSeriesServerResponse,
   TimeSeries,
   TimeSeriesValue,
+  InfluxQLQueryType,
 } from 'src/types/series'
 import {fetchData} from 'src/worker/utils'
 
@@ -18,24 +19,44 @@ export interface TimeSeriesToTableGraphReturnType {
   sortedLabels: Label[]
 }
 
+const timeSeriesToTableData = (
+  timeSeries: TimeSeries[],
+  queryType: InfluxQLQueryType
+): TimeSeriesValue[][] => {
+  switch (queryType) {
+    case InfluxQLQueryType.MetaQuery:
+      return fastMap<TimeSeries, TimeSeriesValue[]>(
+        timeSeries,
+        ({values}) => values
+      )
+    case InfluxQLQueryType.DataQuery:
+      return fastMap<TimeSeries, TimeSeriesValue[]>(
+        timeSeries,
+        ({time, values}) => [time, ...values]
+      )
+    case InfluxQLQueryType.ComboQuery:
+      throw new Error('Cannot display meta and data query')
+  }
+}
+
 export const timeSeriesToTableGraphWork = (
   raw: TimeSeriesServerResponse[]
 ): TimeSeriesToTableGraphReturnType => {
   const isTable = true
-  const {sortedLabels, sortedTimeSeries} = groupByTimeSeriesTransform(
-    raw,
-    isTable
-  )
-
-  const labels = [
-    'time',
-    ...fastMap<Label, string>(sortedLabels, ({label}) => label),
-  ]
-
-  const tableData = fastMap<TimeSeries, TimeSeriesValue[]>(
+  const {
+    sortedLabels,
     sortedTimeSeries,
-    ({time, values}) => [time, ...values]
-  )
+    queryType,
+  } = groupByTimeSeriesTransform(raw, isTable)
+
+  let labels = fastMap<Label, string>(sortedLabels, ({label}) => label)
+
+  if (queryType === InfluxQLQueryType.DataQuery) {
+    labels = ['time', ...labels]
+  }
+
+  const tableData = timeSeriesToTableData(sortedTimeSeries, queryType)
+
   const data = tableData.length ? [labels, ...tableData] : [[]]
   return {
     data,

--- a/ui/test/utils/timeSeriesTransformers.test.ts
+++ b/ui/test/utils/timeSeriesTransformers.test.ts
@@ -454,15 +454,15 @@ describe('timeSeriesToTableGraph', () => {
 
     const actual = timeSeriesToTableGraph(influxResponse)
     const expected = [
-      ['time', 'measurements.name'],
-      [null, 'cpu'],
-      [null, 'disk'],
-      [null, 'diskio'],
-      [null, 'mem'],
-      [null, 'processes'],
-      [null, 'swap'],
-      [null, 'syslog'],
-      [null, 'system'],
+      ['measurements.name'],
+      ['cpu'],
+      ['disk'],
+      ['diskio'],
+      ['mem'],
+      ['processes'],
+      ['swap'],
+      ['syslog'],
+      ['system'],
     ]
 
     expect(actual.data).toEqual(expected)

--- a/ui/test/utils/timeSeriesTransformers.test.ts
+++ b/ui/test/utils/timeSeriesTransformers.test.ts
@@ -395,6 +395,51 @@ describe('timeSeriesToTableGraph', () => {
 
     expect(actual.data).toEqual(expected)
   })
+
+  it('parses raw meta-query responses into table-readable format', () => {
+    const influxResponse = [
+      {
+        response: {
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {
+                  name: 'measurements',
+                  columns: ['name'],
+                  values: [
+                    ['cpu'],
+                    ['disk'],
+                    ['diskio'],
+                    ['mem'],
+                    ['processes'],
+                    ['swap'],
+                    ['syslog'],
+                    ['system'],
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    ]
+
+    const actual = timeSeriesToTableGraph(influxResponse)
+    const expected = [
+      ['time', 'measurements.name'],
+      [null, 'cpu'],
+      [null, 'disk'],
+      [null, 'diskio'],
+      [null, 'mem'],
+      [null, 'processes'],
+      [null, 'swap'],
+      [null, 'syslog'],
+      [null, 'system'],
+    ]
+
+    expect(actual.data).toEqual(expected)
+  })
 })
 
 describe('filterTableColumns', () => {

--- a/ui/test/utils/timeSeriesTransformers.test.ts
+++ b/ui/test/utils/timeSeriesTransformers.test.ts
@@ -270,6 +270,33 @@ describe('timeSeriesToDygraph', () => {
   })
 })
 
+it('parses a single field influxQL query', () => {
+  const influxResponse = [
+    {
+      response: {
+        results: [
+          {
+            statement_id: 0,
+            series: [
+              {
+                name: 'm1',
+                columns: ['time', 'f1'],
+                values: [[100, 1], [3000, 3], [200, 2]],
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ]
+
+  const actual = timeSeriesToTableGraph(influxResponse)
+
+  const expected = [['time', 'm1.f1'], [100, 1], [200, 2], [3000, 3]]
+
+  expect(actual.data).toEqual(expected)
+})
+
 describe('timeSeriesToTableGraph', () => {
   it('parses raw data into a nested array of data', () => {
     const influxResponse = [


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/67
Closes #4485 

_Briefly describe your proposed changes:_
Updates the TableGraph to handle InfluxQL meta query responses
_What was the problem?_
Transforming time series to table graph data were always adding an unnecessary time field to the meta query responses
_What was the solution?_
Don't add time to a meta query and display invalid data if there are both data queries and meta queries

  - [x] Rebased/mergeable
  - [x] Tests pass