### PR TITLE
Prevent step jumping in the wizard if no source

### DIFF
--- a/ui/src/reusable_ui/components/wizard/WizardController.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardController.tsx
@@ -23,6 +23,7 @@ interface Props {
   switchLinkText?: string
   handleSwitch?: () => void
   isUsingAuth: boolean
+  isJumpingAllowed: boolean
 }
 
 @ErrorHandling
@@ -119,9 +120,12 @@ class WizardController extends PureComponent<Props, State> {
   }
 
   private jumpToStep = (jumpIndex: number) => () => {
-    this.setState({
-      currentStepIndex: jumpIndex,
-    })
+    const {isJumpingAllowed} = this.props
+    if (isJumpingAllowed) {
+      this.setState({
+        currentStepIndex: jumpIndex,
+      })
+    }
   }
 
   private get CurrentChild(): JSX.Element {

--- a/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
@@ -15,6 +15,7 @@ interface Props {
   switchLinkText?: string
   handleSwitch?: () => void
   isUsingAuth: boolean
+  isJumpingAllowed: boolean
 }
 
 @ErrorHandling
@@ -38,6 +39,7 @@ class WizardFullScreen extends PureComponent<Props> {
       handleSwitch,
       switchLinkText,
       isUsingAuth,
+      isJumpingAllowed,
     } = this.props
 
     if (children) {
@@ -49,6 +51,7 @@ class WizardFullScreen extends PureComponent<Props> {
           switchLinkText={switchLinkText}
           isUsingAuth={isUsingAuth}
           jumpStep={0}
+          isJumpingAllowed={isJumpingAllowed}
         >
           {children}
         </WizardController>

--- a/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
@@ -22,6 +22,7 @@ interface Props {
   skipLinkText?: string
   maxWidth?: number
   jumpStep: number
+  isJumpingAllowed: boolean
 }
 
 @ErrorHandling
@@ -46,13 +47,14 @@ class WizardOverlay extends PureComponent<Props> {
   }
 
   private get WizardController() {
-    const {children, skipLinkText, jumpStep} = this.props
+    const {children, skipLinkText, jumpStep, isJumpingAllowed} = this.props
     if (children) {
       return (
         <WizardController
           skipLinkText={skipLinkText}
           handleSkip={this.handleSkip}
           jumpStep={jumpStep}
+          isJumpingAllowed={isJumpingAllowed}
         >
           {children}
         </WizardController>

--- a/ui/src/reusable_ui/components/wizard/test/WizardController.test.tsx
+++ b/ui/src/reusable_ui/components/wizard/test/WizardController.test.tsx
@@ -13,6 +13,7 @@ describe('WizardController', () => {
       children: null,
       handleSkip: undefined,
       skipLinkText: undefined,
+      isJumpingAllowed: true,
       ...override,
     }
 

--- a/ui/src/reusable_ui/components/wizard/test/WizardFullScreen.test.tsx
+++ b/ui/src/reusable_ui/components/wizard/test/WizardFullScreen.test.tsx
@@ -13,6 +13,7 @@ describe('WizardFullScreen', () => {
       skipLinkText: undefined,
       handleSkip: undefined,
       isUsingAuth: false,
+      isJumpingAllowed: true,
       ...override,
     }
 

--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -83,6 +83,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
         skipLinkText="Dismiss"
         maxWidth={800}
         jumpStep={jumpStep}
+        isJumpingAllowed={this.isSourceComplete()}
       >
         <WizardStep
           title="InfluxDB Connection"

--- a/ui/src/sources/containers/OnboardingWizard.tsx
+++ b/ui/src/sources/containers/OnboardingWizard.tsx
@@ -73,6 +73,7 @@ class OnboardingWizard extends PureComponent<Props, State> {
           switchLinkText="Switch Organizations"
           handleSwitch={this.resetAndGotoPurgatory}
           isUsingAuth={isUsingAuth}
+          isJumpingAllowed={this.isSourceComplete()}
         >
           <WizardStep
             title="Welcome"


### PR DESCRIPTION
Users should not be able to jump to the end of the wizard if a source has not been created or does not exist. We already prevent skipping/dismissing wizard by checking that a source is available, this PR creates an `isJumpingAllowed` prop, that also prevents jumping using the wizardController