### PR TITLE
Fix logs vertical scroll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 1.  [#4466](https://github.com/influxdata/chronograf/pull/4466): Maintain focus on Flux Editor text area when adding nodes via code
 1.  [#4479](https://github.com/influxdata/chronograf/pull/4479): Add validation to Alert Rule messages
 1.  [#4599](https://github.com/influxdata/chronograf/pull/4599): Fix search results updating race condition
+1.  [#4605](https://github.com/influxdata/chronograf/pull/4605): Fix vertical stuck vertical scroll in firefox
 
 ## v1.6.2 [2018-09-06]
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -854,6 +854,7 @@ class LogsPage extends Component<Props, State> {
   private updateTableData = async (searchStatus: SearchStatus) => {
     this.clearTailInterval()
     await this.cancelChunks()
+    this.setState({hasScrolled: false, liveUpdating: this.shouldLiveUpdate})
     this.props.clearSearchData(searchStatus)
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -466,7 +466,7 @@ class LogsPage extends Component<Props, State> {
   }
 
   private get tableScrollToRow() {
-    if (this.isLiveUpdating === true) {
+    if (this.isLiveUpdating === true && !this.state.hasScrolled) {
       return 0
     }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/162

_Briefly describe your proposed changes:_
Fix scroll to first row when live updating in logs table and in firefox
_What was the problem?_
In firefox scroll positioning is async to create smoother scrolling, but this created a race where rendering and updating the scroll position got stuck at scrollTop `0` in the logs table.
_What was the solution?_
Use `hasScrolled` to attempt to guard against the race in scrollTop position rendering and scroll firing. This allows logs to scroll, but still appears to stick a bit at the top on the first scroll. Note: firefox will continue to warn about this in the console with the following message:

```
This site appears to use a scroll-linked positioning effect. This may not work well with asynchronous 
panning; see https://developer.mozilla.org/docs/Mozilla/Performance/ScrollLinkedEffects for further
details and to join the discussion on related tools and features!
``` 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass