### PR TITLE
Fix scroll loading indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [#4768](https://github.com/influxdata/chronograf/pull/4768): Update dockerfile to include protoboards
 1. [#4772](https://github.com/influxdata/chronograf/pull/4772): Add protoboards enviroment variables to dockerfile
 1. [#4763](https://github.com/influxdata/chronograf/pull/4763): Fix log columns not rendering
+1. [#4767](https://github.com/influxdata/chronograf/pull/4767): Fix scroll loading indicator not hiding in logs
 
 ## v1.7.0 [2018-11-06]
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -374,7 +374,7 @@ class LogsPage extends Component<Props, State> {
 
     if (this.props.nextNewerLowerBound > maxNewerFetchForward) {
       this.props.setNextNewerLowerBound(Date.now())
-      this.currentNewerChunksGenerator.cancelAsync()
+      this.currentNewerChunksGenerator.cancel()
     }
 
     await this.props.fetchNewerChunkAsync()
@@ -481,7 +481,10 @@ class LogsPage extends Component<Props, State> {
     const cancelPendingChunks = _.compact([
       this.currentNewerChunksGenerator,
       this.currentOlderChunksGenerator,
-    ]).map(req => req.cancelAsync())
+    ]).map(req => {
+      req.cancel()
+      return req.promise
+    })
 
     await Promise.all(cancelPendingChunks)
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -374,7 +374,7 @@ class LogsPage extends Component<Props, State> {
 
     if (this.props.nextNewerLowerBound > maxNewerFetchForward) {
       this.props.setNextNewerLowerBound(Date.now())
-      await this.currentNewerChunksGenerator.cancelAsync()
+      this.currentNewerChunksGenerator.cancelAsync()
     }
 
     await this.props.fetchNewerChunkAsync()

--- a/ui/src/logs/utils/fetchUntil.ts
+++ b/ui/src/logs/utils/fetchUntil.ts
@@ -11,13 +11,13 @@ export function fetchUntil<T>(
   const requests = fetchUnless(() => isCanceled || predicate(), request)
 
   const promise = fetchEachAsync(requests)
-  const cancelAsync = async () => {
+  const cancel = () => {
     isCanceled = true
-    await promise
   }
+
   return {
     promise,
-    cancelAsync,
+    cancel,
     isCanceled,
   }
 }

--- a/ui/src/types/logs.ts
+++ b/ui/src/types/logs.ts
@@ -204,6 +204,6 @@ export interface MatchSection {
 
 export interface FetchLoop {
   promise: Promise<void>
-  cancelAsync: () => Promise<void>
+  cancel: () => void
   isCanceled: boolean
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
Fixes an issue where sometimes the loading more indicator does not hide after fetch loop is canceled
_What was the problem?_
Fetch newer is the async iterator func in a fetch loop and cannot await the completion of the fetch loop since it awaiting will block the completion of the fetch loop.
_What was the solution?_
- Remove the await on cancelAsync since calling cancelAsync will prevent further iteration.  
- Remove the cancelAsync method becuase it's a confusing/problematic
- Update pending newer/older chunk cancelation to cancel and then await the chunk to completion

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass