### PR TITLE
Add switch org link and fix routing when auth is enabled in onboarding

### DIFF
--- a/ui/src/reusable_ui/components/wizard/WizardController.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardController.tsx
@@ -20,6 +20,9 @@ interface Props {
   handleSkip?: () => void
   skipLinkText?: string
   jumpStep?: number
+  switchLinkText?: string
+  handleSwitch?: () => void
+  isUsingAuth: boolean
 }
 
 @ErrorHandling
@@ -78,7 +81,9 @@ class WizardController extends PureComponent<Props, State> {
 
   public render() {
     const {steps, currentStepIndex} = this.state
+    const {isUsingAuth} = this.props
     const currentChild = this.CurrentChild
+    const {isSkippableStep} = currentChild.props
     return (
       <div className="wizard-controller">
         <div className="progress-header">
@@ -91,7 +96,8 @@ class WizardController extends PureComponent<Props, State> {
           {this.tipText}
         </div>
         {currentChild}
-        {this.skipLink}
+        {isUsingAuth ? this.switchLink : null}
+        {isSkippableStep ? this.skipLink : null}
       </div>
     )
   }
@@ -172,6 +178,22 @@ class WizardController extends PureComponent<Props, State> {
           onClick={handleSkip}
         >
           {skipLinkText}
+        </button>
+      )
+    }
+    return null
+  }
+
+  private get switchLink() {
+    const {handleSwitch, switchLinkText} = this.props
+
+    if (handleSwitch) {
+      return (
+        <button
+          className="btn btn-xs btn-primary btn-link wizard-skip-link"
+          onClick={handleSwitch}
+        >
+          {switchLinkText}
         </button>
       )
     }

--- a/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
@@ -14,6 +14,9 @@ interface Props {
   title: string
   skipLinkText?: string
   handleSkip?: () => void
+  switchLinkText?: string
+  handleSwitch?: () => void
+  isUsingAuth: boolean
 }
 
 @ErrorHandling
@@ -32,13 +35,23 @@ class WizardFullScreen extends PureComponent<Props> {
   }
 
   private get WizardController() {
-    const {children, skipLinkText, handleSkip} = this.props
+    const {
+      children,
+      skipLinkText,
+      handleSkip,
+      handleSwitch,
+      switchLinkText,
+      isUsingAuth,
+    } = this.props
 
     if (children) {
       return (
         <WizardController
           handleSkip={handleSkip}
           skipLinkText={skipLinkText}
+          handleSwitch={handleSwitch}
+          switchLinkText={switchLinkText}
+          isUsingAuth={isUsingAuth}
           jumpStep={0}
         >
           {children}

--- a/ui/src/reusable_ui/components/wizard/WizardStep.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardStep.tsx
@@ -18,7 +18,7 @@ export interface WizardStepProps {
   isErrored?: boolean | BooleanFunction
   onPrevious?: () => void
   onNext: NextReturnFunction | AsyncNextReturnFunction
-  isBlockingStep?: boolean
+  isSkippableStep?: boolean
   increment?: () => void
   decrement?: () => void
   tipText?: string
@@ -30,7 +30,7 @@ export interface WizardStepProps {
 @ErrorHandling
 class WizardStep extends PureComponent<WizardStepProps> {
   public static defaultProps: Partial<WizardStepProps> = {
-    isBlockingStep: false,
+    isSkippableStep: true,
     isErrored: false,
   }
   public render() {
@@ -66,7 +66,7 @@ class WizardStep extends PureComponent<WizardStepProps> {
   }
 
   private handleClickNext = async () => {
-    const {onNext, increment, isBlockingStep} = this.props
+    const {onNext, increment, isSkippableStep} = this.props
     let payload
     let error = false
 
@@ -77,7 +77,7 @@ class WizardStep extends PureComponent<WizardStepProps> {
     }
 
     if (increment) {
-      if (!isBlockingStep || (isBlockingStep && error === false)) {
+      if (isSkippableStep || (!isSkippableStep && error === false)) {
         increment()
       }
     }

--- a/ui/src/reusable_ui/components/wizard/test/WizardController.test.tsx
+++ b/ui/src/reusable_ui/components/wizard/test/WizardController.test.tsx
@@ -32,7 +32,7 @@ describe('WizardController', () => {
       tipText: undefined,
       nextLabel: undefined,
       previousLabel: undefined,
-      isBlockingStep: undefined,
+      isSkippableStep: undefined,
       lastStep: undefined,
       ...override,
     }

--- a/ui/src/reusable_ui/components/wizard/test/WizardFullScreen.test.tsx
+++ b/ui/src/reusable_ui/components/wizard/test/WizardFullScreen.test.tsx
@@ -14,6 +14,7 @@ describe('WizardFullScreen', () => {
       title: undefined,
       skipLinkText: undefined,
       handleSkip: undefined,
+      isUsingAuth: false,
       ...override,
     }
 

--- a/ui/src/reusable_ui/components/wizard/test/WizardStep.test.tsx
+++ b/ui/src/reusable_ui/components/wizard/test/WizardStep.test.tsx
@@ -12,7 +12,7 @@ describe('WizardStep', () => {
       title: 'my wizard step',
       isComplete: () => true,
       isErrored: undefined,
-      isBlockingStep: undefined,
+      isSkippableStep: undefined,
       onPrevious: undefined,
       onNext: undefined,
       increment: undefined,

--- a/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardController.test.tsx.snap
+++ b/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardController.test.tsx.snap
@@ -32,9 +32,9 @@ exports[`WizardController with multiple children matches snapshot with two child
   <WizardStep
     decrement={null}
     increment={[Function]}
-    isBlockingStep={false}
     isComplete={[Function]}
     isErrored={false}
+    isSkippableStep={true}
     lastStep={false}
     title="wizard step 1"
   >
@@ -74,9 +74,9 @@ exports[`WizardController with multiple children with first step complete matche
   </div>
   <WizardStep
     decrement={[Function]}
-    isBlockingStep={false}
     isComplete={[Function]}
     isErrored={false}
+    isSkippableStep={true}
     lastStep={true}
     title="wizard step 2"
   >
@@ -112,9 +112,9 @@ exports[`WizardController with one child matches snapshot with one child 1`] = `
   </div>
   <WizardStep
     decrement={null}
-    isBlockingStep={false}
     isComplete={[Function]}
     isErrored={false}
+    isSkippableStep={true}
     lastStep={true}
     title="only wizard step"
   >

--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -87,7 +87,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           tipText=""
           isComplete={this.isSourceComplete}
           isErrored={sourceError}
-          isBlockingStep={true}
+          isSkippableStep={false}
           onNext={this.handleSourceNext}
           nextLabel={source ? 'Update Connection' : 'Add Connection'}
           previousLabel="Cancel"
@@ -116,7 +116,6 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           tipText=""
           isComplete={this.isKapacitorComplete}
           isErrored={kapacitorError}
-          isBlockingStep={true}
           onNext={this.handleKapacitorNext}
           onPrevious={this.handleKapacitorPrev}
           nextLabel="Continue"

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -174,13 +174,19 @@ class SourceStep extends PureComponent<Props, State> {
       <div className="text-center">
         {me.role === SUPERADMIN_ROLE ? (
           <h4>
-            <strong>{me.currentOrganization.name}</strong> currently has no
-            connections
+            The organization{' '}
+            <strong>
+              <i>{me.currentOrganization.name}</i>
+            </strong>{' '}
+            currently has no connections
           </h4>
         ) : (
           <h3>
-            <strong>{me.currentOrganization.name}</strong> has no connections
-            available to <em>{me.role}s</em>
+            The organization{' '}
+            <strong>
+              <i>{me.currentOrganization.name}</i>
+            </strong>{' '}
+            has no connections available to <em>{me.role}s</em>
           </h3>
         )}
       </div>

--- a/ui/src/sources/containers/OnboardingWizard.tsx
+++ b/ui/src/sources/containers/OnboardingWizard.tsx
@@ -66,15 +66,18 @@ class OnboardingWizard extends PureComponent<Props, State> {
         <Notifications />
         <WizardFullScreen
           title={'Welcome to Influx'}
-          skipLinkText={'Switch Organizations'}
-          handleSkip={isUsingAuth ? this.gotoPurgatory : null}
+          skipLinkText={'skip'}
+          handleSkip={this.handleCompletionNext}
+          switchLinkText={'switch organizations'}
+          handleSwitch={this.resetAndGotoPurgatory}
+          isUsingAuth={isUsingAuth}
         >
           <WizardStep
             title="InfluxDB Connection"
             tipText=""
             isComplete={this.isSourceComplete}
             isErrored={sourceError}
-            isBlockingStep={true}
+            isSkippableStep={false}
             onNext={this.handleSourceNext}
             nextLabel={source ? 'Update Connection' : 'Add Connection'}
             previousLabel="Cancel"
@@ -107,7 +110,6 @@ class OnboardingWizard extends PureComponent<Props, State> {
             tipText=""
             isComplete={this.isKapacitorComplete}
             isErrored={kapacitorError}
-            isBlockingStep={true}
             onNext={this.handleKapacitorNext}
             onPrevious={this.handleKapacitorPrev}
             nextLabel="Continue"
@@ -224,8 +226,9 @@ class OnboardingWizard extends PureComponent<Props, State> {
     })
   }
 
-  private gotoPurgatory = (): void => {
+  private resetAndGotoPurgatory = (): void => {
     const {router} = this.props
+    this.resetWizardState()
     router.push('/purgatory')
   }
 }


### PR DESCRIPTION
Closes #4496  #4497 
- Added a switch orgs link for users using auth. 
- Added an additional 'skip' link on skippable wizard steps in onboarding wizard. 
- route user using auth to `/manageSources` page when wizard completed, or skipped.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)