### PR TITLE
Fix logs message width

### DIFF
--- a/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandableMessage.tsx
@@ -28,6 +28,7 @@ const PADDING = 8
 const MIN_LEFT = 120
 const MIN_MESSAGE_WIDTH = 200
 const MAX_MESSAGE_HEIGHT = 200
+const SCROLL_MARGIN = 80
 
 @ErrorHandling
 export class ExpandableMessage extends Component<Props, State> {
@@ -84,6 +85,7 @@ export class ExpandableMessage extends Component<Props, State> {
       <ExpandedContainer
         notify={this.props.notify}
         onClose={this.handleClose}
+        scrollMargin={SCROLL_MARGIN}
         maxWidth={this.props.maxWidth}
         minWidth={MIN_MESSAGE_WIDTH}
         maxHeight={MAX_MESSAGE_HEIGHT}

--- a/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
@@ -8,9 +8,6 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 // Types
 import {NotificationAction} from 'src/types'
 
-// Actions
-import {expandMessageError} from 'src/shared/copy/notifications'
-
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -34,19 +31,10 @@ interface State {
 
 @ErrorHandling
 export class ExpandedContainer extends Component<Props, State> {
-  private initialVisibility: boolean
-
   constructor(props: Props) {
     super(props)
 
-    this.initialVisibility = this.isVisible
     this.state = {scrollTop: 0}
-  }
-
-  public componentDidMount() {
-    if (!this.initialVisibility) {
-      this.props.notify(expandMessageError(this.direction))
-    }
   }
 
   public render() {
@@ -119,10 +107,6 @@ export class ExpandedContainer extends Component<Props, State> {
 
   private handleClickOutside = () => {
     this.props.onClose()
-  }
-
-  private get isVisible(): boolean {
-    return this.visibleWidth > this.props.minWidth
   }
 
   private get maxLeft(): number {

--- a/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
+++ b/ui/src/logs/components/expandable_message/ExpandedContainer.tsx
@@ -14,6 +14,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface Props {
   notify: NotificationAction
   onClose: () => void
+  scrollMargin: number
   maxWidth: number
   maxHeight: number
   minWidth: number
@@ -29,6 +30,13 @@ interface State {
   scrollTop: number
 }
 
+enum PinnedState {
+  Left = 'PinnedLeft',
+  Right = 'PinnedRight',
+  Center = 'PinnedCenter',
+  OnMessage = 'PinnedOnMessage',
+}
+
 @ErrorHandling
 export class ExpandedContainer extends Component<Props, State> {
   constructor(props: Props) {
@@ -40,43 +48,19 @@ export class ExpandedContainer extends Component<Props, State> {
   public render() {
     return (
       <ClickOutside onClickOutside={this.handleClickOutside}>
-        {this.renderMessage({
-          top: this.top,
-          left: this.maxLeft,
-          width: this.visibleWidth,
-          padding: this.props.padding,
-          maxHeight: this.props.maxHeight,
-        })}
+        <div className="expanded--message message-wrap" style={this.style}>
+          {this.closeExpansionButton}
+          <FancyScrollbar
+            setScrollTop={this.handleScrollbarScroll}
+            scrollTop={this.state.scrollTop}
+            autoHeight={true}
+            maxHeight={this.maxHeight}
+          >
+            {this.props.children}
+          </FancyScrollbar>
+        </div>
       </ClickOutside>
     )
-  }
-
-  private renderMessage(style: CSSProperties): JSX.Element {
-    if (style.width < this.props.minWidth) {
-      return this.props.children
-    }
-
-    return (
-      <div className="expanded--message message-wrap" style={style}>
-        {this.closeExpansionButton}
-        <FancyScrollbar
-          setScrollTop={this.handleScrollbarScroll}
-          scrollTop={this.state.scrollTop}
-          autoHeight={true}
-          maxHeight={this.maxHeight}
-        >
-          {this.props.children}
-        </FancyScrollbar>
-      </div>
-    )
-  }
-
-  private get direction(): string {
-    if (this.props.left > this.props.minLeft) {
-      return 'right'
-    } else {
-      return 'left'
-    }
   }
 
   private get maxHeight(): number {
@@ -85,10 +69,6 @@ export class ExpandedContainer extends Component<Props, State> {
 
   private get verticalPadding(): number {
     return this.props.padding * 2
-  }
-
-  private get top(): number {
-    return this.props.top - this.props.padding
   }
 
   private handleClickDismiss = (e: MouseEvent<HTMLButtonElement>) => {
@@ -109,33 +89,58 @@ export class ExpandedContainer extends Component<Props, State> {
     this.props.onClose()
   }
 
-  private get maxLeft(): number {
-    return Math.max(this.props.minLeft, this.props.left - this.props.padding)
-  }
-
-  private get visibleWidth(): number {
-    return Math.min(
-      this.remainingWidth,
-      this.maxViewableWidth,
-      this.props.width
-    )
-  }
-
-  private get remainingWidth(): number {
-    if (this.props.left > this.props.minLeft) {
-      return this.props.maxWidth - this.hiddenWidth
-    } else {
-      return this.props.width + this.hiddenWidth
+  private get style(): CSSProperties {
+    return {
+      ...this.position,
+      top: this.props.top,
+      width: this.width,
+      padding: this.props.padding,
+      maxHeight: this.props.maxHeight,
     }
   }
 
-  private get hiddenWidth(): number {
-    return this.props.left - this.props.minLeft
+  private get position(): CSSProperties {
+    switch (this.pinnedState) {
+      case PinnedState.Left:
+        return {left: this.props.minLeft}
+      case PinnedState.Right:
+        return {left: this.props.minLeft + this.props.scrollMargin}
+      case PinnedState.Center:
+        return {left: this.props.minLeft}
+      case PinnedState.OnMessage:
+        return {left: this.props.left}
+    }
   }
 
-  // Table space with room for scrollbar
-  private get maxViewableWidth(): number {
-    return this.props.maxWidth - this.props.padding
+  private get width(): number {
+    switch (this.pinnedState) {
+      case PinnedState.Left:
+      case PinnedState.Right:
+        return (
+          this.props.maxWidth - this.props.scrollMargin - this.props.padding
+        )
+      case PinnedState.Center:
+        return this.props.maxWidth - this.props.padding
+      case PinnedState.OnMessage:
+        return this.props.width
+    }
+  }
+
+  private get pinnedState(): PinnedState {
+    const isLeftOutOfView = this.props.left < this.props.minLeft
+    const isRightOfView =
+      this.props.width + this.props.left - this.props.minLeft >
+      this.props.maxWidth
+
+    if (isLeftOutOfView && isRightOfView) {
+      return PinnedState.Center
+    } else if (!isLeftOutOfView && !isRightOfView) {
+      return PinnedState.OnMessage
+    } else if (!isRightOfView) {
+      return PinnedState.Left
+    } else if (!isLeftOutOfView) {
+      return PinnedState.Right
+    }
   }
 
   private get closeExpansionButton(): JSX.Element {

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -875,11 +875,3 @@ export const annotationsError = (message: string): Notification => ({
   ...defaultErrorNotification,
   message,
 })
-
-// Logs page notifications
-export const expandMessageError = (direction: string): Notification => ({
-  ...defaultErrorNotification,
-  icon: 'expand-a',
-  duration: 1500,
-  message: `Message out of view, scroll ${direction} to see`,
-})


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/241

_Briefly describe your proposed changes:_
Clicking on a log message no longer triggers a notification and will attempt to show the full message. The message will leave space to the left or right to allow one to peak at other columns while scrolling horizontally.
_What was the problem?_
Clicking on a message would shrink or hide depending on how much width was viewable, but the ideal situation would be to see the maximum message width for the table size that allowed the user to still inspect other rows or columns while scrolling.
_What was the solution?_
Remove the hidden message behavior and notification and pin the popover to the left, center, right, or message column to maximize the viewable width of the logs message.

  - [x] Rebased/mergeable
  - [x] Tests pass