### PR TITLE
Flux Functions Toolbar

### DIFF
--- a/ui/src/flux/components/FluxEditor.tsx
+++ b/ui/src/flux/components/FluxEditor.tsx
@@ -1,0 +1,64 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import FluxScriptEditor from 'src/flux/components/FluxScriptEditor'
+import {Button, ComponentSize, ComponentColor} from 'src/reusable_ui'
+
+// Types
+import {Suggestion, ScriptStatus} from 'src/types/flux'
+
+interface Props {
+  status: ScriptStatus
+  script: string
+  visibility: string
+  suggestions: Suggestion[]
+  onChangeScript: (draftScript: string) => void
+  onSubmitScript: () => void
+  onShowWizard: () => void
+}
+
+class FluxEditor extends PureComponent<Props> {
+  public render() {
+    const {
+      status,
+      script,
+      visibility,
+      suggestions,
+      onChangeScript,
+      onSubmitScript,
+      onShowWizard,
+    } = this.props
+
+    return (
+      <div className="flux-editor">
+        <FluxScriptEditor
+          status={status}
+          script={script}
+          visibility={visibility}
+          suggestions={suggestions}
+          onChangeScript={onChangeScript}
+          onSubmitScript={onSubmitScript}
+        >
+          {script.trim() === '' && (
+            <div className="flux-script-wizard--bg-hint">
+              <p>
+                New to Flux? Give the{' '}
+                <Button
+                  text={'Script Wizard'}
+                  color={ComponentColor.Primary}
+                  titleText={'Open Script Wizard'}
+                  size={ComponentSize.Large}
+                  onClick={onShowWizard}
+                />{' '}
+                a try
+              </p>
+            </div>
+          )}
+        </FluxScriptEditor>
+      </div>
+    )
+  }
+}
+
+export default FluxEditor

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -40,7 +40,7 @@ interface EditorInstance extends IInstance {
 }
 
 @ErrorHandling
