### PR TITLE
Update Flux query endpoint

### DIFF
--- a/ui/src/flux/apis/index.ts
+++ b/ui/src/flux/apis/index.ts
@@ -64,7 +64,7 @@ export const getRawTimeSeries = async (
   fluxASTLink: string,
   maxSideLength: number
 ): Promise<GetRawTimeSeriesResult> => {
-  const path = encodeURIComponent(`/v2/query?organization=defaultorgname`)
+  const path = encodeURIComponent(`/api/v2/query?organization=defaultorgname`)
   const url = `${window.basepath}${source.links.flux}?path=${path}`
 
   const renderedScript = await renderTemplatesInScript(

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -138,7 +138,7 @@ const proxy = async (source: Source, script: string) => {
       method: 'POST',
       url: `${
         source.links.flux
-      }?path=/v2/query${mark}organization=defaultorgname`,
+      }?path=/api/v2/query${mark}organization=defaultorgname`,
       data,
       headers: {'Content-Type': 'application/json'},
     })


### PR DESCRIPTION
The end point for querying via Flux has changed from `/v2/query` to `/api/v2/query`.