### PR TITLE
fix canned apps for template variables

### DIFF
--- a/canned/consul.json
+++ b/canned/consul.json
@@ -13,7 +13,7 @@
       "name": "Consul – Number of Critical Health Checks",
       "queries": [
         {
-          "query": "SELECT count(\"check_id\") as \"Number Critical\" FROM \":db:\".\":rp:\".\"consul_health_checks\"",
+          "query": "SELECT count(\"check_id\") AS \"Number Critical\" FROM \":db:\".\":rp:\".\"consul_health_checks\"",
           "label": "count",
           "groupbys": [
             "\"service_name\""
@@ -33,7 +33,7 @@
       "name": "Consul – Number of Warning Health Checks",
       "queries": [
         {
-          "query": "SELECT count(\"check_id\") as \"Number Warning\" FROM \":db:\".\":rp:\".\"consul_health_checks\"",
+          "query": "SELECT count(\"check_id\") AS \"Number Warning\" FROM \":db:\".\":rp:\".\"consul_health_checks\"",
           "label": "count",          
           "groupbys": [
             "\"service_name\""

--- a/canned/consul_leadership.json
+++ b/canned/consul_leadership.json
@@ -13,7 +13,7 @@
             "name": "Consul – Leadership Change",
             "queries": [
                 {
-                    "query": "SELECT max(\"value\") as \"change\" FROM \":db:\".\":rp:\".\"consul_raft_state_leader\"",
+                    "query": "SELECT max(\"value\") AS \"change\" FROM \":db:\".\":rp:\".\"consul_raft_state_leader\"",
                     "label": "count",
                     "groupbys": [],
                     "wheres": []

--- a/canned/elasticsearch.json
+++ b/canned/elasticsearch.json
@@ -13,7 +13,7 @@
       "name": "ElasticSearch - Query Throughput",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(search_query_total)) as searches_per_min, non_negative_derivative(mean(search_scroll_total)) as scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) as fetches_per_min, non_negative_derivative(mean(search_suggest_total)) as suggests_per_min from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_query_total)) AS searches_per_min, non_negative_derivative(mean(search_scroll_total)) AS scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) AS fetches_per_min, non_negative_derivative(mean(search_suggest_total)) AS suggests_per_min FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -28,7 +28,7 @@
       "name": "ElasticSearch - Open Connections",
       "queries": [
         {
-          "query": "select mean(current_open) from elasticsearch_http",
+          "query": "SELECT mean(current_open) FROM elasticsearch_http",
           "groupbys": [],
           "wheres": []
         }
@@ -43,7 +43,7 @@
       "name": "ElasticSearch - Query Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(search_query_time_in_millis)) as mean, non_negative_derivative(median(search_query_time_in_millis)) as median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_query_time_in_millis)) AS mean, non_negative_derivative(median(search_query_time_in_millis)) AS median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -58,7 +58,7 @@
       "name": "ElasticSearch - Fetch Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(search_fetch_time_in_millis)) as mean, non_negative_derivative(median(search_fetch_time_in_millis)) as median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_fetch_time_in_millis)) AS mean, non_negative_derivative(median(search_fetch_time_in_millis)) AS median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -73,7 +73,7 @@
       "name": "ElasticSearch - Suggest Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(search_suggest_time_in_millis)) as mean, non_negative_derivative(median(search_suggest_time_in_millis)) as median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_suggest_time_in_millis)) AS mean, non_negative_derivative(median(search_suggest_time_in_millis)) AS median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -88,7 +88,7 @@
       "name": "ElasticSearch - Scroll Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(search_scroll_time_in_millis)) as mean, non_negative_derivative(median(search_scroll_time_in_millis)) as median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) as ninety_fifth from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_scroll_time_in_millis)) AS mean, non_negative_derivative(median(search_scroll_time_in_millis)) AS median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -103,7 +103,7 @@
       "name": "ElasticSearch - Indexing Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(indexing_index_time_in_millis)) as mean from elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(indexing_index_time_in_millis)) AS mean FROM elasticsearch_indices",
           "groupbys": [],
           "wheres": []
         }
@@ -118,7 +118,7 @@
       "name": "ElasticSearch - JVM GC Collection Counts",
       "queries": [
         {
-          "query": "select mean(gc_collectors_old_collection_count) as old_count, mean(gc_collectors_young_collection_count) as young_count from elasticsearch_jvm",
+          "query": "SELECT mean(gc_collectors_old_collection_count) AS old_count, mean(gc_collectors_young_collection_count) AS young_count FROM elasticsearch_jvm",
           "groupbys": [],
           "wheres": []
         }
@@ -133,7 +133,7 @@
       "name": "ElasticSearch - JVM GC Latency",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(gc_collectors_old_collection_time_in_millis)) as mean_old_time, non_negative_derivative(mean(gc_collectors_young_collection_time_in_millis)) as mean_young_time from elasticsearch_jvm",
+          "query": "SELECT non_negative_derivative(mean(gc_collectors_old_collection_time_in_millis)) AS mean_old_time, non_negative_derivative(mean(gc_collectors_young_collection_time_in_millis)) AS mean_young_time FROM elasticsearch_jvm",
           "groupbys": [],
           "wheres": []
         }
@@ -148,7 +148,7 @@
       "name": "ElasticSearch - JVM Heap Usage",
       "queries": [
         {
-          "query": "select mean(mem_heap_used_percent) from elasticsearch_jvm",
+          "query": "SELECT mean(mem_heap_used_percent) FROM elasticsearch_jvm",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/elasticsearch.json
+++ b/canned/elasticsearch.json
@@ -13,7 +13,7 @@
       "name": "ElasticSearch - Query Throughput",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(search_query_total)) AS searches_per_min, non_negative_derivative(mean(search_scroll_total)) AS scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) AS fetches_per_min, non_negative_derivative(mean(search_suggest_total)) AS suggests_per_min FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_query_total)) AS searches_per_min, non_negative_derivative(mean(search_scroll_total)) AS scrolls_per_min, non_negative_derivative(mean(search_fetch_total)) AS fetches_per_min, non_negative_derivative(mean(search_suggest_total)) AS suggests_per_min FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -28,7 +28,7 @@
       "name": "ElasticSearch - Open Connections",
       "queries": [
         {
-          "query": "SELECT mean(current_open) FROM elasticsearch_http",
+          "query": "SELECT mean(current_open) FROM \":db:\".\":rp:\".\"elasticsearch_http\"",
           "groupbys": [],
           "wheres": []
         }
@@ -43,7 +43,7 @@
       "name": "ElasticSearch - Query Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(search_query_time_in_millis)) AS mean, non_negative_derivative(median(search_query_time_in_millis)) AS median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_query_time_in_millis)) AS mean, non_negative_derivative(median(search_query_time_in_millis)) AS median, non_negative_derivative(percentile(search_query_time_in_millis, 95)) AS ninety_fifth FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -58,7 +58,7 @@
       "name": "ElasticSearch - Fetch Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(search_fetch_time_in_millis)) AS mean, non_negative_derivative(median(search_fetch_time_in_millis)) AS median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_fetch_time_in_millis)) AS mean, non_negative_derivative(median(search_fetch_time_in_millis)) AS median, non_negative_derivative(percentile(search_fetch_time_in_millis, 95)) AS ninety_fifth FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -73,7 +73,7 @@
       "name": "ElasticSearch - Suggest Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(search_suggest_time_in_millis)) AS mean, non_negative_derivative(median(search_suggest_time_in_millis)) AS median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_suggest_time_in_millis)) AS mean, non_negative_derivative(median(search_suggest_time_in_millis)) AS median, non_negative_derivative(percentile(search_suggest_time_in_millis, 95)) AS ninety_fifth FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -88,7 +88,7 @@
       "name": "ElasticSearch - Scroll Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(search_scroll_time_in_millis)) AS mean, non_negative_derivative(median(search_scroll_time_in_millis)) AS median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) AS ninety_fifth FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(search_scroll_time_in_millis)) AS mean, non_negative_derivative(median(search_scroll_time_in_millis)) AS median, non_negative_derivative(percentile(search_scroll_time_in_millis, 95)) AS ninety_fifth FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -103,7 +103,7 @@
       "name": "ElasticSearch - Indexing Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(indexing_index_time_in_millis)) AS mean FROM elasticsearch_indices",
+          "query": "SELECT non_negative_derivative(mean(indexing_index_time_in_millis)) AS mean FROM \":db:\".\":rp:\".\"elasticsearch_indices\"",
           "groupbys": [],
           "wheres": []
         }
