### PR TITLE
Fix grouping in canned queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 1. [#4794](https://github.com/influxdata/chronograf/pull/4794): Handle basepath issue with missing slash
 1. [#4798](https://github.com/influxdata/chronograf/pull/4798): Fix the ping pre canned dashboard
 1. [#4791](https://github.com/influxdata/chronograf/pull/4791): Save fieldOptions to cells created from Data Explorer page
+1. [#4806](https://github.com/influxdata/chronograf/pull/4806): Fix grouping in canned dashboard queries
 
 ## v1.7.2 [2018-11-08]
 

--- a/ui/src/hosts/utils/getCells.ts
+++ b/ui/src/hosts/utils/getCells.ts
@@ -87,11 +87,11 @@ function toCell(layoutCell: LayoutCell, source: Source): Cell {
 }
 
 function toCellQuery(layoutQuery: LayoutQuery, source: Source): CellQuery {
-  const cellQuery = {
-    query: layoutQuery.query,
+  const cellQuery: any = {
+    ...layoutQuery,
     source: source.url,
     type: 'influxql',
   }
 
-  return cellQuery as CellQuery
+  return cellQuery
 }


### PR DESCRIPTION
Closes #4789

Chronograf includes a number of canned dashboards, whose cells are predefined and immutable. A cell in a canned dashboard is called a layout cell, and it has a slightly different schema than a cell in a user-defined dashboard (called a dashboard cell).

For legacy reasons, Chronograf is able to render a layout cell or dashboard cell using the same components via a mix of duck-typing and defensive programming. [#4488][0] attempted to unify the differences between the two possible cell schemas by converting a layout cell to a dashboard cell upon read. This schema conversion was error prone and incomplete.

One difference between a layout cell and dashboard cell that was not handled by the schema conversion involved the `groupbys` and `wheres` fields in a layout cell. In a dashboard cell, these data are stored in the `queryConfig` object instead. The schema conversion omitted these data altogether in the converted cell, which caused the behavior described in [#4789][1]

This commit changes to schema conversion to include all data from the original layout cell in the converted cell, so that the `groupbys` and `wheres` fields are present. Downstream, the `Layout` component will check for these fields when determining how to build a query for a cell.

This is a messy solution that builds upon previous messy solutions. [#4488][0] discusses some alternatives, which were deemed not worth the effort to implement.

[0]: https://github.com/influxdata/chronograf/pull/4488
[1]: https://github.com/influxdata/chronograf/issues/4789
