### PR TITLE
Annotations/fix filter tag update

### DIFF
--- a/ui/src/shared/components/AnnotationEditorContainer.tsx
+++ b/ui/src/shared/components/AnnotationEditorContainer.tsx
@@ -7,6 +7,7 @@ import {
   setEditingAnnotation,
   updateAnnotationAsync,
   deleteAnnotationAsync,
+  setTagKeys as setTagKeysAction,
 } from 'src/shared/actions/annotations'
 import {notify} from 'src/shared/actions/notifications'
 import {notifyErrorWithAltText} from 'src/shared/copy/notifications'
@@ -18,6 +19,7 @@ interface Props {
   onSetEditingAnnotation: typeof setEditingAnnotation
   onDeleteAnnotation: typeof deleteAnnotationAsync
   onSaveAnnotation: typeof updateAnnotationAsync
+  setTagKeys: typeof setTagKeysAction
   onNotify: typeof notify
 }
 
@@ -57,10 +59,16 @@ class AnnotationEditorContainer extends PureComponent<Props> {
   }
 
   private handleSave = async (a: Annotation): Promise<void> => {
-    const {onSaveAnnotation, onSetEditingAnnotation, onNotify} = this.props
+    const {
+      onSaveAnnotation,
+      onSetEditingAnnotation,
+      onNotify,
+      setTagKeys,
+    } = this.props
 
     try {
       await onSaveAnnotation(a)
+      setTagKeys(null)
 
       onSetEditingAnnotation(null)
     } catch (e) {
@@ -92,6 +100,7 @@ const mdtp = {
   onSaveAnnotation: updateAnnotationAsync,
   onSetEditingAnnotation: setEditingAnnotation,
   onDeleteAnnotation: deleteAnnotationAsync,
+  setTagKeys: setTagKeysAction,
   onNotify: notify,
 }
 

--- a/ui/src/shared/components/AnnotationFilterControlInput.tsx
+++ b/ui/src/shared/components/AnnotationFilterControlInput.tsx
@@ -16,8 +16,6 @@ interface State {
   shouldShowAllSuggestions: boolean
 }
 
-const NUM_SUGGESTIONS = 8
-
 const lexographicOrder = (a: string, b: string) => a.localeCompare(b)
 
 class AnnotationFilterControlInput extends PureComponent<Props, State> {
@@ -31,9 +29,7 @@ class AnnotationFilterControlInput extends PureComponent<Props, State> {
       return {filteredSuggestions}
     }
 
-    filteredSuggestions = filteredSuggestions.filter(
-      (v, i) => v.includes(value) && i < NUM_SUGGESTIONS
-    )
+    filteredSuggestions = filteredSuggestions.filter(v => v.includes(value))
 
     return {filteredSuggestions}
   }


### PR DESCRIPTION
Closes #4480

_What was the problem?_
When a new tag key was added to an annotation, it did not immediately become available in the tag key dropdown.

_What was the solution?_
Upon saving an annotation, clear the local state of the tag keys so that a new call to the server is sent when the user focuses on the tag key dropdown. Also, remove an upper limit on the index of the tag keys that could appear in the dropdown.

  - [x] Rebased/mergeable
  - [x] Tests pass