### PR TITLE
Replace toggleFlux with on/off functions

### DIFF
--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -18,7 +18,8 @@ interface Props {
   sourceSupportsFlux: boolean
   queries: QueriesModels.QueryConfig[]
   isDynamicSourceSelected: boolean
-  toggleFlux: () => void
+  toggleFluxOn: () => void
+  toggleFluxOff: () => void
   onSelectDynamicSource: () => void
   onChangeSource: (source: SourcesModels.Source, type: QueryType) => void
 }
@@ -27,7 +28,8 @@ const SourceSelector: SFC<Props> = ({
   source,
   sources = [],
   queries,
-  toggleFlux,
+  toggleFluxOn,
+  toggleFluxOff,
   isFluxSelected,
   onChangeSource,
   sourceSupportsFlux,
@@ -56,7 +58,7 @@ const SourceSelector: SFC<Props> = ({
           id="flux-source"
           titleText="Flux"
           value="Flux"
-          onClick={toggleFlux}
+          onClick={toggleFluxOn}
           active={isFluxSelected}
           disabled={!sourceSupportsFlux}
         >
@@ -66,7 +68,7 @@ const SourceSelector: SFC<Props> = ({
           id="influxql-source"
           titleText="InfluxQL"
           value="InfluxQL"
-          onClick={toggleFlux}
+          onClick={toggleFluxOff}
           active={!isFluxSelected}
           disabled={!sourceSupportsFlux}
         >

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -157,7 +157,8 @@ class TimeMachine extends PureComponent<Props, State> {
           queries={this.queriesWorkingDraft}
           templates={templates}
           source={this.source}
-          toggleFlux={this.toggleFlux}
+          toggleFluxOn={this.toggleFluxOn}
+          toggleFluxOff={this.toggleFluxOff}
           sources={this.formattedSources}
           isFluxSelected={this.isFluxSelected}
           isViewingRawData={isViewingRawData}
@@ -520,13 +521,20 @@ class TimeMachine extends PureComponent<Props, State> {
     this.setState({isViewingRawData: !this.state.isViewingRawData})
   }
 
-  private toggleFlux = (): void => {
-    const newQueryType = this.isFluxSelected
-      ? QueryType.InfluxQL
-      : QueryType.Flux
-    const source = this.useDynamicSource ? null : this.source
+  private toggleFluxOn = (): void => {
+    if (!this.isFluxSelected) {
+      const newQueryType = QueryType.Flux
+      const source = this.useDynamicSource ? null : this.source
+      this.updateQueryDraftsSource(source, newQueryType)
+    }
+  }
 
-    this.updateQueryDraftsSource(source, newQueryType)
+  private toggleFluxOff = (): void => {
+    if (this.isFluxSelected) {
+      const newQueryType = QueryType.InfluxQL
+      const source = this.useDynamicSource ? null : this.source
+      this.updateQueryDraftsSource(source, newQueryType)
+    }
   }
 }
 

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -32,7 +32,8 @@ interface Props {
   onSelectDynamicSource: () => void
   timeRange: QueriesModels.TimeRange
   updateEditorTimeRange: (timeRange: QueriesModels.TimeRange) => void
-  toggleFlux: () => void
+  toggleFluxOn: () => void
+  toggleFluxOff: () => void
   toggleIsViewingRawData: () => void
 }
 
@@ -43,7 +44,8 @@ const TimeMachineControls: SFC<Props> = ({
   queries,
   templates,
   timeRange,
-  toggleFlux,
+  toggleFluxOn,
+  toggleFluxOff,
   isFluxSelected,
   isViewingRawData,
   autoRefreshDuration,
@@ -61,7 +63,8 @@ const TimeMachineControls: SFC<Props> = ({
         source={source}
         sources={sources}
         queries={queries}
-        toggleFlux={toggleFlux}
+        toggleFluxOn={toggleFluxOn}
+        toggleFluxOff={toggleFluxOff}
         sourceSupportsFlux={sourceSupportsFlux}
         isFluxSelected={isFluxSelected}
         onChangeSource={onChangeSource}


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/135

_What was the problem?_
Currently, clicking on the radio button to toggle Flux on or off would switch the language even if you clicked on the one that was already selected.

_What was the solution?_
Replace the toggle function with two separate function: one to turn Flux on, one to turn it off.

  - [x] Rebased/mergeable
  - [x] Tests pass