### PR TITLE
Update refreshing graph to not show error when there's no script

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -133,7 +133,11 @@ class RefreshingGraph extends Component<Props> {
       grabDataForDownload,
     } = this.props
 
-    if (!queries.length) {
+    const isEmptyFluxQuery =
+      _.get(queries, '0.type', '') === 'flux' &&
+      !_.get(queries, '0.text', '').trim()
+
+    if (!queries.length || isEmptyFluxQuery) {
       return (
         <div className="graph-empty">
           <p data-test="data-explorer-no-results">{emptyGraphCopy}</p>
@@ -182,7 +186,7 @@ class RefreshingGraph extends Component<Props> {
                 })
 
               if (!hasValues) {
-                if (errorMessage) {
+                if (errorMessage && _.get(queries, '0.text', '').trim()) {
                   return <InvalidData message={errorMessage} />
                 }
                 if (cellNoteVisibility === NoteVisibility.ShowWhenNoData) {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/181

_Briefly describe your proposed changes:_
_What was the problem?_
After adding in showing errors instead of just showing no results, flux queries show an error when there is no script since that is technically not a valid query.

_What was the solution?_
If there is no script for flux, then show the text for creating new queries instead of showing the error.

  - [x] Rebased/mergeable
  - [x] Tests pass