### PR TITLE
Add check for undefined value in single stat component

### DIFF
--- a/ui/src/dashboards/components/GraphTypeSelector.tsx
+++ b/ui/src/dashboards/components/GraphTypeSelector.tsx
@@ -16,7 +16,7 @@ import {CellType} from 'src/types/dashboards'
 
 interface Props {
   type: string
-  onUpdateVisType: (newType: CellType) => void
+  onUpdateVisType: (newType: CellType) => Promise<void>
 }
 
 @ErrorHandling

--- a/ui/src/shared/components/InvalidData.tsx
+++ b/ui/src/shared/components/InvalidData.tsx
@@ -4,11 +4,10 @@ import {Button} from 'src/reusable_ui'
 
 import {CellType} from 'src/types'
 import {ComponentColor, ComponentSize} from 'src/reusable_ui/types'
-import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 interface Props {
   message?: string
-  onUpdateVisType?: TimeMachineContainer['handleUpdateType']
+  onUpdateVisType?: (cell: CellType) => Promise<void>
 }
 
 class InvalidData extends PureComponent<Props> {

--- a/ui/src/shared/components/LineGraph.tsx
+++ b/ui/src/shared/components/LineGraph.tsx
@@ -37,7 +37,6 @@ import {
   FluxTable,
 } from 'src/types'
 import {DataType} from 'src/shared/constants'
-import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 interface Props {
   axes: Axes
@@ -55,7 +54,7 @@ interface Props {
   onZoom: () => void
   handleSetHoverTime: () => void
   activeQueryIndex?: number
-  onUpdateVisType?: TimeMachineContainer['handleUpdateType']
+  onUpdateVisType?: (type: CellType) => Promise<void>
 }
 
 type LineGraphProps = Props & RouteComponentProps<any, any>

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -320,6 +320,7 @@ class RefreshingGraph extends Component<Props> {
       cellHeight,
       decimalPlaces,
       manualRefresh,
+      onUpdateVisType,
       onUpdateCellColors,
     } = this.props
 
@@ -336,6 +337,7 @@ class RefreshingGraph extends Component<Props> {
         key={manualRefresh}
         cellHeight={cellHeight}
         decimalPlaces={decimalPlaces}
+        onUpdateVisType={onUpdateVisType}
         onUpdateCellColors={onUpdateCellColors}
       />
     )

--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -56,7 +56,6 @@ import {
 } from 'src/types/dashboards'
 import {GrabDataForDownloadHandler} from 'src/types/layout'
 import {TimeSeriesServerResponse} from 'src/types/series'
-import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 interface TypeAndData {
   dataType: DataType
@@ -97,7 +96,7 @@ interface Props {
   editorLocation?: QueryUpdateState
   onUpdateCellColors?: (bgColor: string, textColor: string) => void
   onUpdateFieldOptions?: (fieldOptions: FieldOption[]) => void
-  onUpdateVisType?: TimeMachineContainer['handleUpdateType']
+  onUpdateVisType?: (type: CellType) => Promise<void>
 }
 
 class RefreshingGraph extends Component<Props> {

--- a/ui/src/shared/components/SingleStat.tsx
+++ b/ui/src/shared/components/SingleStat.tsx
@@ -29,7 +29,6 @@ import {ColorString} from 'src/types/colors'
 import {CellType, DecimalPlaces} from 'src/types/dashboards'
 import {TimeSeriesServerResponse} from 'src/types/series'
 import {FluxTable} from 'src/types'
-import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 interface Props {
   decimalPlaces: DecimalPlaces
@@ -42,7 +41,7 @@ interface Props {
   data: TimeSeriesServerResponse[] | FluxTable[]
   dataType: DataType
   onUpdateCellColors?: (bgColor: string, textColor: string) => void
-  onUpdateVisType?: TimeMachineContainer['handleUpdateType']
+  onUpdateVisType?: (cell: CellType) => Promise<void>
 }
 
 interface State {
@@ -102,7 +101,7 @@ class SingleStat extends PureComponent<Props, State> {
 
   public render() {
     if (!this.state.isValidData) {
-      return <InvalidData onUpdateVisType={this.props.onUpdateVisType} />
+      return <InvalidData />
     }
     if (!this.state.lastValues) {
       return <h3 className="graph-spinner" />
@@ -146,7 +145,7 @@ class SingleStat extends PureComponent<Props, State> {
   private get roundedLastValue(): string {
     const {decimalPlaces} = this.props
 
-    if (this.lastValue === null) {
+    if (this.lastValue === null || this.lastValue === undefined) {
       return `${0}`
     }
 
@@ -266,10 +265,6 @@ class SingleStat extends PureComponent<Props, State> {
         lastValues = this.memoizedTimeSeriesToSingleStat(
           data as TimeSeriesServerResponse[]
         )
-      }
-
-      if (typeof _.get(lastValues, 'values.0', null) !== 'number') {
-        isValidData = false
       }
 
       if (

--- a/ui/src/shared/components/SingleStat.tsx
+++ b/ui/src/shared/components/SingleStat.tsx
@@ -29,6 +29,7 @@ import {ColorString} from 'src/types/colors'
 import {CellType, DecimalPlaces} from 'src/types/dashboards'
 import {TimeSeriesServerResponse} from 'src/types/series'
 import {FluxTable} from 'src/types'
+import {TimeMachineContainer} from 'src/shared/utils/TimeMachineContainer'
 
 interface Props {
   decimalPlaces: DecimalPlaces
@@ -41,6 +42,7 @@ interface Props {
   data: TimeSeriesServerResponse[] | FluxTable[]
   dataType: DataType
   onUpdateCellColors?: (bgColor: string, textColor: string) => void
+  onUpdateVisType?: TimeMachineContainer['handleUpdateType']
 }
 
 interface State {
@@ -100,7 +102,7 @@ class SingleStat extends PureComponent<Props, State> {
 
   public render() {
     if (!this.state.isValidData) {
-      return <InvalidData />
+      return <InvalidData onUpdateVisType={this.props.onUpdateVisType} />
     }
     if (!this.state.lastValues) {
       return <h3 className="graph-spinner" />
@@ -264,6 +266,10 @@ class SingleStat extends PureComponent<Props, State> {
         lastValues = this.memoizedTimeSeriesToSingleStat(
           data as TimeSeriesServerResponse[]
         )
+      }
+
+      if (typeof _.get(lastValues, 'values.0', null) !== 'number') {
+        isValidData = false
       }
 
       if (

--- a/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
@@ -30,8 +30,8 @@ import {AutoRefresher} from 'src/utils/AutoRefresher'
 interface ConnectedProps {
   timeRange: TimeRange
   queryType: QueryType
-  onUpdateFieldOptions: TimeMachineContainer['handleUpdateFieldOptions']
-  onUpdateVisType: TimeMachineContainer['handleUpdateType']
+  onUpdateFieldOptions: (fieldOptions: FieldOption[]) => Promise<void>
+  onUpdateVisType: (type: CellType) => Promise<void>
   type: CellType
   axes: Axes | null
   tableOptions: TableOptions


### PR DESCRIPTION
Closes #4735

Previously, the single stat graph component would display "NaN" when the data returned empty or returned a non-number. 

This PR adds a check for the type of the data in the component, and renders an error message prompting the user to switch to a Table Graph if the data is not a number type.

  - [x] Rebased/mergeable
  - [x] Tests pass