### PR TITLE
Change cell sent notification duration to default (5 seconds)

### DIFF
--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -541,7 +541,6 @@ export const notifyCellSent = (
   return {
     ...defaultSuccessNotification,
     icon: 'dash-h',
-    duration: 1900,
     message: `Added "${cellName}" to ${dashboardNum} dashboard${pluralizer}.`,
   }
 }
@@ -553,7 +552,6 @@ export const notifyCellSendFailed = (
   return {
     ...defaultErrorNotification,
     icon: 'dash-h',
-    duration: 1900,
     message: `Could not add "${cellName}" to ${dashboardName}.`,
   }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/136

_What was the problem?_
The notification for a cell being sent to a dashboard from the Data Explorer (or an unsuccessful attempt to do so) was too short.

_What was the solution?_
Set the notification duration to the default time for success and error notifications. 

  - [x] Rebased/mergeable
  - [x] Tests pass