### PR TITLE
Remove dismiss text from and add x-to-dismiss to wizard overlay steps

### DIFF
--- a/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
@@ -38,7 +38,7 @@ class WizardOverlay extends PureComponent<Props> {
       <div className="wizard-overlay">
         <OverlayTechnology visible={visible}>
           <OverlayContainer maxWidth={maxWidth}>
-            <OverlayHeading title={title} />
+            <OverlayHeading title={title} onDismiss={this.handleSkip} />
             <OverlayBody>{this.WizardController}</OverlayBody>
           </OverlayContainer>
         </OverlayTechnology>

--- a/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardOverlay.test.tsx.snap
+++ b/ui/src/reusable_ui/components/wizard/test/__snapshots__/WizardOverlay.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`WizardOverlay matches snapshot with minimal props 1`] = `
     <OverlayContainer
       maxWidth={800}
     >
-      <OverlayHeading />
+      <OverlayHeading
+        onDismiss={[Function]}
+      />
       <OverlayBody />
     </OverlayContainer>
   </OverlayTechnology>
@@ -23,7 +25,9 @@ exports[`WizardOverlay with children matches snapshot with children props 1`] = 
     <OverlayContainer
       maxWidth={800}
     >
-      <OverlayHeading />
+      <OverlayHeading
+        onDismiss={[Function]}
+      />
       <OverlayBody />
     </OverlayContainer>
   </OverlayTechnology>

--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -80,7 +80,6 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
         toggleVisibility={toggleVisibility}
         resetWizardState={this.resetWizardState}
         title="Connection Configuration"
-        skipLinkText="Dismiss"
         maxWidth={800}
         jumpStep={jumpStep}
         isJumpingAllowed={this.isSourceComplete()}
@@ -105,6 +104,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           title="Dashboards"
           tipText="Select Dashboards you would like to create:"
           isComplete={this.isDashboardComplete}
+          isSkippableStep={false}
           isErrored={dashboardError}
           nextLabel={this.dashboardNextLabel}
           onNext={this.handleDashboardNext}
@@ -121,6 +121,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           title="Kapacitor Connection"
           tipText=""
           isComplete={this.isKapacitorComplete}
+          isSkippableStep={false}
           isErrored={kapacitorError}
           onNext={this.handleKapacitorNext}
           onPrevious={this.handleKapacitorPrev}
@@ -139,6 +140,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           title="Setup Complete"
           tipText=""
           isComplete={this.isCompletionComplete}
+          isSkippableStep={false}
           isErrored={false}
           onNext={this.handleCompletionNext}
           onPrevious={this.handleCompletionPrev}


### PR DESCRIPTION
Closes #4784 

_What was the problem?_
It was not possible to cancel and exit out of wizard steps that were designated as compulsory to continue to next wizard step. 
_What was the solution?_
Added x-to-dismiss on upper right of wizard overlay, and removed `dismiss` links on wizard steps. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)