### PR TITLE
Make loading dots visible on graphs in ceo and de

### DIFF
--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -480,7 +480,7 @@ $dash-graph--heading-name-z: $dash-graph--heading-dragger-z + 1;
 
 .graph-panel__refreshing {
   position: absolute;
-  top: -18px !important;
+  top: -1px !important;
   transform: translate(0, 0);
   right: 50%;
   transform: translateX(50%);


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/133

_What was the problem?_
The loading state was not visible in the ceo and de since the dots were not being rendered in the correct location.
_What was the solution?_
Fix location of loading dots inthe de and ceo.

  - [x] Tests pass
  - [x] Rebased/mergeable
