### PR TITLE
Fix issue loading Data Explorer in Safari

### DIFF
--- a/ui/src/worker/JobManager.ts
+++ b/ui/src/worker/JobManager.ts
@@ -18,7 +18,7 @@ interface DecodeFluxRespWithLimitResult {
   uuid?: string
 }
 
-const workerCount = navigator.hardwareConcurrency - 1
+const workerCount = navigator.hardwareConcurrency - 1 || 2
 
 class JobManager {
   private currentIndex: number = 0


### PR DESCRIPTION
Closes #4500 

Spin up 2 WebWorkers by default, unless we are in a browser that defines `navigator.hardwareConcurrency` (Chrome and Firefox do, Safari does not).