### PR TITLE
Avoid uncaught exception in TableGraph

### DIFF
--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -29,6 +29,7 @@ import {
   TimeSeriesServerResponse,
   TimeSeriesValue,
   TimeSeriesToTableGraphReturnType,
+  InfluxQLQueryType,
 } from 'src/types/series'
 import {ColorString} from 'src/types/colors'
 import {
@@ -83,6 +84,7 @@ interface State {
   transformedData: TimeSeriesValue[][]
   sortedTimeVals: TimeSeriesValue[]
   sortedLabels: Label[]
+  influxQLQueryType: InfluxQLQueryType
   hoveredColumnIndex: number
   hoveredRowIndex: number
   timeColumnWidth: number
@@ -115,6 +117,7 @@ class TableGraph extends PureComponent<Props, State> {
       transformedData: [[]],
       sortedTimeVals: [],
       sortedLabels: [],
+      influxQLQueryType: InfluxQLQueryType.DataQuery,
       hoveredColumnIndex: NULL_ARRAY_INDEX,
       hoveredRowIndex: NULL_ARRAY_INDEX,
       sort: {field: sortField, direction: DEFAULT_SORT_DIRECTION},
@@ -303,7 +306,11 @@ class TableGraph extends PureComponent<Props, State> {
         )
       }
       const data = _.get(result, 'data', this.state.data)
-      const influxQLQueryType = _.get(result, 'influxQLQueryType', null)
+      const influxQLQueryType = _.get(
+        result,
+        'influxQLQueryType',
+        this.state.influxQLQueryType
+      )
 
       if (_.isEmpty(data[0])) {
         return
@@ -397,6 +404,7 @@ class TableGraph extends PureComponent<Props, State> {
         this.setState({
           data,
           sortedLabels,
+          influxQLQueryType,
           transformedData,
           sortedTimeVals,
           sort,


### PR DESCRIPTION
Closes #4417 

To reproduce the issue:

1. Create a new table cell
2. Open up the CEO and edit the cell time format option
3. Save the cell

An uncaught exception is thrown in the `TableGraph` component and the table cell fails to render.

The error seems to stem most immediately from calculating a `NaN` column width in the table. Ultimately this `NaN` calculation originates from passing a null `influxQLQueryType` to the `computeFieldOptions` helper. By storing the appropriate `influxQLQueryType` on state and reusing it when necessary, the calculations functions as intended.