### PR TITLE
Increase auto group by resolution

### DIFF
--- a/ui/src/dashboards/components/ReactCodeMirror.tsx
+++ b/ui/src/dashboards/components/ReactCodeMirror.tsx
@@ -12,6 +12,7 @@ import replaceTemplates, {replaceInterval} from 'src/tempVars/utils/replace'
 import {duration} from 'src/shared/apis/query'
 
 import {applyMasks, insertTempVar, unMask} from 'src/tempVars/constants'
+import {DEFAULT_X_PIXELS} from 'src/shared/constants'
 
 import {Template, QueryConfig} from 'src/types'
 import {EditorChange, EditorConfiguration, Position} from 'codemirror'
@@ -333,7 +334,7 @@ class ReactCodeMirror extends PureComponent<Props, State> {
     const query = replaceTemplates(value, templates)
     const durationMs = await duration(query, config.source)
 
-    return replaceInterval(':interval:', 0, durationMs)
+    return replaceInterval(':interval:', DEFAULT_X_PIXELS, durationMs)
   }
 
   private getTemplateTokens() {

--- a/ui/src/flux/helpers/templates.ts
+++ b/ui/src/flux/helpers/templates.ts
@@ -1,10 +1,7 @@
 import {TimeRange} from 'src/types'
 import {getMinDuration} from 'src/shared/parsing/flux/durations'
-import {
-  DEFAULT_PIXELS,
-  DEFAULT_DURATION_MS,
-  RESOLUTION_SCALE_FACTOR,
-} from 'src/shared/constants'
+import {computeInterval} from 'src/tempVars/utils/replace'
+import {DEFAULT_DURATION_MS} from 'src/shared/constants'
 
 // For now we only support these template variables in Flux queries
 const DASHBOARD_TIME = 'dashboardTime'
@@ -17,7 +14,7 @@ export const renderTemplatesInScript = async (
   script: string,
   timeRange: TimeRange,
   astLink: string,
-  maxSideLength: number = DEFAULT_PIXELS
+  xPixels: number
 ): Promise<string> => {
   let dashboardTime: string
   let upperDashboardTime: string
@@ -44,9 +41,9 @@ export const renderTemplatesInScript = async (
     duration = DEFAULT_DURATION_MS
   }
 
-  const interval = duration / (maxSideLength * RESOLUTION_SCALE_FACTOR)
+  const interval = computeInterval(duration, xPixels)
 
-  rendered = `${INTERVAL} = ${Math.floor(interval)}ms\n${rendered}`
+  rendered = `${INTERVAL} = ${interval}ms\n${rendered}`
 
   return rendered
 }

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -18,6 +18,7 @@ import {getDeep} from 'src/utils/wrappers'
 import {restartable} from 'src/shared/utils/restartable'
 import {renderTemplatesInScript} from 'src/flux/helpers/templates'
 import {parseResponse} from 'src/shared/parsing/flux/response'
+import {DEFAULT_X_PIXELS} from 'src/shared/constants'
 
 // Types
 import {
@@ -70,7 +71,7 @@ interface State {
   errorMessage: string
 }
 
-const TEMP_RES = 300 // FIXME
+const TEMP_RES = DEFAULT_X_PIXELS // FIXME
 
 const GraphLoadingDots = () => (
   <div className="graph-panel__refreshing">

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -7,8 +7,8 @@ export const VERSION = process.env.npm_package_version
 export const GIT_SHA = process.env.GIT_SHA
 
 export const DEFAULT_DURATION_MS = 1000
-export const DEFAULT_PIXELS = 333
-export const RESOLUTION_SCALE_FACTOR = 0.5
+export const DEFAULT_X_PIXELS = 700
+export const PIXELS_PER_POINT = 1
 
 export const NO_CELL = 'none'
 
@@ -458,7 +458,7 @@ export const DEFAULT_KAPACITOR = {
 
 export const intervalValuesPoints = [
   {
-    value: `${DEFAULT_PIXELS}`,
+    value: `${DEFAULT_X_PIXELS}`,
     type: TemplateValueType.Points,
     selected: true,
     localSelected: true,

--- a/ui/src/shared/utils/downloadTimeseriesCSV.ts
+++ b/ui/src/shared/utils/downloadTimeseriesCSV.ts
@@ -9,7 +9,7 @@ import {executeQuery as executeFluxQuery} from 'src/shared/apis/flux/query'
 import {renderTemplatesInScript} from 'src/flux/helpers/templates'
 
 // Constants
-import {DEFAULT_PIXELS} from 'src/shared/constants'
+import {DEFAULT_X_PIXELS} from 'src/shared/constants'
 
 // Types
 import {Query, Template, Source, TimeRange} from 'src/types'
@@ -40,7 +40,7 @@ export const downloadFluxCSV = async (
     script,
     timeRange,
     fluxASTLink,
-    DEFAULT_PIXELS
+    DEFAULT_X_PIXELS
   )
 
   const {csv, didTruncate, rowCount} = await executeFluxQuery(

--- a/ui/test/tempVars/utils/replace.test.ts
+++ b/ui/test/tempVars/utils/replace.test.ts
@@ -288,7 +288,7 @@ describe('templates.utils.replace', () => {
   describe('replaceInterval', () => {
     it('can replace :interval:', () => {
       const query = `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(:interval:)`
-      const expected = `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(93405405ms)`
+      const expected = `SELECT mean(usage_idle) from "cpu" where time > now() - 4320h group by time(46702702ms)`
       const pixels = 333
       const durationMs = 15551999999
       const actual = replaceInterval(query, pixels, durationMs)
@@ -298,7 +298,7 @@ describe('templates.utils.replace', () => {
 
     it('can replace multiple intervals', () => {
       const query = `SELECT NON_NEGATIVE_DERIVATIVE(mean(usage_idle), :interval:) from "cpu" where time > now() - 4320h group by time(:interval:)`
-      const expected = `SELECT NON_NEGATIVE_DERIVATIVE(mean(usage_idle), 93405405ms) from "cpu" where time > now() - 4320h group by time(93405405ms)`
+      const expected = `SELECT NON_NEGATIVE_DERIVATIVE(mean(usage_idle), 46702702ms) from "cpu" where time > now() - 4320h group by time(46702702ms)`
 
       const pixels = 333
       const durationMs = 15551999999
@@ -338,7 +338,7 @@ describe('templates.utils.replace', () => {
         const query = `SELECT mean(usage_idle) from "cpu" WHERE time > :dashboardTime: group by time(:interval:)`
         let actual = templateReplace(query, vars)
         actual = replaceInterval(actual, pixels, durationMs)
-        const expected = `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 24h group by time(518918ms)`
+        const expected = `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 24h group by time(259459ms)`
 
         expect(actual).toBe(expected)
       })
@@ -373,7 +373,7 @@ describe('templates.utils.replace', () => {
         const query = `SELECT mean(usage_idle) from "cpu" WHERE time > :dashboardTime: group by time(:interval:)`
         let actual = templateReplace(query, vars)
         actual = replaceInterval(actual, pixels, durationMs)
-        const expected = `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 1h group by time(189473ms)`
+        const expected = `SELECT mean(usage_idle) from "cpu" WHERE time > now() - 1h group by time(94736ms)`
 
         expect(actual).toBe(expected)
       })


### PR DESCRIPTION

- Name variables involved to the auto group by calculation according to the correct units, and specify units for variables that were left ambiguous
- Use the same calculation in both InfluxQL queries and Flux queries
- Increase the level of detail yielded by the auto group by calculation. For now this was done by increasing [`DEFAULT_X_PIXELS`](https://github.com/influxdata/chronograf/blob/e486a61ae312e3d9b3b1763ba1b4ee8fa117f618/ui/src/shared/constants/index.ts#L10), but should be done by decreasing [`PIXELS_PER_POINT`](https://github.com/influxdata/chronograf/blob/e486a61ae312e3d9b3b1763ba1b4ee8fa117f618/ui/src/shared/constants/index.ts#L11) instead after influxdata/applications-team-issues#168 is fixed.
- You can experiment with alternative levels of detail by setting the key in localStorage, i.e. if you open up a dev tools console and set

   ```
   window.localStorage.PIXELS_PER_POINT = 0.1
   ```
   and refresh, the new value will be used. The default is `1`.