### PR TITLE
Fix changing threshold type

### DIFF
--- a/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
@@ -87,8 +87,6 @@ const TimeMachineVisualization: SFC<Props> = props => {
             fieldOptions={props.fieldOptions}
             timeFormat={props.timeFormat}
             decimalPlaces={props.decimalPlaces}
-            thresholdsListColors={props.thresholdsListColors}
-            thresholdsListType={props.thresholdsListType}
             gaugeColors={props.gaugeColors}
             lineColors={props.lineColors}
             cellNote={props.note}

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -251,7 +251,11 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
   public handleUpdateThresholdsListType = (
     thresholdsListType: ThresholdType
   ) => {
-    return this.setAndPersistState({thresholdsListType})
+    const thresholdsListColors = this.state.thresholdsListColors.map(color => ({
+      ...color,
+      type: thresholdsListType,
+    }))
+    return this.setAndPersistState({thresholdsListType, thresholdsListColors})
   }
 
   public handleUpdateGaugeColors = (gaugeColors: ColorNumber[]) => {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/114

_What was the problem?_
The threshold type was getting updated, but not used by the threshold colors

_What was the solution?_
Update the thresholds list colors when updating threshold type

  - [x] Rebased/mergeable
  - [x] Tests pass
