### PR TITLE
Fix issue with stale data in the CellEditorOverlay

### DIFF
--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -23,11 +23,13 @@ import {getDeep} from 'src/utils/wrappers'
 import {
   defaultQueryDraft,
   getLocalStorageKey,
+  getLocalStorage,
+  setLocalStorage,
+  TMLocalStorageKey,
 } from 'src/shared/utils/timeMachine'
 
 // Constants
 import {TYPE_QUERY_CONFIG} from 'src/dashboards/constants'
-import {GIT_SHA} from 'src/shared/constants'
 import {
   DEFAULT_THRESHOLDS_LIST_COLORS,
   DEFAULT_GAUGE_COLORS,
@@ -114,7 +116,7 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
   public state: TimeMachineState = DEFAULT_STATE()
 
   private debouncer: Debouncer = new DefaultDebouncer()
-  private localStorageKey?: string
+  private localStorageKey?: TMLocalStorageKey
 
   public reset = (
     initialState: Partial<TimeMachineState> = {}
@@ -354,25 +356,5 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
 
   private setLocalStorageState = () => {
     setLocalStorage(this.localStorageKey, this.state)
-  }
-}
-
-export function setLocalStorage(key: string, data: TimeMachineState): void {
-  const localStorageData = {version: GIT_SHA, data}
-
-  window.localStorage.setItem(key, JSON.stringify(localStorageData))
-}
-
-export function getLocalStorage(key: string): Partial<TimeMachineState> {
-  try {
-    const {version, data} = JSON.parse(window.localStorage.getItem(key))
-
-    if (version !== GIT_SHA) {
-      return {}
-    }
-
-    return data
-  } catch {
-    return {}
   }
 }

--- a/ui/src/shared/utils/timeMachine.ts
+++ b/ui/src/shared/utils/timeMachine.ts
@@ -9,6 +9,7 @@ import {
   getThresholdsListColors,
   getGaugeColors,
 } from 'src/shared/constants/thresholds'
+import {GIT_SHA} from 'src/shared/constants'
 
 // Types
 import {Cell, NewDefaultCell, CellQuery, QueryType} from 'src/types'
@@ -87,16 +88,48 @@ export function defaultQueryDraft(
   return defaultDraft
 }
 
-enum TMLocalStorageKeys {
-  dataExplorer = 'dataExplorer',
-  ceo = 'cellEditorOverlay',
+export enum TMLocalStorageKey {
+  DataExplorer = 'dataExplorer',
+  CellEditorOverlay = 'cellEditorOverlay',
 }
-export function getLocalStorageKey(): TMLocalStorageKeys {
+
+export function getLocalStorageKey(): TMLocalStorageKey {
   const location = window.location.toString()
 
   if (location.indexOf('/dashboards/') !== -1) {
-    return TMLocalStorageKeys.ceo
+    return TMLocalStorageKey.CellEditorOverlay
   }
 
-  return TMLocalStorageKeys.dataExplorer
+  return TMLocalStorageKey.DataExplorer
+}
+
+export function getLocalStorage(
+  key: TMLocalStorageKey
+): Partial<TimeMachineState> {
+  try {
+    const {version, data} = JSON.parse(window.localStorage.getItem(key))
+
+    if (version !== GIT_SHA) {
+      return {}
+    }
+
+    if (key === TMLocalStorageKey.CellEditorOverlay) {
+      const {fluxProportions, timeMachineProportions} = data
+
+      return {fluxProportions, timeMachineProportions}
+    }
+
+    return data
+  } catch {
+    return {}
+  }
+}
+
+export function setLocalStorage(
+  key: TMLocalStorageKey,
+  data: TimeMachineState
+): void {
+  const localStorageData = {version: GIT_SHA, data}
+
+  window.localStorage.setItem(key, JSON.stringify(localStorageData))
 }


### PR DESCRIPTION
Closes influxdata/applications-team-issues#196

Both the `CellEditorOverlay` and `DataExplorer` components store state in the `TimeMachineContainer`. These components reset the state upon mount, using data that is cached for each component in localStorage.

The `CellEditorOverlay` requires only certain pieces of cached data to be read from localStorage, while the `DataExplorer` wants all data stored in localStorage to be read.

This commit updates the utility used to fetch data from localStorage to be aware of this difference between the two components.
