### PR TITLE
Enable text selection in table cells in Firefox

### DIFF
--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -29,20 +29,9 @@
   white-space: nowrap;
   text-overflow: ellipsis;
 
-  // Highlight
-  &:after {
-    content: "";
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 5;
+  &__highlight-row {
     background-color: rgba(255, 255, 255, 0.2);
-    visibility: hidden;
-    box-sizing: border-box;
   }
-
   &__numerical {
     font-family: $code-font;
     text-align: right;
@@ -65,16 +54,6 @@
     border-left: 0;
     color: $g18-cloud;
     background-color: $g5-pepper;
-  }
-  &__highlight-row:after,
-  &__highlight-column:after {
-    visibility: visible;
-  }
-  &__highlight-row.table-graph-cell__highlight-column {
-    border-color: $g20-white;
-    &:after {
-      visibility: hidden;
-    }
   }
   &__field-name {
     padding-right: 17px;


### PR DESCRIPTION
Closes influxdata/applications-team-issues#252

Previously we would render a semi-transparent rectangle over the currently hovered entry in a table using a CSS `:after` technique. In Firefox, this blocked text selection events on the table entry so that a user could not copy/paste data from a table graph.
    
This commit changes the background color of hovered table entries instead overlaying a semi-transparent rectangle, so that text selection events are not blocked. This results in a slightly different but comparable aesthetic.

Before:

![screen shot 2018-11-05 at 12 58 30 pm](https://user-images.githubusercontent.com/638955/48029924-58c19300-e104-11e8-8000-8400c53a05b3.png)

After:

![screen shot 2018-11-05 at 12 58 01 pm](https://user-images.githubusercontent.com/638955/48029930-5cedb080-e104-11e8-87bd-7a1f1b59de79.png)

cc design lords @alexpaxton @mavarius may I have your blessing :)
