### PR TITLE
Change regex for static legend label to include up to first period

### DIFF
--- a/ui/src/shared/graphs/helpers.test.ts
+++ b/ui/src/shared/graphs/helpers.test.ts
@@ -1,0 +1,19 @@
+import {removeMeasurement} from 'src/shared/graphs/helpers'
+
+describe('removeMeasurement', () => {
+  it('removes the measurement string from a simple label', () => {
+    const label = 'cpu.mean_usage_system'
+    const expected = 'mean_usage_system'
+    const actual = removeMeasurement(label)
+
+    expect(actual).toBe(expected)
+  })
+
+  it('removes the measurement string from a label with a period', () => {
+    const label = 'ping.average[url=www.google.com]'
+    const expected = 'average[url=www.google.com]'
+    const actual = removeMeasurement(label)
+
+    expect(actual).toBe(expected)
+  })
+})

--- a/ui/src/shared/graphs/helpers.ts
+++ b/ui/src/shared/graphs/helpers.ts
@@ -167,9 +167,9 @@ export const makeLegendStyles = (
   }
 }
 
-// globally matches anything that ends in a '.'
+// matches everything up to the first '.'
 export const removeMeasurement = (label = '') => {
-  const [measurement] = label.match(/^(.*)[.]/g) || ['']
+  const [measurement] = label.match(/^([^.])+./g) || ['']
   return label.replace(measurement, '')
 }
 


### PR DESCRIPTION
Closes: https://github.com/influxdata/chronograf/issues/4614

_What was the problem?_
Previously, the label for static legends would cut off everything until the last period in the label name. So if you had a label with a period in it, such as a url, it would only display the last few characters.

_What was the solution?_
Change the regex used to strip the measurement from the label to capture everything up until the first period, rather than everything before the last period.

  - [x] Rebased/mergeable
  - [x] Tests pass