### PR TITLE
Fix switcher links case ordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 1.  [#4436](https://github.com/influxdata/chronograf/pull/4436): Automatically scroll to the current measurement in the explorer
 1.  [#4659](https://github.com/influxdata/chronograf/pull/4659): Simplify Flux explorer tree and improve searching
 1.  [#4744](https://github.com/influxdata/chronograf/pull/4744): Update logs page to show missing syslog message.
+1.  [#4745](https://github.com/influxdata/chronograf/pull/4745): Fix dashboard link text casing changing quick select sort order
 
 ### Bug Fixes
 1.  [#4272](https://github.com/influxdata/chronograf/pull/4272): Fix logs loading description not displaying

--- a/ui/src/dashboards/components/DashboardSwitcher.tsx
+++ b/ui/src/dashboards/components/DashboardSwitcher.tsx
@@ -67,20 +67,22 @@ class DashboardSwitcher extends PureComponent<Props, State> {
   private get links(): JSX.Element[] {
     const {links, active} = this.props.dashboardLinks
 
-    return _.sortBy(links, ['text', 'key']).map(link => {
-      return (
-        <li
-          key={link.key}
-          className={classnames('dropdown-item', {
-            active: link === active,
-          })}
-        >
-          <Link to={link.to} onClick={this.handleCloseMenu}>
-            {link.text}
-          </Link>
-        </li>
-      )
-    })
+    return _.sortBy(links, ({text, key}) => [text.toLowerCase(), key]).map(
+      link => {
+        return (
+          <li
+            key={link.key}
+            className={classnames('dropdown-item', {
+              active: link === active,
+            })}
+          >
+            <Link to={link.to} onClick={this.handleCloseMenu}>
+              {link.text}
+            </Link>
+          </li>
+        )
+      }
+    )
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/258

_Briefly describe your proposed changes:_
Update switcher link sorting to not use casing
_What was the problem?_
Dashboard quick switching links used casing in `sortBy`  
_What was the solution?_
lower case text before sorting

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass