### PR TITLE
Reset scrollLeft on search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [#4764](https://github.com/influxdata/chronograf/pull/4764): Add protoboard environment variables to build scripts
 1. [#4768](https://github.com/influxdata/chronograf/pull/4768): Update dockerfile to include protoboards
 1. [#4772](https://github.com/influxdata/chronograf/pull/4772): Add protoboards enviroment variables to dockerfile
+1. [#4763](https://github.com/influxdata/chronograf/pull/4763): Fix log columns not rendering
 
 ## v1.7.0 [2018-11-06]
 

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -95,7 +95,14 @@ const calculateScrollTop = scrollToRow => {
 
 class LogsTable extends Component<Props, State> {
   public static getDerivedStateFromProps(props, state): State {
-    const {scrollToRow, data, tableColumns, severityFormat, filters} = props
+    const {
+      scrollToRow,
+      data,
+      tableColumns,
+      severityFormat,
+      filters,
+      searchStatus,
+    } = props
     const currentMessageWidth = getMessageWidth(
       data,
       tableColumns,
@@ -103,12 +110,15 @@ class LogsTable extends Component<Props, State> {
     )
 
     let scrollTop = _.get(state, 'scrollTop', 0)
+    let scrollLeft = _.get(state, 'scrollLeft', 0)
 
     if (_.isNumber(scrollToRow)) {
       scrollTop = calculateScrollTop(scrollToRow)
     }
 
-    const scrollLeft = _.get(state, 'scrollLeft', 0)
+    if (searchStatus === SearchStatus.Clearing) {
+      scrollLeft = 0
+    }
 
     let isMessageVisible: boolean = false
     const visibleColumnsCount = props.tableColumns.filter(c => {
@@ -236,6 +246,7 @@ class LogsTable extends Component<Props, State> {
                   }}
                   setScrollTop={this.handleScrollbarScroll}
                   scrollTop={this.state.scrollTop}
+                  scrollLeft={this.state.scrollLeft}
                   autoHide={false}
                 >
                   <Grid


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Set scroll left to zero on new search 
_What was the problem?_
Scroll left would not be reset on a new search
_What was the solution?_
Set scroll left to 0 when a search is cleared

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass