### PR TITLE
Clear old dygraphs before redrawing

### DIFF
--- a/ui/src/shared/components/Dygraph.tsx
+++ b/ui/src/shared/components/Dygraph.tsx
@@ -168,7 +168,7 @@ class Dygraph extends Component<Props, State> {
       dygraph.resetZoom()
     }
 
-    if (staticLegendChanged) {
+    if (staticLegendChanged || optionsChanged) {
       setTimeout(this.resize, 0)
     }
   }
@@ -466,6 +466,8 @@ class Dygraph extends Component<Props, State> {
 
   private resize = () => {
     if (this.dygraph) {
+      this.dygraph.resizeElements_()
+      this.dygraph.predraw_()
       this.dygraph.resize()
     }
   }


### PR DESCRIPTION
Closes https://github.com/influxdata/applications-team-issues/issues/256

_Briefly describe your proposed changes:_
_What was the problem?_
old drawings of dygraph were still visible after redrawing
_What was the solution?_
remove the old drawings


  - [x] Rebased/mergeable
  - [x] Tests pass