### PR TITLE
Increase z-index for time dropdown

### DIFF
--- a/ui/src/style/components/custom-time-range.scss
+++ b/ui/src/style/components/custom-time-range.scss
@@ -306,7 +306,7 @@ $rd-cell-size: 30px;
   position: absolute;
   top: 0;
   right: calc(100% + 4px);
-  z-index: 4;
+  z-index: $date-picker-z;
 
   .custom-time--container {
     display: flex;

--- a/ui/src/style/modules/_variables.scss
+++ b/ui/src/style/modules/_variables.scss
@@ -9,6 +9,16 @@ $z--notifications: 9999;
 $z--overlays: 9990;
 $z--drag-n-drop: 5000;
 
+$dash-graph-border-z: 4;
+$dash-graph-resizer-z: 5;
+$dash-graph-header-z: 2;
+$dash-graph-context-z: 5;
+$dash-graph-note-z: 7;
+$dash-graph-context-expanded-z: 20;
+$dash-graph-interacting-z: 21;
+
+$date-picker-z: 8;
+
 /* Motifs */
 
 $radius: 4px;

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -7,14 +7,6 @@ $dash-graph-heading: 30px;
 $dash-graph-heading-context: $dash-graph-heading - 8px;
 $dash-graph-options-arrow: 8px;
 
-$dash-graph-border-z: 4;
-$dash-graph-resizer-z: 5;
-$dash-graph-header-z: 2;
-$dash-graph-context-z: 5;
-$dash-graph-note-z: 7;
-$dash-graph-context-expanded-z: 20;
-$dash-graph-interacting-z: 21;
-
 /*
   Animations
   ------------------------------------------------------


### PR DESCRIPTION
Closes #4493

_What was the problem?_
When the dashboard date picker overlay was opened to overlap with a cell, the cell's menu buttons would appear on top of the date picker, even though the overlay was meant to sit on top of the cells.

_What was the solution?_
The overlay had a higher z-index than the cell menu buttons, but the overlay's parent had a lower z-index, which overruled in the css hierarchy. The solution was to increase the z-index of the date picker overlay's parent.

  - [x] Rebased/mergeable
  - [x] Tests pass