### PR TITLE
Allow note cell without query

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -137,8 +137,12 @@ class CellEditorOverlay extends Component<Props, State> {
   }
 
   private get isSaveable(): boolean {
-    const {queryDrafts} = this.timeMachineContainer.state
+    const {queryDrafts, type} = this.timeMachineContainer.state
     const {status} = this.state
+
+    if (type === 'note') {
+      return true
+    }
 
     if (this.isFluxSource) {
       return _.get(status, 'type', '') === 'success'

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -43,10 +43,7 @@ import {ColorString, ColorNumber} from 'src/types/colors'
 
 interface ConnectedProps {
   queryDrafts: CellQuery[]
-  timeRange: TimeRange
   script: string
-  onUpdateQueryDrafts: (queryDrafts: CellQuery[]) => void
-  onChangeScript: TimeMachineContainer['handleChangeScript']
   type: CellType
   axes: Axes | null
   tableOptions: TableOptions
@@ -314,10 +311,7 @@ const ConnectedCellEditorOverlay = (props: PassedProps) => {
         <CellEditorOverlay
           {...props}
           queryDrafts={timeMachineContainer.state.queryDrafts}
-          timeRange={timeMachineContainer.state.timeRange}
           script={timeMachineContainer.state.script}
-          onChangeScript={timeMachineContainer.handleChangeScript}
-          onUpdateQueryDrafts={timeMachineContainer.handleUpdateQueryDrafts}
           type={timeMachineContainer.state.type}
           axes={timeMachineContainer.state.axes}
           tableOptions={timeMachineContainer.state.tableOptions}

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -128,6 +128,8 @@ interface State {
 
 @ErrorHandling
 class DashboardPage extends Component<Props, State> {
+  private timeMachineContainer: TimeMachineContainer
+
   public constructor(props: Props) {
     super(props)
 
@@ -281,18 +283,7 @@ class DashboardPage extends Component<Props, State> {
     return (
       <Page>
         <OverlayTechnology visible={showCellEditorOverlay}>
-          <Provider
-            inject={
-              this.state.selectedCell
-                ? [
-                    new TimeMachineContainer({
-                      ...initialStateFromCell(this.state.selectedCell),
-                      timeRange,
-                    }),
-                  ]
-                : null
-            }
-          >
+          <Provider inject={[this.timeMachineContainer]}>
             <CellEditorOverlay
               source={source}
               sources={sources}
@@ -430,6 +421,13 @@ class DashboardPage extends Component<Props, State> {
   }
 
   private handleShowCellEditorOverlay = (cell: DashboardsModels.Cell): void => {
+    const {timeRange} = this.props
+
+    this.timeMachineContainer = new TimeMachineContainer({
+      ...initialStateFromCell(cell),
+      timeRange,
+    })
+
     this.setState({selectedCell: cell, showCellEditorOverlay: true})
   }
 

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -3,6 +3,7 @@ import React, {Component, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 import _ from 'lodash'
+import {Provider} from 'unstated'
 
 // Components
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -28,6 +29,8 @@ import * as errorActions from 'src/shared/actions/errors'
 import * as notifyActions from 'src/shared/actions/notifications'
 
 // Utils
+import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
+import {initialStateFromCell} from 'src/shared/utils/timeMachine'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {getDeep} from 'src/utils/wrappers'
 import {updateDashboardLinks} from 'src/dashboards/utils/dashboardSwitcherLinks'
@@ -278,20 +281,33 @@ class DashboardPage extends Component<Props, State> {
     return (
       <Page>
         <OverlayTechnology visible={showCellEditorOverlay}>
-          <CellEditorOverlay
-            source={source}
-            sources={sources}
-            notify={notify}
-            fluxLinks={fluxLinks}
-            cell={selectedCell}
-            dashboardID={dashboardID}
-            queryStatus={cellQueryStatus}
-            onSave={this.handleSaveEditedCell}
-            onCancel={this.handleHideCellEditorOverlay}
-            templates={templatesIncludingDashTime}
-            editQueryStatus={this.props.editCellQueryStatus}
-            dashboardTimeRange={timeRange}
-          />
+          <Provider
+            inject={
+              this.state.selectedCell
+                ? [
+                    new TimeMachineContainer({
+                      ...initialStateFromCell(this.state.selectedCell),
+                      timeRange,
+                    }),
+                  ]
+                : null
+            }
+          >
+            <CellEditorOverlay
+              source={source}
+              sources={sources}
+              notify={notify}
+              fluxLinks={fluxLinks}
+              cell={selectedCell}
+              dashboardID={dashboardID}
+              queryStatus={cellQueryStatus}
+              onSave={this.handleSaveEditedCell}
+              onCancel={this.handleHideCellEditorOverlay}
+              templates={templatesIncludingDashTime}
+              editQueryStatus={this.props.editCellQueryStatus}
+              dashboardTimeRange={timeRange}
+            />
+          </Provider>
         </OverlayTechnology>
         <DashboardHeader
           dashboard={dashboard}

--- a/ui/src/shared/utils/timeMachine.ts
+++ b/ui/src/shared/utils/timeMachine.ts
@@ -14,7 +14,7 @@ import {
 import {Cell, NewDefaultCell, CellQuery, QueryType} from 'src/types'
 import {TimeMachineState} from 'src/shared/utils/TimeMachineContainer'
 
-export function intialStateFromCell(
+export function initialStateFromCell(
   cell: Cell | NewDefaultCell
 ): Partial<TimeMachineState> {
   const initialState: Partial<TimeMachineState> = {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/97

_What was the problem?_
Previously, the CEO would check if a cell had a query and not allow the user to save a cell without a query, even for a note type cell.

_What was the solution?_
Add a check for note type in the `isSaveable` function in the CEO. Additionally, move the `TimeMachineContainer` which holds the state for cell type to be above the CEO. This way, the `isSaveable` function is called every time the cell type changes.

  - [x] Rebased/mergeable
  - [ ] Tests pass