### PR TITLE
Fix logs search race

### DIFF
--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -350,7 +350,7 @@ class LogsPage extends Component<Props, State> {
 
     if (this.props.nextNewerLowerBound > maxNewerFetchForward) {
       this.props.setNextNewerLowerBound(Date.now())
-      this.currentNewerChunksGenerator.cancel()
+      await this.currentNewerChunksGenerator.cancelAsync()
     }
 
     await this.props.fetchNewerChunkAsync()
@@ -457,7 +457,7 @@ class LogsPage extends Component<Props, State> {
     const cancelPendingChunks = _.compact([
       this.currentNewerChunksGenerator,
       this.currentOlderChunksGenerator,
-    ]).map(req => req.cancel())
+    ]).map(req => req.cancelAsync())
 
     await Promise.all(cancelPendingChunks)
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -422,9 +422,6 @@ class LogsPage extends Component<Props, State> {
       console.error(error)
     }
 
-    if (!this.currentNewerChunksGenerator.isCanceled) {
-      this.currentNewerChunksGenerator.cancel()
-    }
     this.loadingNewer = false
     this.currentNewerChunksGenerator = null
   }
@@ -446,10 +443,6 @@ class LogsPage extends Component<Props, State> {
       console.error(error)
     }
 
-    if (!this.currentOlderChunksGenerator.isCanceled) {
-      this.currentOlderChunksGenerator.cancel()
-    }
-
     this.currentOlderChunksGenerator = null
   }
 
@@ -460,16 +453,16 @@ class LogsPage extends Component<Props, State> {
     }
   }
 
-  private cancelChunks() {
-    if (this.currentNewerChunksGenerator) {
-      this.currentNewerChunksGenerator.cancel()
-      this.currentNewerChunksGenerator = null
-    }
+  private cancelChunks = async () => {
+    const cancelPendingChunks = _.compact([
+      this.currentNewerChunksGenerator,
+      this.currentOlderChunksGenerator,
+    ]).map(req => req.cancel())
 
-    if (this.currentOlderChunksGenerator) {
-      this.currentOlderChunksGenerator.cancel()
-      this.currentOlderChunksGenerator = null
-    }
+    await Promise.all(cancelPendingChunks)
+
+    this.currentNewerChunksGenerator = null
+    this.currentOlderChunksGenerator = null
   }
 
   private get tableScrollToRow() {
@@ -858,9 +851,9 @@ class LogsPage extends Component<Props, State> {
     this.updateTableData(SearchStatus.UpdatingNamespace)
   }
 
-  private updateTableData(searchStatus: SearchStatus) {
+  private updateTableData = async (searchStatus: SearchStatus) => {
     this.clearTailInterval()
-    this.cancelChunks()
+    await this.cancelChunks()
     this.props.clearSearchData(searchStatus)
   }
 

--- a/ui/src/logs/utils/fetchUntil.ts
+++ b/ui/src/logs/utils/fetchUntil.ts
@@ -11,13 +11,13 @@ export function fetchUntil<T>(
   const requests = fetchUnless(() => isCanceled || predicate(), request)
 
   const promise = fetchEachAsync(requests)
-  const cancel = async () => {
+  const cancelAsync = async () => {
     isCanceled = true
     await promise
   }
   return {
     promise,
-    cancel,
+    cancelAsync,
     isCanceled,
   }
 }

--- a/ui/src/logs/utils/fetchUntil.ts
+++ b/ui/src/logs/utils/fetchUntil.ts
@@ -11,12 +11,13 @@ export function fetchUntil<T>(
   const requests = fetchUnless(() => isCanceled || predicate(), request)
 
   const promise = fetchEachAsync(requests)
-
+  const cancel = async () => {
+    isCanceled = true
+    await promise
+  }
   return {
     promise,
-    cancel() {
-      isCanceled = true
-    },
+    cancel,
     isCanceled,
   }
 }

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -203,6 +203,6 @@ export interface MatchSection {
 
 export interface FetchLoop {
   promise: Promise<void>
-  cancel: () => void
+  cancelAsync: () => Promise<void>
   isCanceled: boolean
 }


### PR DESCRIPTION
Closes influxdata/applications-team-issues#163

_Briefly describe your proposed changes:_
Fixes a race condition where a previously canceled searches data may be appended to the next search results
_What was the problem?_
Log viewer was appending stale results from a previous search because a chunk of stale search results from a previous search were not being awaited after they were canceled.
_What was the solution?_
Cancel the previous search and await the completion of the request before clearing the table and fetching new results.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass