### PR TITLE
Fix missing selected state in TimeMachineTables

### DIFF
--- a/ui/src/flux/components/TableSidebar.tsx
+++ b/ui/src/flux/components/TableSidebar.tsx
@@ -8,7 +8,7 @@ import TableSidebarItem from 'src/flux/components/TableSidebarItem'
 
 interface Props {
   data: FluxTable[]
-  selectedResultID: string
+  selectedResultName: string
   onSelectResult: (id: string) => void
 }
 
@@ -27,7 +27,7 @@ export default class TableSidebar extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {selectedResultID, onSelectResult} = this.props
+    const {selectedResultName, onSelectResult} = this.props
     const {searchTerm} = this.state
 
     return (
@@ -53,7 +53,7 @@ export default class TableSidebar extends PureComponent<Props, State> {
                   name={name}
                   groupKey={groupKey}
                   onSelect={onSelectResult}
-                  isSelected={id === selectedResultID}
+                  isSelected={name === selectedResultName}
                 />
               )
             })}

--- a/ui/src/flux/components/TimeMachineTables.tsx
+++ b/ui/src/flux/components/TimeMachineTables.tsx
@@ -35,7 +35,7 @@ interface Props {
 }
 
 interface State {
-  selectedResultID: string | null
+  selectedResultName: string | null
 }
 
 const filterTables = (tables: FluxTable[]): FluxTable[] => {
@@ -63,13 +63,13 @@ class TimeMachineTables extends PureComponent<Props, State> {
     super(props)
 
     this.state = {
-      selectedResultID: this.defaultResultId,
+      selectedResultName: this.defaultResultName,
     }
   }
 
   public componentDidUpdate() {
     if (!this.selectedResult) {
-      this.setState({selectedResultID: this.defaultResultId})
+      this.setState({selectedResultName: this.defaultResultName})
     }
   }
 
@@ -90,7 +90,7 @@ class TimeMachineTables extends PureComponent<Props, State> {
         {this.showSidebar && (
           <TableSidebar
             data={this.props.data}
-            selectedResultID={this.state.selectedResultID}
+            selectedResultName={this.state.selectedResultName}
             onSelectResult={this.handleSelectResult}
           />
         )}
@@ -156,8 +156,8 @@ class TimeMachineTables extends PureComponent<Props, State> {
     return fieldOptions
   }
 
-  private handleSelectResult = (selectedResultID: string): void => {
-    this.setState({selectedResultID})
+  private handleSelectResult = (selectedResultName: string): void => {
+    this.setState({selectedResultName})
   }
 
   private get showSidebar(): boolean {
@@ -172,7 +172,7 @@ class TimeMachineTables extends PureComponent<Props, State> {
     return !!this.props.data && !!this.selectedResult
   }
 
-  private get defaultResultId() {
+  private get defaultResultName() {
     const {data} = this.props
 
     if (data.length && !!data[0]) {
@@ -185,7 +185,7 @@ class TimeMachineTables extends PureComponent<Props, State> {
   private get selectedResult(): FluxTable {
     const filteredTables = this.filteredTablesMemoized(this.props.data)
     const table = filteredTables.find(
-      d => d.name === this.state.selectedResultID
+      d => d.name === this.state.selectedResultName
     )
 
     return table


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/132

A little while back we switched to using a `FluxTable`'s `name` as an identifier in `TimeMachineTables`. We never updated some state keys to reflect this, which was confusing and likely resulted in the aforementioned bug. 

This PR fixes the bug and changes the state keys to reflect that a table's `name` is being stored, rather than it's `id`.