### PR TITLE
Remove old flux services from dashboard export

### DIFF
--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -18,7 +18,6 @@ import {
   retainRangesDashTimeV1 as retainRangesDashTimeV1Action,
 } from 'src/dashboards/actions'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
-import {fetchAllFluxServicesAsync} from 'src/shared/actions/services'
 
 import {
   NEW_DASHBOARD,
@@ -31,7 +30,7 @@ import {
   notifyDashboardExportFailed,
 } from 'src/shared/copy/notifications'
 
-import {Source, Dashboard, RemoteDataState, Service} from 'src/types'
+import {Source, Dashboard, RemoteDataState} from 'src/types'
 import {Notification} from 'src/types/notifications'
 import {DashboardFile, Cell} from 'src/types/dashboards'
 
@@ -46,9 +45,7 @@ export interface Props {
   handleImportDashboard: (dashboard: Dashboard) => void
   notify: (message: Notification) => void
   retainRangesDashTimeV1: (dashboardIDs: number[]) => void
-  fetchAllFluxServices: (sources: Source[]) => Promise<void>
   dashboards: Dashboard[]
-  services: Service[]
 }
 
 interface State {
@@ -70,8 +67,6 @@ export class DashboardsPage extends PureComponent<Props, State> {
 
     try {
       dashboards = await this.props.handleGetDashboards()
-
-      await this.props.fetchAllFluxServices(this.props.sources)
 
       const dashboardIDs = dashboards.map(d => d.id)
 
@@ -162,10 +157,10 @@ export class DashboardsPage extends PureComponent<Props, State> {
   private modifyDashboardForDownload = async (
     dashboard: Dashboard
   ): Promise<DashboardFile> => {
-    const {sources, services, handleGetChronografVersion} = this.props
+    const {sources, handleGetChronografVersion} = this.props
     const version = await handleGetChronografVersion()
 
-    return mapDashboardForDownload(sources, services, dashboard, version)
+    return mapDashboardForDownload(sources, dashboard, version)
   }
 
   private handleImportDashboard = async (
@@ -189,12 +184,10 @@ export class DashboardsPage extends PureComponent<Props, State> {
 const mapStateToProps = ({
   dashboardUI: {dashboards, dashboard},
   sources,
-  services,
 }): Partial<Props> => ({
   dashboards,
   dashboard,
   sources,
-  services,
 })
 
 const mapDispatchToProps = {
@@ -204,7 +197,6 @@ const mapDispatchToProps = {
   handleImportDashboard: importDashboardAsync,
   notify: notifyAction,
   retainRangesDashTimeV1: retainRangesDashTimeV1Action,
-  fetchAllFluxServices: fetchAllFluxServicesAsync,
 }
 
 export default withRouter(

--- a/ui/src/dashboards/utils/export.ts
+++ b/ui/src/dashboards/utils/export.ts
@@ -1,22 +1,8 @@
 import _ from 'lodash'
 
-import {Source, Dashboard, Service, Cell} from 'src/types'
+import {Source, Dashboard, Cell} from 'src/types'
 import {CellQuery} from 'src/types/dashboards'
 import {DashboardFile} from 'src/types/dashboards'
-
-export const isFluxService = (link: string) => link.includes('service')
-
-export const mapServicesForDownload = (originalServices: Service[]) =>
-  _.reduce(
-    originalServices,
-    (acc, service) => {
-      const {name, id, links, sourceID} = service
-      const link = _.get(links, 'self', '')
-      acc[id] = {name, link, sourceID}
-      return acc
-    },
-    {}
-  )
 
 export const mapSourcesForDownload = (originalSources: Source[]) =>
   _.reduce(
@@ -30,28 +16,11 @@ export const mapSourcesForDownload = (originalSources: Source[]) =>
     {}
   )
 
-export const matchSourceLink = (cellQuery: CellQuery) => {
-  if (!isFluxService(cellQuery.source)) {
-    return cellQuery.source
-  }
-
-  return null
-}
-
-export const matchServiceLink = (cellQuery: CellQuery) => {
-  if (isFluxService(cellQuery.source)) {
-    return cellQuery.source
-  }
-
-  return null
-}
-
 export const mapQueriesToSources = (queries: CellQuery[]) => {
   return queries.map(query => {
     return {
       ...query,
-      source: matchSourceLink(query),
-      service: matchServiceLink(query),
+      source: query.source,
     }
   })
 }
@@ -69,13 +38,11 @@ export const mapCellsToSources = (cells: Cell[]) => {
 
 export const mapDashboardForDownload = (
   originalSources: Source[],
-  originalServices: Service[],
   originalDashboard: Dashboard,
   chronografVersion: string
 ): DashboardFile => {
   const sources = mapSourcesForDownload(originalSources)
-  const services = mapServicesForDownload(originalServices)
-  const meta = {chronografVersion, sources, services}
+  const meta = {chronografVersion, sources}
 
   const dashboard = {
     ...originalDashboard,


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/111

_What was the problem?_
Dashboards were previously exported with Flux services, which have now been removed 

_What was the solution?_
Use a Source link for both Flux and InfluxQL cells when exporting or importing a dashboard

  - [x] Rebased/mergeable
  - [x] Tests pass