### PR TITLE
Fix logs loading newer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Bug Fixes
+1. [4814](https://github.com/influxdata/chronograf/pull/4814): Fixes logs page getting stuck on scroll to top
 
 ### UI Improvements
 1. [#4809](https://github.com/influxdata/chronograf/pull/4809): Add loading spinners while fetching protoboards

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -159,6 +159,7 @@ interface State {
   isOverlayVisible: boolean
   histogramColors: HistogramColor[]
   hasScrolled: boolean
+  isLoadingNewer: boolean
 }
 
 class LogsPage extends Component<Props, State> {
@@ -177,7 +178,6 @@ class LogsPage extends Component<Props, State> {
   }
 
   private interval: number
-  private loadingNewer: boolean = false
   private currentOlderChunksGenerator: FetchLoop = null
   private currentNewerChunksGenerator: FetchLoop = null
   private loadingSourcesStatus: RemoteDataState = RemoteDataState.NotStarted
@@ -186,6 +186,7 @@ class LogsPage extends Component<Props, State> {
     super(props)
 
     this.state = {
+      isLoadingNewer: false,
       searchString: '',
       liveUpdating: false,
       isOverlayVisible: false,
@@ -421,7 +422,7 @@ class LogsPage extends Component<Props, State> {
     if (this.isLiveUpdating || this.shouldLiveUpdate) {
       return
     }
-    this.loadingNewer = true
+    this.setState({isLoadingNewer: true})
     await this.startFetchingNewer()
   }
 
@@ -446,7 +447,7 @@ class LogsPage extends Component<Props, State> {
       console.error(error)
     }
 
-    this.loadingNewer = false
+    this.setState({isLoadingNewer: false})
     this.currentNewerChunksGenerator = null
   }
 
@@ -497,8 +498,7 @@ class LogsPage extends Component<Props, State> {
       return 0
     }
 
-    if (this.loadingNewer && this.props.newRowsAdded) {
-      this.loadingNewer = false
+    if (this.state.isLoadingNewer && this.props.newRowsAdded) {
       return this.props.newRowsAdded || 0
     }
 


### PR DESCRIPTION
Closes #https://github.com/influxdata/applications-team-issues/issues/267

_Briefly describe your proposed changes:_
Makes `isLoadingNewer` part of the `LogsPage` state so the table will be re-rendered once the logs table has finished loading newer rows. This fixes a race condition where scrolling to the top of the logs table could cause scroll position to get stuck if the user did not scroll while new rows were being added.
_What was the problem?_
Scroll position could get stuck because the update that signaled loading newer had completed was not causing the table to be rendered 
_What was the solution?_
Move `isLoadingNewer` into the `LogsPage` state and update state once a fetch for newer data has completed.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass