### PR TITLE
Remove Markdown Shadows and Prefix/Suffix Limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@
 1.  [#4429](https://github.com/influxdata/chronograf/pull/4429): Fix query editor flickering on update
 1.  [#4452](https://github.com/influxdata/chronograf/pull/4452): Improve log search spinner info
 1.  [#4525](https://github.com/influxdata/chronograf/pull/4525): Move expanded log message copy button to top right
+1.  [#4665](https://github.com/influxdata/chronograf/pull/4665): Remove shadow from note cells
+1.  [#4665](https://github.com/influxdata/chronograf/pull/4665): Remove character count limit from prefix and suffix for Single Stat and Gauge cells
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/ui/src/dashboards/components/GaugeOptions.tsx
+++ b/ui/src/dashboards/components/GaugeOptions.tsx
@@ -73,7 +73,6 @@ class GaugeOptions extends PureComponent<Props> {
                 placeholder="%, MPH, etc."
                 defaultValue={y.prefix}
                 onChange={this.handleUpdatePrefix}
-                maxLength={5}
               />
             </div>
             <div className="form-group col-xs-6">
@@ -83,7 +82,6 @@ class GaugeOptions extends PureComponent<Props> {
                 placeholder="%, MPH, etc."
                 defaultValue={y.suffix}
                 onChange={this.handleUpdateSuffix}
-                maxLength={5}
               />
             </div>
             <GraphOptionsDecimalPlaces

--- a/ui/src/dashboards/components/SingleStatOptions.tsx
+++ b/ui/src/dashboards/components/SingleStatOptions.tsx
@@ -58,7 +58,6 @@ class SingleStatOptions extends PureComponent<Props> {
                 placeholder="%, MPH, etc."
                 defaultValue={prefix}
                 onChange={this.handleUpdatePrefix}
-                maxLength={5}
               />
             </div>
             <div className="form-group col-xs-6">
@@ -68,7 +67,6 @@ class SingleStatOptions extends PureComponent<Props> {
                 placeholder="%, MPH, etc."
                 defaultValue={suffix}
                 onChange={this.handleUpdateSuffix}
-                maxLength={5}
               />
             </div>
             <GraphOptionsDecimalPlaces

--- a/ui/src/shared/components/MarkdownCell.scss
+++ b/ui/src/shared/components/MarkdownCell.scss
@@ -18,18 +18,6 @@
   z-index: 2;
 }
 
-.markdown-cell:after {
-  pointer-events: none;
-  content: '';
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 20px;
-  width: 100%;
-  @include gradient-v(rgba($g3-castle, 0), $g3-castle);
-  z-index: 1;
-}
-
 /*
   General Markdown Formatting
   ------------------------------------------------------------------------------


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/197
Closes https://github.com/influxdata/applications-team-issues/issues/198

Remove the shadow positioned at the bottom of note cells. Remove the 5 character maximum for prefix and suffix fields located in Gauge and Single Stat options

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass