### PR TITLE
Fix empty Raw Data table

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -208,7 +208,13 @@ class RefreshingGraph extends Component<Props> {
                     }
 
                     if (showRawFluxData) {
-                      return <RawFluxDataTable csv={rawFluxData} />
+                      return (
+                        <RawFluxDataTable
+                          csv={rawFluxData}
+                          width={width}
+                          height={height}
+                        />
+                      )
                     }
 
                     switch (type) {

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.scss
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.scss
@@ -1,9 +1,3 @@
-.raw-flux-data-table {
-  padding: 10px;
-  width: 100%;
-  height: 100%;
-}
-
 .raw-flux-data-table--cell {
   border: 1px solid $g4-onyx;
   font-family: $code-font;

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
@@ -1,5 +1,6 @@
 import React, {PureComponent, MouseEvent, CSSProperties} from 'react'
-import {AutoSizer, Grid} from 'react-virtualized'
+import {Grid} from 'react-virtualized'
+import memoizeOne from 'memoize-one'
 
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
@@ -7,70 +8,54 @@ import {parseResponseRaw} from 'src/shared/parsing/flux/response'
 
 interface Props {
   csv: string
-
-  // Used to give component explicit dimensions in testing. The component is
-  // sized automatically otherwise
-  width?: number
-  height?: number
+  width: number
+  height: number
 }
 
 interface State {
-  data: string[][]
-  maxColumnCount: number
   scrollLeft: number
   scrollTop: number
 }
 
 const ROW_HEIGHT = 30
 const MIN_COLUMN_WIDTH = 100
+const PADDING = 10
+
+const parseResponseRawMemoized = memoizeOne(parseResponseRaw)
 
 class RawFluxDataTable extends PureComponent<Props, State> {
-  public static getDerivedStateFromProps(props): Partial<State> {
-    // We are using `getDerivedStateFromProps` since this component only
-    // accepts one prop, and we want to recompute the state every time that prop
-    // changes. We can't use `memoizeOne`, since the prop is a large string and
-    // the equality check used in the `memoizeOne` helper is itself potentially
-    // quite expensive.
-    const {data, maxColumnCount} = parseResponseRaw(props.csv)
-
-    return {data, maxColumnCount}
-  }
-
-  public state = {data: [], maxColumnCount: 0, scrollLeft: 0, scrollTop: 0}
+  public state = {scrollLeft: 0, scrollTop: 0}
 
   public render() {
-    const {width, height} = this.props
+    const {width, height, csv} = this.props
     const {scrollTop, scrollLeft} = this.state
+    const {data, maxColumnCount} = parseResponseRawMemoized(csv)
+
+    const tableWidth = width - PADDING * 2
+    const tableHeight = height - PADDING * 2
 
     return (
-      <div className="raw-flux-data-table">
-        <AutoSizer>
-          {({width: autoWidth, height: autoHeight}) => {
-            const resolvedWidth = width ? width : autoWidth
-            const resolvedHeight = height ? height : autoHeight
-
-            return (
-              <FancyScrollbar
-                style={{
-                  overflowY: 'hidden',
-                  width: resolvedWidth,
-                  height: resolvedHeight,
-                }}
-                autoHide={false}
-                scrollTop={scrollTop}
-                scrollLeft={scrollLeft}
-                setScrollTop={this.onScrollbarsScroll}
-              >
-                {this.renderGrid(
-                  resolvedWidth,
-                  resolvedHeight,
-                  scrollLeft,
-                  scrollTop
-                )}
-              </FancyScrollbar>
-            )
+      <div className="raw-flux-data-table" style={{padding: `${PADDING}px`}}>
+        <FancyScrollbar
+          style={{
+            overflowY: 'hidden',
+            width: tableWidth,
+            height: tableHeight,
           }}
-        </AutoSizer>
+          autoHide={false}
+          scrollTop={scrollTop}
+          scrollLeft={scrollLeft}
+          setScrollTop={this.onScrollbarsScroll}
+        >
+          {this.renderGrid(
+            tableWidth,
+            tableHeight,
+            data,
+            maxColumnCount,
+            scrollLeft,
+            scrollTop
+          )}
+        </FancyScrollbar>
       </div>
     )
   }
@@ -78,19 +63,20 @@ class RawFluxDataTable extends PureComponent<Props, State> {
   private renderGrid(
     width: number,
     height: number,
+    data: string[][],
+    maxColumnCount: number,
     scrollLeft: number,
     scrollTop: number
   ): JSX.Element {
-    const {maxColumnCount, data} = this.state
     const rowCount = data.length
     const columnWidth = Math.max(MIN_COLUMN_WIDTH, width / maxColumnCount)
-    const style = this.gridStyle(columnWidth, rowCount)
+    const style = this.gridStyle(columnWidth, maxColumnCount, rowCount)
 
     return (
       <Grid
         width={width}
         height={height}
-        cellRenderer={this.renderCell}
+        cellRenderer={this.renderCell(data)}
         columnCount={maxColumnCount}
         rowCount={rowCount}
         rowHeight={ROW_HEIGHT}
@@ -102,8 +88,11 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     )
   }
 
-  private gridStyle(columnWidth: number, rowCount: number): CSSProperties {
-    const {maxColumnCount} = this.state
+  private gridStyle(
+    columnWidth: number,
+    maxColumnCount: number,
+    rowCount: number
+  ): CSSProperties {
     const width = columnWidth * maxColumnCount
     const height = ROW_HEIGHT * rowCount
 
@@ -119,8 +108,13 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     this.setState({scrollLeft, scrollTop})
   }
 
-  private renderCell = ({columnIndex, key, rowIndex, style}) => {
-    const datum = this.state.data[rowIndex][columnIndex]
+  private renderCell = (data: string[][]) => ({
+    columnIndex,
+    key,
+    rowIndex,
+    style,
+  }) => {
+    const datum = data[rowIndex][columnIndex]
 
     return (
       <div

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -135,6 +135,9 @@ export const parseResponseRaw = (response: string): ParseResponseRawResult => {
     }
 
     data.push(...parsedChunks[i])
+
+    // Add an empty line at the end
+    data.push([])
   }
 
   return {data, maxColumnCount}

--- a/ui/src/style/components/graph.scss
+++ b/ui/src/style/components/graph.scss
@@ -124,6 +124,9 @@ $graph-gutter: 16px;
 .graph-empty {
   width: 100%;
   height: 100%;
+  position: absolute;
+  padding: 10px;
+  overflow: hidden;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/ui/src/style/pages/dashboards.scss
+++ b/ui/src/style/pages/dashboards.scss
@@ -80,14 +80,6 @@ $dash-graph-options-arrow: 8px;
   .react-grid-item {
     @extend %cell-styles;
   }
-  .graph-empty {
-    background-color: transparent;
-    position: absolute;
-    width: 100%;
-    height: 100%;
-    top: 0;
-    left: 0;
-  }
 }
 
 .dash-graph {

--- a/ui/test/shared/components/RawFluxDataTable.test.tsx
+++ b/ui/test/shared/components/RawFluxDataTable.test.tsx
@@ -16,9 +16,6 @@ describe('RawFluxDataTable', () => {
     )
 
     const cells = wrapper.find('.raw-flux-data-table--cell')
-    const expectedCellCount = 182 // 14 rows x 13 columns
-
-    expect(cells).toHaveLength(expectedCellCount)
 
     expect(cells.at(0).text()).toEqual('#datatype')
     expect(cells.at(14).text()).toEqual('#group')


### PR DESCRIPTION
Fixes some issues introduced by #4663.

Those issues were:

- The “Raw Data” table for Flux was empty
- Empty graph messages were clipped and off-center

The commit messages have some more detail.