### PR TITLE
Add dynamic expanded message container

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -134,6 +134,7 @@ class LogsTable extends Component<Props, State> {
     }
   }
 
+  private currentWidth: number
   private grid: Grid | null
   private headerGrid: React.RefObject<Grid>
 
@@ -151,6 +152,7 @@ class LogsTable extends Component<Props, State> {
       return c.visible
     }).length
 
+    this.currentWidth = null
     this.state = {
       searchPattern: null,
       scrollTop: 0,
@@ -267,6 +269,8 @@ class LogsTable extends Component<Props, State> {
     columnCount: number,
     registerChild: (g: Grid) => void
   ) => {
+    this.currentWidth = width
+
     const {scrollToRow} = this.props
     const {scrollTop, scrollLeft} = this.state
 
@@ -581,6 +585,7 @@ class LogsTable extends Component<Props, State> {
           formattedValue={formattedValue}
           onExpand={this.props.onExpandMessage}
           searchPattern={searchPattern}
+          maxWidth={this.currentWidth}
         />
       )
     }

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.scss
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.scss
@@ -77,3 +77,8 @@
     cursor: pointer;
   }
 }
+
+/* TODO: Make fancyscroll more customizable */
+.expanded--message .fancy-scroll--track-h {
+  display: none;
+}

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -26,6 +26,8 @@ interface Props {
 
 const PADDING = 8
 const MIN_LEFT = 120
+const MIN_MESSAGE_WIDTH = 200
+const MAX_MESSAGE_HEIGHT = 200
 
 @ErrorHandling
 export class ExpandableMessage extends Component<Props, State> {
@@ -83,8 +85,8 @@ export class ExpandableMessage extends Component<Props, State> {
         notify={this.props.notify}
         onClose={this.handleClose}
         maxWidth={this.props.maxWidth}
-        minWidth={200}
-        maxHeight={100}
+        minWidth={MIN_MESSAGE_WIDTH}
+        maxHeight={MAX_MESSAGE_HEIGHT}
         padding={PADDING}
         top={top}
         left={left}

--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -1,10 +1,10 @@
 // Libraries
-import React, {Component, MouseEvent} from 'react'
+import React, {Component} from 'react'
 import ReactDOM from 'react-dom'
 
 // Components
-import {ClickOutside} from 'src/shared/components/ClickOutside'
 import LogsMessage from 'src/logs/components/logs_message/LogsMessage'
+import {ExpandedContainer} from 'src/logs/components/expandable_message/ExpandedContainer'
 
 // Types
 import {NotificationAction} from 'src/types'
@@ -21,7 +21,11 @@ interface Props {
   notify: NotificationAction
   onExpand?: () => void
   searchPattern: string
+  maxWidth: number
 }
+
+const PADDING = 8
+const MIN_LEFT = 120
 
 @ErrorHandling
 export class ExpandableMessage extends Component<Props, State> {
@@ -71,37 +75,27 @@ export class ExpandableMessage extends Component<Props, State> {
 
     const portalElement = document.getElementById('expanded-message-container')
     const containerRect = this.containerRef.current.getBoundingClientRect()
-    const padding = 8
 
-    const style = {
-      top: containerRect.top - padding,
-      left: containerRect.left - padding,
-      width: containerRect.width + padding + padding,
-      padding,
-    }
+    const {top, left, width} = containerRect
 
     const message = (
-      <ClickOutside onClickOutside={this.handleClickOutside}>
-        <div className="expanded--message message-wrap" style={style}>
-          {this.closeExpansionButton}
-          {this.message}
-        </div>
-      </ClickOutside>
+      <ExpandedContainer
+        notify={this.props.notify}
+        onClose={this.handleClose}
+        maxWidth={this.props.maxWidth}
+        minWidth={200}
+        maxHeight={100}
+        padding={PADDING}
+        top={top}
+        left={left}
+        minLeft={MIN_LEFT}
+        width={width}
+      >
+        {this.message}
+      </ExpandedContainer>
     )
 
     return ReactDOM.createPortal(message, portalElement)
-  }
-
-  private get closeExpansionButton(): JSX.Element {
-    return (
-      <button className="expanded--dismiss" onClick={this.handleClickDismiss} />
-    )
-  }
-
-  private handleClickDismiss = (e: MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation()
-
-    this.setState({expanded: false})
   }
 
   private handleClick = () => {
@@ -117,7 +111,7 @@ export class ExpandableMessage extends Component<Props, State> {
     })
   }
 
-  private handleClickOutside = () => {
+  private handleClose = () => {
     this.setState({
       expanded: false,
     })

--- a/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
@@ -8,6 +8,9 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 // Types
 import {NotificationAction} from 'src/types'
 
+// Actions
+import {expandMessageError} from 'src/shared/copy/notifications'
+
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -42,7 +45,7 @@ export class ExpandedContainer extends Component<Props, State> {
 
   public componentDidMount() {
     if (!this.initialVisibility) {
-      this.props.onClose()
+      this.props.notify(expandMessageError(this.direction))
     }
   }
 
@@ -78,6 +81,14 @@ export class ExpandedContainer extends Component<Props, State> {
         </FancyScrollbar>
       </div>
     )
+  }
+
+  private get direction(): string {
+    if (this.props.left > this.props.minLeft) {
+      return 'right'
+    } else {
+      return 'left'
+    }
   }
 
   private get maxHeight(): number {

--- a/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
@@ -1,0 +1,151 @@
+// Libraries
+import React, {Component, MouseEvent, CSSProperties} from 'react'
+
+// Components
+import {ClickOutside} from 'src/shared/components/ClickOutside'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+
+// Types
+import {NotificationAction} from 'src/types'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  notify: NotificationAction
+  onClose: () => void
+  maxWidth: number
+  maxHeight: number
+  minWidth: number
+  minLeft: number
+  width: number
+  left: number
+  top: number
+  padding: number
+  children: JSX.Element
+}
+
+interface State {
+  scrollTop: number
+}
+
+const MIN_LEFT = 120
+
+@ErrorHandling
+export class ExpandedContainer extends Component<Props, State> {
+  private initialVisibility: boolean
+
+  constructor(props: Props) {
+    super(props)
+
+    this.initialVisibility = this.isVisible
+    this.state = {scrollTop: 0}
+  }
+
+  public componentDidMount() {
+    if (!this.initialVisibility) {
+      this.props.onClose()
+    }
+  }
+
+  public render() {
+    return (
+      <ClickOutside onClickOutside={this.handleClickOutside}>
+        {this.renderMessage({
+          top: this.top,
+          left: this.maxLeft,
+          width: this.visibleWidth,
+          padding: this.props.padding,
+          maxHeight: this.maxHeight,
+        })}
+      </ClickOutside>
+    )
+  }
+
+  private renderMessage(style: CSSProperties): JSX.Element {
+    if (style.width < this.props.minWidth) {
+      return this.props.children
+    }
+
+    return (
+      <div className="expanded--message message-wrap" style={style}>
+        {this.closeExpansionButton}
+        <FancyScrollbar
+          setScrollTop={this.handleScrollbarScroll}
+          scrollTop={this.state.scrollTop}
+          autoHeight={true}
+          maxHeight={this.props.maxHeight}
+        >
+          {this.props.children}
+        </FancyScrollbar>
+      </div>
+    )
+  }
+
+  private get maxHeight(): number {
+    return this.props.maxHeight + 2 * this.props.padding
+  }
+
+  private get top(): number {
+    return this.props.top - this.props.padding
+  }
+
+  private handleClickDismiss = (e: MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation()
+
+    this.props.onClose()
+  }
+
+  private handleScrollbarScroll = (e: MouseEvent<HTMLElement>): void => {
+    e.stopPropagation()
+    e.preventDefault()
+    const {scrollTop} = e.currentTarget
+
+    this.setState({scrollTop})
+  }
+
+  private handleClickOutside = () => {
+    this.props.onClose()
+  }
+
+  private get isVisible(): boolean {
+    return this.visibleWidth > this.props.minWidth
+  }
+
+  private get maxLeft(): number {
+    return Math.max(MIN_LEFT, this.props.left - this.props.padding)
+  }
+
+  private get visibleWidth(): number {
+    return Math.min(
+      this.remainingWidth,
+      this.maxViewableWidth,
+      this.props.width
+    )
+  }
+
+  private get remainingWidth(): number {
+    if (this.props.left > MIN_LEFT) {
+      return this.props.maxWidth - this.hiddenWidth
+    } else {
+      return this.props.width + this.hiddenWidth
+    }
+  }
+
+  private get hiddenWidth(): number {
+    return this.props.left - MIN_LEFT
+  }
+
+  // Table space with room for scrollbar
+  private get maxViewableWidth(): number {
+    return this.props.maxWidth - this.props.padding
+  }
+
+  private get closeExpansionButton(): JSX.Element {
+    return (
+      <button className="expanded--dismiss" onClick={this.handleClickDismiss} />
+    )
+  }
+}
+
+export default ExpandedContainer

--- a/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
@@ -29,8 +29,6 @@ interface State {
   scrollTop: number
 }
 
-const MIN_LEFT = 120
-
 @ErrorHandling
 export class ExpandedContainer extends Component<Props, State> {
   private initialVisibility: boolean
@@ -56,7 +54,7 @@ export class ExpandedContainer extends Component<Props, State> {
           left: this.maxLeft,
           width: this.visibleWidth,
           padding: this.props.padding,
-          maxHeight: this.maxHeight,
+          maxHeight: this.props.maxHeight,
         })}
       </ClickOutside>
     )
@@ -74,7 +72,7 @@ export class ExpandedContainer extends Component<Props, State> {
           setScrollTop={this.handleScrollbarScroll}
           scrollTop={this.state.scrollTop}
           autoHeight={true}
-          maxHeight={this.props.maxHeight}
+          maxHeight={this.maxHeight}
         >
           {this.props.children}
         </FancyScrollbar>
@@ -83,7 +81,11 @@ export class ExpandedContainer extends Component<Props, State> {
   }
 
   private get maxHeight(): number {
-    return this.props.maxHeight + 2 * this.props.padding
+    return this.props.maxHeight - this.verticalPadding
+  }
+
+  private get verticalPadding(): number {
+    return this.props.padding * 2
   }
 
   private get top(): number {
@@ -113,7 +115,7 @@ export class ExpandedContainer extends Component<Props, State> {
   }
 
   private get maxLeft(): number {
-    return Math.max(MIN_LEFT, this.props.left - this.props.padding)
+    return Math.max(this.props.minLeft, this.props.left - this.props.padding)
   }
 
   private get visibleWidth(): number {
@@ -125,7 +127,7 @@ export class ExpandedContainer extends Component<Props, State> {
   }
 
   private get remainingWidth(): number {
-    if (this.props.left > MIN_LEFT) {
+    if (this.props.left > this.props.minLeft) {
       return this.props.maxWidth - this.hiddenWidth
     } else {
       return this.props.width + this.hiddenWidth
@@ -133,7 +135,7 @@ export class ExpandedContainer extends Component<Props, State> {
   }
 
   private get hiddenWidth(): number {
-    return this.props.left - MIN_LEFT
+    return this.props.left - this.props.minLeft
   }
 
   // Table space with room for scrollbar

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -880,5 +880,6 @@ export const annotationsError = (message: string): Notification => ({
 export const expandMessageError = (direction: string): Notification => ({
   ...defaultErrorNotification,
   icon: 'expand-a',
+  duration: 1500,
   message: `Message out of view, scroll ${direction} to see`,
 })

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -875,3 +875,10 @@ export const annotationsError = (message: string): Notification => ({
   ...defaultErrorNotification,
   message,
 })
+
+// Logs page notifications
+export const expandMessageError = (direction: string): Notification => ({
+  ...defaultErrorNotification,
+  icon: 'expand-a',
+  message: `Message out of view, scroll ${direction} to see`,
+})


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/214

_Briefly describe your proposed changes:_


![kapture 2018-10-31 at 18 45 36](https://user-images.githubusercontent.com/4994741/47823153-3105b000-dd3d-11e8-9e45-16419c3873a7.gif)


_What was the problem?_
The expandable message would render outside the bounds of the logs table and the message contents could overflow the max height.
_What was the solution?_
- Make the expanded message render only the viewable width of the logs table
- Make the expanded message not render if width below 200px
- Make the expanded message use fancy scrollbars to scroll vertically


  - [x] Rebased/mergeable
  - [x] Tests pass