### PR TITLE
Fix infinite loop bug in Flux autocompletions

### DIFF
--- a/ui/src/flux/helpers/autoComplete.ts
+++ b/ui/src/flux/helpers/autoComplete.ts
@@ -152,8 +152,8 @@ const shouldCompleteParam = (currentLineText, cursorPosition) => {
   let i = cursorPosition
 
   while (i) {
-    const char = currentLineText[i]
-    const charBefore = currentLineText[i - 1]
+    const char = currentLineText[i - 1]
+    const charBefore = currentLineText[i - 2]
 
     if (char === ':' || char === '>' || char === ')') {
       return false


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/167

An off-by-one error meant that we were attempting to provide parameter suggestions for a Flux function at the wrong time.

The helper that actually provides parameter suggestions assumes that it has been called with the appropriate state—since it wasn't, we hit some undefined behavior which manifested as an infinite loop.