### PR TITLE
Add scrollbars to raw flux data table

### DIFF
--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -528,7 +528,7 @@ class DashboardPage extends Component<Props, State> {
     })
   }
 
-  private setScrollTop = (e: MouseEvent<JSX.Element>): void => {
+  private setScrollTop = (e: MouseEvent<HTMLElement>): void => {
     const target = e.target as HTMLElement
 
     this.setState({scrollTop: target.scrollTop})

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -315,7 +315,7 @@ class LogsTable extends Component<Props, State> {
     this.handleScroll({scrollLeft})
   }
 
-  private handleScrollbarScroll = (e: MouseEvent<JSX.Element>): void => {
+  private handleScrollbarScroll = (e: MouseEvent<HTMLElement>): void => {
     e.stopPropagation()
     e.preventDefault()
     const {scrollTop, scrollLeft} = e.target as HTMLElement

--- a/ui/src/shared/components/FancyScrollbar.tsx
+++ b/ui/src/shared/components/FancyScrollbar.tsx
@@ -8,7 +8,7 @@ interface DefaultProps {
   autoHide: boolean
   autoHeight: boolean
   maxHeight: number
-  setScrollTop: (value: React.MouseEvent<JSX.Element>) => void
+  setScrollTop: (value: React.MouseEvent<HTMLElement>) => void
   style: React.CSSProperties
 }
 

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -256,7 +256,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
     return this.topGridHeight
   }
 
-  private onScrollbarsScroll = (e: React.MouseEvent<JSX.Element>) => {
+  private onScrollbarsScroll = (e: React.MouseEvent<HTMLElement>) => {
     const {scrollTop} = e.target as HTMLElement
     const {scrollLeft} = this.state
 

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {AutoSizer, Grid} from 'react-virtualized'
 
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
@@ -90,11 +90,11 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     )
   }
 
-  private onScrollbarsScroll = e => {
+  private onScrollbarsScroll = (e: MouseEvent<HTMLElement>) => {
     e.preventDefault()
     e.stopPropagation()
 
-    const {scrollTop, scrollLeft} = e.target as HTMLElement
+    const {scrollTop, scrollLeft} = e.currentTarget
 
     this.setState({scrollLeft, scrollTop})
   }

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
@@ -1,6 +1,8 @@
 import React, {PureComponent} from 'react'
 import {AutoSizer, Grid} from 'react-virtualized'
 
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+
 import {parseResponseRaw} from 'src/shared/parsing/flux/response'
 
 interface Props {
@@ -15,6 +17,8 @@ interface Props {
 interface State {
   data: string[][]
   maxColumnCount: number
+  scrollLeft: number
+  scrollTop: number
 }
 
 const ROW_HEIGHT = 30
@@ -32,11 +36,11 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     return {data, maxColumnCount}
   }
 
-  public state = {data: [], maxColumnCount: 0}
+  public state = {data: [], maxColumnCount: 0, scrollLeft: 0, scrollTop: 0}
 
   public render() {
     const {width, height} = this.props
-    const {data, maxColumnCount} = this.state
+    const {data, maxColumnCount, scrollTop, scrollLeft} = this.state
 
     return (
       <div className="raw-flux-data-table">
@@ -48,22 +52,51 @@ class RawFluxDataTable extends PureComponent<Props, State> {
               MIN_COLUMN_WIDTH,
               resolvedWidth / maxColumnCount
             )
+            const gridScrollWidth = columnWidth * maxColumnCount
+            const gridScrollHeight = ROW_HEIGHT * data.length
 
             return (
-              <Grid
-                width={resolvedWidth}
-                height={resolvedHeight}
-                cellRenderer={this.renderCell}
-                columnCount={maxColumnCount}
-                rowCount={data.length}
-                rowHeight={ROW_HEIGHT}
-                columnWidth={columnWidth}
-              />
+              <FancyScrollbar
+                style={{
+                  overflowY: 'hidden',
+                  width: resolvedWidth,
+                  height: resolvedHeight,
+                }}
+                autoHide={false}
+                scrollTop={scrollTop}
+                scrollLeft={scrollLeft}
+                setScrollTop={this.onScrollbarsScroll}
+              >
+                <Grid
+                  width={resolvedWidth}
+                  height={resolvedHeight}
+                  cellRenderer={this.renderCell}
+                  columnCount={maxColumnCount}
+                  rowCount={data.length}
+                  rowHeight={ROW_HEIGHT}
+                  columnWidth={columnWidth}
+                  scrollLeft={scrollLeft}
+                  scrollTop={scrollTop}
+                  style={{
+                    width: gridScrollWidth,
+                    height: gridScrollHeight,
+                  }}
+                />
+              </FancyScrollbar>
             )
           }}
         </AutoSizer>
       </div>
     )
+  }
+
+  private onScrollbarsScroll = e => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    const {scrollTop, scrollLeft} = e.target as HTMLElement
+
+    this.setState({scrollLeft, scrollTop})
   }
 
   private renderCell = ({columnIndex, key, rowIndex, style}) => {

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, MouseEvent} from 'react'
+import React, {PureComponent, MouseEvent, CSSProperties} from 'react'
 import {AutoSizer, Grid} from 'react-virtualized'
 
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
@@ -40,7 +40,7 @@ class RawFluxDataTable extends PureComponent<Props, State> {
 
   public render() {
     const {width, height} = this.props
-    const {data, maxColumnCount, scrollTop, scrollLeft} = this.state
+    const {scrollTop, scrollLeft} = this.state
 
     return (
       <div className="raw-flux-data-table">
@@ -48,12 +48,6 @@ class RawFluxDataTable extends PureComponent<Props, State> {
           {({width: autoWidth, height: autoHeight}) => {
             const resolvedWidth = width ? width : autoWidth
             const resolvedHeight = height ? height : autoHeight
-            const columnWidth = Math.max(
-              MIN_COLUMN_WIDTH,
-              resolvedWidth / maxColumnCount
-            )
-            const gridScrollWidth = columnWidth * maxColumnCount
-            const gridScrollHeight = ROW_HEIGHT * data.length
 
             return (
               <FancyScrollbar
@@ -67,27 +61,53 @@ class RawFluxDataTable extends PureComponent<Props, State> {
                 scrollLeft={scrollLeft}
                 setScrollTop={this.onScrollbarsScroll}
               >
-                <Grid
-                  width={resolvedWidth}
-                  height={resolvedHeight}
-                  cellRenderer={this.renderCell}
-                  columnCount={maxColumnCount}
-                  rowCount={data.length}
-                  rowHeight={ROW_HEIGHT}
-                  columnWidth={columnWidth}
-                  scrollLeft={scrollLeft}
-                  scrollTop={scrollTop}
-                  style={{
-                    width: gridScrollWidth,
-                    height: gridScrollHeight,
-                  }}
-                />
+                {this.renderGrid(
+                  resolvedWidth,
+                  resolvedHeight,
+                  scrollLeft,
+                  scrollTop
+                )}
               </FancyScrollbar>
             )
           }}
         </AutoSizer>
       </div>
     )
+  }
+
+  private renderGrid(
+    width: number,
+    height: number,
+    scrollLeft: number,
+    scrollTop: number
+  ): JSX.Element {
+    const {maxColumnCount, data} = this.state
+    const rowCount = data.length
+    const columnWidth = Math.max(MIN_COLUMN_WIDTH, width / maxColumnCount)
+    const style = this.gridStyle(columnWidth, rowCount)
+
+    return (
+      <Grid
+        width={width}
+        height={height}
+        cellRenderer={this.renderCell}
+        columnCount={maxColumnCount}
+        rowCount={rowCount}
+        rowHeight={ROW_HEIGHT}
+        columnWidth={columnWidth}
+        scrollLeft={scrollLeft}
+        scrollTop={scrollTop}
+        style={style}
+      />
+    )
+  }
+
+  private gridStyle(columnWidth: number, rowCount: number): CSSProperties {
+    const {maxColumnCount} = this.state
+    const width = columnWidth * maxColumnCount
+    const height = ROW_HEIGHT * rowCount
+
+    return {width, height}
   }
 
   private onScrollbarsScroll = (e: MouseEvent<HTMLElement>) => {


### PR DESCRIPTION
Closes influxdata/applications-team-issues#189

_Briefly describe your proposed changes:_
Adds fancy scrollbars around the raw response grid
_What was the problem?_
There were none
_What was the solution?_
The solution was to add the scrollbars without causing the grid to render more columns/rows than are visible. This is achieved by styling the width/height  but allowing the table to have width/height set by autosizer. Also, some debugging revealed that scrollTop/scrollLeft were being redundantly updated in state if `onScroll` was added to the `Grid` itself. 

As a follow up a similar fix can be used to resolve: https://github.com/influxdata/applications-team-issues/issues/184 

  - [x] Rebased/mergeable
  - [x] Tests pass