-class TimeMachineEditor extends PureComponent<Props, State> {
+class FluxScriptEditor extends PureComponent<Props, State> {
   private editor: EditorInstance
   private lineWidgets: Widget[] = []
 
@@ -87,7 +87,7 @@ class TimeMachineEditor extends PureComponent<Props, State> {
     }
 
     return (
-      <div className="time-machine-editor">
+      <div className="flux-script-editor">
         <ReactCodeMirror
           autoFocus={true}
           autoCursor={true}
@@ -222,4 +222,4 @@ class TimeMachineEditor extends PureComponent<Props, State> {
   }
 }
 
-export default TimeMachineEditor
+export default FluxScriptEditor

--- a/ui/src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar.scss
+++ b/ui/src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar.scss
@@ -1,0 +1,185 @@
+.flux-functions-toolbar {
+  height: 100%;
+  background-color: $g3-castle;
+}
+
+.flux-functions-toolbar--category {
+  dt, dd {
+    height: 30px;
+    display: flex;
+    align-items: center;
+    padding-left: 10px;
+  }
+  
+  dt {
+    background-color: $g6-smoke;
+    font-weight: 600;
+    color: $g18-cloud;
+  }
+
+  dd {
+    font-family: "RobotoMono", monospace;
+  }
+
+  dd:hover, dd:active {
+    background-color: $g4-onyx;
+    color: $c-laser;
+  }
+}
+
+.flux-functions-toolbar--function {
+  position: relative;
+}
+
+.flux-functions-toolbar--helper {
+  color: $g10-wolf;
+  padding: 15px;
+}
+
+.flux-functions-toolbar--tooltip {
+  padding-right: 8px;
+  max-width: 600px;
+  position: fixed;
+  margin-top: 15px;
+  transform: translateY(-50%);
+  z-index: 10;
+}
+
+.flux-functions-toolbar--tooltip-caret {
+  content: "";
+  width: 0;
+  height: 0;
+  position: fixed;
+  border-top: 6px solid transparent;
+  border-bottom: 6px solid transparent;
+  border-left: 6px solid $c-pool;
+  margin-top: 9px;
+  margin-left: -8px;
+  z-index: 9999;
+}
+
+.flux-functions-toolbar--tooltip-contents {
+  border: $ix-border solid $c-pool;
+  border-radius: $radius;
+  width: 100%;
+  max-width: 600px;
+  display: inline-flex;
+  align-items: center;
+  background-color: $g1-raven;
+  padding: 10px;
+
+  article {
+    margin-bottom: $ix-marg-c;
+  }
+}
+
+.flux-functions-toolbar--heading {
+  font-weight: 600;
+  margin-bottom: $ix-marg-a;
+}
+
+.flux-functions-toolbar--snippet {
+  background-color: $g3-castle;
+  border-radius: $radius;
+  margin: $ix-marg-a 0;
+  padding: $ix-marg-b;
+  font-family: "RobotoMono", monospace;
+}
+
+.flux-functions-toolbar--arguments {
+  span:first-child {
+    font-weight: 600;
+    color: $c-pool;
+    margin-right: $ix-marg-a;
+  }
+
+  span:nth-child(2) {
+    color: $c-rainforest;
+    font-style: italic;
+    margin-right: 2px;
+  }
+
+  div {
+    margin: $ix-marg-a 0 $ix-marg-c 0;
+  }
+}
+
+.flux-functions-toolbar--tooltip-dismiss {
+  position: absolute;
+  z-index: 5000;
+  top: 0;
+  right: 0;
+  transform: translate(0,-50%);
+  width: 24px;
+  height: 24px;
+  outline: none;
+  border-radius: 50%;
+  background-color: $c-pool;
+  transition: background-color 0.25s ease;
+  border: 0;
+
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    width: 13px;
+    height: 3px;
+    top: 50%;
+    left: 50%;
+    border-radius: 1px;
+    background-color: $g20-white;
+  }
+
+  &:before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  &:after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+
+  &:hover {
+    background-color: $c-laser;
+    cursor: pointer;
+  }
+}
+
+.flux-functions-toolbar--tooltip-dismiss {
+  position: absolute;
+  z-index: 5000;
+  top: 0;
+  right: 0;
+  transform: translate(0,-50%);
+  width: 24px;
+  height: 24px;
+  outline: none;
+  border-radius: 50%;
+  background-color: $c-pool;
+  transition: background-color 0.25s ease;
+  border: 0;
+
+  &:before,
+  &:after {
+    content: '';
+    position: absolute;
+    width: 13px;
+    height: 3px;
+    top: 50%;
+    left: 50%;
+    border-radius: 1px;
+    background-color: $g20-white;
+  }
+
+  &:before {
+    transform: translate(-50%, -50%) rotate(45deg);
+  }
+
+  &:after {
+    transform: translate(-50%, -50%) rotate(-45deg);
+  }
+
+  &:hover {
+    background-color: $c-laser;
+    cursor: pointer;
+  }
+}

--- a/ui/src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar.tsx
@@ -1,0 +1,42 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import TransformToolbarFunctions from 'src/flux/components/flux_functions_toolbar/TransformToolbarFunctions'
+import FunctionCategory from 'src/flux/components/flux_functions_toolbar/FunctionCategory'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+
+// Constants
+import {functions as FUNCTIONS} from 'src/flux/constants'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+@ErrorHandling
+class FluxFunctionsToolbar extends PureComponent {
+  public render() {
+    return (
+      <div className="flux-functions-toolbar">
+        <FancyScrollbar>
+          <TransformToolbarFunctions funcs={FUNCTIONS}>
+            {sortedFunctions => {
+              return Object.entries(sortedFunctions).map(
+                ([category, funcs]) => {
+                  return (
+                    <FunctionCategory
+                      key={category}
+                      category={category}
+                      funcs={funcs}
+                    />
+                  )
+                }
+              )
+            }}
+          </TransformToolbarFunctions>
+        </FancyScrollbar>
+      </div>
+    )
+  }
+}
+
+export default FluxFunctionsToolbar

--- a/ui/src/flux/components/flux_functions_toolbar/FunctionCategory.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/FunctionCategory.tsx
@@ -1,0 +1,31 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Components
+import ToolbarFunction from 'src/flux/components/flux_functions_toolbar/ToolbarFunction'
+
+// Types
+import {FluxToolbarFunction} from 'src/types/flux'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  category: string
+  funcs: FluxToolbarFunction[]
+}
+
+@ErrorHandling
+class FunctionCategory extends PureComponent<Props> {
+  public render() {
+    const {category, funcs} = this.props
+    return (
+      <dl className="flux-functions-toolbar--category">
+        <dt>{category}</dt>
+        {funcs.map(func => <ToolbarFunction key={func.name} func={func} />)}
+      </dl>
+    )
+  }
+}
+
+export default FunctionCategory

--- a/ui/src/flux/components/flux_functions_toolbar/FunctionTooltip.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/FunctionTooltip.tsx
@@ -1,0 +1,94 @@
+// Libraries
+import React, {PureComponent, MouseEvent, CSSProperties} from 'react'
+
+// Components
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
+import TooltipDescription from 'src/flux/components/flux_functions_toolbar/TooltipDescription'
+import TooltipArguments from 'src/flux/components/flux_functions_toolbar/TooltipArguments'
+import TooltipExample from 'src/flux/components/flux_functions_toolbar/TooltipExample'
+import TooltipLink from 'src/flux/components/flux_functions_toolbar/TooltipLink'
+
+// Types
+import {FluxToolbarFunction} from 'src/types/flux'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  func: FluxToolbarFunction
+  onDismiss: () => void
+  tipPosition?: {top: number; right: number}
+}
+
+const MAX_HEIGHT = 400
+
+@ErrorHandling
+class FunctionTooltip extends PureComponent<Props> {
+  public render() {
+    const {
+      func: {desc, args, example, link},
+    } = this.props
+
+    return (
+      <>
+        <div
+          style={this.stylePosition}
+          className="flux-functions-toolbar--tooltip"
+        >
+          <button
+            className="flux-functions-toolbar--tooltip-dismiss"
+            onClick={this.handleDismiss}
+          />{' '}
+          <div className="flux-functions-toolbar--tooltip-contents">
+            <FancyScrollbar
+              autoHeight={true}
+              maxHeight={MAX_HEIGHT}
+              autoHide={false}
+            >
+              <TooltipDescription description={desc} />
+              <TooltipArguments argsList={args} />
+              <TooltipExample example={example} />
+              <TooltipLink link={link} />
+            </FancyScrollbar>
+          </div>
+        </div>
+        <span
+          className="flux-functions-toolbar--tooltip-caret"
+          style={this.styleCaretPosition}
+        />
+      </>
+    )
+  }
+
+  private get styleCaretPosition(): CSSProperties {
+    const {
+      tipPosition: {top, right},
+    } = this.props
+
+    return {
+      top: `${Math.min(top, window.innerHeight)}px`,
+      right: `${right + 4}px`,
+    }
+  }
+
+  private get stylePosition(): CSSProperties {
+    const {
+      tipPosition: {top, right},
+    } = this.props
+
+    return {
+      top: `${Math.min(top, window.innerHeight - MAX_HEIGHT / 2 - 28)}px`,
+      right: `${right + 2}px`,
+    }
+  }
+
+  private handleDismiss = (e: MouseEvent<HTMLElement>) => {
+    const {onDismiss} = this.props
+
+    e.preventDefault()
+    e.stopPropagation()
+    onDismiss()
+  }
+}
+
+export default FunctionTooltip

--- a/ui/src/flux/components/flux_functions_toolbar/ToolbarFunction.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/ToolbarFunction.tsx
@@ -1,0 +1,110 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {Subscribe} from 'unstated'
+
+// Component
+import FunctionTooltip from 'src/flux/components/flux_functions_toolbar/FunctionTooltip'
+
+// Utils
+import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
+
+// Types
+import {FluxToolbarFunction} from 'src/types/flux'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface PassedProps {
+  func: FluxToolbarFunction
+}
+
+interface ConnectedProps {
+  script: string
+  onUpdateScript: (script: string) => void
+}
+
+type Props = PassedProps & ConnectedProps
+
+interface State {
+  isActive: boolean
+  hoverPosition: {top: number; right: number}
+}
+
+@ErrorHandling
+class ToolbarFunction extends PureComponent<Props, State> {
+  private functionRef: HTMLElement
+
+  constructor(props: Props) {
+    super(props)
+
+    this.state = {isActive: false, hoverPosition: undefined}
+  }
+  public render() {
+    const {func} = this.props
+    return (
+      <div
+        className="flux-functions-toolbar--function"
+        ref={r => (this.functionRef = r)}
+        onMouseEnter={this.handleHover}
+        onMouseLeave={this.handleStopHover}
+        onClick={this.handleClickFunction}
+      >
+        {this.tooltip}
+        <dd>
+          {func.name} {this.helperText}
+        </dd>
+      </div>
+    )
+  }
+
+  private get tooltip(): JSX.Element {
+    if (this.state.isActive) {
+      return (
+        <FunctionTooltip
+          func={this.props.func}
+          onDismiss={this.handleStopHover}
+          tipPosition={this.state.hoverPosition}
+        />
+      )
+    }
+  }
+
+  private get helperText(): JSX.Element {
+    if (this.state.isActive) {
+      return (
+        <span className="flux-functions-toolbar--helper">Click to Add</span>
+      )
+    }
+  }
+
+  private handleHover = () => {
+    const {top, left} = this.functionRef.getBoundingClientRect()
+    const right = window.innerWidth - left
+    this.setState({isActive: true, hoverPosition: {top, right}})
+  }
+
+  private handleStopHover = () => {
+    this.setState({isActive: false})
+  }
+
+  private handleClickFunction = () => {
+    const {script, onUpdateScript, func} = this.props
+
+    const updatedScript = `${script}\n  |> ${func.example}`
+    onUpdateScript(updatedScript)
+  }
+}
+
+const ConnectedFunctionsToolbarFunction = (props: PassedProps) => (
+  <Subscribe to={[TimeMachineContainer]}>
+    {(container: TimeMachineContainer) => (
+      <ToolbarFunction
+        {...props}
+        script={container.state.draftScript}
+        onUpdateScript={container.handleUpdateDraftScript}
+      />
+    )}
+  </Subscribe>
+)
+
+export default ConnectedFunctionsToolbarFunction

