### PR TITLE
Fix stat graphs for flux responses

### DIFF
--- a/ui/src/shared/components/Gauge.tsx
+++ b/ui/src/shared/components/Gauge.tsx
@@ -47,6 +47,7 @@ class Gauge extends Component<Props> {
 
   public render() {
     const {width, height} = this.props
+
     return (
       <canvas
         className="gauge"
@@ -366,7 +367,13 @@ class Gauge extends Component<Props> {
     const {degree, needleColor0, needleColor1} = GAUGE_SPECS
     const arcDistance = Math.PI * 1.5
 
-    const needleRotation = (gaugePosition - minValue) / (maxValue - minValue)
+    const limitedGaugePosition = Math.max(
+      Math.min(gaugePosition, maxValue),
+      minValue
+    )
+
+    const needleRotation =
+      (limitedGaugePosition - minValue) / (maxValue - minValue)
 
     const needleGradient = ctx.createLinearGradient(0, -10, 0, radius)
     needleGradient.addColorStop(0, needleColor0)

--- a/ui/src/shared/components/SingleStat.tsx
+++ b/ui/src/shared/components/SingleStat.tsx
@@ -42,11 +42,12 @@ interface Props {
   dataType: DataType
   onUpdateCellColors?: (bgColor: string, textColor: string) => void
   onUpdateVisType?: (cell: CellType) => Promise<void>
+  fluxTablesToSingleStat?: typeof manager.fluxTablesToSingleStat
 }
 
 interface State {
   lastValues?: {
-    values: number[]
+    values: string[] | number[]
     series: string[]
   }
   isValidData: boolean
@@ -60,6 +61,7 @@ class SingleStat extends PureComponent<Props, State> {
     prefix: '',
     suffix: '',
     onUpdateCellColors: NOOP,
+    fluxTablesToSingleStat: manager.fluxTablesToSingleStat,
   }
 
   private isComponentMounted: boolean
@@ -68,13 +70,15 @@ class SingleStat extends PureComponent<Props, State> {
     getLastValues,
     isInluxQLDataEqual
   )
-  private memoizedFluxTablesToSingleStat = memoizeOne(
-    manager.fluxTablesToSingleStat,
-    isFluxDataEqual
-  )
+  private memoizedFluxTablesToSingleStat: typeof manager.fluxTablesToSingleStat
 
   constructor(props: Props) {
     super(props)
+
+    this.memoizedFluxTablesToSingleStat = memoizeOne(
+      props.fluxTablesToSingleStat,
+      isFluxDataEqual
+    )
 
     this.state = {isValidData: true}
   }
@@ -138,7 +142,7 @@ class SingleStat extends PureComponent<Props, State> {
         firstAlphabeticalSeriesName
       )
 
-      return values[firstAlphabeticalIndex]
+      return Number(values[firstAlphabeticalIndex])
     }
   }
 
@@ -196,7 +200,7 @@ class SingleStat extends PureComponent<Props, State> {
         series,
         firstAlphabeticalSeriesName
       )
-      lastValue = values[firstAlphabeticalIndex]
+      lastValue = Number(values[firstAlphabeticalIndex])
     }
 
     const {bgColor, textColor} = generateThresholdsListHexs({

--- a/ui/test/shared/components/SingleStat.test.tsx
+++ b/ui/test/shared/components/SingleStat.test.tsx
@@ -1,7 +1,6 @@
 import {shallow} from 'enzyme'
 import React from 'react'
-import Gauge from 'src/shared/components/Gauge'
-import GaugeChart from 'src/shared/components/GaugeChart'
+import SingleStat from 'src/shared/components/SingleStat'
 import {DataType} from 'src/shared/constants'
 
 import {
@@ -21,6 +20,9 @@ const defaultProps = {
     isEnforced: true,
   },
   dataType: DataType.influxQL,
+  cellHeight: 10,
+  colors: [],
+  lineGraph: false,
 }
 
 const setup = (overrides = {}) => {
@@ -29,17 +31,19 @@ const setup = (overrides = {}) => {
     ...overrides,
   }
 
-  return shallow(<GaugeChart {...props} />)
+  return shallow(<SingleStat {...props} />)
 }
 
-describe('GaugeChart', () => {
+describe('SingleStat', () => {
+  const StatSelector = '.single-stat--text'
+
   describe('rendering influxQL response', () => {
     describe('when data is empty', () => {
       it('renders the correct number', () => {
         const wrapper = setup()
 
-        expect(wrapper.find(Gauge).exists()).toBe(true)
-        expect(wrapper.find(Gauge).props().gaugePosition).toBe(0)
+        expect(wrapper.find(StatSelector)).toHaveLength(1)
+        expect(wrapper.find(StatSelector).text()).toBe('0')
       })
     })
 
@@ -47,8 +51,8 @@ describe('GaugeChart', () => {
       it('renders the correct number', () => {
         const wrapper = setup({data: createInfluxQLDataValue(2)})
 
-        expect(wrapper.find(Gauge).exists()).toBe(true)
-        expect(wrapper.find(Gauge).props().gaugePosition).toBe(2)
+        expect(wrapper.find(StatSelector).exists()).toBe(true)
+        expect(wrapper.find(StatSelector).text()).toBe('2')
       })
     })
   })
@@ -58,29 +62,33 @@ describe('GaugeChart', () => {
       it('renders the correct number', () => {
         const wrapper = setup({datatype: DataType.flux, data: []})
 
-        expect(wrapper.find(Gauge).exists()).toBe(true)
-        expect(wrapper.find(Gauge).props().gaugePosition).toBe(0)
+        expect(wrapper.find(StatSelector).exists()).toBe(true)
+        expect(wrapper.find(StatSelector).text()).toBe('0')
       })
     })
 
     describe('when data has a value', () => {
       it('renders the correct number', async () => {
-        const data = createFluxDataValue('67.3901637395223')
+        const data = createFluxDataValue('9000.123456790235')
         const mockFluxToSingleStat = jest.fn(
-          fluxValueToSingleStat('67.3901637395223')
+          fluxValueToSingleStat('9000.123456790235')
         )
 
         const wrapper = await setup({
           data,
           dataType: DataType.flux,
           fluxTablesToSingleStat: mockFluxToSingleStat,
+          prefix: 'Over ',
+          suffix: ' battle power!',
         })
 
         expect(mockFluxToSingleStat).toBeCalledWith(data)
         await expect(mockFluxToSingleStat).toReturn()
         await wrapper.update()
-        expect(wrapper.find(Gauge).exists()).toBe(true)
-        expect(wrapper.find(Gauge).props().gaugePosition).toBe(67.3901637395223)
+        expect(wrapper.find(StatSelector).exists()).toBe(true)
+        expect(wrapper.find(StatSelector).text()).toBe(
+          'Over 9,000.12 battle power!'
+        )
       })
     })
   })

--- a/ui/test/shared/components/helpers.ts
+++ b/ui/test/shared/components/helpers.ts
@@ -1,0 +1,76 @@
+import {TimeSeriesServerResponse} from 'src/types/series'
+import {FluxTable} from 'src/types/flux'
+
+export const createInfluxQLDataValue = (
+  value: number
+): TimeSeriesServerResponse[] => [
+  {
+    response: {
+      results: [
+        {
+          series: [
+            {
+              values: [[1, value]],
+              columns: ['time', 'value'],
+            },
+          ],
+          statement_id: 123,
+        },
+      ],
+    },
+  },
+]
+
+export const createFluxDataValue = (value: string): FluxTable[] => [
+  {
+    data: [
+      [
+        '',
+        'result',
+        'table',
+        '_start',
+        '_stop',
+        '_field',
+        '_measurement',
+        'host',
+        '_value',
+      ],
+      [
+        '',
+        '',
+        '0',
+        '2018-11-29T14:07:08.214Z',
+        '2018-11-29T14:07:28.785Z',
+        'used_percent',
+        'mem',
+        'user.local',
+        value,
+      ],
+    ],
+    dataTypes: {
+      '': '#datatype',
+      host: 'string',
+      result: 'string',
+      table: 'long',
+      _field: 'string',
+      _measurement: 'string',
+      _start: 'dateTime:RFC3339',
+      _stop: 'dateTime:RFC3339',
+      _value: 'double',
+    },
+    groupKey: {
+      host: 'user.local',
+      _field: 'used_percent',
+      _measurement: 'mem',
+    },
+    id: '20d646ad-51a6-4e11-829a-0dcc186ba919',
+    name: '_field=used_percent _measurement=mem host=user.local',
+  },
+]
+
+export const fluxValueToSingleStat = (value: string) => async (
+  __: FluxTable
+) => ({
+  series: ['_value[host=user.local][_field=used_percent][_measurement=mem]'],
+  values: [value],
+})


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/4813

_Briefly describe your proposed changes:_
Fix typing for stat charts to ensure a number is provided 
_What was the problem?_
The lastValues for a stat chart could be an array of strings if the data was a flux response but was typed as always being number.
_What was the solution?_
Update the types and add tests. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass