### PR TITLE
Refactor Flux fetching

### DIFF
--- a/ui/src/shared/apis/flux/ast.ts
+++ b/ui/src/shared/apis/flux/ast.ts
@@ -1,0 +1,27 @@
+import AJAX from 'src/utils/ajax'
+
+interface ASTRequest {
+  url: string
+  body: string
+}
+
+export const getAST = async (request: ASTRequest) => {
+  const {url, body} = request
+
+  const {data, status} = await AJAX({
+    method: 'POST',
+    url,
+    data: {body},
+    validateStatus: () => true,
+  })
+
+  if (status !== 200) {
+    throw new Error('Failed to parse query')
+  }
+
+  if (!data.valid) {
+    throw new Error(data.error)
+  }
+
+  return data.ast
+}

--- a/ui/src/shared/apis/flux/query.ts
+++ b/ui/src/shared/apis/flux/query.ts
@@ -1,4 +1,3 @@
-import AJAX from 'src/utils/ajax'
 import {Source, FluxTable, TimeRange} from 'src/types'
 import {
   parseResponse,
@@ -8,45 +7,6 @@ import {MAX_RESPONSE_BYTES} from 'src/flux/constants'
 import {manager} from 'src/worker/JobManager'
 import {renderTemplatesInScript} from 'src/flux/helpers/templates'
 import _ from 'lodash'
-
-export const getSuggestions = async (url: string) => {
-  try {
-    const {data} = await AJAX({
-      url,
-    })
-
-    return data.funcs
-  } catch (error) {
-    console.error('Could not get suggestions', error)
-    throw error
-  }
-}
-
-interface ASTRequest {
-  url: string
-  body: string
-}
-
-export const getAST = async (request: ASTRequest) => {
-  const {url, body} = request
-
-  const {data, status} = await AJAX({
-    method: 'POST',
-    url,
-    data: {body},
-    validateStatus: () => true,
-  })
-
-  if (status !== 200) {
-    throw new Error('Failed to parse query')
-  }
-
-  if (!data.valid) {
-    throw new Error(data.error)
-  }
-
-  return data.ast
-}
 
 export interface GetRawTimeSeriesResult {
   didTruncate: boolean

--- a/ui/src/shared/apis/flux/suggestions.ts
+++ b/ui/src/shared/apis/flux/suggestions.ts
@@ -1,0 +1,14 @@
+import AJAX from 'src/utils/ajax'
+
+export const getSuggestions = async (url: string) => {
+  try {
+    const {data} = await AJAX({
+      url,
+    })
+
+    return data.funcs
+  } catch (error) {
+    console.error('Could not get suggestions', error)
+    throw error
+  }
+}

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -12,7 +12,8 @@ import {Button, ComponentSize, ComponentColor} from 'src/reusable_ui'
 import {HANDLE_VERTICAL} from 'src/shared/constants'
 
 // Utils
-import {getSuggestions, getAST} from 'src/flux/apis'
+import {getSuggestions} from 'src/shared/apis/flux/suggestions'
+import {getAST} from 'src/shared/apis/flux/ast'
 import {restartable} from 'src/shared/utils/restartable'
 import DefaultDebouncer, {Debouncer} from 'src/shared/utils/debouncer'
 import {parseError} from 'src/flux/helpers/scriptBuilder'

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -7,7 +7,7 @@ import {executeQueries} from 'src/shared/apis/query'
 import {
   getTimeSeries as fetchFluxTimeSeries,
   GetTimeSeriesResult,
-} from 'src/flux/apis'
+} from 'src/shared/apis/flux/query'
 
 // Types
 import {

--- a/ui/src/shared/parsing/flux/durations.ts
+++ b/ui/src/shared/parsing/flux/durations.ts
@@ -1,5 +1,5 @@
 import {get, isObject, isArray} from 'lodash'
-import {getAST} from 'src/flux/apis'
+import {getAST} from 'src/shared/apis/flux/ast'
 
 export async function getMinDuration(
   astLink: string,

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -6,20 +6,6 @@ import {FluxTable} from 'src/types'
 
 const GROUP_KEY_EXCLUSIONS = []
 
-export const parseResponseError = (response: string): FluxTable[] => {
-  const data = Papa.parse(response.trim()).data as string[][]
-
-  return [
-    {
-      id: uuid.v4(),
-      name: 'Error',
-      groupKey: {},
-      dataTypes: {},
-      data,
-    },
-  ]
-}
-
 export const parseResponse = (response: string): FluxTable[] => {
   const chunks = parseChunks(response)
   const tables = chunks.reduce(

--- a/ui/src/shared/utils/downloadTimeseriesCSV.ts
+++ b/ui/src/shared/utils/downloadTimeseriesCSV.ts
@@ -1,12 +1,12 @@
 // Libraries
 import moment from 'moment'
 import {unparse} from 'papaparse'
-import uuid from 'uuid'
 
 // Utils
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
 import {executeQuery as executeInfluxQLQuery} from 'src/shared/apis/query'
 import {getRawTimeSeries as executeFluxQuery} from 'src/shared/apis/flux/query'
+import {renderTemplatesInScript} from 'src/flux/helpers/templates'
 
 // Constants
 import {DEFAULT_PIXELS} from 'src/shared/constants'
@@ -36,14 +36,14 @@ export const downloadFluxCSV = async (
   timeRange: TimeRange,
   fluxASTLink: string
 ): Promise<{didTruncate: boolean}> => {
-  const {csv, didTruncate} = await executeFluxQuery(
-    source,
+  const renderedScript = await renderTemplatesInScript(
     script,
-    uuid.v4(),
     timeRange,
     fluxASTLink,
     DEFAULT_PIXELS
   )
+
+  const {csv, didTruncate} = await executeFluxQuery(source, renderedScript)
 
   downloadCSV(csv, csvName())
 

--- a/ui/src/shared/utils/downloadTimeseriesCSV.ts
+++ b/ui/src/shared/utils/downloadTimeseriesCSV.ts
@@ -6,7 +6,7 @@ import uuid from 'uuid'
 // Utils
 import {timeSeriesToTableGraph} from 'src/utils/timeSeriesTransformers'
 import {executeQuery as executeInfluxQLQuery} from 'src/shared/apis/query'
-import {getRawTimeSeries as executeFluxQuery} from 'src/flux/apis/index'
+import {getRawTimeSeries as executeFluxQuery} from 'src/shared/apis/flux/query'
 
 // Constants
 import {DEFAULT_PIXELS} from 'src/shared/constants'

--- a/ui/test/flux/apis/flux.test.ts
+++ b/ui/test/flux/apis/flux.test.ts
@@ -1,4 +1,4 @@
-import {getSuggestions} from 'src/flux/apis'
+import {getSuggestions} from 'src/shared/apis/flux/suggestions'
 import AJAX from 'src/utils/ajax'
 
 jest.mock('src/utils/ajax', () => require('mocks/utils/ajax'))


### PR DESCRIPTION
Just a minor little refactor of Flux fetching in preparation for #4030. Reorganizes the various Flux API utilities and separates the `getTimeSeries` and `getTimeSeriesRaw` utilities from logic to render template variables in Flux scripts.