### PR TITLE
Table graph update time

### DIFF
--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -20,7 +20,7 @@ const calculateSize = (message: string): number => {
   return message.length * 7
 }
 
-interface ColumnWidths {
+export interface ColumnWidths {
   totalWidths: number
   widths: {[x: string]: number}
 }
@@ -35,6 +35,20 @@ interface TransformTableDataReturnType {
   transformedData: TimeSeriesValue[][]
   sortedTimeVals: TimeSeriesValue[]
   columnWidths: ColumnWidths
+}
+
+export enum ErrorTypes {
+  MetaQueryCombo = 'MetaQueryCombo',
+  GeneralError = 'Error',
+}
+
+export const getInvalidDataMessage = (errorType: ErrorTypes): string => {
+  switch (errorType) {
+    case ErrorTypes.MetaQueryCombo:
+      return 'Cannot display data for meta queries mixed with data queries'
+    default:
+      return null
+  }
 }
 
 const calculateTimeColumnWidth = (timeFormat: string): number => {

--- a/ui/src/flux/components/TimeMachineTables.tsx
+++ b/ui/src/flux/components/TimeMachineTables.tsx
@@ -1,5 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
+import uuid from 'uuid'
 import memoizeOne from 'memoize-one'
 
 // Components
@@ -7,6 +8,8 @@ import TableSidebar from 'src/flux/components/TableSidebar'
 import {FluxTable} from 'src/types'
 import NoResults from 'src/flux/components/NoResults'
 import TableGraph from 'src/shared/components/TableGraph'
+import TableGraphTransform from 'src/shared/components/TableGraphTransform'
+import TableGraphFormat from 'src/shared/components/TableGraphFormat'
 
 // Utils
 import {getDeep} from 'src/utils/wrappers'
@@ -19,6 +22,7 @@ import {QueryUpdateState} from 'src/types'
 
 interface Props {
   data: FluxTable[]
+  uuid: string
   dataType: DataType
   tableOptions: TableOptions
   timeFormat: string
@@ -91,18 +95,40 @@ class TimeMachineTables extends PureComponent<Props, State> {
           />
         )}
         {this.shouldShowTable && (
-          <TableGraph
+          <TableGraphTransform
             data={this.selectedResult}
             dataType={dataType}
-            colors={colors}
-            tableOptions={tableOptions}
-            fieldOptions={this.fieldOptions}
-            timeFormat={timeFormat}
-            decimalPlaces={decimalPlaces}
-            editorLocation={editorLocation}
-            handleSetHoverTime={handleSetHoverTime}
-            onUpdateFieldOptions={onUpdateFieldOptions}
-          />
+            uuid={uuid.v4()}
+          >
+            {(transformedData, nextUUID) => (
+              <TableGraphFormat
+                data={transformedData}
+                uuid={nextUUID}
+                dataType={dataType}
+                tableOptions={tableOptions}
+                timeFormat={timeFormat}
+                decimalPlaces={decimalPlaces}
+                fieldOptions={this.fieldOptions}
+              >
+                {(formattedData, sort, computedFieldOptions, onSort) => (
+                  <TableGraph
+                    data={formattedData}
+                    sort={sort}
+                    onSort={onSort}
+                    dataType={dataType}
+                    colors={colors}
+                    tableOptions={tableOptions}
+                    fieldOptions={computedFieldOptions}
+                    timeFormat={timeFormat}
+                    decimalPlaces={decimalPlaces}
+                    editorLocation={editorLocation}
+                    handleSetHoverTime={handleSetHoverTime}
+                    onUpdateFieldOptions={onUpdateFieldOptions}
+                  />
+                )}
+              </TableGraphFormat>
+            )}
+          </TableGraphTransform>
         )}
         {!this.hasResults && <NoResults />}
       </div>

--- a/ui/src/flux/components/YieldFuncNode.tsx
+++ b/ui/src/flux/components/YieldFuncNode.tsx
@@ -87,9 +87,10 @@ class YieldFuncNode extends PureComponent<Props, State> {
       <div className="yield-node">
         <div className="func-node--connector" />
         <TimeSeries source={source} queries={queries} timeRange={timeRange}>
-          {({timeSeriesFlux}) => (
+          {({timeSeriesFlux, uuid}) => (
             <YieldNodeVis
               data={timeSeriesFlux}
+              uuid={uuid}
               yieldName={yieldName}
               axes={axes}
               tableOptions={tableOptions}

--- a/ui/src/flux/components/YieldNodeVis.tsx
+++ b/ui/src/flux/components/YieldNodeVis.tsx
@@ -20,6 +20,7 @@ import {ColorNumber, ColorString} from 'src/types/colors'
 
 interface Props {
   data: FluxTable[]
+  uuid: string
   yieldName: string
   axes: Axes | null
   tableOptions: TableOptions
@@ -86,6 +87,7 @@ class YieldNodeVis extends PureComponent<Props, State> {
     const {visType} = this.state
     const {
       data,
+      uuid,
       tableOptions,
       timeFormat,
       decimalPlaces,
@@ -113,6 +115,7 @@ class YieldNodeVis extends PureComponent<Props, State> {
     return (
       <TimeMachineTables
         data={data}
+        uuid={uuid}
         dataType={DataType.flux}
         tableOptions={tableOptions}
         timeFormat={timeFormat}

--- a/ui/src/shared/components/TableGraphFormat.tsx
+++ b/ui/src/shared/components/TableGraphFormat.tsx
@@ -1,0 +1,216 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import _ from 'lodash'
+
+// Utils
+import {manager} from 'src/worker/JobManager'
+import {
+  ErrorTypes,
+  getInvalidDataMessage,
+  computeFieldOptions,
+  getDefaultTimeField,
+} from 'src/dashboards/utils/tableGraph'
+
+// Components
+import InvalidData from 'src/shared/components/InvalidData'
+
+// Constants
+import {
+  DEFAULT_SORT_DIRECTION,
+  ASCENDING,
+  DESCENDING,
+} from 'src/shared/constants/tableGraph'
+
+// Types
+import {
+  TimeSeriesValue,
+  TimeSeriesToTableGraphReturnType,
+} from 'src/types/series'
+import {
+  TableOptions,
+  FieldOption,
+  DecimalPlaces,
+  Sort,
+} from 'src/types/dashboards'
+import {DataType} from 'src/shared/constants'
+import {ColumnWidths} from 'src/dashboards/utils/tableGraph'
+
+interface Props {
+  data: TimeSeriesToTableGraphReturnType
+  dataType: DataType
+  tableOptions: TableOptions
+  timeFormat: string
+  decimalPlaces: DecimalPlaces
+  fieldOptions: FieldOption[]
+  uuid: string
+  children: (
+    data: FormattedTableData,
+    sort: Sort,
+    computedFieldOptions: FieldOption[],
+    resortData: (fieldName: string) => void
+  ) => JSX.Element
+}
+
+export interface FormattedTableData {
+  transformedData: TimeSeriesValue[][]
+  sortedTimeVals: TimeSeriesValue[]
+  columnWidths: ColumnWidths
+}
+
+interface State {
+  formattedData: FormattedTableData
+  sort: Sort
+  computedFieldOptions: FieldOption[]
+  invalidDataError: ErrorTypes
+}
+
+class TableGraphFormat extends PureComponent<Props, State> {
+  private isComponentMounted: boolean
+
+  constructor(props: Props) {
+    super(props)
+
+    const sortField: string = _.get(
+      this.props,
+      'tableOptions.sortBy.internalName',
+      ''
+    )
+
+    this.state = {
+      formattedData: null,
+      sort: {field: sortField, direction: DEFAULT_SORT_DIRECTION},
+      computedFieldOptions: props.fieldOptions,
+      invalidDataError: null,
+    }
+  }
+
+  public render() {
+    if (this.state.invalidDataError) {
+      return (
+        <InvalidData
+          message={getInvalidDataMessage(this.state.invalidDataError)}
+        />
+      )
+    }
+
+    if (!this.state.formattedData) {
+      return null
+    }
+
+    return this.props.children(
+      this.state.formattedData,
+      this.state.sort,
+      this.state.computedFieldOptions,
+      this.formatData
+    )
+  }
+
+  public componentDidMount() {
+    this.isComponentMounted = true
+
+    this.formatData()
+  }
+
+  public componentWillUnmount() {
+    this.isComponentMounted = false
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    const updatedProps = _.keys(_.omit(prevProps, 'data')).filter(
+      k => !_.isEqual(this.props[k], prevProps[k])
+    )
+
+    if (
+      this.props.uuid !== prevProps.uuid ||
+      _.includes(updatedProps, 'tableOptions') ||
+      _.includes(updatedProps, 'fieldOptions') ||
+      _.includes(updatedProps, 'timeFormat')
+    ) {
+      this.formatData()
+    }
+  }
+
+  private formatData = async (sortField?: string) => {
+    const {
+      fieldOptions,
+      data: {sortedLabels, influxQLQueryType},
+      dataType,
+      tableOptions,
+      timeFormat,
+      decimalPlaces,
+    } = this.props
+
+    const {sort} = this.state
+
+    if (sortField === sort.field) {
+      sort.direction = sort.direction === ASCENDING ? DESCENDING : ASCENDING
+    } else {
+      sort.field = sortField || this.sortField
+      sort.direction = DEFAULT_SORT_DIRECTION
+    }
+
+    const latestUUID = this.props.uuid
+
+    const computedFieldOptions = computeFieldOptions(
+      fieldOptions,
+      sortedLabels,
+      dataType,
+      influxQLQueryType
+    )
+
+    try {
+      const formattedData = await manager.tableTransform(
+        this.props.data.data,
+        sort,
+        computedFieldOptions,
+        tableOptions,
+        timeFormat,
+        decimalPlaces
+      )
+
+      if (!this.isComponentMounted) {
+        return
+      }
+
+      if (this.props.uuid === latestUUID) {
+        this.setState({
+          formattedData,
+          sort,
+          computedFieldOptions,
+          invalidDataError: null,
+        })
+      }
+    } catch (err) {
+      if (!this.isComponentMounted) {
+        return
+      }
+
+      this.setState({invalidDataError: ErrorTypes.GeneralError})
+    }
+  }
+
+  private get sortField(): string {
+    const {fieldOptions, dataType} = this.props
+
+    let sortField: string = _.get(
+      this.props,
+      ['tableOptions', 'sortBy', 'internalName'],
+      ''
+    )
+    const isValidSortField = !!fieldOptions.find(
+      f => f.internalName === sortField
+    )
+
+    if (!isValidSortField) {
+      sortField = _.get(
+        getDefaultTimeField(dataType),
+        'internalName',
+        _.get(fieldOptions, '0.internalName', '')
+      )
+    }
+
+    return sortField
+  }
+}
+
+export default TableGraphFormat

--- a/ui/src/shared/components/TableGraphTransform.tsx
+++ b/ui/src/shared/components/TableGraphTransform.tsx
@@ -1,0 +1,136 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import _ from 'lodash'
+import uuid from 'uuid'
+
+// Components
+import InvalidData from 'src/shared/components/InvalidData'
+
+// Utils
+import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
+import {
+  ErrorTypes,
+  getInvalidDataMessage,
+} from 'src/dashboards/utils/tableGraph'
+
+// Types
+import {
+  Label,
+  TimeSeriesValue,
+  TimeSeriesServerResponse,
+  TimeSeriesToTableGraphReturnType,
+} from 'src/types/series'
+import {FluxTable} from 'src/types'
+import {DataType} from 'src/shared/constants'
+
+interface Props {
+  data: TimeSeriesServerResponse[] | FluxTable
+  uuid: string
+  dataType: DataType
+  children: (
+    data: TimeSeriesToTableGraphReturnType,
+    uuid: string
+  ) => JSX.Element
+}
+
+interface State {
+  transformedData: TimeSeriesToTableGraphReturnType
+  invalidDataError: ErrorTypes
+}
+
+class TableGraphTransform extends PureComponent<Props, State> {
+  private isComponentMounted: boolean
+
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {transformedData: null, invalidDataError: null}
+  }
+
+  public render() {
+    if (this.state.invalidDataError) {
+      return (
+        <InvalidData
+          message={getInvalidDataMessage(this.state.invalidDataError)}
+        />
+      )
+    }
+
+    if (!this.state.transformedData) {
+      return null
+    }
+
+    return this.props.children(this.state.transformedData, uuid.v4())
+  }
+
+  public componentDidMount() {
+    this.isComponentMounted = true
+    this.transformData()
+  }
+
+  public componentWillUnmount() {
+    this.isComponentMounted = false
+  }
+
+  public componentDidUpdate(prevProps: Props) {
+    if (prevProps.uuid !== this.props.uuid) {
+      this.transformData()
+    }
+  }
+
+  private async transformData() {
+    const {dataType, data} = this.props
+
+    if (dataType === DataType.influxQL) {
+      try {
+        const influxQLData = await timeSeriesToTableGraph(
+          data as TimeSeriesServerResponse[]
+        )
+
+        if (!this.isComponentMounted) {
+          return
+        }
+
+        this.setState({transformedData: influxQLData, invalidDataError: null})
+      } catch (err) {
+        let invalidDataError: ErrorTypes
+        switch (err.toString()) {
+          case 'Error: Cannot display meta and data query':
+            invalidDataError = ErrorTypes.MetaQueryCombo
+            break
+          default:
+            invalidDataError = ErrorTypes.GeneralError
+            break
+        }
+
+        if (!this.isComponentMounted) {
+          return
+        }
+        this.setState({invalidDataError})
+      }
+
+      return
+    }
+
+    const resultData = (data as FluxTable).data
+    const sortedLabels = _.get(resultData, '0', []).map(label => ({
+      label,
+      seriesIndex: 0,
+      responseIndex: 0,
+    }))
+
+    const fluxData = {data: resultData, sortedLabels} as {
+      data: TimeSeriesValue[][]
+      sortedLabels: Label[]
+      influxQLQueryType: null
+    }
+
+    if (!this.isComponentMounted) {
+      return
+    }
+
+    this.setState({transformedData: fluxData})
+  }
+}
+
+export default TableGraphTransform


### PR DESCRIPTION
Connects https://github.com/influxdata/applications-team-issues/issues/102

_What was the problem?_
Because time range getting updated caused a change in data, the async data transformations and the async transformations based on table visualization props were called. This was causing a race conditions so the previous data was getting set.
_What was the solution?_
Extract functionality from table graphs into different functions. Keep track of the requests and only update state with the most recent request's result. 

  - [x] Rebased/mergeable
  - [x] Tests pass
