### PR TITLE
Persist Data Explorer state to localStorage

### DIFF
--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -216,3 +216,5 @@ export const WRITE_DATA_DOCS_LINK =
 export const DEFAULT_TIME_RANGE = timeRanges.find(
   tr => tr.lower === 'now() - 1h'
 )
+
+export const DE_LOCAL_STORAGE_KEY = 'dataExplorer'

--- a/ui/src/data_explorer/containers/DataExplorerPage.tsx
+++ b/ui/src/data_explorer/containers/DataExplorerPage.tsx
@@ -5,6 +5,7 @@ import DataExplorer from './DataExplorer'
 
 import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import {DE_LOCAL_STORAGE_KEY} from 'src/data_explorer/constants'
 
 import {Source} from 'src/types'
 
@@ -19,7 +20,10 @@ class DataExplorerPage extends PureComponent<Props> {
   constructor(props: Props) {
     super(props)
 
-    this.timeMachineContainer = new TimeMachineContainer()
+    this.timeMachineContainer = new TimeMachineContainer(
+      {},
+      DE_LOCAL_STORAGE_KEY
+    )
   }
 
   public render() {

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -6,11 +6,9 @@ import {
 } from 'src/shared/copy/notifications'
 
 import {defaultTableData} from 'src/logs/constants'
+import {VERSION, GIT_SHA} from 'src/shared/constants'
 
 import {LocalStorage} from 'src/types/localStorage'
-
-const VERSION = process.env.npm_package_version
-const GIT_SHA = process.env.GIT_SHA
 
 export const loadLocalStorage = (errorsQueue: any[]): LocalStorage | {} => {
   try {

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -3,6 +3,9 @@ import _ from 'lodash'
 import {TemplateValueType, TemplateType, Template} from 'src/types'
 import {CellType} from 'src/types/dashboards'
 
+export const VERSION = process.env.npm_package_version
+export const GIT_SHA = process.env.GIT_SHA
+
 export const DEFAULT_DURATION_MS = 1000
 export const DEFAULT_PIXELS = 333
 

--- a/ui/src/shared/utils/localStorage.ts
+++ b/ui/src/shared/utils/localStorage.ts
@@ -1,0 +1,21 @@
+import {GIT_SHA} from 'src/shared/constants'
+
+export function setLocalStorage(key: string, data: any): void {
+  const localStorageData = {version: GIT_SHA, data}
+
+  window.localStorage.setItem(key, JSON.stringify(localStorageData))
+}
+
+export function getLocalStorage(key: string): any {
+  try {
+    const {version, data} = JSON.parse(window.localStorage.getItem(key))
+
+    if (version !== GIT_SHA) {
+      return {}
+    }
+
+    return data
+  } catch {
+    return {}
+  }
+}


### PR DESCRIPTION
Previously, we used localStorage to persist state in the Data Explorer across page refreshes. The implementation used some Redux middleware to achieve this.

#4509 removed the use of Redux in the Data Explorer, and the localStorage persistence along with it. This PR adds back localStorage persistence to the Data Explorer.