### PR TITLE
Bugfix/Flux query in InfluxQL mode in DE

### DIFF
--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -43,6 +43,7 @@ import {Links, ScriptStatus} from 'src/types/flux'
 import {ColorString, ColorNumber} from 'src/types/colors'
 
 interface ConnectedProps {
+  queryType: QueryType
   queryDrafts: CellQuery[]
   script: string
   draftScript: string
@@ -189,12 +190,9 @@ class CellEditorOverlay extends Component<Props, State> {
   }
 
   private get isFluxQuery(): boolean {
-    const {queryDrafts} = this.props
+    const {queryType} = this.props
 
-    if (getDeep<string>(queryDrafts, '0.type', '') === QueryType.Flux) {
-      return true
-    }
-    return false
+    return queryType === QueryType.Flux
   }
 
   private handleUpdateScriptStatus = (scriptStatus: ScriptStatus): void => {
@@ -327,6 +325,7 @@ const ConnectedCellEditorOverlay = (props: PassedProps) => {
         return (
           <CellEditorOverlay
             {...props}
+            queryType={state.queryType}
             queryDrafts={state.queryDrafts}
             script={state.script}
             draftScript={state.draftScript}

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -18,8 +18,7 @@ interface Props {
   sourceSupportsFlux: boolean
   queries: QueriesModels.QueryConfig[]
   isDynamicSourceSelected: boolean
-  toggleFluxOn: () => void
-  toggleFluxOff: () => void
+  toggleFlux: (queryType: QueryType) => void
   onSelectDynamicSource: () => void
   onChangeSource: (source: SourcesModels.Source, type: QueryType) => void
 }
@@ -28,8 +27,7 @@ const SourceSelector: SFC<Props> = ({
   source,
   sources = [],
   queries,
-  toggleFluxOn,
-  toggleFluxOff,
+  toggleFlux,
   isFluxSelected,
   onChangeSource,
   sourceSupportsFlux,
@@ -57,8 +55,8 @@ const SourceSelector: SFC<Props> = ({
         <Radio.Button
           id="influxql-source"
           titleText="InfluxQL"
-          value="InfluxQL"
-          onClick={toggleFluxOff}
+          value={QueryType.InfluxQL}
+          onClick={toggleFlux}
           active={!isFluxSelected}
           disabled={!sourceSupportsFlux}
         >
@@ -67,8 +65,8 @@ const SourceSelector: SFC<Props> = ({
         <Radio.Button
           id="flux-source"
           titleText="Flux"
-          value="Flux"
-          onClick={toggleFluxOn}
+          value={QueryType.Flux}
+          onClick={toggleFlux}
           active={isFluxSelected}
           disabled={!sourceSupportsFlux}
         >

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -274,24 +274,27 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       noteVisibility,
     } = visualizationOptions
 
-    const newCellQueries =
-      queryType === QueryType.Flux
-        ? [
-            {
-              queryConfig: null,
-              query: script,
-              source: source.links.self,
-              type: QueryType.Flux,
-            },
-          ]
-        : [
-            {
-              queryConfig,
-              query: rawText,
-              source: source.links.self,
-              type: QueryType.InfluxQL,
-            },
-          ]
+    const isFluxQuery = queryType === QueryType.Flux
+
+    let newCellQueries = [
+      {
+        queryConfig,
+        query: rawText,
+        source: source.links.self,
+        type: QueryType.InfluxQL,
+      },
+    ]
+
+    if (isFluxQuery) {
+      newCellQueries = [
+        {
+          queryConfig: null,
+          query: script,
+          source: source.links.self,
+          type: QueryType.Flux,
+        },
+      ]
+    }
 
     const colors: ColorString[] = getCellTypeColors({
       cellType: type,

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -51,7 +51,6 @@ interface PassedProps {
   dashboards: Dashboard[]
   source: Source
   rawText: string
-  isFluxQuery: boolean
   onCancel: () => void
   sendDashboardCell: (
     dashboard: Dashboard,
@@ -63,6 +62,7 @@ interface PassedProps {
 }
 
 interface ConnectedProps {
+  queryType: QueryType
   visualizationOptions: VisualizationOptions
 }
 
@@ -200,8 +200,8 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
   }
 
   private get hasQuery(): boolean {
-    const {queryConfig, script, isFluxQuery} = this.props
-    if (isFluxQuery) {
+    const {queryConfig, script, queryType} = this.props
+    if (queryType === QueryType.Flux) {
       return !!script.length
     }
     return getDeep<number>(queryConfig, 'fields.length', 0) !== 0
@@ -252,6 +252,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
   private sendToDashboard = async () => {
     const {name, newDashboardName} = this.state
     const {
+      queryType,
       queryConfig,
       script,
       sendDashboardCell,
@@ -260,7 +261,6 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       onCancel,
       visualizationOptions,
       isStaticLegend,
-      isFluxQuery,
     } = this.props
     const {
       type,
@@ -274,23 +274,24 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       noteVisibility,
     } = visualizationOptions
 
-    const newCellQueries = isFluxQuery
-      ? [
-          {
-            queryConfig: null,
-            query: script,
-            source: source.links.self,
-            type: QueryType.Flux,
-          },
-        ]
-      : [
-          {
-            queryConfig,
-            query: rawText,
-            source: source.links.self,
-            type: QueryType.InfluxQL,
-          },
-        ]
+    const newCellQueries =
+      queryType === QueryType.Flux
+        ? [
+            {
+              queryConfig: null,
+              query: script,
+              source: source.links.self,
+              type: QueryType.Flux,
+            },
+          ]
+        : [
+            {
+              queryConfig,
+              query: rawText,
+              source: source.links.self,
+              type: QueryType.InfluxQL,
+            },
+          ]
 
     const colors: ColorString[] = getCellTypeColors({
       cellType: type,
@@ -360,6 +361,7 @@ const ConnectedSendToDashboardOverlay = (props: PassedProps) => {
           thresholdsListType,
           gaugeColors,
           lineColors,
+          queryType,
         } = timeMachineContainer.state
 
         const visualizationOptions = {
@@ -380,6 +382,7 @@ const ConnectedSendToDashboardOverlay = (props: PassedProps) => {
         return (
           <SendToDashboardOverlay
             {...props}
+            queryType={queryType}
             visualizationOptions={visualizationOptions}
           />
         )

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -92,6 +92,7 @@ interface PassedProps {
 }
 
 interface ConnectedProps {
+  queryType: QueryType
   queryDrafts: CellQuery[]
   timeRange: TimeRange
   draftScript: string
@@ -264,9 +265,9 @@ export class DataExplorer extends PureComponent<Props, State> {
   }
 
   private writeQueryParams() {
-    const {router, queryDrafts, script} = this.props
+    const {router, queryDrafts, script, queryType} = this.props
     const query = _.get(queryDrafts, '0.query')
-    const isFlux = _.get(queryDrafts, '0.type') === QueryType.Flux
+    const isFlux = queryType === QueryType.Flux
 
     let queryParams
 
@@ -319,7 +320,6 @@ export class DataExplorer extends PureComponent<Props, State> {
             queryConfig={this.activeQueryConfig}
             script={draftScript}
             source={source}
-            isFluxQuery={this.isFluxQuery}
             rawText={this.rawText}
             dashboards={dashboards}
             handleGetDashboards={handleGetDashboards}
@@ -329,12 +329,6 @@ export class DataExplorer extends PureComponent<Props, State> {
         </OverlayTechnology>
       </Authorized>
     )
-  }
-
-  private get isFluxQuery(): boolean {
-    const {queryDrafts} = this.props
-    const type = getDeep<string>(queryDrafts, '0.type', '')
-    return type === 'flux'
   }
 
   private get templates(): Template[] {
@@ -440,6 +434,7 @@ const ConnectedDataExplorer = (props: PassedProps & WithRouterProps) => {
           <DataExplorer
             {...props}
             queryDrafts={state.queryDrafts}
+            queryType={state.queryType}
             draftScript={state.draftScript}
             timeRange={state.timeRange}
             script={state.script}

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -10,7 +10,6 @@ import _ from 'lodash'
 import {Subscribe} from 'unstated'
 
 // Utils
-import {getDeep} from 'src/utils/wrappers'
 import {stripPrefix} from 'src/utils/basepath'
 import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 import {getConfig} from 'src/dashboards/utils/cellGetters'

--- a/ui/src/shared/components/Layout.tsx
+++ b/ui/src/shared/components/Layout.tsx
@@ -15,7 +15,7 @@ import {getDeep} from 'src/utils/wrappers'
 import {IS_STATIC_LEGEND} from 'src/shared/constants'
 
 // Types
-import {TimeRange, Cell, Template, Source} from 'src/types'
+import {TimeRange, Cell, Template, Source, QueryType} from 'src/types'
 import {TimeSeriesServerResponse} from 'src/types/series'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {GrabDataForDownloadHandler} from 'src/types/layout'
@@ -99,6 +99,7 @@ class Layout extends Component<Props, State> {
     return (
       <RefreshingGraph
         onZoom={onZoom}
+        queryType={QueryType.Flux}
         timeFormat={cell.timeFormat}
         axes={cell.axes}
         type={cell.type}
@@ -142,6 +143,7 @@ class Layout extends Component<Props, State> {
     return (
       <RefreshingGraph
         onZoom={onZoom}
+        queryType={QueryType.InfluxQL}
         timeFormat={cell.timeFormat}
         axes={cell.axes}
         type={cell.type}

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -66,6 +66,7 @@ interface Props {
   axes: Axes
   source: Source
   queries: Query[]
+  queryType: QueryType
   timeRange: TimeRange
   colors: ColorString[]
   templates: Template[]
@@ -119,6 +120,7 @@ class RefreshingGraph extends Component<Props> {
       queries,
       cellNote,
       onNotify,
+      queryType,
       timeRange,
       templates,
       fluxASTLink,
@@ -216,7 +218,11 @@ class RefreshingGraph extends Component<Props> {
                       )
                     }
 
-                    if (showRawFluxData) {
+                    if (
+                      showRawFluxData &&
+                      queryType === QueryType.Flux &&
+                      !_.isEmpty(rawFluxData)
+                    ) {
                       return (
                         <RawFluxDataTable
                           csv={rawFluxData}
@@ -260,9 +266,9 @@ class RefreshingGraph extends Component<Props> {
   }
 
   private get isFluxQuery(): boolean {
-    const {queries} = this.props
+    const {queryType} = this.props
 
-    return getDeep<string>(queries, '0.type', '') === QueryType.Flux
+    return queryType === QueryType.Flux
   }
 
   private get shouldShowNoResults(): boolean {

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -32,8 +32,7 @@ interface Props {
   onSelectDynamicSource: () => void
   timeRange: QueriesModels.TimeRange
   updateEditorTimeRange: (timeRange: QueriesModels.TimeRange) => void
-  toggleFluxOn: () => void
-  toggleFluxOff: () => void
+  toggleFlux: (queryType: QueryType) => void
   toggleIsViewingRawData: () => void
 }
 
@@ -44,8 +43,7 @@ const TimeMachineControls: SFC<Props> = ({
   queries,
   templates,
   timeRange,
-  toggleFluxOn,
-  toggleFluxOff,
+  toggleFlux,
   isFluxSelected,
   isViewingRawData,
   autoRefreshDuration,
@@ -63,8 +61,7 @@ const TimeMachineControls: SFC<Props> = ({
         source={source}
         sources={sources}
         queries={queries}
-        toggleFluxOn={toggleFluxOn}
-        toggleFluxOff={toggleFluxOff}
+        toggleFlux={toggleFlux}
         sourceSupportsFlux={sourceSupportsFlux}
         isFluxSelected={isFluxSelected}
         onChangeSource={onChangeSource}

--- a/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
@@ -14,6 +14,7 @@ import {
   Query,
   Template,
   Status,
+  QueryType,
   QueryUpdateState,
 } from 'src/types'
 import {ColorString, ColorNumber} from 'src/types/colors'
@@ -28,6 +29,7 @@ import {AutoRefresher} from 'src/utils/AutoRefresher'
 
 interface ConnectedProps {
   timeRange: TimeRange
+  queryType: QueryType
   onUpdateFieldOptions: TimeMachineContainer['handleUpdateFieldOptions']
   type: CellType
   axes: Axes | null
@@ -72,6 +74,7 @@ const TimeMachineVisualization: SFC<Props> = props => {
           <RefreshingGraph
             source={props.source}
             colors={colors}
+            queryType={props.queryType}
             autoRefresher={props.autoRefresher}
             queries={props.queries}
             templates={props.templates}
@@ -110,6 +113,7 @@ const ConnectedTimeMachineVisualization = (props: PassedProps) => (
           timeRange={state.timeRange}
           type={state.type}
           axes={state.axes}
+          queryType={state.queryType}
           tableOptions={state.tableOptions}
           fieldOptions={state.fieldOptions}
           timeFormat={state.timeFormat}

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -70,12 +70,13 @@ import {ColorString, ColorNumber} from 'src/types/colors'
 
 const LOCAL_STORAGE_DELAY_MS = 1000
 
-const DEFAULT_STATE = () => ({
+const DEFAULT_STATE = (): TimeMachineState => ({
   script: '',
   draftScript: '',
   queryDrafts: [defaultQueryDraft(QueryType.InfluxQL)],
   timeRange: DEFAULT_TIME_RANGE,
   type: CellType.Line,
+  queryType: QueryType.InfluxQL,
   note: '',
   noteVisibility: NoteVisibility.Default,
   thresholdsListType: ThresholdType.Text,
@@ -97,6 +98,7 @@ export interface TimeMachineState {
   queryDrafts: CellQuery[]
   timeRange: TimeRange
   type: CellType
+  queryType: QueryType
   axes: Axes | null
   tableOptions: TableOptions
   fieldOptions: FieldOption[]
@@ -141,6 +143,10 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
     }
 
     return this.setAndPersistState(state)
+  }
+
+  public handleUpdateQueryType = (queryType: QueryType) => {
+    return this.setAndPersistState({queryType})
   }
 
   public handleChangeScript = (script: string) => {

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -158,12 +158,9 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
   }
 
   public handleInitFluxScript = (script: string) => {
-    const queryDraft = {...defaultQueryDraft(QueryType.Flux), query: script}
-
     this.setAndPersistState({
       script,
       draftScript: script,
-      queryDrafts: [queryDraft],
     })
   }
 

--- a/ui/src/shared/utils/timeMachine.ts
+++ b/ui/src/shared/utils/timeMachine.ts
@@ -4,6 +4,7 @@ import {get} from 'lodash'
 
 // Utils
 import defaultQueryConfig from 'src/utils/defaultQueryConfig'
+import {getDeep} from 'src/utils/wrappers'
 import {getLineColors} from 'src/shared/constants/graphColorPalettes'
 import {
   getThresholdsListColors,
@@ -19,9 +20,11 @@ import {TimeMachineState} from 'src/shared/utils/TimeMachineContainer'
 export function initialStateFromCell(
   cell: Cell | NewDefaultCell
 ): Partial<TimeMachineState> {
+  const queryDrafts = initialQueryDrafts(cell)
   const initialState: Partial<TimeMachineState> = {
-    queryDrafts: initialQueryDrafts(cell),
+    queryDrafts,
     type: cell.type,
+    queryType: getDeep<QueryType>(queryDrafts, '0.type', QueryType.InfluxQL),
     fieldOptions: cell.fieldOptions,
     timeFormat: cell.timeFormat,
     decimalPlaces: cell.decimalPlaces,

--- a/ui/src/shared/utils/timeMachine.ts
+++ b/ui/src/shared/utils/timeMachine.ts
@@ -24,7 +24,7 @@ export function initialStateFromCell(
   const initialState: Partial<TimeMachineState> = {
     queryDrafts,
     type: cell.type,
-    queryType: getDeep<QueryType>(queryDrafts, '0.type', QueryType.InfluxQL),
+    queryType: getDeep<QueryType>(cell, 'queries.0.type', QueryType.InfluxQL),
     fieldOptions: cell.fieldOptions,
     timeFormat: cell.timeFormat,
     decimalPlaces: cell.decimalPlaces,
@@ -65,7 +65,7 @@ function initialQueryDrafts(cell: Cell | NewDefaultCell): CellQuery[] {
   }
 
   if (cell.queries[0].type === QueryType.Flux) {
-    return [defaultQueryDraft(QueryType.Flux, cell.queries[0].source)]
+    return [defaultQueryDraft(QueryType.InfluxQL, cell.queries[0].source)]
   }
 
   return queries.map(q => {

--- a/ui/src/shared/utils/timeMachine.ts
+++ b/ui/src/shared/utils/timeMachine.ts
@@ -21,10 +21,16 @@ export function initialStateFromCell(
   cell: Cell | NewDefaultCell
 ): Partial<TimeMachineState> {
   const queryDrafts = initialQueryDrafts(cell)
+  const queryType = getDeep<QueryType>(
+    cell,
+    'queries.0.type',
+    QueryType.InfluxQL
+  )
+
   const initialState: Partial<TimeMachineState> = {
     queryDrafts,
     type: cell.type,
-    queryType: getDeep<QueryType>(cell, 'queries.0.type', QueryType.InfluxQL),
+    queryType,
     fieldOptions: cell.fieldOptions,
     timeFormat: cell.timeFormat,
     decimalPlaces: cell.decimalPlaces,


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/199

_What was the problem?_
Previously, the language type (InfluxQL or Flux) was obtained from the queryDrafts object. This created conflicting sources of truth, which resulted in a bug where if the user refreshed the page while on a Flux query in the Data Explorer and then switched to InfluxQL mode, the user would see their Flux query in the InfluxQL query builder.

_What was the solution?_
Create a `queryType` property on the `TimeMachineContainer` component and use this as a single source of truth for the language type throughout the Data Explorer and Cell Editor Overlay.

  - [x] Rebased/mergeable
  - [x] Tests pass