### PR TITLE
Fix logs scrollbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 1.  [#4605](https://github.com/influxdata/chronograf/pull/4605): Fix vertical stuck vertical scroll in firefox
 1.  [#4612](https://github.com/influxdata/chronograf/pull/4612): Fix issue with disappearing alias'
 1.  [#4621](https://github.com/influxdata/chronograf/pull/4621): Fix log viewer message expansion
+1.  [#4640](https://github.com/influxdata/chronograf/pull/4640): Fix missing horizontal scrollbar
 
 ## v1.6.2 [2018-09-06]
 

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -25,6 +25,7 @@ import {
   getColumnWidth,
   getMessageWidth,
   getColumnsFromData,
+  getMinTableWidth,
 } from 'src/logs/utils/table'
 import {
   getValidMessageFilters,
@@ -255,7 +256,7 @@ class LogsTable extends Component<Props, State> {
                 >
                   <Grid
                     {...this.gridProperties(
-                      width,
+                      Math.max(this.minTableWidth, width),
                       height,
                       onRowsRendered,
                       columnCount,
@@ -284,7 +285,7 @@ class LogsTable extends Component<Props, State> {
     registerChild: (g: Grid) => void
   ) => {
     const {scrollToRow} = this.props
-    const {scrollLeft, scrollTop} = this.state
+    const {scrollTop, scrollLeft} = this.state
 
     let rowHeight: number | RowHeightHandler = ROW_HEIGHT
 
@@ -324,10 +325,11 @@ class LogsTable extends Component<Props, State> {
   private handleScrollbarScroll = (e: MouseEvent<JSX.Element>): void => {
     e.stopPropagation()
     e.preventDefault()
-    const {scrollTop} = e.target as HTMLElement
+    const {scrollTop, scrollLeft} = e.target as HTMLElement
 
     this.handleScroll({
       scrollTop,
+      scrollLeft,
     })
   }
 
@@ -711,6 +713,14 @@ class LogsTable extends Component<Props, State> {
       <div className={className}>
         <h6>Loading more logs...</h6>
       </div>
+    )
+  }
+
+  private get minTableWidth(): number {
+    return getMinTableWidth(
+      this.props.data,
+      this.props.tableColumns,
+      this.props.severityFormat
     )
   }
 }

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -228,11 +228,10 @@ class LogsTable extends Component<Props, State> {
               rowCount={1}
               width={width}
               scrollLeft={this.state.scrollLeft}
-              onScroll={this.handleHeaderScroll}
               cellRenderer={this.headerRenderer}
               columnCount={columnCount}
               columnWidth={this.getColumnWidth}
-              style={{overflowX: 'hidden'}}
+              style={{overflow: 'hidden'}}
             />
           )}
         </AutoSizer>
@@ -264,7 +263,7 @@ class LogsTable extends Component<Props, State> {
                     )}
                     style={{
                       height: this.calculateTotalHeight(),
-                      overflowY: 'hidden',
+                      overflow: 'hidden',
                     }}
                   />
                 </FancyScrollbar>
@@ -415,9 +414,6 @@ class LogsTable extends Component<Props, State> {
       ),
     })
   }
-
-  private handleHeaderScroll = ({scrollLeft}): void =>
-    this.setState({scrollLeft})
 
   private getColumnWidth = ({index}: {index: number}): number => {
     const {severityFormat} = this.props

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -247,7 +247,7 @@ class LogsTable extends Component<Props, State> {
                 <FancyScrollbar
                   style={{
                     width,
-                    height,
+                    height: height - ROW_HEIGHT,
                     marginTop: `${ROW_HEIGHT}px`,
                   }}
                   setScrollTop={this.handleScrollbarScroll}

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -110,13 +110,14 @@ export const calculateMessageHeight = (
   return Math.max(lines, 1) * ROW_HEIGHT + 2
 }
 
-export const getMessageWidth = (
+export const getFixedColumnsTotalWidth = (
   data: TableData,
   tableColumns: LogsTableColumn[],
   severityFormat: SeverityFormat
 ): number => {
   const columns = getColumnsFromData(data)
-  const otherWidth = columns.reduce((acc, col) => {
+
+  return columns.reduce((acc, col) => {
     const colConfig = tableColumns.find(c => c.internalName === col)
     const isColVisible = colConfig && colConfig.visible
     if (col === 'message' || col === 'time' || !isColVisible) {
@@ -130,13 +131,40 @@ export const getMessageWidth = (
 
     return acc + getColumnWidth(columnName)
   }, 0)
+}
+
+export const getMessageWidth = (
+  data: TableData,
+  tableColumns: LogsTableColumn[],
+  severityFormat: SeverityFormat
+): number => {
+  const otherColumnsWidth = getFixedColumnsTotalWidth(
+    data,
+    tableColumns,
+    severityFormat
+  )
 
   const calculatedWidth = Math.max(
-    window.innerWidth - (otherWidth + 180),
+    window.innerWidth - (otherColumnsWidth + 180),
     100 * CHAR_WIDTH
   )
 
   return calculatedWidth - CHAR_WIDTH
+}
+
+const MIN_MESSAGE_WIDTH = 99 * CHAR_WIDTH
+export const getMinTableWidth = (
+  data: TableData,
+  tableColumns: LogsTableColumn[],
+  severityFormat: SeverityFormat
+): number => {
+  const otherColumnsWidth = getFixedColumnsTotalWidth(
+    data,
+    tableColumns,
+    severityFormat
+  )
+
+  return MIN_MESSAGE_WIDTH + otherColumnsWidth
 }
 
 export const applyChangesToTableData = (

--- a/ui/src/shared/components/FancyScrollbar.tsx
+++ b/ui/src/shared/components/FancyScrollbar.tsx
@@ -87,6 +87,7 @@ class FancyScrollbar extends Component<Props & Partial<DefaultProps>> {
         renderThumbHorizontal={this.handleMakeDiv('thumb-h')}
         renderThumbVertical={this.handleMakeDiv('thumb-v')}
         renderView={this.handleMakeDiv('view')}
+        thumbMinSize={30}
       >
         {children}
       </Scrollbars>


### PR DESCRIPTION
Closes #4578

_Briefly describe your proposed changes:_
Set a minimum `Grid` width so `FancyScrollBar` (`react-custom-scrollbar` wrapper) to read the correct inner scroll width of the `Grid` and move the `Grid` bottom up high enough so that it's visible.
_What was the problem?_
The FancyScrollBar was not displaying a correct scrollbar because the react virtualized `Grid` has a virtual width that is unavailable to FancyScrollBar. FancyScrollBar needs some child element that actually has the correct width in order to scroll.
_What was the solution?_
This solution is to just make the Grid render it's full width and pay the penalty of rendering more columns than are visible as we'll only pay this rendering cost on visible rows.

I'll create a follow up issue to continue an investigation into a solution that does not cause us to loose many of the benefits of the virtualized rendering of columns. In that issue I'll outline some better performing solution to investigate.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass