### PR TITLE
Fix TimeSeries uuid race condition

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -118,7 +118,6 @@ class CellEditorOverlay extends Component<Props, State> {
       editQueryStatus,
       fluxLinks,
       notify,
-      onCancel,
       source,
       sources,
       templates,
@@ -153,7 +152,7 @@ class CellEditorOverlay extends Component<Props, State> {
               title={_.get(cell, 'name', '')}
               renameCell={this.handleRenameCell}
               onSave={this.handleSaveCell}
-              onCancel={onCancel}
+              onCancel={this.handleCancel}
               activeEditorTab={activeEditorTab}
               onSetActiveEditorTab={onSetActiveEditorTab}
               isSaveable={this.isSaveable}
@@ -263,10 +262,18 @@ class CellEditorOverlay extends Component<Props, State> {
   }
 
   private handleSaveCell = () => {
-    const {onSave} = this.props
+    const {onSave, onResetTimeMachine} = this.props
     const cell = this.collectCell()
 
     onSave(cell)
+    onResetTimeMachine()
+  }
+
+  private handleCancel = () => {
+    const {onCancel, onResetTimeMachine} = this.props
+
+    onCancel()
+    onResetTimeMachine()
   }
 
   private handleKeyDown = e => {

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -16,6 +16,38 @@ interface Query {
   rp?: string
 }
 
+interface QueryResult {
+  value: TimeSeriesResponse | null
+  error: any | null
+}
+
+export function executeQueries(
+  source: Source,
+  queries: Query[],
+  templates: Template[],
+  resolution?: number,
+  uuid?: string
+): Promise<QueryResult[]> {
+  return new Promise(resolve => {
+    const results = []
+
+    let counter = queries.length
+
+    for (let i = 0; i < queries.length; i++) {
+      executeQuery(source, queries[i], templates, resolution, uuid)
+        .then(result => (results[i] = {value: result, error: null}))
+        .catch(result => (results[i] = {value: null, error: result}))
+        .then(() => {
+          counter -= 1
+
+          if (counter === 0) {
+            resolve(results)
+          }
+        })
+    }
+  })
+}
+
 export const executeQuery = async (
   source: Source,
   query: Query,


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/166

_Briefly describe your proposed changes:_
Updates the TimeSeries component to not rely on storing/updating the latestUUID in state related to a request, and wraps API calls using `restartable` to ensure we always get the latest response.

_What was the problem?_
Storing and updating state containing the latestUUID before fetching data lead to a race condition. Subsequent state updates could cause rendering that caused the latestUUID to be paired with stale data .

_What was the solution?_
Use restartable to wrap requests.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass

----

- [x] Verify cpu usage is not high