### PR TITLE
Remove notification for failing to fetch JSON feed

### DIFF
--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -230,11 +230,6 @@ export const notifyCurrentOrgDeleted = (): Notification => ({
   message: 'Your current organization was deleted.',
 })
 
-export const notifyJSONFeedFailed = (url: string): Notification => ({
-  ...defaultErrorNotification,
-  message: `Failed to fetch JSON Feed for News Feed from '${url}'`,
-})
-
 //  Chronograf Admin Notifications
 //  ----------------------------------------------------------------------------
 export const notifyMappingDeleted = (

--- a/ui/src/status/actions/index.ts
+++ b/ui/src/status/actions/index.ts
@@ -4,9 +4,6 @@ import {Dispatch} from 'redux'
 
 import {fetchJSONFeed as fetchJSONFeedAJAX} from 'src/status/apis'
 
-import {notify} from 'src/shared/actions/notifications'
-import {notifyJSONFeedFailed} from 'src/shared/copy/notifications'
-
 import {JSONFeedData} from 'src/types'
 
 export enum ActionTypes {
@@ -72,6 +69,5 @@ export const fetchJSONFeedAsync = (url: string) => async (
   } catch (error) {
     console.error(error)
     dispatch(fetchJSONFeedFailed())
-    dispatch(notify(notifyJSONFeedFailed(url)))
   }
 }


### PR DESCRIPTION
Closes: https://github.com/influxdata/chronograf/issues/4579

_What was the problem?_
Previously, a notification popup would be shown if the news feed on the status page failed to load.

_What was the solution?_
Remove the notification.

  - [x] Rebased/mergeable
  - [x] Tests pass