### PR TITLE
Add logs hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 1.  [#4612](https://github.com/influxdata/chronograf/pull/4612): Fix issue with disappearing alias'
 1.  [#4621](https://github.com/influxdata/chronograf/pull/4621): Fix log viewer message expansion
 1.  [#4640](https://github.com/influxdata/chronograf/pull/4640): Fix missing horizontal scrollbar
+1.  [#4645](https://github.com/influxdata/chronograf/pull/4645): Add hostname to log viewer
 
 ## v1.6.2 [2018-09-06]
 

--- a/bolt/org_config.go
+++ b/bolt/org_config.go
@@ -221,8 +221,18 @@ func newOrganizationConfig(orgID string) chronograf.OrganizationConfig {
 					},
 				},
 				{
-					Name:     "host",
+					Name:     "hostname",
 					Position: 7,
+					Encodings: []chronograf.ColumnEncoding{
+						{
+							Type:  "visibility",
+							Value: "visible",
+						},
+					},
+				},
+				{
+					Name:     "host",
+					Position: 8,
 					Encodings: []chronograf.ColumnEncoding{
 						{
 							Type:  "visibility",

--- a/bolt/org_config_test.go
+++ b/bolt/org_config_test.go
@@ -165,8 +165,18 @@ func TestOrganizationConfig_FindOrCreate(t *testing.T) {
 								},
 							},
 							{
-								Name:     "host",
+								Name:     "hostname",
 								Position: 7,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
+							{
+								Name:     "host",
+								Position: 8,
 								Encodings: []chronograf.ColumnEncoding{
 									{
 										Type:  "visibility",
@@ -322,8 +332,18 @@ func TestOrganizationConfig_FindOrCreate(t *testing.T) {
 								},
 							},
 							{
-								Name:     "host",
+								Name:     "hostname",
 								Position: 7,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
+							{
+								Name:     "host",
+								Position: 8,
 								Encodings: []chronograf.ColumnEncoding{
 									{
 										Type:  "visibility",
@@ -488,6 +508,16 @@ func TestOrganizationConfig_FindOrCreate(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name:     "hostname",
+								Position: 8,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -645,6 +675,16 @@ func TestOrganizationConfig_FindOrCreate(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name:     "hostname",
+								Position: 8,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
 						},
 					},
 				},
@@ -652,37 +692,38 @@ func TestOrganizationConfig_FindOrCreate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		client, err := NewTestClient()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer client.Close()
-
-		s := client.OrganizationConfigStore
-
-		if tt.addFirst {
-			if err := s.Put(context.Background(), tt.wants.organizationConfig); err != nil {
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewTestClient()
+			if err != nil {
 				t.Fatal(err)
 			}
-		}
+			defer client.Close()
 
-		got, err := s.FindOrCreate(context.Background(), tt.args.organizationID)
+			s := client.OrganizationConfigStore
 
-		if (tt.wants.err != nil) != (err != nil) {
-			t.Errorf("%q. OrganizationConfigStore.FindOrCreate() error = %v, wantErr %v", tt.name, err, tt.wants.err)
-			continue
-		}
-		if diff := cmp.Diff(got, tt.wants.organizationConfig); diff != "" {
-			t.Errorf("%q. OrganizationConfigStore.FindOrCreate():\n-got/+want\ndiff %s", tt.name, diff)
-		}
+			if tt.addFirst {
+				if err := s.Put(context.Background(), tt.wants.organizationConfig); err != nil {
+					t.Fatal(err)
+				}
+			}
 
-		d, err := s.Get(context.Background(), tt.args.organizationID)
-		if err != nil {
-			t.Errorf("%q. OrganizationConfigStore.Get(): Failed to retrieve organization config", tt.name)
-		}
-		if diff := cmp.Diff(got, d); diff != "" {
-			t.Errorf("%q. OrganizationConfigStore.Get():\n-got/+want\ndiff %s", tt.name, diff)
-		}
+			got, err := s.FindOrCreate(context.Background(), tt.args.organizationID)
+			if (tt.wants.err != nil) != (err != nil) {
+				t.Errorf("%q. OrganizationConfigStore.FindOrCreate() error = %v, wantErr %v", tt.name, err, tt.wants.err)
+				return
+			}
+			if diff := cmp.Diff(got, tt.wants.organizationConfig); diff != "" {
+				t.Errorf("%q. OrganizationConfigStore.FindOrCreate():\n-got/+want\ndiff %s", tt.name, diff)
+			}
+
+			d, err := s.Get(context.Background(), tt.args.organizationID)
+			if err != nil {
+				t.Errorf("%q. OrganizationConfigStore.Get(): Failed to retrieve organization config", tt.name)
+			}
+			if diff := cmp.Diff(got, d); diff != "" {
+				t.Errorf("%q. OrganizationConfigStore.Get():\n-got/+want\ndiff %s", tt.name, diff)
+			}
+		})
 	}
 }
 
@@ -910,6 +951,16 @@ func TestOrganizationConfig_Put(t *testing.T) {
 									},
 								},
 							},
+							{
+								Name:     "hostname",
+								Position: 8,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
 						},
 					},
 					OrganizationID: "default",
@@ -1011,8 +1062,18 @@ func TestOrganizationConfig_Put(t *testing.T) {
 								},
 							},
 							{
-								Name:     "host",
+								Name:     "hostname",
 								Position: 7,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
+							{
+								Name:     "host",
+								Position: 8,
 								Encodings: []chronograf.ColumnEncoding{
 									{
 										Type:  "visibility",
@@ -1117,8 +1178,18 @@ func TestOrganizationConfig_Put(t *testing.T) {
 								},
 							},
 							{
-								Name:     "host",
+								Name:     "hostname",
 								Position: 7,
+								Encodings: []chronograf.ColumnEncoding{
+									{
+										Type:  "visibility",
+										Value: "visible",
+									},
+								},
+							},
+							{
+								Name:     "host",
+								Position: 8,
 								Encodings: []chronograf.ColumnEncoding{
 									{
 										Type:  "visibility",
@@ -1134,27 +1205,29 @@ func TestOrganizationConfig_Put(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		client, err := NewTestClient()
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer client.Close()
+		t.Run(tt.name, func(t *testing.T) {
+			client, err := NewTestClient()
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer client.Close()
 
-		s := client.OrganizationConfigStore
-		err = s.Put(context.Background(), tt.args.organizationConfig)
-		if (tt.wants.err != nil) != (err != nil) {
-			t.Errorf("%q. OrganizationConfigStore.Put() error = %v, wantErr %v", tt.name, err, tt.wants.err)
-			continue
-		}
+			s := client.OrganizationConfigStore
+			err = s.Put(context.Background(), tt.args.organizationConfig)
+			if (tt.wants.err != nil) != (err != nil) {
+				t.Errorf("%q. OrganizationConfigStore.Put() error = %v, wantErr %v", tt.name, err, tt.wants.err)
+				return
+			}
 
-		got, _ := s.FindOrCreate(context.Background(), tt.args.organizationID)
-		if (tt.wants.err != nil) != (err != nil) {
-			t.Errorf("%q. OrganizationConfigStore.Put() error = %v, wantErr %v", tt.name, err, tt.wants.err)
-			continue
-		}
+			got, _ := s.FindOrCreate(context.Background(), tt.args.organizationID)
+			if (tt.wants.err != nil) != (err != nil) {
+				t.Errorf("%q. OrganizationConfigStore.Put() error = %v, wantErr %v", tt.name, err, tt.wants.err)
+				return
+			}
 
-		if diff := cmp.Diff(got, tt.wants.organizationConfig); diff != "" {
-			t.Errorf("%q. OrganizationConfigStore.Put():\n-got/+want\ndiff %s", tt.name, diff)
-		}
+			if diff := cmp.Diff(got, tt.wants.organizationConfig); diff != "" {
+				t.Errorf("%q. OrganizationConfigStore.Put():\n-got/+want\ndiff %s", tt.name, diff)
+			}
+		})
 	}
 }

--- a/integrations/server_test.go
+++ b/integrations/server_test.go
@@ -2252,8 +2252,18 @@ func TestServer(t *testing.T) {
 							]
 						},
 						{
-							"name": "host",
+							"name": "hostname",
 							"position": 7,
+							"encodings": [
+								{
+									"type": "visibility",
+									"value": "visible"
+								}
+							]
+						},
+						{
+							"name": "host",
+							"position": 8,
 							"encodings": [
 								{
 									"type": "visibility",
@@ -2435,8 +2445,18 @@ func TestServer(t *testing.T) {
 						]
 					},
 					{
-						"name": "host",
+						"name": "hostname",
 						"position": 7,
+						"encodings": [
+							{
+								"type": "visibility",
+								"value": "visible"
+							}
+						]
+					},
+					{
+						"name": "host",
+						"position": 8,
 						"encodings": [
 							{
 								"type": "visibility",

--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -37,21 +37,8 @@ import {
   DEFAULT_OLDER_CHUNK_DURATION_MS,
   DEFAULT_NEWER_CHUNK_DURATION_MS,
   DEFAULT_MAX_TAIL_BUFFER_DURATION_MS,
+  defaultTableData,
 } from 'src/logs/constants'
-
-const defaultTableData: TableData = {
-  columns: [
-    'time',
-    'severity',
-    'timestamp',
-    'message',
-    'facility',
-    'procid',
-    'appname',
-    'host',
-  ],
-  values: [],
-}
 
 interface State {
   logs: LogsState

--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -240,6 +240,7 @@ export const defaultTableData: TableData = {
     'facility',
     'procid',
     'appname',
+    'hostname',
     'host',
   ],
   values: [],

--- a/ui/src/logs/utils/index.ts
+++ b/ui/src/logs/utils/index.ts
@@ -66,6 +66,11 @@ const tableFields = [
     value: 'appname',
   },
   {
+    alias: 'hostname',
+    type: 'field',
+    value: 'hostname',
+  },
+  {
     alias: 'host',
     type: 'field',
     value: 'host',

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -43,6 +43,7 @@ export const formatColumnValue = (
       return moment(+value / 1000000).format(DEFAULT_TIME_FORMAT)
     case 'procid':
     case 'host':
+    case 'hostname':
     case 'appname':
       return truncateText(value, column)
     case 'message':


### PR DESCRIPTION
Closes #4598 

_Briefly describe your proposed changes:_
Updates org config with a live migration to log viewer config to ensure it includes a hostname and includes hostname in the default fields for the org config.
_What was the problem?_
Hostname was not present in the default fields for log viewer
_What was the solution?_
Add hostname to org config.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass

----

- [x] switch between `master` and `fix/logs-hostname` to try to capture any log viewer migration issues in the UI 
