### PR TITLE
Fix table formatting of stringy numbers

### DIFF
--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -507,7 +507,17 @@ class TableGraph extends PureComponent<Props, State> {
         : rowIndex === this.timeFieldIndex && isFirstCol)
     const isFieldName = this.isVerticalTimeAxis ? isFirstRow : isFirstCol
     const isFixedCorner = isFirstRow && isFirstCol
-    const isNumerical = !isNaN(Number.parseFloat(cellData as string))
+
+    // Note that
+    //
+    // - `Number('')` is 0
+    // - `Number('02abc')` is NaN
+    // - `parseFloat('')` is NaN
+    // - `parseFloat('02abc')` is 2
+    //
+    // which is why there are two slightly different `isNaN` checks here
+    const isNumerical =
+      !isNaN(Number(cellData)) && !isNaN(parseFloat(cellData as string))
 
     let cellStyle: React.CSSProperties = style //tslint:disable-line
     if (


### PR DESCRIPTION
Closes influxdata/applications-team-issues#250

Fixes an issue in the `TableGraph` component where a string such as `02dec` would be interpreted as a number. This created visual inconsistencies when viewing a table of UUIDs, for example.
