### PR TITLE
Fix de not respecting time range selection

### DIFF
--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -154,16 +154,21 @@ export const getClonedDashboardCell = (
 }
 
 export const getTimeRange = (queryConfig: QueryConfig): DurationRange => {
-  const isUsingDashTime =
-    queryConfig.range &&
-    queryConfig.originalQuery &&
-    queryConfig.originalQuery.indexOf(TEMPLATE_RANGE.lower) !== -1
+  return getRangeForOriginalQuery(queryConfig.originalQuery, queryConfig.range)
+}
 
-  if (isUsingDashTime || !queryConfig.range) {
+const getRangeForOriginalQuery = (
+  originalQuery: string,
+  range: DurationRange
+): DurationRange => {
+  const isUsingDashTime =
+    range && originalQuery && originalQuery.indexOf(TEMPLATE_RANGE.lower) !== -1
+
+  if (isUsingDashTime || !range) {
     return TEMPLATE_RANGE
   }
 
-  return queryConfig.range
+  return range
 }
 
 export const getConfig = async (
@@ -177,6 +182,11 @@ export const getConfig = async (
     {query: renderedQuery, id},
   ])
   const {queryConfig} = queries.find(q => q.id === id)
+  const range = getRangeForOriginalQuery(query, queryConfig.range)
 
-  return {...queryConfig, originalQuery: query}
+  return {
+    ...queryConfig,
+    originalQuery: query,
+    range,
+  }
 }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/202

_Briefly describe your proposed changes:_
Add range to query config using the original query when calling `getConfig`
_What was the problem?_
The `getConfig` util was creating a default timeRange for the query
_What was the solution?_
Use the `getTimeRange` util to determine what range should be added when using `getConfig`

  - [ ] Rebased/mergeable
  - [ ] Tests pass