### PR TITLE
Feat/switch kapacitors on alert rules

### DIFF
--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -1,39 +1,54 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {bindActionCreators} from 'redux'
 
 // APIs
-import {getActiveKapacitor} from 'src/shared/apis'
+import {pingKapacitor} from 'src/shared/apis'
+
+// Utils
+import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+import {notifyKapacitorConnectionFailed} from 'src/shared/copy/notifications'
 
 // Actions
-import * as kapacitorActionCreators from '../actions/view'
+import * as kapacitorActions from 'src/kapacitor/actions/view'
+import * as sourcesActions from 'src/shared/actions/sources'
+import {notify as notifyAction} from 'src/shared/actions/notifications'
 
 // Components
 import KapacitorRules from 'src/kapacitor/components/KapacitorRules'
 import QuestionMarkTooltip from 'src/shared/components/QuestionMarkTooltip'
 import {Page, Spinner} from 'src/reusable_ui'
+import Dropdown from 'src/reusable_ui/components/dropdowns/Dropdown'
 
 // Types
-import {Source, Kapacitor, AlertRule, RemoteDataState} from 'src/types'
+import {
+  Source,
+  Kapacitor,
+  AlertRule,
+  RemoteDataState,
+  Notification,
+  NotificationFunc,
+} from 'src/types'
 
 // Decorators
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import NoKapacitorError from 'src/shared/components/NoKapacitorError'
+import {getDeep} from 'src/utils/wrappers'
 
 interface Props {
   source: Source
-  actions: {
-    fetchRules: (kapacitor: Kapacitor) => void
-    deleteRule: (rule: AlertRule) => void
-    updateRuleStatus: (rule: AlertRule, status: string) => void
-    updateRuleStatusSuccess: (id: string, status: string) => void
-  }
+  sources: Source[]
+  fetchRules: (kapacitor: Kapacitor) => void
+  deleteRule: (rule: AlertRule) => void
+  notify: (message: Notification | NotificationFunc) => void
+  updateRuleStatus: (rule: AlertRule, status: string) => void
+  updateRuleStatusSuccess: (id: string, status: string) => void
+  fetchKapacitors: sourcesActions.FetchKapacitorsAsync
+  setActiveKapacitor: sourcesActions.SetActiveKapacitorAsync
   rules: AlertRule[]
 }
 
 interface State {
-  kapacitor: Kapacitor
   loading: RemoteDataState
 }
 
