### PR TITLE
Switch order of cell name and target dashboard in send to dashboard

### DIFF
--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -106,13 +106,6 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
         <OverlayHeading title="Send to Dashboard" onDismiss={onCancel} />
         <OverlayBody>
           <Form>
-            <Form.Element label="Cell Name">
-              <Input
-                value={name}
-                onChange={this.handleChangeName}
-                placeholder={'Name this new cell'}
-              />
-            </Form.Element>
             <Form.Element label="Target Dashboard(s)">
               <MultiSelectDropdown
                 onChange={this.handleSelect}
@@ -121,6 +114,13 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
               >
                 {this.dropdownItems}
               </MultiSelectDropdown>
+            </Form.Element>
+            <Form.Element label="Cell Name">
+              <Input
+                value={name}
+                onChange={this.handleChangeName}
+                placeholder={'Name this new cell'}
+              />
             </Form.Element>
             <Form.Footer>
               <Button


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/144

_What was the problem?_
When sending a cell to a dashboard from the Data Explorer, users want to select the dashboard(s) before naming the cell. However, the "name cell" field was above the "target dashboards" field.

_What was the solution?_
Switch the order of the "name cell" and "target dashboards" fields for a smoother user experience. 

  - [x] Rebased/mergeable
  - [x] Tests pass