### PR TITLE
Add logs page spinner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 1.  [#4525](https://github.com/influxdata/chronograf/pull/4525): Move expanded log message copy button to top right
 1.  [#4665](https://github.com/influxdata/chronograf/pull/4665): Remove shadow from note cells
 1.  [#4665](https://github.com/influxdata/chronograf/pull/4665): Remove character count limit from prefix and suffix for Single Stat and Gauge cells
+1.  [#4715](https://github.com/influxdata/chronograf/pull/4715): Add logs page loading spinner
 
 ### UI Improvements
 1.  [#4236](https://github.com/influxdata/chronograf/pull/4236): Add spinner when loading logs table rows

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -211,7 +211,6 @@ class LogsPage extends Component<Props, State> {
 
   public async componentDidMount() {
     await this.getSources()
-
     await this.setCurrentSource()
 
     await this.props.getConfig(this.logConfigLink)

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -1,3 +1,4 @@
+// Libraries
 import React, {Component} from 'react'
 import uuid from 'uuid'
 import _ from 'lodash'
@@ -5,21 +6,34 @@ import {connect} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
 import {withRouter, InjectedRouter} from 'react-router'
 
+// Components
+import LogsHeader from 'src/logs/components/LogsHeader'
+import HistogramChart from 'src/shared/components/HistogramChart'
+import LogsGraphContainer from 'src/logs/components/LogsGraphContainer'
+import TimeWindowDropdown from 'src/logs/components/TimeWindowDropdown'
+import OptionsOverlay from 'src/logs/components/OptionsOverlay'
+import SearchBar from 'src/logs/components/LogsSearchBar'
+import FilterBar from 'src/logs/components/LogsFilterBar'
+import LogsTable from 'src/logs/components/LogsTable'
+import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
+import HistogramResults from 'src/logs/components/HistogramResults'
+import PageSpinner from 'src/shared/components/PageSpinner'
+
+// Utils
+import {getDeep} from 'src/utils/wrappers'
 import {searchToFilters} from 'src/logs/utils/search'
 import {fetchChunk} from 'src/logs/utils/fetchChunk'
-import {notify as notifyAction} from 'src/shared/actions/notifications'
-
-import {Greys} from 'src/reusable_ui/types'
-import HistogramResults from 'src/logs/components/HistogramResults'
-
+import {colorForSeverity} from 'src/logs/utils/colors'
 import {
-  NOW,
-  DEFAULT_TAIL_CHUNK_DURATION_MS,
-  DEFAULT_NEWER_CHUNK_DURATION_MS,
-  NEWER_CHUNK_OPTIONS,
-  OLDER_CHUNK_OPTIONS,
-} from 'src/logs/constants'
+  applyChangesToTableData,
+  isEmptyInfiniteData,
+} from 'src/logs/utils/table'
+import extentBy from 'src/utils/extentBy'
+import {computeTimeBounds} from 'src/logs/utils/timeBounds'
+import {formatTime} from 'src/logs/utils'
 
+// Actions
+import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {
   setTableCustomTimeAsync,
   setTableRelativeTimeAsync,
@@ -47,21 +61,20 @@ import {
   executeHistogramQueryAsync,
 } from 'src/logs/actions'
 import {getSourcesAsync} from 'src/shared/actions/sources'
-import LogsHeader from 'src/logs/components/LogsHeader'
-import HistogramChart from 'src/shared/components/HistogramChart'
-import LogsGraphContainer from 'src/logs/components/LogsGraphContainer'
-import TimeWindowDropdown from 'src/logs/components/TimeWindowDropdown'
-import OptionsOverlay from 'src/logs/components/OptionsOverlay'
-import SearchBar from 'src/logs/components/LogsSearchBar'
-import FilterBar from 'src/logs/components/LogsFilterBar'
-import LogsTable from 'src/logs/components/LogsTable'
-import {getDeep} from 'src/utils/wrappers'
-import {colorForSeverity} from 'src/logs/utils/colors'
-import OverlayTechnology from 'src/reusable_ui/components/overlays/OverlayTechnology'
+
+// Constants
+import {
+  NOW,
+  DEFAULT_TAIL_CHUNK_DURATION_MS,
+  DEFAULT_NEWER_CHUNK_DURATION_MS,
+  NEWER_CHUNK_OPTIONS,
+  OLDER_CHUNK_OPTIONS,
+} from 'src/logs/constants'
 import {SeverityFormatOptions, SEVERITY_SORTING_ORDER} from 'src/logs/constants'
 
+// Types
+import {Greys} from 'src/reusable_ui/types'
 import {Source, Namespace, NotificationAction} from 'src/types'
-
 import {
   HistogramData,
   HistogramColor,
@@ -81,13 +94,6 @@ import {
   SearchStatus,
   FetchLoop,
 } from 'src/types/logs'
-import {
-  applyChangesToTableData,
-  isEmptyInfiniteData,
-} from 'src/logs/utils/table'
-import extentBy from 'src/utils/extentBy'
-import {computeTimeBounds} from 'src/logs/utils/timeBounds'
-import {formatTime} from 'src/logs/utils'
 
 interface Props {
   sources: Source[]
@@ -232,6 +238,10 @@ class LogsPage extends Component<Props, State> {
       searchStatus,
       tableTime,
     } = this.props
+
+    if (this.isLoadingSources) {
+      return <PageSpinner />
+    }
 
     return (
       <>
@@ -965,6 +975,10 @@ class LogsPage extends Component<Props, State> {
 
   private get shouldLiveUpdate(): boolean {
     return this.props.tableTime.relative === 0
+  }
+
+  private get isLoadingSources(): boolean {
+    return this.props.sources.length === 0
   }
 }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -178,7 +178,7 @@ class LogsPage extends Component<Props, State> {
   private loadingNewer: boolean = false
   private currentOlderChunksGenerator: FetchLoop = null
   private currentNewerChunksGenerator: FetchLoop = null
-  private loadingSources: RemoteDataState = RemoteDataState.NotStarted
+  private loadingSourcesStatus: RemoteDataState = RemoteDataState.NotStarted
 
   constructor(props: Props) {
     super(props)
@@ -241,7 +241,7 @@ class LogsPage extends Component<Props, State> {
       tableTime,
     } = this.props
 
-    if (this.isLoadingSources) {
+    if (this.isLoadingSourcesStatus) {
       return <PageSpinner />
     }
 
@@ -960,11 +960,11 @@ class LogsPage extends Component<Props, State> {
 
   private getSources = async (): Promise<void> => {
     try {
-      this.loadingSources = RemoteDataState.Loading
+      this.loadingSourcesStatus = RemoteDataState.Loading
       await this.props.getSources()
-      this.loadingSources = RemoteDataState.Done
+      this.loadingSourcesStatus = RemoteDataState.Done
     } catch (err) {
-      this.loadingSources = RemoteDataState.Error
+      this.loadingSourcesStatus = RemoteDataState.Error
     }
   }
 
@@ -989,8 +989,8 @@ class LogsPage extends Component<Props, State> {
     return this.props.tableTime.relative === 0
   }
 
-  private get isLoadingSources(): boolean {
-    switch (this.loadingSources) {
+  private get isLoadingSourcesStatus(): boolean {
+    switch (this.loadingSourcesStatus) {
       case RemoteDataState.Loading:
       case RemoteDataState.NotStarted:
         return true
@@ -1000,7 +1000,7 @@ class LogsPage extends Component<Props, State> {
   }
 
   private get isSourcesEmpty(): boolean {
-    if (this.isLoadingSources) {
+    if (this.isLoadingSourcesStatus) {
       return false
     }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/235

_Briefly describe your proposed changes:_
Render a page spinner as sources are being fetched
_What was the problem?_
The logs page was visible but not responsive 
_What was the solution?_
Add a page spinner as sources are being fetched.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass