### PR TITLE
Measure plot dimensions for auto group by queries

### DIFF
--- a/ui/src/flux/components/TimeMachineTables.tsx
+++ b/ui/src/flux/components/TimeMachineTables.tsx
@@ -28,6 +28,8 @@ interface Props {
   timeFormat: string
   decimalPlaces: DecimalPlaces
   fieldOptions: FieldOption[]
+  width: number
+  height: number
   handleSetHoverTime?: (hovertime: string) => void
   colors: ColorString[]
   editorLocation?: QueryUpdateState
@@ -75,6 +77,8 @@ class TimeMachineTables extends PureComponent<Props, State> {
 
   public render() {
     const {
+      width,
+      height,
       colors,
       dataType,
       timeFormat,
@@ -86,7 +90,10 @@ class TimeMachineTables extends PureComponent<Props, State> {
     } = this.props
 
     return (
-      <div className="time-machine-tables">
+      <div
+        className="time-machine-tables"
+        style={{width: `${width}px`, height: `${height}px`}}
+      >
         {this.showSidebar && (
           <TableSidebar
             data={this.props.data}


### PR DESCRIPTION
Closes influxdata/applications-team-issues#168

To compute the auto group by template variables (`:interval:` and `autoInterval`), we need to measure the number of pixels in the _x_ dimension of a plot. Previously, we used a hardcoded value of `700` for this measurement. 

Now, the `RefreshingGraph` will measure the actual value, and the `TimeSeries` component will consume it.

I also took this opportunity to extract some getters from the `render` method of the `RefreshingGraph`, which has become quite unwieldy. Unfortunately, adding in the measurement logic has exasperated the issue 😞 

![resampling](https://user-images.githubusercontent.com/638955/47672538-87bd8f00-db6f-11e8-9c3b-80ccd9472129.gif)
