### PR TITLE
Add fieldOptions when creating new cell from SendToDashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bug Fixes
 
 1. [#4786](https://github.com/influxdata/chronograf/pull/4786): Get protoboards from multistore if not able to find from ProtoboardsPath
+1.  [#4791](https://github.com/influxdata/chronograf/pull/4791): Save fieldOptions to cells created from Data Explorer page
 
 ## v1.7.2 [2018-11-08]
 

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -277,6 +277,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       timeFormat,
       note,
       noteVisibility,
+      fieldOptions,
     } = visualizationOptions
 
     const isFluxQuery = queryType === QueryType.Flux
@@ -343,6 +344,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
           timeFormat,
           note,
           noteVisibility,
+          fieldOptions,
         }
         return sendDashboardCell(dashboard, newCell)
       })


### PR DESCRIPTION
Closes: https://github.com/influxdata/applications-team-issues/issues/266

_What was the problem?_
Custom column names were not saved when a new table graph cell was created from the "Send to Dashboard" overlay in the Data Explorer.

_What was the solution?_
Save `fieldOptions` to the cell when it is created.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass