### PR TITLE
fix(db-admin): only handle db state on db create

### DIFF
--- a/ui/src/admin/components/DatabaseRow.js
+++ b/ui/src/admin/components/DatabaseRow.js
@@ -169,7 +169,7 @@ class DatabaseRow extends Component {
               autoComplete="false"
             />
           </td>
-          {isRFDisplayed ? (
+          {isRFDisplayed && (
             <td style={{width: `${DATABASE_TABLE.colReplication}px`}}>
               <input
                 className="form-control input-xs"
@@ -184,7 +184,7 @@ class DatabaseRow extends Component {
                 autoComplete="false"
               />
             </td>
-          ) : null}
+          )}
           <td
             className="text-right"
             style={{width: `${DATABASE_TABLE.colDelete}px`}}

--- a/ui/src/admin/components/DatabaseTable.js
+++ b/ui/src/admin/components/DatabaseTable.js
@@ -47,45 +47,47 @@ const DatabaseTable = ({
         onDatabaseDeleteConfirm={onDatabaseDeleteConfirm}
         isAddRPDisabled={!!database.retentionPolicies.some(rp => rp.isNew)}
       />
-      <div className="db-manager-table">
-        <table className="table v-center table-highlight">
-          <thead>
-            <tr>
-              <th style={{width: `${DATABASE_TABLE.colRetentionPolicy}px`}}>
-                Retention Policy
-              </th>
-              <th style={{width: `${DATABASE_TABLE.colDuration}px`}}>
-                Duration
-              </th>
-              {isRFDisplayed ? (
-                <th style={{width: `${DATABASE_TABLE.colReplication}px`}}>
-                  Replication Factor
+      {!database.isNew && (
+        <div className="db-manager-table">
+          <table className="table v-center table-highlight">
+            <thead>
+              <tr>
+                <th style={{width: `${DATABASE_TABLE.colRetentionPolicy}px`}}>
+                  Retention Policy
                 </th>
-              ) : null}
-              <th style={{width: `${DATABASE_TABLE.colDelete}px`}} />
-            </tr>
-          </thead>
-          <tbody>
-            {_.sortBy(database.retentionPolicies, ({name}) =>
-              name.toLowerCase()
-            ).map(rp => {
-              return (
-                <DatabaseRow
-                  key={rp.links.self}
-                  database={database}
-                  retentionPolicy={rp}
-                  onCreate={onCreateRetentionPolicy}
-                  onUpdate={onUpdateRetentionPolicy}
-                  onRemove={onRemoveRetentionPolicy}
-                  onDelete={onDeleteRetentionPolicy}
-                  isRFDisplayed={isRFDisplayed}
-                  isDeletable={database.retentionPolicies.length > 1}
-                />
-              )
-            })}
-          </tbody>
-        </table>
-      </div>
+                <th style={{width: `${DATABASE_TABLE.colDuration}px`}}>
+                  Duration
+                </th>
+                {isRFDisplayed ? (
+                  <th style={{width: `${DATABASE_TABLE.colReplication}px`}}>
+                    Replication Factor
+                  </th>
+                ) : null}
+                <th style={{width: `${DATABASE_TABLE.colDelete}px`}} />
+              </tr>
+            </thead>
+            <tbody>
+              {_.sortBy(database.retentionPolicies, ({name}) =>
+                name.toLowerCase()
+              ).map(rp => {
+                return (
+                  <DatabaseRow
+                    key={rp.links.self}
+                    database={database}
+                    retentionPolicy={rp}
+                    onCreate={onCreateRetentionPolicy}
+                    onUpdate={onUpdateRetentionPolicy}
+                    onRemove={onRemoveRetentionPolicy}
+                    onDelete={onDeleteRetentionPolicy}
+                    isRFDisplayed={isRFDisplayed}
+                    isDeletable={database.retentionPolicies.length > 1}
+                  />
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Closes #4801

_Briefly describe your proposed changes:_

When creating a new database, the UI is a bit confusing.  There are two "save" buttons (one for the DB and one for the RP).  I have decided to have the "create DB" ui exclusively create a database and a default retention policy.  Should a user want to add / manipulate the default retention policy after creation.

_What was the problem?_

When the user hits "save" on an RP whose database has not yet been created we get various runtime errors.

#### Before
![kapture 2018-11-12 at 11 36 46](https://user-images.githubusercontent.com/7582765/48370872-4a78f700-e66f-11e8-9d30-dc0e049b5bb1.gif)

#### After
![kapture 2018-11-12 at 11 35 41](https://user-images.githubusercontent.com/7582765/48370871-4a78f700-e66f-11e8-871b-3078c08b1fb7.gif)

