### PR TITLE
Encode github issue url

### DIFF
--- a/ui/src/shared/decorators/errors.tsx
+++ b/ui/src/shared/decorators/errors.tsx
@@ -15,7 +15,9 @@ class DefaultError extends Component<{error: Error}> {
     const {stack, message} = error
     const finalMessage = ` Chronograf (${VERSION}) ${message}`
     const finalStack = '```' + stack + '```'
-    const href = `https://github.com/influxdata/chronograf/issues/new?title=${finalMessage}&body=${finalStack}`
+    const href = encodeURI(
+      `https://github.com/influxdata/chronograf/issues/new?title=${finalMessage}&body=${finalStack}`
+    )
 
     return (
       <p className="unexpected-error">


### PR DESCRIPTION
Github issues link was not encoded, so in some cases chrome would not allow you to go to the url.

  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)