### PR TITLE
Create field to name new dashboard from DE

### DIFF
--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -304,14 +304,18 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
     let selectedDashboards = this.selectedDashboards
 
     if (this.isNewDashboardSelected) {
-      const {data} =
-        newDashboardName === ''
-          ? await createDashboard(NEW_EMPTY_DASHBOARD)
-          : await createDashboard({
-              ...NEW_EMPTY_DASHBOARD,
-              name: newDashboardName,
-            })
-      const newDashboard: Dashboard = data
+      let result
+
+      if (newDashboardName === '') {
+        result = await createDashboard(NEW_EMPTY_DASHBOARD)
+      } else {
+        result = await createDashboard({
+          ...NEW_EMPTY_DASHBOARD,
+          name: newDashboardName,
+        })
+      }
+
+      const newDashboard: Dashboard = result.data
       selectedDashboards = [...selectedDashboards, newDashboard]
     }
 


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/145

_What was the problem?_
When sending a cell to a new dashboard from the Data Explorer, there was no way for the user to name this new dashboard. 

_What was the solution?_
Add a field to name the new dashboard if the user selects "send to new dashboard."

  - [x] Rebased/mergeable
  - [x] Tests pass