### PR TITLE
Misc TimeMachineContainer cleanup

### DIFF
--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -63,27 +63,25 @@ export const saveToLocalStorage = ({
 
     window.localStorage.setItem(
       'state',
-      JSON.stringify(
-        _.omit({
-          ...appPersisted,
-          VERSION,
-          GIT_SHA,
-          timeRange,
-          dashTimeV1,
-          script,
-          logs: {
-            ...minimalLogs,
-            histogramData: [],
-            tableData: {},
-            queryCount: 0,
-            tableInfiniteData: {
-              forward: defaultTableData,
-              backward: defaultTableData,
-            },
-            tableTime: minimalLogs.tableTime || {},
+      JSON.stringify({
+        ...appPersisted,
+        VERSION,
+        GIT_SHA,
+        timeRange,
+        dashTimeV1,
+        script,
+        logs: {
+          ...minimalLogs,
+          histogramData: [],
+          tableData: {},
+          queryCount: 0,
+          tableInfiniteData: {
+            forward: defaultTableData,
+            backward: defaultTableData,
           },
-        })
-      )
+          tableTime: minimalLogs.tableTime || {},
+        },
+      })
     )
   } catch (err) {
     console.error('Unable to save data explorer: ', JSON.parse(err))

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -116,72 +116,18 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
   }
 
   public handleToggleField = (queryID: string, fieldFunc: Field) => {
-    const {queryDrafts} = this.state
-    const updatedQueryDrafts = queryDrafts.map(query => {
-      if (query.id === queryID) {
-        const nextQueryConfig = {
-          ...toggleField(query.queryConfig, fieldFunc),
-          rawText: null,
-        }
-
-        return {
-          ...query,
-          query: buildQuery(
-            TYPE_QUERY_CONFIG,
-            getTimeRange(nextQueryConfig),
-            nextQueryConfig
-          ),
-          queryConfig: nextQueryConfig,
-        }
-      }
-      return query
-    })
-
-    this.setState({queryDrafts: updatedQueryDrafts})
+    this.updateQueryDrafts(queryID, q => ({
+      ...toggleField(q, fieldFunc),
+      rawText: null,
+    }))
   }
 
   public handleGroupByTime = (queryID: string, time: string) => {
-    const {queryDrafts} = this.state
-    const updatedQueryDrafts = queryDrafts.map(query => {
-      if (query.id === queryID) {
-        const nextQueryConfig = groupByTime(query.queryConfig, time)
-
-        return {
-          ...query,
-          query: buildQuery(
-            TYPE_QUERY_CONFIG,
-            getTimeRange(nextQueryConfig),
-            nextQueryConfig
-          ),
-          queryConfig: nextQueryConfig,
-        }
-      }
-      return query
-    })
-
-    this.setState({queryDrafts: updatedQueryDrafts})
+    this.updateQueryDrafts(queryID, q => groupByTime(q, time))
   }
 
   public handleFill = (queryID: string, value: string) => {
-    const {queryDrafts} = this.state
-    const updatedQueryDrafts = queryDrafts.map(query => {
-      if (query.id === queryID) {
-        const nextQueryConfig = fill(query.queryConfig, value)
-
-        return {
-          ...query,
-          query: buildQuery(
-            TYPE_QUERY_CONFIG,
-            getTimeRange(nextQueryConfig),
-            nextQueryConfig
-          ),
-          queryConfig: nextQueryConfig,
-        }
-      }
-      return query
-    })
-
-    this.setState({queryDrafts: updatedQueryDrafts})
+    this.updateQueryDrafts(queryID, q => fill(q, value))
   }
 
   public handleRemoveFuncs = (queryID: string, fields: Field[]) => {

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -104,34 +104,34 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
   }
 
   public handleChangeScript = (script: string) => {
-    this.setState({script})
+    return this.setState({script})
   }
 
   public handleUpdateTimeRange = (timeRange: TimeRange) => {
-    this.setState({timeRange})
+    return this.setState({timeRange})
   }
 
   public handleUpdateQueryDrafts = (queryDrafts: CellQuery[]) => {
-    this.setState({queryDrafts})
+    return this.setState({queryDrafts})
   }
 
   public handleToggleField = (queryID: string, fieldFunc: Field) => {
-    this.updateQueryDrafts(queryID, q => ({
+    return this.updateQueryDrafts(queryID, q => ({
       ...toggleField(q, fieldFunc),
       rawText: null,
     }))
   }
 
   public handleGroupByTime = (queryID: string, time: string) => {
-    this.updateQueryDrafts(queryID, q => groupByTime(q, time))
+    return this.updateQueryDrafts(queryID, q => groupByTime(q, time))
   }
 
   public handleFill = (queryID: string, value: string) => {
-    this.updateQueryDrafts(queryID, q => fill(q, value))
+    return this.updateQueryDrafts(queryID, q => fill(q, value))
   }
 
   public handleRemoveFuncs = (queryID: string, fields: Field[]) => {
-    this.updateQueryDrafts(queryID, q => removeFuncs(q, fields))
+    return this.updateQueryDrafts(queryID, q => removeFuncs(q, fields))
   }
 
   public handleApplyFuncsToField = (
@@ -139,35 +139,35 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
     fieldFunc: ApplyFuncsToFieldArgs,
     groupBy?: GroupBy
   ) => {
-    this.updateQueryDrafts(queryID, q =>
+    return this.updateQueryDrafts(queryID, q =>
       applyFuncsToField(q, fieldFunc, groupBy)
     )
   }
 
   public handleChooseTag = (queryID: string, tag: Tag) => {
-    this.updateQueryDrafts(queryID, q => chooseTag(q, tag))
+    return this.updateQueryDrafts(queryID, q => chooseTag(q, tag))
   }
 
   public handleChooseNamespace = (
     queryID: string,
     options: {database: string; retentionPolicy: string}
   ) => {
-    this.updateQueryDrafts(queryID, q => chooseNamespace(q, options))
+    return this.updateQueryDrafts(queryID, q => chooseNamespace(q, options))
   }
 
   public handleChooseMeasurement = (queryID: string, measurement: string) => {
-    this.updateQueryDrafts(queryID, q => ({
+    return this.updateQueryDrafts(queryID, q => ({
       ...chooseMeasurement(q, measurement),
       rawText: q.rawText || '',
     }))
   }
 
   public handleGroupByTag = (queryID: string, tagKey: string) => {
-    this.updateQueryDrafts(queryID, q => groupByTag(q, tagKey))
+    return this.updateQueryDrafts(queryID, q => groupByTag(q, tagKey))
   }
 
   public handleToggleTagAcceptance = (queryID: string) => {
-    this.updateQueryDrafts(queryID, q => toggleTagAcceptance(q))
+    return this.updateQueryDrafts(queryID, q => toggleTagAcceptance(q))
   }
 
   public handleAddInitialField = (
@@ -175,18 +175,20 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
     field: Field,
     groupBy: GroupBy
   ) => {
-    this.updateQueryDrafts(queryID, q => addInitialField(q, field, groupBy))
+    return this.updateQueryDrafts(queryID, q =>
+      addInitialField(q, field, groupBy)
+    )
   }
 
   public handleEditQueryStatus = (queryID: string, status: Status) => {
-    this.updateQueryDrafts(queryID, q => ({...q, status}))
+    return this.updateQueryDrafts(queryID, q => ({...q, status}))
   }
 
   public handleTimeShift = (queryID: string, shift: TimeShift) => {
-    this.updateQueryDrafts(queryID, q => timeShift(q, shift))
+    return this.updateQueryDrafts(queryID, q => timeShift(q, shift))
   }
 
-  public handleAddQuery = () => {
+  public handleAddQuery = (): Promise<void> => {
     const {queryDrafts} = this.state
     const queryID = uuid.v4()
     const newQueryDraft: CellQuery = {
@@ -197,66 +199,66 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
       type: QueryType.InfluxQL,
     }
 
-    this.setState({queryDrafts: [...queryDrafts, newQueryDraft]})
+    return this.setState({queryDrafts: [...queryDrafts, newQueryDraft]})
   }
 
   public handleDeleteQuery = (queryID: string) => {
     const {queryDrafts} = this.state
     const updatedQueryDrafts = queryDrafts.filter(query => query.id !== queryID)
 
-    this.setState({queryDrafts: updatedQueryDrafts})
+    return this.setState({queryDrafts: updatedQueryDrafts})
   }
 
   public handleUpdateType = (type: CellType) => {
-    this.setState({type})
+    return this.setState({type})
   }
 
   public handleUpdateNote = (note: string) => {
-    this.setState({note})
+    return this.setState({note})
   }
 
   public handleUpdateNoteVisibility = (noteVisibility: NoteVisibility) => {
-    this.setState({noteVisibility})
+    return this.setState({noteVisibility})
   }
 
   public handleUpdateThresholdsListColors = (
     thresholdsListColors: ColorNumber[]
   ) => {
-    this.setState({thresholdsListColors})
+    return this.setState({thresholdsListColors})
   }
 
   public handleUpdateThresholdsListType = (
     thresholdsListType: ThresholdType
   ) => {
-    this.setState({thresholdsListType})
+    return this.setState({thresholdsListType})
   }
 
   public handleUpdateGaugeColors = (gaugeColors: ColorNumber[]) => {
-    this.setState({gaugeColors})
+    return this.setState({gaugeColors})
   }
 
   public handleUpdateAxes = (axes: Axes) => {
-    this.setState({axes})
+    return this.setState({axes})
   }
 
   public handleUpdateTableOptions = (tableOptions: TableOptions) => {
-    this.setState({tableOptions})
+    return this.setState({tableOptions})
   }
 
   public handleUpdateLineColors = (lineColors: ColorString[]) => {
-    this.setState({lineColors})
+    return this.setState({lineColors})
   }
 
   public handleUpdateTimeFormat = (timeFormat: string) => {
-    this.setState({timeFormat})
+    return this.setState({timeFormat})
   }
 
   public handleUpdateDecimalPlaces = (decimalPlaces: DecimalPlaces) => {
-    this.setState({decimalPlaces})
+    return this.setState({decimalPlaces})
   }
 
   public handleUpdateFieldOptions = (fieldOptions: FieldOption[]) => {
-    this.setState({fieldOptions})
+    return this.setState({fieldOptions})
   }
 
   private updateQueryDrafts = (
@@ -281,6 +283,6 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
       return query
     })
 
-    this.setState({queryDrafts: updatedQueryDrafts})
+    return this.setState({queryDrafts: updatedQueryDrafts})
   }
 }

--- a/ui/test/shared/utils/TimeMachineContainer.test.ts
+++ b/ui/test/shared/utils/TimeMachineContainer.test.ts
@@ -1,0 +1,363 @@
+import {
+  TimeMachineContainer,
+  TimeMachineState,
+} from 'src/shared/utils/TimeMachineContainer'
+
+import {LINEAR, NULL_STRING} from 'src/shared/constants/queryFillOptions'
+
+import {defaultQueryDraft} from 'src/shared/utils/timeMachine'
+
+import {QueryType} from 'src/types'
+
+describe('TimeMachineContainer', () => {
+  let initialState: Partial<TimeMachineState>
+
+  beforeEach(() => {
+    const queryDraft1 = defaultQueryDraft(QueryType.InfluxQL)
+    const queryDraft2 = defaultQueryDraft(QueryType.InfluxQL)
+
+    queryDraft1.id = '1'
+    queryDraft1.queryConfig.id = '1'
+    queryDraft2.id = '2'
+    queryDraft2.queryConfig.id = '2'
+
+    initialState = {queryDrafts: [queryDraft1, queryDraft2]}
+  })
+
+  test('handleAddQuery', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    expect(container.state.queryDrafts).toHaveLength(2)
+
+    await container.handleAddQuery()
+
+    expect(container.state.queryDrafts).toHaveLength(3)
+  })
+
+  test('handleChooseNamespace', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleChooseNamespace('1', {
+      database: 'foo',
+      retentionPolicy: 'bar',
+    })
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.database).toBe('foo')
+    expect(queryConfig.retentionPolicy).toBe('bar')
+  })
+
+  test('handleChooseMeasurement', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleChooseMeasurement('1', 'foo')
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.measurement).toBe('foo')
+  })
+
+  test('handleToggleField', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleToggleField('1', {value: 'a', type: 'field'})
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.fields).toEqual([{value: 'a', type: 'field'}])
+  })
+
+  test('handleApplyFuncsToField', async () => {
+    const f1 = {value: 'f1', type: 'field'}
+    const f2 = {value: 'f2', type: 'field'}
+
+    initialState.queryDrafts[0].queryConfig.fields = [
+      {
+        value: 'fn1',
+        type: 'func',
+        args: [f1],
+        alias: `fn1_${f1.value}`,
+      },
+      {
+        value: 'fn1',
+        type: 'func',
+        args: [f2],
+        alias: `fn1_${f2.value}`,
+      },
+      {
+        value: 'fn2',
+        type: 'func',
+        args: [f1],
+        alias: `fn2_${f1.value}`,
+      },
+    ]
+
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleApplyFuncsToField('1', {
+      field: {
+        value: 'f1',
+        type: 'field',
+      },
+      funcs: [
+        {
+          value: 'fn3',
+          type: 'func',
+        },
+        {
+          value: 'fn4',
+          type: 'func',
+        },
+      ],
+    })
+
+    expect(container.state.queryDrafts[0].queryConfig.fields).toEqual([
+      {
+        value: 'fn3',
+        type: 'func',
+        args: [f1],
+        alias: `fn3_${f1.value}`,
+      },
+      {
+        value: 'fn4',
+        type: 'func',
+        args: [f1],
+        alias: `fn4_${f1.value}`,
+      },
+      {
+        value: 'fn1',
+        type: 'func',
+        args: [f2],
+        alias: `fn1_${f2.value}`,
+      },
+    ])
+  })
+
+  test('handleRemoveFuncs', async () => {
+    const f1 = {value: 'f1', type: 'field'}
+    const f2 = {value: 'f2', type: 'field'}
+    const groupBy = {time: '1m', tags: []}
+
+    const fields = [
+      {
+        value: 'fn1',
+        type: 'func',
+        args: [f1],
+        alias: `fn1_${f1.value}`,
+      },
+      {
+        value: 'fn1',
+        type: 'func',
+        args: [f2],
+        alias: `fn1_${f2.value}`,
+      },
+    ]
+
+    Object.assign(initialState.queryDrafts[0].queryConfig, {
+      id: '123',
+      database: 'db1',
+      measurement: 'm1',
+      fields,
+      groupBy,
+    })
+
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleRemoveFuncs('1', fields)
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.fields).toEqual([f1, f2])
+    expect(queryConfig.groupBy.time).toBe(null)
+  })
+
+  describe('handleChooseTag', () => {
+    test('can add a tag', async () => {
+      initialState.queryDrafts[0].queryConfig.tags = {
+        k1: ['v0'],
+        k2: ['foo'],
+      }
+
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleChooseTag('1', {
+        key: 'k1',
+        value: 'v1',
+      })
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.tags).toEqual({
+        k1: ['v0', 'v1'],
+        k2: ['foo'],
+      })
+    })
+
+    test("creates a new entry if it's the first key", async () => {
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleChooseTag('1', {
+        key: 'k1',
+        value: 'v1',
+      })
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.tags).toEqual({
+        k1: ['v1'],
+      })
+    })
+
+    test('removes a value that is already in the list', async () => {
+      initialState.queryDrafts[0].queryConfig.tags = {
+        k1: ['v1'],
+      }
+
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleChooseTag('1', {
+        key: 'k1',
+        value: 'v1',
+      })
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.tags).toEqual({})
+    })
+  })
+
+  describe('handleGroupByTag', () => {
+    it('adds a tag key/value to the query', async () => {
+      Object.assign(initialState.queryDrafts[0].queryConfig, {
+        database: 'db1',
+        measurement: 'm1',
+        fields: [],
+        tags: {},
+        groupBy: {
+          tags: [],
+          time: null,
+        },
+      })
+
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleGroupByTag('1', 'k1')
+
+      expect(container.state.queryDrafts[0].queryConfig.groupBy).toEqual({
+        time: null,
+        tags: ['k1'],
+      })
+    })
+
+    it('removes a tag if the given tag key is already in the GROUP BY list', async () => {
+      Object.assign(initialState.queryDrafts[0].queryConfig, {
+        database: 'db1',
+        measurement: 'm1',
+        fields: [],
+        tags: {},
+        groupBy: {
+          tags: ['k1'],
+          time: null,
+        },
+      })
+
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleGroupByTag('1', 'k1')
+
+      expect(container.state.queryDrafts[0].queryConfig.groupBy).toEqual({
+        time: null,
+        tags: [],
+      })
+    })
+  })
+
+  test('handleToggleTagAcceptance', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleToggleTagAcceptance('1')
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.areTagsAccepted).toBe(false)
+  })
+
+  test('handleGroupByTime', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleGroupByTime('1', '100y')
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.groupBy.time).toBe('100y')
+  })
+
+  test('handleEditQueryStatus', async () => {
+    const container = new TimeMachineContainer(initialState)
+
+    await container.handleEditQueryStatus('1', {success: 'yay'})
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.status).toEqual({success: 'yay'})
+  })
+
+  describe('handleFill', () => {
+    it('applies an explicit fill when group by time is used', async () => {
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleGroupByTime('1', '10s')
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.fill).toBe(NULL_STRING)
+    })
+
+    it('updates fill to non-null-string non-number string value', async () => {
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleFill('1', LINEAR)
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.fill).toBe(LINEAR)
+    })
+
+    it('updates fill to string integer value', async () => {
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleFill('1', '1337')
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.fill).toBe('1337')
+    })
+
+    it('updates fill to string float value', async () => {
+      const container = new TimeMachineContainer(initialState)
+
+      await container.handleFill('1', '1.337')
+
+      const queryConfig = container.state.queryDrafts[0].queryConfig
+
+      expect(queryConfig.fill).toBe('1.337')
+    })
+  })
+
+  test('handleTimeShift', async () => {
+    const container = new TimeMachineContainer(initialState)
+    const shift = {
+      quantity: '1',
+      unit: 'd',
+      duration: '1d',
+      label: 'label',
+    }
+
+    await container.handleTimeShift('1', shift)
+
+    const queryConfig = container.state.queryDrafts[0].queryConfig
+
+    expect(queryConfig.shifts).toEqual([shift])
+  })
+})


### PR DESCRIPTION
Just some minor chores to clean up after #4509. Mainly, porting over some [query config tests](https://github.com/influxdata/chronograf/blob/42a73792a21bb355fce893d316ebaaf0b0973e3d/ui/test/data_explorer/reducers/queryConfig.test.ts) to make use of the new `TimeMachine` state container.