### PR TITLE
Fix minimize and maximize buttons

### DIFF
--- a/ui/src/shared/components/threesizer/Threesizer.tsx
+++ b/ui/src/shared/components/threesizer/Threesizer.tsx
@@ -265,15 +265,15 @@ class Threesizer extends PureComponent<Props, State> {
       return
     }
 
-    const divisions = this.state.divisions.map(d => {
+    const divisionSizes = this.state.divisions.map(d => {
       if (d.id !== id) {
-        return {...d, size: 0}
+        return 0
       }
 
-      return {...d, size: 1}
+      return 1
     })
 
-    this.setState({divisions})
+    this.props.onResize(divisionSizes)
   }
 
   private handleMinimize = (id: string): void => {
@@ -291,15 +291,15 @@ class Threesizer extends PureComponent<Props, State> {
       size = 1 / (this.state.divisions.length - 1)
     }
 
-    const divisions = this.state.divisions.map(d => {
+    const divisionSizes = this.state.divisions.map(d => {
       if (d.id !== id) {
-        return {...d, size}
+        return size
       }
 
-      return {...d, size: 0}
+      return 0
     })
 
-    this.setState({divisions})
+    this.props.onResize(divisionSizes)
   }
 
   private equalize = () => {


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/211

_Briefly describe your proposed changes:_
_What was the problem?_
minimize and maximize buttons did not do anything since the division sizes were determined by division props and no longer changed based on state.
_What was the solution?_
Use the onresize prop when handling max and min.

  - [x] Rebased/mergeable
  - [x] Tests pass