@@ -118,7 +118,7 @@
       "name": "ElasticSearch - JVM GC Collection Counts",
       "queries": [
         {
-          "query": "SELECT mean(gc_collectors_old_collection_count) AS old_count, mean(gc_collectors_young_collection_count) AS young_count FROM elasticsearch_jvm",
+          "query": "SELECT mean(gc_collectors_old_collection_count) AS old_count, mean(gc_collectors_young_collection_count) AS young_count FROM \":db:\".\":rp:\".\"elasticsearch_jvm\"",
           "groupbys": [],
           "wheres": []
         }
@@ -133,7 +133,7 @@
       "name": "ElasticSearch - JVM GC Latency",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(gc_collectors_old_collection_time_in_millis)) AS mean_old_time, non_negative_derivative(mean(gc_collectors_young_collection_time_in_millis)) AS mean_young_time FROM elasticsearch_jvm",
+          "query": "SELECT non_negative_derivative(mean(gc_collectors_old_collection_time_in_millis)) AS mean_old_time, non_negative_derivative(mean(gc_collectors_young_collection_time_in_millis)) AS mean_young_time FROM \":db:\".\":rp:\".\"elasticsearch_jvm\"",
           "groupbys": [],
           "wheres": []
         }
@@ -148,7 +148,7 @@
       "name": "ElasticSearch - JVM Heap Usage",
       "queries": [
         {
-          "query": "SELECT mean(mem_heap_used_percent) FROM elasticsearch_jvm",
+          "query": "SELECT mean(mem_heap_used_percent) FROM \":db:\".\":rp:\".\"elasticsearch_jvm\"",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/haproxy.json
+++ b/canned/haproxy.json
@@ -13,7 +13,7 @@
       "name": "HAProxy – Number of Servers",
       "queries": [
         {
-          "query": "select mean(\"active_servers\") AS active_servers, mean(\"backup_servers\") AS backup_servers FROM \":db:\".\":rp:\".\"haproxy\"",
+          "query": "SELECT mean(\"active_servers\") AS active_servers, mean(\"backup_servers\") AS backup_servers FROM \":db:\".\":rp:\".\"haproxy\"",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/mongodb.json
+++ b/canned/mongodb.json
@@ -61,7 +61,7 @@
       "name": "MongoDB – Reads/Writes Waiting in Queue",
       "queries": [
         {
-          "query": "SELECT max(queued_reads) AS queued_reads, max(queued_writes) as queued_writes FROM \":db:\".\":rp:\".\"mongodb\"",
+          "query": "SELECT max(queued_reads) AS queued_reads, max(queued_writes) AS queued_writes FROM \":db:\".\":rp:\".\"mongodb\"",
           "label": "count",
           "groupbys": [],
           "wheres": []
@@ -77,7 +77,7 @@
       "name": "MongoDB – Network Bytes/Second",
       "queries": [
         {
-          "query": "SELECT mean(net_in_bytes) AS net_in_bytes, mean(net_out_bytes) as net_out_bytes FROM \":db:\".\":rp:\".\"mongodb\"",
+          "query": "SELECT mean(net_in_bytes) AS net_in_bytes, mean(net_out_bytes) AS net_out_bytes FROM \":db:\".\":rp:\".\"mongodb\"",
           "label": "bytes/s",
           "groupbys": [],
           "wheres": []
@@ -109,7 +109,7 @@
       "name": "MongoDB – Memory Usage (MB)",
       "queries": [
         {
-          "query": "SELECT mean(vsize_megabytes) AS virtual_memory_megabytes, mean(resident_megabytes) as resident_memory_megabytes FROM \":db:\".\":rp:\".\"mongodb\"",
+          "query": "SELECT mean(vsize_megabytes) AS virtual_memory_megabytes, mean(resident_megabytes) AS resident_memory_megabytes FROM \":db:\".\":rp:\".\"mongodb\"",
           "label": "MB",
           "groupbys": [],
           "wheres": []

--- a/canned/net.json
+++ b/canned/net.json
@@ -13,13 +13,13 @@
 			"name": "System – Network Mb/s",
 			"queries": [
 				{
-					"query": "SELECT non_negative_derivative(max(\"bytes_recv\"), 1s) / 125000 as \"rx_megabits_per_second\" FROM \":db:\".\":rp:\".\"net\"",
+					"query": "SELECT non_negative_derivative(max(\"bytes_recv\"), 1s) / 125000 AS \"rx_megabits_per_second\" FROM \":db:\".\":rp:\".\"net\"",
 					"groupbys": [],
 					"wheres": [],
 					"label": "Mb/s"
 				},
 				{
-					"query": "SELECT non_negative_derivative(max(\"bytes_sent\"), 1s) / 125000 as \"tx_megabits_per_second\" FROM \":db:\".\":rp:\".\"net\"",
+					"query": "SELECT non_negative_derivative(max(\"bytes_sent\"), 1s) / 125000 AS \"tx_megabits_per_second\" FROM \":db:\".\":rp:\".\"net\"",
 					"groupbys": [],
 					"wheres": []
 				}
@@ -34,12 +34,12 @@
 			"name": "System – Network Error Rate",
 			"queries": [
 				{
-					"query": "SELECT non_negative_derivative(max(\"err_in\"), 1s) / 125000 as \"tx_errors_per_second\" FROM \":db:\".\":rp:\".\"net\"",
+					"query": "SELECT non_negative_derivative(max(\"err_in\"), 1s) / 125000 AS \"tx_errors_per_second\" FROM \":db:\".\":rp:\".\"net\"",
 					"groupbys": [],
 					"wheres": []
 				},
 				{
-					"query": "SELECT non_negative_derivative(max(\"err_out\"), 1s) / 125000 as \"rx_errors_per_second\" FROM \":db:\".\":rp:\".\"net\"",
+					"query": "SELECT non_negative_derivative(max(\"err_out\"), 1s) / 125000 AS \"rx_errors_per_second\" FROM \":db:\".\":rp:\".\"net\"",
 					"groupbys": [],
 					"wheres": []
 				}

--- a/canned/new_apps.sh
+++ b/canned/new_apps.sh
@@ -49,7 +49,7 @@ cat > $APP_FILE << EOF
 		"i": "$CELLID",
 		"name": "User facing cell Name",
 		"queries": [{
-			"query": "select mean(\"used_percent\") from disk",
+			"query": "SELECT mean(\"used_percent\") FROM disk",
 			"groupbys": [],
 			"wheres": []
 				}]

--- a/canned/new_apps.sh
+++ b/canned/new_apps.sh
@@ -49,7 +49,7 @@ cat > $APP_FILE << EOF
 		"i": "$CELLID",
 		"name": "User facing cell Name",
 		"queries": [{
-			"query": "SELECT mean(\"used_percent\") FROM disk",
+			"query": "SELECT mean(\"used_percent\") FROM \":db:\".\":rp:\".\"disk\"",
 			"groupbys": [],
 			"wheres": []
 				}]

--- a/canned/phpfpm.json
+++ b/canned/phpfpm.json
@@ -30,7 +30,7 @@
       "name": "phpfpm – Processes",
       "queries": [
         {
-          "query": "SELECT mean(\"active_processes\") as \"active\",mean(\"idle_processes\") as \"idle\"  FROM \":db:\".\":rp:\".\"phpfpm\"",
+          "query": "SELECT mean(\"active_processes\") AS \"active\",mean(\"idle_processes\") AS \"idle\"  FROM \":db:\".\":rp:\".\"phpfpm\"",
           "label": "count",
           "groupbys": [
             "\"pool\""

--- a/canned/ping.json
+++ b/canned/ping.json
@@ -13,7 +13,7 @@
       "name": "Ping – Packet Loss Percent",
       "queries": [
         {
-          "query": "select max(\"percent_packet_loss\") as \"packet_loss\" from \":db:\".\":rp:\".ping",
+          "query": "SELECT max(\"percent_packet_loss\") AS \"packet_loss\" FROM \":db:\".\":rp:\".ping",
           "groupbys": [
             "\"url\""
           ],
@@ -30,7 +30,7 @@
       "name": "Ping – Response Times (ms)",
       "queries": [
         {
-          "query": "select mean(\"average_response_ms\") as \"average\", mean(\"minimum_response_ms\") as \"min\", mean(\"maximum_response_ms\") as \"max\" from \":db:\".\":rp:\".ping",
+          "query": "SELECT mean(\"average_response_ms\") AS \"average\", mean(\"minimum_response_ms\") AS \"min\", mean(\"maximum_response_ms\") AS \"max\" FROM \":db:\".\":rp:\".ping",
           "groupbys": [
             "\"url\""
           ],

--- a/canned/ping.json
+++ b/canned/ping.json
@@ -13,7 +13,7 @@
       "name": "Ping – Packet Loss Percent",
       "queries": [
         {
-          "query": "SELECT max(\"percent_packet_loss\") AS \"packet_loss\" FROM \":db:\".\":rp:\".ping",
+          "query": "SELECT max(\"percent_packet_loss\") AS \"packet_loss\" FROM \":db:\".\":rp:\".\"ping\"",
           "groupbys": [
             "\"url\""
           ],
@@ -30,7 +30,7 @@
       "name": "Ping – Response Times (ms)",
       "queries": [
         {
-          "query": "SELECT mean(\"average_response_ms\") AS \"average\", mean(\"minimum_response_ms\") AS \"min\", mean(\"maximum_response_ms\") AS \"max\" FROM \":db:\".\":rp:\".ping",
+          "query": "SELECT mean(\"average_response_ms\") AS \"average\", mean(\"minimum_response_ms\") AS \"min\", mean(\"maximum_response_ms\") AS \"max\" FROM \":db:\".\":rp:\".\"ping\"",
           "groupbys": [
             "\"url\""
           ],

--- a/canned/rabbitmq.json
+++ b/canned/rabbitmq.json
@@ -12,17 +12,17 @@
 					"name": "RabbitMQ - Overview",
 					"queries": [
 						{
-							"query": "SELECT mean(\"consumers\") AS \"consumers\" FROM rabbitmq_overview",
+							"query": "SELECT mean(\"consumers\") AS \"consumers\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "SELECT mean(\"exchanges\") AS \"exchanges\" FROM rabbitmq_overview",
+							"query": "SELECT mean(\"exchanges\") AS \"exchanges\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "SELECT mean(\"queues\") AS \"queues\" FROM rabbitmq_overview",
+							"query": "SELECT mean(\"queues\") AS \"queues\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						}
@@ -37,12 +37,12 @@
 					"name": "RabbitMQ - Published/Delivered per second",
 					"queries": [
 						{
-							"query": "SELECT derivative(mean(\"messages_published\"), 1s) AS \"published_per_sec\" FROM rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_published\"), 1s) AS \"published_per_sec\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "SELECT derivative(mean(\"messages_delivered\"), 1s) AS \"delivered_per_sec\" FROM rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_delivered\"), 1s) AS \"delivered_per_sec\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						}
@@ -57,12 +57,12 @@
 					"name": "RabbitMQ - Acked/Unacked per second",
 					"queries": [
 						{
-							"query": "SELECT derivative(mean(\"messages_acked\"), 1s) AS \"acked_per_sec\" FROM rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_acked\"), 1s) AS \"acked_per_sec\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "SELECT derivative(mean(\"messages_unacked\"), 1s) AS \"unacked_per_sec\" FROM rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_unacked\"), 1s) AS \"unacked_per_sec\" FROM \":db:\".\":rp:\".\"rabbitmq_overview\"",
 							"groupbys": [],
 							"wheres": []
 						}

--- a/canned/rabbitmq.json
+++ b/canned/rabbitmq.json
@@ -12,17 +12,17 @@
 					"name": "RabbitMQ - Overview",
 					"queries": [
 						{
-							"query": "select mean(\"consumers\") AS \"consumers\" from rabbitmq_overview",
+							"query": "SELECT mean(\"consumers\") AS \"consumers\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "select mean(\"exchanges\") AS \"exchanges\" from rabbitmq_overview",
+							"query": "SELECT mean(\"exchanges\") AS \"exchanges\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "select mean(\"queues\") AS \"queues\" from rabbitmq_overview",
+							"query": "SELECT mean(\"queues\") AS \"queues\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						}
@@ -37,12 +37,12 @@
 					"name": "RabbitMQ - Published/Delivered per second",
 					"queries": [
 						{
-							"query": "select derivative(mean(\"messages_published\"), 1s) AS \"published_per_sec\" from rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_published\"), 1s) AS \"published_per_sec\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "select derivative(mean(\"messages_delivered\"), 1s) AS \"delivered_per_sec\" from rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_delivered\"), 1s) AS \"delivered_per_sec\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						}
@@ -57,12 +57,12 @@
 					"name": "RabbitMQ - Acked/Unacked per second",
 					"queries": [
 						{
-							"query": "select derivative(mean(\"messages_acked\"), 1s) AS \"acked_per_sec\" from rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_acked\"), 1s) AS \"acked_per_sec\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						},
 						{
-							"query": "select derivative(mean(\"messages_unacked\"), 1s) AS \"unacked_per_sec\" from rabbitmq_overview",
+							"query": "SELECT derivative(mean(\"messages_unacked\"), 1s) AS \"unacked_per_sec\" FROM rabbitmq_overview",
 							"groupbys": [],
 							"wheres": []
 						}

--- a/canned/riak.json
+++ b/canned/riak.json
@@ -13,7 +13,7 @@
       "name": "Riak – Total Memory Bytes",
       "queries": [
         {
-          "query": "SELECT max(\"memory_total\") as memory_total_bytes FROM \":db:\".\":rp:\".\"riak\"",
+          "query": "SELECT max(\"memory_total\") AS memory_total_bytes FROM \":db:\".\":rp:\".\"riak\"",
           "groupbys": [
             "\"nodename\""
           ],

--- a/canned/varnish.json
+++ b/canned/varnish.json
@@ -12,7 +12,7 @@
       "name": "Varnish - Cache Hits/Misses",
       "queries": [
         {
-          "query": "select non_negative_derivative(mean(cache_hit)) as hits, non_negative_derivative(mean(cache_miss)) as misses from varnish",
+          "query": "SELECT non_negative_derivative(mean(cache_hit)) AS hits, non_negative_derivative(mean(cache_miss)) AS misses FROM varnish",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/varnish.json
+++ b/canned/varnish.json
@@ -12,7 +12,7 @@
       "name": "Varnish - Cache Hits/Misses",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(cache_hit)) AS hits, non_negative_derivative(mean(cache_miss)) AS misses FROM varnish",
+          "query": "SELECT non_negative_derivative(mean(cache_hit)) AS hits, non_negative_derivative(mean(cache_miss)) AS misses FROM \":db:\".\":rp:\".\"varnish\"",
           "groupbys": [],
           "wheres": []
         }


### PR DESCRIPTION
Closes #4787 

_Briefly describe your proposed changes:_

Two things: first, normalize the case of the queries in the canned applications.  Second, apply the patch from April that missed several applications because the case was wrong.

I don't see evidence the test suite covers the canned apps, and the only modified apps I've tested are rabbitmq and ping, done by copying the modified versions over the 1.7.2 installation.  So somebody should look this over closely.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)