--- a/ui/src/flux/components/flux_functions_toolbar/TooltipArguments.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/TooltipArguments.tsx
@@ -1,0 +1,47 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Args {
+  name: string
+  type: string
+  desc: string
+}
+
+interface Props {
+  argsList?: Args[]
+}
+
+@ErrorHandling
+class TooltipArguments extends PureComponent<Props> {
+  public render() {
+    return (
+      <article>
+        <div className="flux-functions-toolbar--heading">Arguments</div>
+        <div className="flux-functions-toolbar--snippet">{this.arguments}</div>
+      </article>
+    )
+  }
+
+  private get arguments(): JSX.Element | JSX.Element[] {
+    const {argsList} = this.props
+
+    if (argsList.length > 0) {
+      return argsList.map(a => {
+        return (
+          <div className="flux-functions-toolbar--arguments" key={a.name}>
+            <span>{a.name}:</span>
+            <span>{a.type}</span>
+            <div>{a.desc}</div>
+          </div>
+        )
+      })
+    }
+
+    return <div className="flux-functions-toolbar--arguments">None</div>
+  }
+}
+
+export default TooltipArguments

--- a/ui/src/flux/components/flux_functions_toolbar/TooltipDescription.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/TooltipDescription.tsx
@@ -1,0 +1,25 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  description: string
+}
+
+@ErrorHandling
+class TooltipDescription extends PureComponent<Props> {
+  public render() {
+    const {description} = this.props
+
+    return (
+      <article className="flux-functions-toolbar--description">
+        <div className="flux-functions-toolbar--heading">Description</div>
+        <span>{description}</span>
+      </article>
+    )
+  }
+}
+
+export default TooltipDescription

--- a/ui/src/flux/components/flux_functions_toolbar/TooltipExample.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/TooltipExample.tsx
@@ -1,0 +1,25 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  example: string
+}
+
+@ErrorHandling
+class TooltipExample extends PureComponent<Props> {
+  public render() {
+    const {example} = this.props
+
+    return (
+      <article>
+        <div className="flux-functions-toolbar--heading">Example</div>
+        <div className="flux-functions-toolbar--snippet">{example}</div>
+      </article>
+    )
+  }
+}
+
+export default TooltipExample

--- a/ui/src/flux/components/flux_functions_toolbar/TooltipLink.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/TooltipLink.tsx
@@ -1,0 +1,27 @@
+// Libraries
+import React, {PureComponent} from 'react'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  link: string
+}
+
+@ErrorHandling
+class TooltipLink extends PureComponent<Props> {
+  public render() {
+    const {link} = this.props
+
+    return (
+      <p>
+        Have questions? Read the{' '}
+        <a target="_blank" href={link}>
+          InfluxDB 2.0 Docs
+        </a>
+      </p>
+    )
+  }
+}
+
+export default TooltipLink

--- a/ui/src/flux/components/flux_functions_toolbar/TransformToolbarFunctions.tsx
+++ b/ui/src/flux/components/flux_functions_toolbar/TransformToolbarFunctions.tsx
@@ -1,0 +1,37 @@
+// Libraries
+import {PureComponent} from 'react'
+import _ from 'lodash'
+
+// Types
+import {FluxToolbarFunction} from 'src/types/flux'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  funcs: FluxToolbarFunction[]
+  children: (
+    sortedFunctions: {[category: string]: FluxToolbarFunction[]}
+  ) => JSX.Element | JSX.Element[]
+}
+
+@ErrorHandling
+class TransformToolbarFunctions extends PureComponent<Props> {
+  public render() {
+    return this.props.children(this.sortedFunctions)
+  }
+
+  private get sortedFunctions() {
+    const {funcs} = this.props
+    const grouped = _.groupBy(funcs, 'category')
+    const sorted = Object.keys(grouped)
+      .sort()
+      .reduce((acc, key) => {
+        acc[key] = grouped[key]
+        return acc
+      }, {})
+    return sorted
+  }
+}
+
+export default TransformToolbarFunctions

