### PR TITLE
fix(flux/pivot): specify the right named parameters for columnKey and valueKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#4772](https://github.com/influxdata/chronograf/pull/4772): Add protoboards enviroment variables to dockerfile
 1. [#4763](https://github.com/influxdata/chronograf/pull/4763): Fix log columns not rendering
 1. [#4767](https://github.com/influxdata/chronograf/pull/4767): Fix scroll loading indicator not hiding in logs
+1. [#4776](https://github.com/influxdata/chronograf/pull/4776): Fix flux pivot function using wrong named parameters
 
 ## v1.7.0 [2018-11-06]
 

--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -857,13 +857,13 @@ export const functions: FluxToolbarFunction[] = [
         type: 'Array of Strings',
       },
       {
-        name: 'colKey',
+        name: 'columnKey',
         desc:
           'List of columns used to pivot values onto each row identified by the rowKey.',
         type: 'Array of Strings',
       },
       {
-        name: 'valueCol',
+        name: 'valueColumn',
         desc:
           'The single column that contains the value to be moved around the pivot.',
         type: 'String',
@@ -871,7 +871,7 @@ export const functions: FluxToolbarFunction[] = [
     ],
     desc:
       'Collects values stored vertically (column-wise) in a table and aligns them horizontally (row-wise) into logical sets.',
-    example: 'pivot(rowKey:["_time"], colKey: ["_field"], valueCol: "_value")',
+    example: 'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/flux/latest/functions/transformations/pivot',


### PR DESCRIPTION
Signed-off-by: Lorenzo Fontana <lo@linux.com>

_Briefly describe your proposed changes:_
Use the right keys as flux espects them for the pivot function.

_What was the problem?_
The `pivot` function generated by chronograf doesn't use the right named parameters for `columnKey` and `valueKey`.

![image](https://user-images.githubusercontent.com/3083633/48194675-f2c84c00-e34d-11e8-8721-1d3867792502.png)

_What was the solution?_
Change the named parameters names!


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)