### PR TITLE
fix(flux/pivot): make CI pass for new pivot description

### DIFF
--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -871,7 +871,8 @@ export const functions: FluxToolbarFunction[] = [
     ],
     desc:
       'Collects values stored vertically (column-wise) in a table and aligns them horizontally (row-wise) into logical sets.',
-    example: 'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
+    example:
+      'pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/flux/latest/functions/transformations/pivot',


### PR DESCRIPTION
Merging my last PR (https://github.com/influxdata/chronograf/pull/4776) broke CI because of some linting problem, opening this to fix. 

Signed-off-by: Lorenzo Fontana <lo@linux.com>

  - [x] Rebased/mergeable
  - [x] Tests pass