### PR TITLE
 Don't display fallback notes on initial fetch 

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -175,9 +175,18 @@ class RefreshingGraph extends Component<Props> {
                     timeSeriesFlux,
                     rawFluxData,
                     loading,
+                    isInitialFetch,
                     uuid,
                     errorMessage,
                   }) => {
+                    if (isInitialFetch && loading === RemoteDataState.Loading) {
+                      return (
+                        <div className="graph-empty">
+                          <h3 className="graph-spinner" />
+                        </div>
+                      )
+                    }
+
                     if (!this.hasValues(timeSeriesFlux, timeSeriesInfluxQL)) {
                       if (errorMessage && _.get(queries, '0.text', '').trim()) {
                         return <InvalidData message={errorMessage} />


### PR DESCRIPTION
Closes influxdata/applications-team-issues#201

We store a piece of state called `isFirstFetch` on the `TimeSeries` component. We use it to display a large loading spinner when a cell is first rendered and otherwise display a small loading spinner if the cell is refetching.

Due to a double render on the initial `TimeSeries` mount, this `isFirstFetch` state was quickly set to false. Thus instead of a loading spinner displaying initially, the no-data fallback of a note was displayed in each cell.

This PR fixes the double render. It also lifts and renames the `isFirstFetch` state from the `TimeSeries` component to the `RefreshingGraph`, which allows us to extract more presentational logic from the `TimeSeries` component.

Before:

![before](https://user-images.githubusercontent.com/638955/47684639-cb74c080-db90-11e8-8be3-3dd12f02f0bb.gif)

After:

![after](https://user-images.githubusercontent.com/638955/47684643-cf084780-db90-11e8-802f-755f93690b64.gif)
