### PR TITLE
Sort dashboard items in SendToDashboardOverlay by name

### DIFF
--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -158,10 +158,15 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
     const {dashboards} = this.props
     const {newDashboardName} = this.state
 
-    const simpleArray = dashboards.map(d => ({
-      id: d.id.toString(),
-      name: d.name,
-    }))
+    const simpleArray = _.sortBy(
+      dashboards.map(d => ({
+        id: d.id.toString(),
+        name: d.name,
+      })),
+      element => {
+        return element.name.toLowerCase()
+      }
+    )
 
     const items = simpleArray.map(dashboard => {
       return (


### PR DESCRIPTION
Previously, the list of dashboards in the `SendToDashboardOverlay` dropdown were in a random order. This PR sorts them alphabetically (ignoring upper/lower case).

  - [x] Rebased/mergeable
  - [x] Tests pass