### PR TITLE
Fix setup wizard dashboard count

### DIFF
--- a/ui/src/sources/components/DashboardStep.tsx
+++ b/ui/src/sources/components/DashboardStep.tsx
@@ -65,7 +65,6 @@ class DashboardStep extends Component<Props, State> {
 
   public async componentDidMount() {
     const protoboards = await getProtoboards()
-    this.props.countSelected(0)
     this.setState({protoboards}, this.handleSuggest)
   }
 

--- a/ui/src/sources/components/DashboardStep.tsx
+++ b/ui/src/sources/components/DashboardStep.tsx
@@ -33,10 +33,14 @@ import {
 import {Protoboard, Source} from 'src/types'
 import {NextReturn} from 'src/types/wizard'
 
+interface SelectedDashboard {
+  [x: string]: boolean
+}
+
 interface State {
-  selected: object
   searchTerm: string
   protoboards: Protoboard[]
+  selected: SelectedDashboard
   suggestedProtoboards: Protoboard[]
 }
 
@@ -51,12 +55,8 @@ interface Props {
 class DashboardStep extends Component<Props, State> {
   public constructor(props: Props) {
     super(props)
-    const selected = props.dashboardsCreated.reduce(
-      (acc, d) => ({...acc, [d.id]: true}),
-      {}
-    )
     this.state = {
-      selected,
+      selected: this.selected,
       protoboards: [],
       searchTerm: '',
       suggestedProtoboards: [],
@@ -119,6 +119,13 @@ class DashboardStep extends Component<Props, State> {
 
   private setSearchTerm = searchTerm => {
     this.setState({searchTerm})
+  }
+
+  private get selected(): SelectedDashboard {
+    return this.props.dashboardsCreated.reduce(
+      (acc, d) => ({...acc, [d.id]: true}),
+      {}
+    )
   }
 
   private get dashboardCards() {

--- a/ui/src/sources/containers/OnboardingWizard.tsx
+++ b/ui/src/sources/containers/OnboardingWizard.tsx
@@ -69,8 +69,8 @@ class OnboardingWizard extends PureComponent<Props, State> {
       <>
         <Notifications />
         <WizardFullScreen
-          skipLinkText={'skip'}
-          switchLinkText={'Switch Organizations'}
+          skipLinkText="skip"
+          switchLinkText="Switch Organizations"
           handleSwitch={this.resetAndGotoPurgatory}
           isUsingAuth={isUsingAuth}
         >
@@ -115,10 +115,10 @@ class OnboardingWizard extends PureComponent<Props, State> {
             previousLabel="Go Back"
           >
             <DashboardStep
-              ref={c => (this.dashboardStepRef = c && c.getWrappedInstance())}
-              dashboardsCreated={dashboardsCreated}
               source={source}
               countSelected={this.countSelected}
+              dashboardsCreated={dashboardsCreated}
+              ref={c => (this.dashboardStepRef = c && c.getWrappedInstance())}
             />
           </WizardStep>
           <WizardStep


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/215

_What was the problem?_
As can be seen in [this GIF](https://github.com/influxdata/applications-team-issues/issues/215).  The dashboard count resets and is not displayed when the user hits "Go Back" from the setup kapacitor stage.

_What was the solution?_
Don't reset the dashboard count when `DashboardStep` remounts.

### Additional Thoughts
Really, we shouldn't be creating these dashboards at all until the user is done with all of the steps.  