### PR TITLE
Update refreshing graph if inView changes

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -303,6 +303,7 @@ class RefreshingGraph extends Component<Props> {
       'templates',
       'manualRefresh',
       'timeRange',
+      'inView',
     ]
 
     const prevVisValues = _.pick(prevProps, visProps)


### PR DESCRIPTION

_What was the problem?_
Refreshing graph only updated if certain props changed. InView was changing but was not among those props so refreshing graph did not update. Since time series will only execute the queries for the cells that are inview, those cells who became in view but were not originally never had their queries run.

_What was the solution?_
InView is now one of the props that cause refreshing graph to update.

  - [x] Rebased/mergeable
  - [x] Tests pass