### PR TITLE
Flux/time range update

### DIFF
--- a/ui/src/dashboards/components/DisplayOptions.tsx
+++ b/ui/src/dashboards/components/DisplayOptions.tsx
@@ -18,13 +18,12 @@ import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 // Constants
 import {HANDLE_VERTICAL} from 'src/shared/constants'
-import {QueryUpdateState} from 'src/shared/actions/queries'
 import {DEFAULT_AXES} from 'src/dashboards/constants/cellEditor'
 
 // Types
 import {buildDefaultYLabel} from 'src/shared/presenters'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Axes, QueryConfig, CellType} from 'src/types'
+import {Axes, QueryConfig, CellType, QueryUpdateState} from 'src/types'
 import {
   FieldOption,
   DecimalPlaces,

--- a/ui/src/flux/components/TimeMachineTables.tsx
+++ b/ui/src/flux/components/TimeMachineTables.tsx
@@ -12,10 +12,10 @@ import TableGraph from 'src/shared/components/TableGraph'
 import {getDeep} from 'src/utils/wrappers'
 
 // Types
-import {QueryUpdateState} from 'src/shared/actions/queries'
 import {ColorString} from 'src/types/colors'
 import {TableOptions, FieldOption, DecimalPlaces} from 'src/types/dashboards'
 import {DataType} from 'src/shared/constants'
+import {QueryUpdateState} from 'src/types'
 
 interface Props {
   data: FluxTable[]

--- a/ui/src/shared/actions/queries.ts
+++ b/ui/src/shared/actions/queries.ts
@@ -1,4 +1,0 @@
-export enum QueryUpdateState {
-  CEO = 'cellEditorOverlay',
-  DE = 'dataExplorer',
-}

--- a/ui/src/shared/components/Gauge.tsx
+++ b/ui/src/shared/components/Gauge.tsx
@@ -1,8 +1,9 @@
+// Libraries
 import React, {Component} from 'react'
 import _ from 'lodash'
 
+// Constants
 import {GAUGE_SPECS} from 'src/shared/constants/gaugeSpecs'
-
 import {
   COLOR_TYPE_MIN,
   COLOR_TYPE_MAX,
@@ -10,8 +11,10 @@ import {
 } from 'src/shared/constants/thresholds'
 import {MAX_TOLOCALESTRING_VAL} from 'src/dashboards/constants'
 
+// Utils
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+// Types
 import {ColorString} from 'src/types/colors'
 import {DecimalPlaces} from 'src/types/dashboards'
 

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -29,7 +29,6 @@ import {setHoverTime} from 'src/dashboards/actions'
 import {notify} from 'src/shared/actions/notifications'
 
 // Types
-import {QueryUpdateState} from 'src/shared/actions/queries'
 import {ColorString} from 'src/types/colors'
 import {
   Source,
@@ -40,6 +39,7 @@ import {
   CellType,
   FluxTable,
   RemoteDataState,
+  QueryUpdateState,
 } from 'src/types'
 import {
   TableOptions,

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -1,19 +1,26 @@
+// Libraries
 import React, {PureComponent} from 'react'
 import _ from 'lodash'
 import classnames from 'classnames'
 import {connect} from 'react-redux'
 import moment from 'moment'
-
 import {ColumnSizer, SizedColumnProps, AutoSizer} from 'react-virtualized'
+
+// Components
 import {MultiGrid, PropsMultiGrid} from 'src/shared/components/MultiGrid'
 import InvalidData from 'src/shared/components/InvalidData'
+
+// Utils
 import {fastReduce} from 'src/utils/fast'
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
 import {
   computeFieldOptions,
   getDefaultTimeField,
 } from 'src/dashboards/utils/tableGraph'
-import {QueryUpdateState} from 'src/shared/actions/queries'
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {manager} from 'src/worker/JobManager'
+
+// Constants
 import {
   ASCENDING,
   DESCENDING,
@@ -24,7 +31,9 @@ import {
   DEFAULT_SORT_DIRECTION,
 } from 'src/shared/constants/tableGraph'
 import {generateThresholdsListHexs} from 'src/shared/constants/colorOperations'
-import {ErrorHandling} from 'src/shared/decorators/errors'
+import {DataType} from 'src/shared/constants'
+
+// Types
 import {
   TimeSeriesServerResponse,
   TimeSeriesValue,
@@ -38,10 +47,7 @@ import {
   DecimalPlaces,
   Sort,
 } from 'src/types/dashboards'
-import {FluxTable} from 'src/types'
-import {DataType} from 'src/shared/constants'
-
-import {manager} from 'src/worker/JobManager'
+import {FluxTable, QueryUpdateState} from 'src/types'
 
 const COLUMN_MIN_WIDTH = 100
 const ROW_HEIGHT = 30

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -28,7 +28,6 @@ import {HANDLE_HORIZONTAL} from 'src/shared/constants'
 import {CEOTabs} from 'src/dashboards/constants'
 
 // Types
-import {QueryUpdateState} from 'src/shared/actions/queries'
 import {
   TimeRange,
   QueryConfig,
@@ -40,6 +39,7 @@ import {
   Status,
   Query,
   QueryType,
+  QueryUpdateState,
 } from 'src/types'
 import {SourceOption} from 'src/types/sources'
 import {Links, ScriptStatus} from 'src/types/flux'

--- a/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
@@ -14,9 +14,9 @@ import {
   Query,
   Template,
   Status,
+  QueryUpdateState,
 } from 'src/types'
 import {ColorString, ColorNumber} from 'src/types/colors'
-import {QueryUpdateState} from 'src/shared/actions/queries'
 import {
   TableOptions,
   FieldOption,

--- a/ui/src/shared/graphs/helpers.ts
+++ b/ui/src/shared/graphs/helpers.ts
@@ -1,6 +1,18 @@
+// Libraries
+import _ from 'lodash'
 /* eslint-disable no-magic-numbers */
 import {toRGB_} from 'dygraphs/src/dygraph-utils'
 import {CSSProperties} from 'react'
+
+// Utils
+import {getDeep} from 'src/utils/wrappers'
+
+// Constants
+import {DataType} from 'src/shared/constants'
+
+// Types
+import {FluxTable, TimeRange} from 'src/types'
+import {TimeSeriesServerResponse} from 'src/types/series'
 
 export const LINE_COLORS = [
   '#00C9FF',
@@ -169,3 +181,38 @@ export const hasherino = (str, len) =>
 
 export const LABEL_WIDTH = 44
 export const CHAR_PIXELS = 7
+
+export const getDataUUID = (
+  data: TimeSeriesServerResponse[] | FluxTable[],
+  dataType: DataType
+): string => {
+  if (dataType === DataType.influxQL) {
+    return getDeep(data, '0.response.uuid', '')
+  } else {
+    return getDeep(data, '0.id', '')
+  }
+}
+
+interface DataProps {
+  data: TimeSeriesServerResponse[] | FluxTable[]
+  dataType: DataType
+  timeRange?: TimeRange
+}
+export const hasDataChanged = (
+  prevProps: DataProps,
+  newProps: DataProps
+): boolean => {
+  const isDataTypeChanged = prevProps.dataType !== newProps.dataType
+  const isDataIDsChanged = !_.isEqual(
+    getDataUUID(prevProps.data, prevProps.dataType),
+    getDataUUID(newProps.data, newProps.dataType)
+  )
+  const isTimeRangeChanged = !!_.isEqual(
+    _.get(prevProps, 'timeRange'),
+    _.get(newProps, 'timeRange')
+  )
+  const isDataChanged =
+    isDataTypeChanged || isDataIDsChanged || isTimeRangeChanged
+
+  return isDataChanged
+}

--- a/ui/src/types/dataExplorer.ts
+++ b/ui/src/types/dataExplorer.ts
@@ -36,3 +36,8 @@ export interface VisualizationOptions {
   gaugeColors: ColorNumber[]
   lineColors: ColorString[]
 }
+
+export enum QueryUpdateState {
+  CEO = 'cellEditorOverlay',
+  DE = 'dataExplorer',
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -68,7 +68,7 @@ import {
 } from './dygraphs'
 import {JSONFeedData} from './status'
 import {Annotation} from './annotations'
-import {WriteDataMode} from './dataExplorer'
+import {WriteDataMode, QueryUpdateState} from './dataExplorer'
 import {Host, Layout} from './hosts'
 
 export {
@@ -143,4 +143,5 @@ export {
   Host,
   Layout,
   QueryType,
+  QueryUpdateState,
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/102

_What was the problem?_
Because time range getting updated caused a change in data, the async data transformations were called. This was causing a race condition so the previous data was often getting set.
_What was the solution?_
Keep track of the requests and only update state with the most recent request's result.

This does not take into account table graphs. A different pr will deal with that

  - [x] Rebased/mergeable
  - [x] Tests pass