### PR TITLE
Show item labels in the Flux explorer always, not just on hover

### DIFF
--- a/ui/src/style/components/time-machine/flux-explorer.scss
+++ b/ui/src/style/components/time-machine/flux-explorer.scss
@@ -259,11 +259,8 @@ $flux-tree-gutter: 11px;
   color: $g11-sidewalk;
   display: inline-block;
   margin-left: 8px;
-  opacity: 0;
-  transition: opacity 0.25s ease;
-  .flux-schema--item:hover & {
-    opacity: 1;
-  }
+  opacity: .7;
+  font-style: italic;
 }
 
 .flux-schema--header {


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/138

_What was the problem?_
Previously, the user would have to hover on an item in the Flux explorer to see its type (bucket, tag key, etc.)

_What was the solution?_
Change the style of the item label to be visible at all times, and also make it italic and more transparent as shown here:

<img width="397" alt="screen shot 2018-10-22 at 11 42 29 am" src="https://user-images.githubusercontent.com/15273162/47311993-03f42780-d5f0-11e8-8391-68275e8d8272.png">


  - [x] Rebased/mergeable
  - [ ] Tests pass