### PR TITLE
Update logs copy button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 1.  [#2265](https://github.com/influxdata/chronograf/pull/2265): Autofocus dashboard query editor
 1.  [#4429](https://github.com/influxdata/chronograf/pull/4429): Fix query editor flickering on update
 1.  [#4452](https://github.com/influxdata/chronograf/pull/4452): Improve log search spinner info
+1.  [#4525](https://github.com/influxdata/chronograf/pull/4525): Move expanded log message copy button to top right
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/ui/src/logs/components/logs_message/LogsMessage.scss
+++ b/ui/src/logs/components/logs_message/LogsMessage.scss
@@ -4,31 +4,27 @@
 */
 
 .logs-message--copy {
-    font-size: 11px;
-    text-transform: uppercase;
-    color: $c-pool;
-    display: inline-block;
-    opacity: 0;
-    transition: opacity 0.25s ease;
-    margin-left: $ix-marg-a;
+  position: absolute;
+  right: $ix-marg-a;
+  bottom: 50%;
+  transform: translateY(50%);
+  opacity: 0;
+  z-index: 20;
+}
 
-    > .icon {
-      position: relative;
-      top: -1px;
-      margin-right: $ix-marg-a;
-      display: inline-block;
-    }
+.expanded--message .logs-message--copy {
+  top: $ix-marg-a;
+  transform: none;
+}
 
-    .logs-message:hover & {
-      opacity: 1;
-    }
+.logs-message:hover {
+  color: $g20-white;
+}
 
-    &:hover {
-      color: $c-laser;
-      cursor: pointer;
-    }
-  }
-  
-  .logs-message--match {
-    color: $c-laser;
-  }
+.logs-message:hover .logs-message--copy {
+  opacity: 1;
+}
+
+.logs-message--match {
+  color: $c-laser;
+}

--- a/ui/src/logs/components/logs_message/LogsMessage.tsx
+++ b/ui/src/logs/components/logs_message/LogsMessage.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 
 import CopyToClipboard from 'react-copy-to-clipboard'
 
@@ -7,6 +7,7 @@ import {
   notifyCopyToClipboardFailed,
 } from 'src/shared/copy/notifications'
 import {getMatchSections} from 'src/logs/utils/matchSections'
+import {Button, IconFont, ComponentColor, ComponentSize} from 'src/reusable_ui'
 
 import {NotificationAction} from 'src/types'
 
@@ -24,10 +25,15 @@ class LogsMessage extends PureComponent<Props> {
       <div className="logs-message">
         {this.messageSections}
         <CopyToClipboard text={formattedValue} onCopy={this.handleCopyAttempt}>
-          <div className="logs-message--copy" title="copy to clipboard">
-            <span className="icon duplicate" />
-            Copy
-          </div>
+          <Button
+            size={ComponentSize.ExtraSmall}
+            color={ComponentColor.Primary}
+            customClass="logs-message--copy"
+            titleText="copy to clipboard"
+            icon={IconFont.Duplicate}
+            text="Copy"
+            onClick={this.handleClickCopy}
+          />
         </CopyToClipboard>
       </div>
     )
@@ -63,6 +69,11 @@ class LogsMessage extends PureComponent<Props> {
         {s.text}
       </span>
     ))
+  }
+
+  private handleClickCopy(e: MouseEvent<HTMLDivElement>) {
+    e.stopPropagation()
+    e.preventDefault()
   }
 }
 

--- a/ui/src/reusable_ui/components/Button/index.tsx
+++ b/ui/src/reusable_ui/components/Button/index.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {Component} from 'react'
+import React, {Component, MouseEvent} from 'react'
 import classnames from 'classnames'
 
 // Types
@@ -15,7 +15,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   text?: string
-  onClick?: () => void
+  onClick?: (e?: MouseEvent) => void
   color?: ComponentColor
   size?: ComponentSize
   shape?: ButtonShape


### PR DESCRIPTION
Closes #4505

_Briefly describe your proposed changes:_
Move logs button up to the right corner when expanded.

_What was the problem?_
The button was in the lower right and could not be reached in longer log messages.

_What was the solution?_
*  Move the log copy button to the upper right and turn it into an actual button to make it easier to spot.
 *  Cancel click events on the copy button so that copying the log message doesn't open the popover for a long message.


<img width="1211" alt="screen shot 2018-10-01 at 7 26 13 pm" src="https://user-images.githubusercontent.com/4994741/46321192-ea8f2b00-c5af-11e8-93d3-9ec10268f611.png">

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass