### PR TITLE
Fix logs expansion handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 1.  [#4599](https://github.com/influxdata/chronograf/pull/4599): Fix search results updating race condition
 1.  [#4605](https://github.com/influxdata/chronograf/pull/4605): Fix vertical stuck vertical scroll in firefox
 1.  [#4612](https://github.com/influxdata/chronograf/pull/4612): Fix issue with disappearing alias'
+1.  [#4621](https://github.com/influxdata/chronograf/pull/4621): Fix log viewer message expansion
 
 ## v1.6.2 [2018-09-06]
 

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.scss
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.scss
@@ -32,6 +32,10 @@
   transform: translate(-$ix-border, -$ix-border);
   font-size: 12px;
   font-family: $code-font;
+
+  &.message-wrap {
+    word-break: break-all
+  }
 }
 
 .expanded--dismiss {

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -82,7 +82,7 @@ export class ExpandableMessage extends Component<Props, State> {
 
     const message = (
       <ClickOutside onClickOutside={this.handleClickOutside}>
-        <div className="expanded--message" style={style}>
+        <div className="expanded--message message-wrap" style={style}>
           {this.closeExpansionButton}
           {this.message}
         </div>

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -315,7 +315,7 @@ class LogsPage extends Component<Props, State> {
   }
 
   private handleExpandMessage = () => {
-    this.setState({liveUpdating: false})
+    this.handleVerticalScroll()
   }
 
   private startLogsTailFetchingInterval = () => {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/182 https://github.com/influxdata/chronograf/issues/4610

_Briefly describe your proposed changes:_
Pauses live updating on click and wraps messages in popover.
_What was the problem?_
Expanding a message did not include the message wrapping used for wrapped log messages. 
Clicking a message also did not pause the logs, allowing new logs to load, and then close a log message being viewed.
_What was the solution?_
Add a `.message-wrap` that reflects the wrapping used for untruncated log lines. 
Clear the tailing interval and update scroll/liveUpdating state on message click.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass