### PR TITLE
Add loading state to protoboards onboarding step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### UI Improvements
+1. [#4809](https://github.com/influxdata/chronograf/pull/4809): Add loading spinners while fetching protoboards
 
 ### Bug Fixes
 

--- a/ui/src/sources/components/DashboardStep.scss
+++ b/ui/src/sources/components/DashboardStep.scss
@@ -20,3 +20,7 @@
   color: $g12-forge;
   margin: $ix-marg-b 0 $ix-marg-a 2px;
 }
+
+.dashboard-step--loading{
+  padding: 15px;
+}


### PR DESCRIPTION
Closes #4803 

_Briefly describe your proposed changes:_
_What was the problem?_
Theres no loading state on the dashboard step of the onboarding process.
_What was the solution?_
Add loading state for both fetching initial protoboards and the loading suggestions state

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass