### PR TITLE
Ensure de can find update query drafts correctly

### DIFF
--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -9,7 +9,8 @@ import {
   UNTITLED_GRAPH,
   NEW_DEFAULT_DASHBOARD_CELL,
 } from 'src/dashboards/constants'
-import {TEMP_VAR_DASHBOARD_TIME} from 'src/shared/constants'
+import {TEMPLATE_RANGE} from 'src/tempVars/constants'
+
 const MAX_COLUMNS = 12
 
 // Types
@@ -153,12 +154,16 @@ export const getClonedDashboardCell = (
 }
 
 export const getTimeRange = (queryConfig: QueryConfig): DurationRange => {
-  return (
-    queryConfig.range || {
-      upper: null,
-      lower: TEMP_VAR_DASHBOARD_TIME,
-    }
-  )
+  const isUsingDashTime =
+    queryConfig.range &&
+    queryConfig.originalQuery &&
+    queryConfig.originalQuery.indexOf(TEMPLATE_RANGE.lower) !== -1
+
+  if (isUsingDashTime || !queryConfig.range) {
+    return TEMPLATE_RANGE
+  }
+
+  return queryConfig.range
 }
 
 export const getConfig = async (
@@ -173,5 +178,5 @@ export const getConfig = async (
   ])
   const {queryConfig} = queries.find(q => q.id === id)
 
-  return queryConfig
+  return {...queryConfig, originalQuery: query}
 }

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -231,14 +231,16 @@ export class DataExplorer extends PureComponent<Props, State> {
         return
       }
 
+      const id = uuid.v4()
       const queryConfig = await getConfig(
         source.links.queries,
-        uuid.v4(),
+        id,
         query,
         this.templates
       )
 
       const queryDraft = {
+        id,
         query,
         queryConfig,
         source: sourceLink,

--- a/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
@@ -14,14 +14,17 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 import {buildQuery} from 'src/utils/influxql'
 import {TYPE_QUERY_CONFIG} from 'src/dashboards/constants'
-import {TEMPLATE_RANGE} from 'src/tempVars/constants'
 import {AUTO_GROUP_BY} from 'src/shared/constants'
+import {getTimeRange} from 'src/dashboards/utils/cellGetters'
 
 // Types
 import {QueryConfig, Source, TimeRange, Template} from 'src/types'
 
-const buildText = (q: QueryConfig): string =>
-  q.rawText || buildQuery(TYPE_QUERY_CONFIG, q.range || TEMPLATE_RANGE, q) || ''
+const buildText = (q: QueryConfig): string => {
+  const range = getTimeRange(q)
+
+  return q.rawText || buildQuery(TYPE_QUERY_CONFIG, range, q) || ''
+}
 
 interface ConnectedProps {
   timeRange: TimeRange

--- a/ui/src/types/queries.ts
+++ b/ui/src/types/queries.ts
@@ -26,6 +26,7 @@ export interface QueryConfig {
   lower?: string
   upper?: string
   isQuerySupportedByExplorer?: boolean // doesn't come from server -- is set in CellEditorOverlay
+  originalQuery?: string
 }
 
 export interface QueryStatus {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/191

_What was the problem?_
In de, when a query matching the url param could not be found, it would create a new query. It would give an id to the query config and not the query draft, which meant later down the line when trying to modify a query/query config, the correct query could not be found.

Additionally, the query in the text box was always rendering the :dashboardTime: temp var so rather than keeping the var, meaning the url param would never match what was in the box. This would make it so on every refresh, new queries would be created rather than using existing ones. 
_What was the solution?_
Add the query to both the query and query config when creating a new query. 

When generating a query config, template variables must be replaced for the server to be able to create the config meaning that the server was always seeing now - 1h (or whatever) and adding range on to the query config. Later down the line, logic for creating a query from a config relied on there being no range in the query config. This logic has changed by adding the original query when returning a query config and if this original query has a dashboard time template variable, use that as the range rather than the range from the config.

  - [x] Rebased/mergeable
  - [x] Tests pass