@@ -42,22 +57,22 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
-      kapacitor: null,
       loading: RemoteDataState.NotStarted,
     }
   }
 
   public async componentDidMount() {
-    const {source, actions} = this.props
+    const {source, fetchKapacitors} = this.props
     this.setState({loading: RemoteDataState.Loading})
-    const kapacitor: Kapacitor = await getActiveKapacitor(source)
 
-    if (!kapacitor) {
-      return this.setState({loading: RemoteDataState.Done, kapacitor: null})
+    await fetchKapacitors(source)
+
+    const kapacitor = this.kapacitor
+    if (kapacitor) {
+      await this.pingAndFetchRules(kapacitor)
     }
 
-    await actions.fetchRules(kapacitor)
-    this.setState({loading: RemoteDataState.Done, kapacitor})
+    this.setState({loading: RemoteDataState.Done})
   }
 
   public render() {
@@ -66,6 +81,7 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
         <Page.Header>
           <Page.Header.Left>
             <Page.Title title={this.headerTitle} />
+            {this.kapacitorsDropdown}
           </Page.Header.Left>
           <Page.Header.Right showSourceIndicator={true}>
             <QuestionMarkTooltip
@@ -82,7 +98,7 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
   }
 
   private get rules(): JSX.Element {
-    const {kapacitor} = this.state
+    const kapacitor = this.kapacitor
     const {source, rules} = this.props
 
     if (!kapacitor) {
@@ -99,18 +115,75 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
     )
   }
 
+  private get kapacitorsDropdown(): JSX.Element {
+    const kapacitor = this.kapacitor
+    const kapacitors = this.kapacitors
+
+    if (!kapacitor) {
+      return null
+    }
+
+    const dropDownItems = kapacitors.map(k => (
+      <Dropdown.Item key={k.id} id={k.id} value={k.id}>
+        {`${k.name} @ ${k.url}`}
+      </Dropdown.Item>
+    ))
+
+    return (
+      <Dropdown
+        customClass="kapacitor-switcher"
+        onChange={this.handleSetActiveKapacitor}
+        widthPixels={330}
+        selectedID={kapacitor.id}
+      >
+        {dropDownItems}
+      </Dropdown>
+    )
+  }
+
+  private get kapacitors(): Kapacitor[] {
+    const {sources, source} = this.props
+    const activeSource = sources.find(s => s.id === source.id)
+    return getDeep<Kapacitor[]>(activeSource, 'kapacitors', [])
+  }
+
+  private get kapacitor(): Kapacitor {
+    const {sources, source} = this.props
+    return ActiveKapacitorFromSources(source, sources)
+  }
+
+  private handleSetActiveKapacitor = async (
+    kapacitorID: string
+  ): Promise<void> => {
+    const {setActiveKapacitor} = this.props
+    const kapacitors = this.kapacitors
+    const toKapacitor = kapacitors.find(k => k.id === kapacitorID)
+    await setActiveKapacitor(toKapacitor)
+    await this.pingAndFetchRules(toKapacitor)
+  }
+
+  private pingAndFetchRules = async (kapacitor: Kapacitor): Promise<void> => {
+    try {
+      await this.props.fetchRules(kapacitor)
+      await pingKapacitor(kapacitor)
+    } catch (error) {
+      console.error(error)
+      this.props.notify(notifyKapacitorConnectionFailed())
+    }
+  }
+
   private get headerTitle(): string {
-    const {kapacitor} = this.state
+    const kapacitor = this.kapacitor
 
     if (!kapacitor) {
       return 'Manage Tasks'
     }
 
-    return `Manage Tasks on "${kapacitor.name}" @ ${kapacitor.url}`
+    return `Manage Tasks on`
   }
 
   private get className(): string {
-    const {kapacitor} = this.state
+    const kapacitor = this.kapacitor
 
     if (!kapacitor) {
       return 'empty-tasks-page'
@@ -120,30 +193,32 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
   }
 
   private handleDeleteRule = (rule: AlertRule) => {
-    const {actions} = this.props
-
-    actions.deleteRule(rule)
+    const {deleteRule} = this.props
+    deleteRule(rule)
   }
 
   private handleRuleStatus = (rule: AlertRule) => {
-    const {actions} = this.props
+    const {updateRuleStatus, updateRuleStatusSuccess} = this.props
     const status = rule.status === 'enabled' ? 'disabled' : 'enabled'
 
-    actions.updateRuleStatus(rule, status)
-    actions.updateRuleStatusSuccess(rule.id, status)
+    updateRuleStatus(rule, status)
+    updateRuleStatusSuccess(rule.id, status)
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    rules: Object.values(state.rules),
-  }
+const mstp = ({rules, sources}) => ({
+  rules: Object.values(rules),
+  sources,
+})
+
+const mdtp = {
+  fetchRules: kapacitorActions.fetchRules,
+  deleteRule: kapacitorActions.deleteRule,
+  updateRuleStatus: kapacitorActions.updateRuleStatus,
+  updateRuleStatusSuccess: kapacitorActions.updateRuleStatusSuccess,
+  fetchKapacitors: sourcesActions.fetchKapacitorsAsync,
+  setActiveKapacitor: sourcesActions.setActiveKapacitorAsync,
+  notify: notifyAction,
 }
 
-const mapDispatchToProps = dispatch => {
-  return {
-    actions: bindActionCreators(kapacitorActionCreators, dispatch),
-  }
-}
-
-export default connect(mapStateToProps, mapDispatchToProps)(KapacitorRulesPage)
+export default connect(mstp, mdtp)(KapacitorRulesPage)

--- a/ui/src/kapacitor/utils/ActiveKapacitorFromSources.ts
+++ b/ui/src/kapacitor/utils/ActiveKapacitorFromSources.ts
@@ -1,0 +1,19 @@
+import {Source, Kapacitor} from 'src/types'
+
+const ActiveKapacitorFromSources = (
+  source: Source,
+  sources: Source[]
+): Kapacitor => {
+  if (!source || !sources) {
+    return null
+  }
+
+  const ActiveSource = sources.find(s => s.id === source.id)
+  if (!ActiveSource || !ActiveSource.kapacitors) {
+    return null
+  }
+
+  return ActiveSource.kapacitors.find(k => k.active)
+}
+
+export default ActiveKapacitorFromSources

--- a/ui/src/reusable_ui/components/page_layout/Page.scss
+++ b/ui/src/reusable_ui/components/page_layout/Page.scss
@@ -90,7 +90,8 @@
   flex: 1 0 0;
   justify-content: flex-start;
   > * {
-    margin: 0 4px 0 0;
+    margin: 0;
+    margin-right: 4px;
   }
 }
 .page-header--right {
@@ -112,7 +113,8 @@
   text-transform: none;
   font-size: $page-header-size;
   font-weight: $page-header-weight;
-  margin: 0;
+  margin-top: 0;
+  margin-bottom: 0;
   display: inline-block;
   vertical-align: middle;
   @include no-user-select();

--- a/ui/src/reusable_ui/components/wizard/WizardController.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardController.tsx
@@ -28,7 +28,7 @@ interface Props {
 @ErrorHandling
 class WizardController extends PureComponent<Props, State> {
   public static defaultProps: Partial<Props> = {
-    skipLinkText: 'skip',
+    skipLinkText: 'Skip',
     jumpStep: -1,
   }
 

--- a/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardController.test.tsx.snap
+++ b/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardController.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`WizardController with multiple children matches snapshot with two child
     className="btn btn-xs btn-primary btn-link wizard-skip-link"
     onClick={[Function]}
   >
-    skip
+    Skip
   </button>
 </div>
 `;
@@ -92,7 +92,7 @@ exports[`WizardController with multiple children with first step complete matche
     className="btn btn-xs btn-primary btn-link wizard-skip-link"
     onClick={[Function]}
   >
-    skip
+    Skip
   </button>
 </div>
 `;
@@ -136,7 +136,7 @@ exports[`WizardController with one child matches snapshot with one child 1`] = `
     className="btn btn-xs btn-primary btn-link wizard-skip-link"
     onClick={[Function]}
   >
-    skip
+    Skip
   </button>
 </div>
 `;

--- a/ui/src/sources/components/CompletionStep.tsx
+++ b/ui/src/sources/components/CompletionStep.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 @ErrorHandling
-class SourceStep extends PureComponent<Props> {
+class CompletionStep extends PureComponent<Props> {
   constructor(props: Props) {
     super(props)
   }
@@ -26,7 +26,8 @@ class SourceStep extends PureComponent<Props> {
     return (
       <div className="wizard-step--bookend">
         <div className="auth-logo" />
-        <p>Continue to view your existing connections.</p>
+        <p>You have successfully configured your connection</p>
+        <p>Continue to view your connections</p>
       </div>
     )
   }
@@ -36,4 +37,4 @@ const mdtp = {
   notify: notifyAction,
 }
 
-export default connect(null, mdtp, null, {withRef: true})(SourceStep)
+export default connect(null, mdtp, null, {withRef: true})(CompletionStep)

--- a/ui/src/sources/components/DashboardStep.tsx
+++ b/ui/src/sources/components/DashboardStep.tsx
@@ -26,7 +26,6 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {
   notifyDashboardCreated,
   notifyDashboardCreationFailed,
-  notifyNoSuggestedDashboards,
 } from 'src/shared/copy/notifications'
 
 // Types
@@ -194,7 +193,7 @@ class DashboardStep extends Component<Props, State> {
 
   private handleSuggest = async () => {
     const {protoboards} = this.state
-    const {source, notify} = this.props
+    const {source} = this.props
 
     if (source) {
       const suggestedProtoboardsList = await getSuggestedProtoboards(
@@ -203,7 +202,6 @@ class DashboardStep extends Component<Props, State> {
       )
 
       if (suggestedProtoboardsList.length === 0) {
-        notify(notifyNoSuggestedDashboards())
         return
       }
 

--- a/ui/src/sources/components/KapacitorStep.tsx
+++ b/ui/src/sources/components/KapacitorStep.tsx
@@ -8,6 +8,9 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import KapacitorDropdown from 'src/sources/components/KapacitorDropdown'
 import KapacitorForm from 'src/sources/components/KapacitorForm'
 
+// Utils
+import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 import * as sourcesActions from 'src/shared/actions/sources'
@@ -45,18 +48,6 @@ interface State {
   kapacitor: Kapacitor
 }
 
-const getActiveKapacitor = (source: Source, sources: Source[]): Kapacitor => {
-  if (!source || !sources) {
-    return null
-  }
-  const ActiveSource = sources.find(s => s.id === source.id)
-  if (!ActiveSource || !ActiveSource.kapacitors) {
-    return null
-  }
-  const activeKapacitor = ActiveSource.kapacitors.find(k => k.active)
-  return activeKapacitor
-}
-
 const syncHostnames = (source: Source, kapacitor: Kapacitor) => {
   try {
     // new URL(input) throws error if input is not a valid url.
@@ -82,7 +73,10 @@ class KapacitorStep extends Component<Props, State> {
   constructor(props: Props) {
     super(props)
 
-    const ActiveKapacitor = getActiveKapacitor(props.source, props.sources)
+    const ActiveKapacitor = ActiveKapacitorFromSources(
+      props.source,
+      props.sources
+    )
 
     let kapacitor
     if (props.showNewKapacitor) {
@@ -179,7 +173,7 @@ class KapacitorStep extends Component<Props, State> {
     const {source, sources} = this.props
     const {kapacitor} = this.state
 
-    const activeKapacitor = getActiveKapacitor(source, sources)
+    const activeKapacitor = ActiveKapacitorFromSources(source, sources)
     return !_.isEqual(activeKapacitor, kapacitor)
   }
 

--- a/ui/src/sources/components/WelcomeStep.tsx
+++ b/ui/src/sources/components/WelcomeStep.tsx
@@ -27,7 +27,7 @@ class SourceStep extends PureComponent<Props> {
       <div className="wizard-step--bookend">
         <div className="auth-logo" />
         <h1>Welcome to Chronograf</h1>
-        <p>Start using Chronograf in a few easy steps.</p>
+        <p>Start using Chronograf in a few easy steps</p>
       </div>
     )
   }

--- a/ui/src/sources/containers/OnboardingWizard.tsx
+++ b/ui/src/sources/containers/OnboardingWizard.tsx
@@ -69,7 +69,7 @@ class OnboardingWizard extends PureComponent<Props, State> {
       <>
         <Notifications />
         <WizardFullScreen
-          skipLinkText="skip"
+          skipLinkText="Skip"
           switchLinkText="Switch Organizations"
           handleSwitch={this.resetAndGotoPurgatory}
           isUsingAuth={isUsingAuth}

--- a/ui/src/style/unsorted.scss
+++ b/ui/src/style/unsorted.scss
@@ -479,3 +479,7 @@ $deceo--tab-width: 220px;
   justify-content: center;
   align-items: center;
 }
+
+.kapacitor-switcher {
+  margin-left: 6px;
+}


### PR DESCRIPTION
Closes #4702 

This PR adds functionality that allows user to switch the kapacitor that is 'active' without leaving the KapacitorRulesPage. The rules that are displayed on the page also update when active kapacitor is switched. 