### PR TITLE
fix(flux): create unique link for querying flux

### DIFF
--- a/flux/client.go
+++ b/flux/client.go
@@ -53,6 +53,34 @@ func (c *Client) pingTimeout(ctx context.Context) error {
 	}
 }
 
+// FluxEnabled returns true if the server has flux querying enabled.
+func (c *Client) FluxEnabled() (bool, error) {
+	url := c.URL
+	url.Path = "/api/v2/query"
+
+	req, err := http.NewRequest("POST", url.String(), nil)
+	if err != nil {
+		return false, err
+	}
+
+	hc := &http.Client{}
+	if c.InsecureSkipVerify {
+		hc.Transport = skipVerifyTransport
+	} else {
+		hc.Transport = defaultTransport
+	}
+
+	resp, err := hc.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	// TODO(goller): add comments about why you and watts did this.
+	contentType := resp.Header.Get("Content-Type")
+	return contentType == "application/json", nil
+}
+
 func (c *Client) ping(u *url.URL) error {
 	u.Path = "ping"
 

--- a/server/influx.go
+++ b/server/influx.go
@@ -82,7 +82,7 @@ func (s *Service) Influx(w http.ResponseWriter, r *http.Request) {
 	if uniqueID == "" {
 		newUUID, err := (&uuid.UUID{}).Generate()
 		if err != nil {
-			Error(w, 500, "Failed to create a unique identifier", s.Logger)
+			Error(w, http.StatusInternalServerError, "Failed to create a unique identifier", s.Logger)
 			return
 		}
 		uniqueID = newUUID

--- a/server/mux.go
+++ b/server/mux.go
@@ -179,6 +179,10 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	influx := gziphandler.GzipHandler(http.HandlerFunc(EnsureViewer(service.Influx)))
 	router.Handler("POST", "/chronograf/v1/sources/:id/proxy", influx)
 
+	// Source Proxy to Influx's flux endpoint; compression because the responses from
+	// flux could be large.
+	router.Handler("POST", "/chronograf/v1/sources/:id/proxy/flux", EnsureViewer(service.ProxyFlux))
+
 	// Write proxies line protocol write requests to InfluxDB
 	router.POST("/chronograf/v1/sources/:id/write", EnsureViewer(service.Write))
 


### PR DESCRIPTION
#### Problem
The server treated all query requests as requests to influxql.  

#### Solution
Create a flux proxy link with a custom handler.