### PR TITLE
Move and rename Flux Schema Explorer

### DIFF
--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -84,6 +84,14 @@ class FluxQueryMaker extends PureComponent<Props, State> {
 
     const divisions = [
       {
+        name: 'Explore Schema',
+        size: rightSize,
+        headerButtons: [],
+        menuOptions: [],
+        render: () => <SchemaExplorer source={source} notify={notify} />,
+        headerOrientation: HANDLE_VERTICAL,
+      },
+      {
         name: 'Script',
         size: leftSize,
         headerOrientation: HANDLE_VERTICAL,
@@ -125,14 +133,6 @@ class FluxQueryMaker extends PureComponent<Props, State> {
             )}
           </TimeMachineEditor>
         ),
-      },
-      {
-        name: 'Explore',
-        size: rightSize,
-        headerButtons: [],
-        menuOptions: [],
-        render: () => <SchemaExplorer source={source} notify={notify} />,
-        headerOrientation: HANDLE_VERTICAL,
       },
     ]
 


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/4624

_Briefly describe your proposed changes:_
Move script to the right side and make explorer say `Explore Schema`

  - [ ] Rebased/mergeable
  - [ ] Tests pass
