### PR TITLE
Prevent error message from closing bucket in explorer

### DIFF
--- a/ui/src/flux/components/FieldList.tsx
+++ b/ui/src/flux/components/FieldList.tsx
@@ -70,6 +70,7 @@ class FieldList extends PureComponent<Props, State> {
       return (
         <div
           className={`flux-schema-tree flux-schema--child flux-schema-tree--error`}
+          onClick={this.handleClick}
         >
           Could not fetch fields
         </div>

--- a/ui/src/flux/components/MeasurementList.tsx
+++ b/ui/src/flux/components/MeasurementList.tsx
@@ -69,6 +69,7 @@ class MeasurementsList extends PureComponent<Props, State> {
       return (
         <div
           className={`flux-schema-tree flux-schema--child flux-schema-tree--error`}
+          onClick={this.handleClick}
         >
           Could not fetch measurements
         </div>

--- a/ui/src/flux/components/TagKeyList.tsx
+++ b/ui/src/flux/components/TagKeyList.tsx
@@ -45,6 +45,7 @@ class TagKeyList extends PureComponent<Props, State> {
       return (
         <div
           className={`flux-schema-tree flux-schema--child flux-schema-tree--error`}
+          onClick={this.handleClick}
         >
           Could not fetch tag keys
         </div>

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -98,6 +98,17 @@ class TagValueList extends PureComponent<Props, State> {
     const {source, db, tagKey, measurement, notify} = this.props
     const {searchTerm, loading, shouldShowMoreValues} = this.state
 
+    if (loading === RemoteDataState.Error) {
+      return (
+        <div
+          className={`flux-schema-tree flux-schema--child flux-schema-tree--error`}
+          onClick={this.handleClick}
+        >
+          Could not fetch tag values
+        </div>
+      )
+    }
+
     if (loading === RemoteDataState.Loading) {
       return <LoaderSkeleton />
     }


### PR DESCRIPTION
_What was the problem?_
Clicking on an error message in the schema explorer would close the entire bucket section that the error message was in.

_What was the solution?_
Add an click handler with a call to `e.stopPropagation()` to the error message element. Also add an error message for tag keys.

  - [x] Rebased/mergeable
  - [x] Tests pass
