### PR TITLE
Improve scrolling for logs table

### DIFF
--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -262,7 +262,6 @@ class LogsPage extends Component<Props, State> {
               data={this.tableData}
               onScrollVertical={this.handleVerticalScroll}
               onScrolledToTop={this.handleScrollToTop}
-              isScrolledToTop={false}
               isTruncated={this.isTruncated}
               onTagSelection={this.handleTagSelection}
               fetchMore={this.handleFetchOlderChunk}
@@ -576,6 +575,10 @@ class LogsPage extends Component<Props, State> {
   }
 
   private handleVerticalScroll = () => {
+    if (!this.isLiveUpdating && this.state.hasScrolled) {
+      return
+    }
+
     if (this.isLiveUpdating) {
       this.clearTailInterval()
     }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/184

_Briefly describe your proposed changes:_
Improves scroll by removing a redundant scroll handler on `Grid` and uses the `style` prop to render the desired `width` and `height` that `FancyScrollBar` expects.
_What was the problem?_
Using the `width` prop for fancy scrollbars total `Grid` width causes the `Grid` to render more columns than necessary. Also, having both a `Grid` scroll and `FancyScrollbar` scroll handler caused redundant rendering that created a bit more lag when scrolling. 
_What was the solution?_
Use one scrolling handler to update `scrollLeft` and `scrollTop` and style the `Grid` with the total scrollable width and height, but limit the rendered `width` and `height` to viewable area set by `AutoSizer`.

  - [ ] Rebased/mergeable
  - [ ] Tests pass