### PR TITLE
Display data without _time column as graph

### DIFF
--- a/ui/src/shared/parsing/flux/parseTablesByTime.ts
+++ b/ui/src/shared/parsing/flux/parseTablesByTime.ts
@@ -56,17 +56,26 @@ export const parseTablesByTime = (
       allColumnNames.push(uniqueColumnName)
     }
 
-    const timeIndex = header.indexOf('_time')
+    let timeIndex = header.indexOf('_time')
 
+    let isTimeFound = true
     if (timeIndex < 0) {
-      throw new Error('Could not find time index in FluxTable')
+      timeIndex = header.indexOf('_stop')
+      isTimeFound = false
     }
 
     const result = {}
     for (let i = 1; i < table.data.length; i++) {
       const row = table.data[i]
-      const time = row[timeIndex].toString()
+      const timeValue = row[timeIndex]
+      let time = ''
 
+      if (isTimeFound) {
+        time = timeValue.toString()
+      } else {
+        // _stop and _start have values in date string format instead of number
+        time = Date.parse(timeValue as string).toString()
+      }
       result[time] = Object.entries(columnNames).reduce(
         (acc, [valueIndex, columnName]) => ({
           ...acc,


### PR DESCRIPTION
Connects https://github.com/influxdata/applications-team-issues/issues/156

_What was the problem?_
When using a query with aggregates, the _time column is left off and graphs dont know how to parse it so they display 'Cannot visualize data with this graph type'

_What was the solution?_
If there is not _time, use _stop as the time field


  - [x] Rebased/mergeable
  - [x] Tests pass