--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -1,0 +1,433 @@
+// Types
+import {FluxToolbarFunction} from 'src/types/flux'
+
+export const functions: FluxToolbarFunction[] = [
+  {
+    name: 'count()',
+    args: [
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    desc: 'Outputs the number of non-null records in each aggregated column.',
+    example: 'count(columns: ["_value"])',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'covariance()',
+    args: [
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Exactly two columns must be provided.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'pearsonr',
+        desc:
+          'Indicates whether the result should be normalized to be the Pearson R coefficient',
+        type: 'Boolean',
+      },
+      {
+        name: 'valueDst',
+        desc:
+          'The column into which the result will be placed. Defaults to `"_value"`.',
+        type: 'String',
+      },
+    ],
+    desc: 'Computes the covariance between two columns.',
+    example:
+      'covariance(columns: ["column_x", "column_y"], pearsonr: false, valueDst: "_value")',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'cumulativeSum()',
+    args: [
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    desc:
+      'Computes a running sum for non-null records in the table. The output table schema will be the same as the input table.',
+    example: 'cumulativeSum(columns: ["_value"])',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'derivative()',
+    args: [
+      {
+        name: 'unit',
+        desc: 'The time duration used when creating the derivative.',
+        type: 'Duration',
+      },
+      {
+        name: 'nonNegative',
+        desc:
+          'Indicates if the derivative is allowed to be negative. When set to `true`, if a value is less than the previous value, it is assumed the previous value should have been a zero.',
+        type: 'Boolean',
+      },
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'timeSrc',
+        desc: 'The column containing time values. Defaults to `"_time"`.',
+        type: 'String',
+      },
+    ],
+    desc:
+      'Computes the rate of change per unit of time between subsequent non-null records. The output table schema will be the same as the input table.',
+    example:
+      'derivative(unit: 100ms, nonNegative: false, columns: ["_value"], timeSrc: "_time")',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'difference()',
+    args: [
+      {
+        name: 'nonNegative',
+        desc:
+          'Indicates if the derivative is allowed to be negative. When set to `true`, if a value is less than the previous value, it is assumed the previous value should have been a zero.',
+        type: 'Boolean',
+      },
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    desc: 'Computes the difference between subsequent non-null records.',
+    example: 'difference(nonNegative: false, columns: ["_value"])',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'distinct()',
+    args: [
+      {
+        name: 'column',
+        desc: 'Column on which to track unique values.',
+        type: 'String',
+      },
+    ],
+    desc: 'Returns the unique values for a given column.',
+    example: 'distinct(column: "host")',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'drop()',
+    args: [
+      {
+        name: 'columns',
+        desc:
+          'A list of columns to be removed from the table. Cannot be used with `fn`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'fn',
+        desc:
+          'A function which takes a column name as a parameter and returns a boolean indicating whether or not the column should be removed from the table. Cannot be used with `columns`.',
+        type: 'Function',
+      },
+    ],
+    desc:
+      'Removes specified columns from a table. Columns can be specified either through a list or a predicate function. When a dropped column is part of the group key, it will be removed from the key.',
+    example: 'drop(columns: ["col1", "col2"])',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+  {
+    name: 'duplicate()',
+    args: [
+      {
+        name: 'column',
+        desc: 'The column name to duplicate.',
+        type: 'String',
+      },
+      {
+        name: 'as',
+        desc: 'The name assigned to the duplicate column.',
+        type: 'String',
+      },
+    ],
+    desc: 'Duplicates a specified column in a table.',
+    example: 'duplicate(column: "column-name", as: "duplicate-name")',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+  {
+    name: 'filter()',
+    args: [
+      {
+        name: 'fn',
+        desc:
+          'A single argument function that evaluates true or false. Records are passed to the function. Those that evaluate to true are included in the output tables.',
+        type: 'Function',
+      },
+    ],
+    desc:
+      'Filters data based on conditions defined in the function. The output tables have the same schema as the corresponding input tables.',
+    example: 'filter(fn: (r) => r._measurement == "cpu")',
+    category: 'Filter',
+    link: 'http://example.com',
+  },
+  {
+    name: 'first()',
+    args: [],
+    desc: 'Selects the first non-null record from an input table.',
+    example: 'first()',
+    category: 'Selector',
+    link: 'http://example.com',
+  },
+  {
+    name: 'from()',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The name of the bucket to query.',
+        type: 'String',
+      },
+      {
+        name: 'bucketID',
+        desc: 'The string-encoded ID of the bucket to query.',
+        type: 'String',
+      },
+    ],
+    desc:
+      'Used to retrieve data from an InfluxDB data source. It returns a stream of tables from the specified bucket. Each unique series is contained within its own table. Each record in the table represents a single point in the series.',
+    example: 'from(bucket: "telegraf/autogen")',
+    category: 'Source',
+    link: 'http://example.com',
+  },
+  {
+    name: 'fromRows()',
+    args: [
+      {
+        name: 'bucket',
+        desc: 'The name of the bucket to query.',
+        type: 'String',
+      },
+      {
+        name: 'bucketID',
+        desc: 'The string-encoded ID of the bucket to query.',
+        type: 'String',
+      },
+    ],
+    desc:
+      'This is a special application of the `pivot()` function that will automatically align fields within each measurement that have the same timestamp.',
+    example: 'fromRows(bucket: "bucket-name")',
+    category: 'Source',
+    link: 'http://example.com',
+  },
+  {
+    name: 'group()',
+    args: [
+      {
+        name: 'by',
+        desc:
+          'List of columns by which to group. Cannot be used with `except`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'except',
+        desc:
+          'List of columns by which to NOT group. All other columns are used to group records. Cannot be used with `by`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'none',
+        desc: 'Remove existing groups.',
+        type: 'Boolean',
+      },
+    ],
+    desc:
+      'Groups records based on their values for specific columns. It produces tables with new group keys based on provided properties.',
+    example: 'group(by: ["host", "_measurement"])',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+  {
+    name: 'histogram()',
+    args: [
+      {
+        name: 'column',
+        desc:
+          'The name of a column containing input data values. The column type must be float. Defaults to `"_value"`.',
+        type: 'Strings',
+      },
+      {
+        name: 'upperBoundColumn',
+        desc:
+          'The name of the column in which to store the histogram\'s upper bounds. Defaults to `"le"`.',
+        type: 'String',
+      },
+      {
+        name: 'countColumn',
+        desc:
+          'The name of the column in which to store the histogram counts. Defaults to `"_value"`.',
+        type: 'String',
+      },
+      {
+        name: 'buckets',
+        desc:
+          'A list of upper bounds to use when computing the histogram frequencies. Buckets should contain a bucket whose bound is the maximum value of the data set. This value can be set to positive infinity if no maximum is known.',
+        type: 'Array of Floats',
+      },
+      {
+        name: 'normalize',
+        desc:
+          'When `true`, will convert the counts into frequency values between 0 and 1. Defaults to `false`.',
+        type: 'Boolean',
+      },
+    ],
+    desc:
+      'Approximates the cumulative distribution function of a dataset by counting data frequencies for a list of buckets.',
+    example:
+      'histogram(column: "_value", upperBoundColumn: "le", countColumn: "_value", buckets: [50.0, 75.0, 90.0], normalize: false)',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+  {
+    name: 'histogramQuantile()',
+    args: [
+      {
+        name: 'quantile',
+        desc:
+          'A value between 0 and 1 indicating the desired quantile to compute.',
+        type: 'Float',
+      },
+      {
+        name: 'upperBoundColumn',
+        desc:
+          'The name of the column in which to store the histogram\'s upper bounds. The count column type must be float. Defaults to `"le"`.',
+        type: 'String',
+      },
+      {
+        name: 'countColumn',
+        desc:
+          'The name of the column in which to store the histogram counts. The count column type must be float. Defaults to `"_value"`.',
+        type: 'String',
+      },
+      {
+        name: 'valueColumn',
+        desc:
+          'The name of the output column which will contain the computed quantile. Defaults to `"_value"`.',
+        type: 'String',
+      },
+      {
+        name: 'minValue',
+        desc:
+          'The assumed minimum value of the dataset. When the quantile falls below the lowest upper bound, interpolation is performed between `minValue` and the lowest upper bound. When `minValue` is equal to negative infinity, the lowest upper bound is used. Defaults to `0`.',
+        type: 'Float',
+      },
+    ],
+    desc:
+      'Approximates a quantile given a histogram that approximates the cumulative distribution of the dataset.',
+    example:
+      'histogramQuantile(quantile: 0.5, countColumn: "_value", upperBoundColumn: "le", valueColumn: "_value", minValue: 0)',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+  {
+    name: 'integral()',
+    args: [
+      {
+        name: 'unit',
+        desc: 'The time duration used when computing the integral.',
+        type: 'Duration',
+      },
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+    ],
+    desc:
+      'Computes the area under the curve per unit of time of subsequent non-null records. The curve is defined using `_time` as the domain and record values as the range.',
+    example: 'integral(unit: 10s, columns: ["_value"])',
+    category: 'Aggregate',
+    link: 'http://example.com',
+  },
+  {
+    name: 'intervals()',
+    args: [
+      {
+        name: 'every',
+        desc:
+          'The duration between starts of each of the intervals. Defaults to the value of the `period` duration.',
+        type: 'Duration',
+      },
+      {
+        name: 'period',
+        desc:
+          'The length of each interval. Defaults to the value of the `every` duration.',
+        type: 'Duration',
+      },
+      {
+        name: 'offset',
+        desc:
+          'The offset duration relative to the location offset. Defaults to `0h`.',
+        type: 'Duration',
+      },
+      {
+        name: 'columns',
+        desc:
+          'A list of columns on which to operate. Defaults to `["_value"]`.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'fn',
+        desc:
+          'A function that accepts an interval object and returns a boolean value. Each potential interval is passed to the filter function. When the function returns false, that interval is excluded from the set of intervals. Defaults to include all intervals.',
+        type: 'Function',
+      },
+    ],
+    desc: 'Generates a set of time intervals over a range of time.',
+    example: 'intervals()',
+    category: 'Generator',
+    link: 'http://example.com',
+  },
+  {
+    name: 'join()',
+    args: [
+      {
+        name: 'tables',
+        desc: 'The map of streams to be joined.',
+        type: 'Object',
+      },
+      {
+        name: 'on',
+        desc: 'The list of columns on which to join.',
+        type: 'Array of Strings',
+      },
+      {
+        name: 'method',
+        desc:
+          'The method used to join. Possible values are: `inner`, `cross`, `left`, `right`, or `full`. Defaults to `"inner"`.',
+        type: 'String',
+      },
+    ],
+    desc:
+      'Merges two or more input streams, whose values are equal on a set of common columns, into a single output stream. The resulting schema is the union of the input schemas. The resulting group key is the union of the input group keys.',
+    example:
+      'join(tables: {key1: table1, key2: table2}, on: ["_time", "_field"], method: "inner")',
+    category: 'Transformation',
+    link: 'http://example.com',
+  },
+]

--- a/ui/src/flux/constants/index.ts
+++ b/ui/src/flux/constants/index.ts
@@ -2,5 +2,6 @@ import {ast} from 'src/flux/constants/ast'
 import * as argTypes from 'src/flux/constants/argumentTypes'
 import * as vis from 'src/flux/constants/vis'
 import * as explorer from 'src/flux/constants/explorer'
+import {functions} from 'src/flux/constants/functions'
 
-export {ast, argTypes, vis, explorer}
+export {ast, argTypes, vis, explorer, functions}

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -4,10 +4,11 @@ import {Subscribe} from 'unstated'
 
 // Components
 import SchemaExplorer from 'src/flux/components/SchemaExplorer'
-import TimeMachineEditor from 'src/flux/components/TimeMachineEditor'
+import FluxEditor from 'src/flux/components/FluxEditor'
 import FluxScriptWizard from 'src/shared/components/TimeMachine/FluxScriptWizard'
 import Threesizer from 'src/shared/components/threesizer/Threesizer'
 import {Button, ComponentSize, ComponentColor} from 'src/reusable_ui'
+import FluxFunctionsToolbar from 'src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar'
 
 // Constants
 import {HANDLE_VERTICAL} from 'src/shared/constants'
@@ -81,7 +82,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
     } = this.props
     const {suggestions, isWizardActive, draftScriptStatus} = this.state
 
-    const [leftSize, rightSize] = fluxProportions
+    const [leftSize, middleSize, rightSize] = fluxProportions
 
     const divisions = [
       {
@@ -94,7 +95,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
       },
       {
         name: 'Script',
-        size: rightSize,
+        size: middleSize,
         customClass: 'flux-query-maker--script',
         headerOrientation: HANDLE_VERTICAL,
         headerButtons: [
@@ -114,31 +115,24 @@ class FluxQueryMaker extends PureComponent<Props, State> {
         ],
         menuOptions: [],
         render: visibility => (
-          <TimeMachineEditor
+          <FluxEditor
             status={draftScriptStatus}
             script={draftScript}
             visibility={visibility}
             suggestions={suggestions}
             onChangeScript={this.handleChangeDraftScript}
             onSubmitScript={this.handleSubmitScript}
-          >
-            {draftScript.trim() === '' && (
-              <div className="flux-script-wizard--bg-hint">
-                <p>
-                  New to Flux? Give the{' '}
-                  <Button
-                    text={'Script Wizard'}
-                    color={ComponentColor.Primary}
-                    titleText={'Open Script Wizard'}
-                    size={ComponentSize.Large}
-                    onClick={this.handleShowWizard}
-                  />{' '}
-                  a try
-                </p>
-              </div>
-            )}
-          </TimeMachineEditor>
+            onShowWizard={this.handleShowWizard}
+          />
         ),
+      },
+      {
+        name: 'Explore Functions',
+        size: rightSize,
+        headerButtons: [],
+        menuOptions: [],
+        render: () => <FluxFunctionsToolbar />,
+        headerOrientation: HANDLE_VERTICAL,
       },
     ]
 

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -87,7 +87,7 @@ const DEFAULT_STATE = () => ({
   timeFormat: DEFAULT_TIME_FORMAT,
   decimalPlaces: DEFAULT_DECIMAL_PLACES,
   fieldOptions: DEFAULT_FIELD_OPTIONS,
-  fluxProportions: [0.34, 0.66],
+  fluxProportions: [0.2, 0.6, 0.2],
   timeMachineProportions: [0.33, 0.67],
 })
 

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -81,6 +81,7 @@
 @import '../logs/components/logs_message/LogsMessage';
 @import '../logs/components/expandable_message/ExpandableMessage';
 @import '../dashboards/components/import_dashboard_mappings/ImportDashboardMappings.scss';
+@import 'src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar';
 @import 'components/dashboard-empty';
 @import 'components/template-control-bar';
 @import 'components/edit-template-variable';

--- a/ui/src/style/components/time-machine/flux-editor.scss
+++ b/ui/src/style/components/time-machine/flux-editor.scss
@@ -10,12 +10,13 @@
   align-items: stretch;
 }
 
-.func-nodes-container,
-.time-machine-editor-container {
-  flex: 1 0 50%;
+.flux-editor {
+display: flex;
+flex-direction: row;
+height: 100%;
 }
 
-.time-machine-editor {
+.flux-script-editor {
   width: 100%;
   height: 100%;
   position: relative;

--- a/ui/src/types/flux.ts
+++ b/ui/src/types/flux.ts
@@ -185,3 +185,18 @@ export enum VisType {
   Graph,
   Table,
 }
+
+export interface FluxToolbarArg {
+  name: string
+  desc: string
+  type: string
+}
+
+export interface FluxToolbarFunction {
+  name: string
+  args: FluxToolbarArg[]
+  desc: string
+  example: string
+  category: string
+  link: string
+}

--- a/ui/test/flux/components/FluxScriptEditor.test.tsx
+++ b/ui/test/flux/components/FluxScriptEditor.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import TimeMachineEditor from 'src/flux/components/TimeMachineEditor'
+import FluxScriptEditor from 'src/flux/components/FluxScriptEditor'
 import {shallow} from 'enzyme'
 
 const setup = (override?) => {
@@ -9,7 +9,7 @@ const setup = (override?) => {
     ...override,
   }
 
-  const wrapper = shallow(<TimeMachineEditor {...props} />)
+  const wrapper = shallow(<FluxScriptEditor {...props} />)
 
   return {
     wrapper,
@@ -17,7 +17,7 @@ const setup = (override?) => {
   }
 }
 
-describe('Flux.Components.TimeMachineEditor', () => {
+describe('Flux.Components.FluxScriptEditor', () => {
   describe('rendering', () => {
     it('renders without error', () => {
       const {wrapper} = setup()


### PR DESCRIPTION
Closes # influxdata/chronograf/issues/4628

![functions_toolbar](https://user-images.githubusercontent.com/11937365/47876899-b6d63980-ddd7-11e8-885e-c86d6db1e86f.gif)

_Briefly describe your proposed changes:_
Implement a toolbar to showcase a selection of the most commonly used functions with the ability to click to add them and quick access to documentation.

_What was the problem?_
Users who don't know Flux need a way to know what functions are available and how to use them.

_What was the solution?_
Implement a toolbar to showcase a selection of the most commonly used functions with the ability to click to add them and quick access to documentation.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass