### PR TITLE
Change dash header button z index

### DIFF
--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -10,7 +10,7 @@ $dash-graph-options-arrow: 8px;
 $dash-graph-border-z: 4;
 $dash-graph-resizer-z: 5;
 $dash-graph-header-z: 2;
-$dash-graph-context-z: 6;
+$dash-graph-context-z: 5;
 $dash-graph-note-z: 7;
 $dash-graph-context-expanded-z: 20;
 $dash-graph-interacting-z: 21;


### PR DESCRIPTION
Closes #https://github.com/influxdata/applications-team-issues/issues/93

_What was the problem?_
When hovering over an annotation close to the top right of a dashboard cell, the menu buttons would obscure the annotations tooltip that appears

![image](https://user-images.githubusercontent.com/15273162/46108677-7a3d6f80-c193-11e8-9e56-863defc148bb.png)

_What was the solution?_
Lower the z-index of the dashboard cell menu buttons to fall behind the annotations tooltip.

<img width="305" alt="screen shot 2018-09-26 at 1 53 56 pm" src="https://user-images.githubusercontent.com/15273162/46108756-a35e0000-c193-11e8-8513-c199bfcd1ad1.png">

  - [x] Rebased/mergeable
  - [x] Tests pass