### PR TITLE
Fix React 'key' warning in SendToDashboard overlay

### DIFF
--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -168,7 +168,9 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       </MultiSelectDropdown.Item>
     )
 
-    const divider = <MultiSelectDropdown.Divider id={'divider'} />
+    const divider = (
+      <MultiSelectDropdown.Divider key={'divider'} id={'divider'} />
+    )
 
     return [newDashboardItem, divider, ...items]
   }


### PR DESCRIPTION
Closes #4548

_What was the problem?_
One of the items in the dashboard dropdown menu in the `SendToDashboard` overlay was missing a key prop, causing React to throw the error "each child in an array or iterator should have a unique 'key' prop.:"

_What was the solution?_
Add a key prop to the 'divider' item in the dropdown.

  - [x] Rebased/mergeable
  - [x] Tests pass