### PR TITLE
Flux editor styling tweaks

### DIFF
--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.scss
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.scss
@@ -61,16 +61,16 @@
   user-select: none;
 
   p {
-    font-size: 24px;
+    font-size: 17px;
     color: $g9-mountain;
+    text-align: center;
     position: relative;
     left: -50%;
     top: -45%;
+    min-width: 200px;
 
-    a {
-      color: $g12-forge;
-      border-bottom: 1px solid $g12-forge;
-      cursor: pointer;
+    button {
+      margin: 0 5px;
     }
   }
 }

--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
@@ -34,9 +34,10 @@ import {
 // Types
 import {RemoteDataState, Source} from 'src/types'
 
-// This constant is selected so that dropdown menus will not overflow out of
-// the `.flux-script-wizard--wizard` window
+// These constants are selected so that the dropdown menus will not overflow
+// out of the `.flux-script-wizard--wizard` window
 const DROPDOWN_MENU_HEIGHT = 110
+const LAST_DROPDOWN_MENU_HEIGHT = 70
 
 interface Props {
   source: Source
@@ -164,6 +165,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
                 <Dropdown
                   selectedID={selectedAggFunction}
                   onChange={this.handleSelectAggFunction}
+                  maxMenuHeight={LAST_DROPDOWN_MENU_HEIGHT}
                 >
                   {AGG_FUNCTIONS.map(({description, value}) => (
                     <Dropdown.Item key={value} id={value} value={value}>


### PR DESCRIPTION
Before:

<img width="472" alt="screen shot 2018-11-01 at 2 05 30 pm" src="https://user-images.githubusercontent.com/638955/47880299-146e8400-dde0-11e8-9c01-d03b428fe8a8.png">

After:

<img width="495" alt="screen shot 2018-11-01 at 2 04 23 pm" src="https://user-images.githubusercontent.com/638955/47880305-1c2e2880-dde0-11e8-88e9-457a2549bcd8.png">

Before:

<img width="830" alt="screen shot 2018-11-01 at 2 05 20 pm" src="https://user-images.githubusercontent.com/638955/47880308-20f2dc80-dde0-11e8-8fb7-d5f00b8c59a5.png">

After:

<img width="829" alt="screen shot 2018-11-01 at 2 04 31 pm" src="https://user-images.githubusercontent.com/638955/47880313-26502700-dde0-11e8-8e73-60a98e59b699.png">
