### PR TITLE
Allow skipping add Kapacitor step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### UI Improvements
 1. [#4809](https://github.com/influxdata/chronograf/pull/4809): Add loading spinners while fetching protoboards
+1. [4845](https://github.com/influxdata/chronograf/pull/4845): Allow Kapacitor step in Connection Configuration to be skipped
 
 ## v1.7.3 [2018-11-13]
 

--- a/ui/src/reusable_ui/components/wizard/WizardController.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardController.tsx
@@ -17,7 +17,7 @@ interface State {
 
 interface Props {
   children: Array<ReactElement<WizardStepProps>>
-  handleSkip?: () => void
+  handleFinish?: () => void
   skipLinkText?: string
   jumpStep?: number
   switchLinkText?: string
@@ -129,11 +129,11 @@ class WizardController extends PureComponent<Props, State> {
   }
 
   private get CurrentChild(): JSX.Element {
-    const {children, handleSkip} = this.props
+    const {children, handleFinish} = this.props
     const {currentStepIndex, steps} = this.state
     const lastStep = currentStepIndex === steps.length - 1
 
-    const advance = lastStep ? handleSkip : this.incrementStep
+    const advance = lastStep ? handleFinish : this.incrementStep
     const retreat = currentStepIndex === 0 ? null : this.decrementStep
 
     let currentChild
@@ -173,13 +173,13 @@ class WizardController extends PureComponent<Props, State> {
   }
 
   private get skipLink() {
-    const {handleSkip, skipLinkText} = this.props
-    const {steps} = this.state
+    const {skipLinkText} = this.props
+    const {currentStepIndex} = this.state
 
     return (
       <button
         className="btn btn-xs btn-primary btn-link wizard-skip-link"
-        onClick={handleSkip || this.jumpToStep(steps.length - 1)}
+        onClick={this.jumpToStep(currentStepIndex + 1)}
       >
         {skipLinkText}
       </button>

--- a/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardFullScreen.tsx
@@ -11,7 +11,6 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 interface Props {
   children: Array<ReactElement<WizardStepProps>>
   skipLinkText?: string
-  handleSkip?: () => void
   switchLinkText?: string
   handleSwitch?: () => void
   isUsingAuth: boolean
@@ -35,7 +34,6 @@ class WizardFullScreen extends PureComponent<Props> {
     const {
       children,
       skipLinkText,
-      handleSkip,
       handleSwitch,
       switchLinkText,
       isUsingAuth,
@@ -45,7 +43,6 @@ class WizardFullScreen extends PureComponent<Props> {
     if (children) {
       return (
         <WizardController
-          handleSkip={handleSkip}
           skipLinkText={skipLinkText}
           handleSwitch={handleSwitch}
           switchLinkText={switchLinkText}

--- a/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardOverlay.tsx
@@ -38,7 +38,7 @@ class WizardOverlay extends PureComponent<Props> {
       <div className="wizard-overlay">
         <OverlayTechnology visible={visible}>
           <OverlayContainer maxWidth={maxWidth}>
-            <OverlayHeading title={title} onDismiss={this.handleSkip} />
+            <OverlayHeading title={title} onDismiss={this.handleFinish} />
             <OverlayBody>{this.WizardController}</OverlayBody>
           </OverlayContainer>
         </OverlayTechnology>
@@ -52,7 +52,7 @@ class WizardOverlay extends PureComponent<Props> {
       return (
         <WizardController
           skipLinkText={skipLinkText}
-          handleSkip={this.handleSkip}
+          handleFinish={this.handleFinish}
           jumpStep={jumpStep}
           isJumpingAllowed={isJumpingAllowed}
         >
@@ -64,8 +64,9 @@ class WizardOverlay extends PureComponent<Props> {
     return null
   }
 
-  private handleSkip = () => {
+  private handleFinish = () => {
     const {toggleVisibility, resetWizardState} = this.props
+
     toggleVisibility(false)()
     resetWizardState()
   }

--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -121,7 +121,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
           title="Kapacitor Connection"
           tipText=""
           isComplete={this.isKapacitorComplete}
-          isSkippableStep={false}
+          isSkippableStep={true}
           isErrored={kapacitorError}
           onNext={this.handleKapacitorNext}
           onPrevious={this.handleKapacitorPrev}


### PR DESCRIPTION
Closes #4842 

_What was the problem?_
Previously, the "Add Kapacitor" step in the Connections Wizard could not be skipped.

_What was the solution?_
Make the Kapacitor step skippable, as well as changing the Skip function to go to the next step rather than close the WizardOverlay.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass