### PR TITLE
Fix filter type radio button in flux builder tag list dropdown 

### DIFF
--- a/ui/src/flux/components/FilterTagListItem.tsx
+++ b/ui/src/flux/components/FilterTagListItem.tsx
@@ -89,7 +89,7 @@ export default class FilterTagListItem extends PureComponent<Props, State> {
           active={operator === '!='}
           onClick={this.setEquality}
         >
-          =
+          !=
         </Radio.Button>
       </Radio>
     )
@@ -156,13 +156,9 @@ export default class FilterTagListItem extends PureComponent<Props, State> {
     )
   }
 
-  private setEquality(equal: boolean) {
-    return (e): void => {
-      e.stopPropagation()
-
-      const {tagKey} = this.props
-      this.props.onSetEquality(tagKey, equal)
-    }
+  private setEquality = (equal: boolean) => {
+    const {tagKey} = this.props
+    this.props.onSetEquality(tagKey, equal)
   }
 
   private get spinnerStyle(): CSSProperties {


### PR DESCRIPTION
Closes #4484

_What was the problem?_
When the user clicked on the radio button to toggle between "=" and "!=" filter types, the tag key list item would simply close and would not switch the filter type. 

_What was the solution?_
Change the onClick function to be an arrow function and remove the event handler sub-function. This does not fix the list item closing on click, but it does allow the user to toggle between "=" and "!=". The closing problem will be addressed in a separate PR

  - [x] Rebased/mergeable
  - [x] Tests pass