### PR TITLE
Fix logs query error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [4819](https://github.com/influxdata/chronograf/pull/4819): Fix issue displaying UUIDs in table cells
 1. [4854](https://github.com/influxdata/chronograf/pull/4854): Update functions list for Flux 0.7.1
 1. [4846](https://github.com/influxdata/chronograf/pull/4846): Fix missing data and type in refreshing graph
+1. [4861](https://github.com/influxdata/chronograf/pull/4861): Fix logs stuck in loading state
 
 
 ### UI Improvements

--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -290,7 +290,7 @@ interface SetNextTailLowerBoundAction {
   }
 }
 
-interface SetSearchStatusAction {
+export interface SetSearchStatusAction {
   type: ActionTypes.SetSearchStatus
   payload: {
     searchStatus: SearchStatus
@@ -923,11 +923,15 @@ export const fetchNamespaceSyslogStatusAsync = (namespace: Namespace) => async (
   dispatch: Dispatch<SetSearchStatusAction>,
   getState: GetState
 ) => {
-  const proxyLink = getProxyLink(getState())
-  const response = await getSyslogMeasurement(proxyLink, namespace)
-  const series = getDeep(response, 'results.0.series', [])
+  try {
+    const proxyLink = getProxyLink(getState())
+    const response = await getSyslogMeasurement(proxyLink, namespace)
+    const series = getDeep(response, 'results.0.series', [])
 
-  if (_.isEmpty(series)) {
+    if (_.isEmpty(series)) {
+      await dispatch(setSearchStatus(SearchStatus.MeasurementMissing))
+    }
+  } catch (error) {
     await dispatch(setSearchStatus(SearchStatus.MeasurementMissing))
   }
 }

--- a/ui/src/logs/api/index.ts
+++ b/ui/src/logs/api/index.ts
@@ -3,6 +3,7 @@ import AJAX from 'src/utils/ajax'
 import {Namespace} from 'src/types'
 import {TimeSeriesResponse} from 'src/types/series'
 import {ServerLogConfig} from 'src/types/logs'
+import {buildFindMeasurementQuery} from 'src/logs/utils'
 
 export const executeQueryAsync = async (
   proxyLink: string,
@@ -54,9 +55,7 @@ export const updateLogConfig = async (
 export const getSyslogMeasurement = async (
   proxyLink: string,
   namespace: Namespace
-) => {
-  const query = `SHOW MEASUREMENTS ON ${
-    namespace.database
-  } WITH measurement = "syslog"`
+): Promise<TimeSeriesResponse> => {
+  const query = buildFindMeasurementQuery(namespace, 'syslog')
   return executeQueryAsync(proxyLink, namespace, query)
 }

--- a/ui/src/logs/utils/index.ts
+++ b/ui/src/logs/utils/index.ts
@@ -355,3 +355,11 @@ export const parseHistogramQueryResponse = (
 export const formatTime = (time: number): string => {
   return moment(time).format(DEFAULT_TIME_FORMAT)
 }
+
+export const buildFindMeasurementQuery = (
+  namespace: Namespace,
+  measurement: string
+) =>
+  `SHOW MEASUREMENTS ON "${
+    namespace.database
+  }" WITH measurement = "${measurement}"`

--- a/ui/test/logs/actions/checkSyslogStatus.test.ts
+++ b/ui/test/logs/actions/checkSyslogStatus.test.ts
@@ -1,0 +1,94 @@
+// Libs
+import thunkMidddleware from 'redux-thunk'
+
+// Mock
+import {getSyslogMeasurement} from 'test/logs/apiMock'
+
+// Actions
+import {
+  fetchNamespaceSyslogStatusAsync,
+  SetSearchStatusAction,
+  ActionTypes,
+} from 'src/logs/actions'
+
+// Types
+import {LogsState, SearchStatus} from 'src/types/logs'
+import {Namespace} from 'src/types'
+import {TimeSeriesResponse} from 'src/types/series'
+
+// Fixtures
+import {source} from 'test/fixtures'
+
+describe('Logs.Actions.checkSyslogStatus', () => {
+  const proxy = 'logsProxyLink'
+
+  const currentSource = {
+    ...source,
+    links: {
+      ...source.links,
+      proxy,
+    },
+  }
+
+  const namespace: Namespace = {
+    database: 'logs-test',
+    retentionPolicy: 'autogen',
+  }
+
+  const dispatch = jest.fn()
+  const getState = jest.fn((): {logs: Partial<LogsState>} => ({
+    logs: {currentSource},
+  }))
+
+  const thunkWareMock = thunkMidddleware({dispatch, getState})
+  const mockActionHandler = thunkWareMock()
+
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it('can fetch syslog measurement', async () => {
+    const response: TimeSeriesResponse = {
+      results: [
+        {
+          statement_id: 0,
+          series: [
+            {name: 'measurements', columns: ['name'], values: [['syslog']]},
+          ],
+        },
+      ],
+    }
+
+    getSyslogMeasurement.mockResolvedValue(Promise.resolve(response))
+    mockActionHandler(fetchNamespaceSyslogStatusAsync(namespace))
+    expect(getSyslogMeasurement).toBeCalledWith(proxy, namespace)
+  })
+
+  const missingSyslogStatus: SetSearchStatusAction = {
+    type: ActionTypes.SetSearchStatus,
+    payload: {
+      searchStatus: SearchStatus.MeasurementMissing,
+    },
+  }
+
+  it('can update missing measurement status', async () => {
+    const response = {
+      results: [{statement_id: 0}],
+    }
+
+    getSyslogMeasurement.mockResolvedValue(Promise.resolve(response))
+    await mockActionHandler(fetchNamespaceSyslogStatusAsync(namespace))
+    await expect(dispatch).toBeCalledWith(missingSyslogStatus)
+  })
+
+  it('can update for querying errors', async () => {
+    getSyslogMeasurement.mockRejectedValue({
+      code: 400,
+      message:
+        'received status code 400 from server: err: error parsing query: found -, expected ; at line 1, char 30',
+    })
+
+    await mockActionHandler(fetchNamespaceSyslogStatusAsync(namespace))
+    await expect(dispatch).toBeCalledWith(missingSyslogStatus)
+  })
+})

--- a/ui/test/logs/apiMock.ts
+++ b/ui/test/logs/apiMock.ts
@@ -1,0 +1,5 @@
+export const getSyslogMeasurement = jest.fn()
+
+jest.mock('src/logs/api', () => ({
+  getSyslogMeasurement,
+}))

--- a/ui/test/logs/utils/queryBuilder.test.ts
+++ b/ui/test/logs/utils/queryBuilder.test.ts
@@ -1,0 +1,18 @@
+import {buildFindMeasurementQuery} from 'src/logs/utils'
+import {Namespace} from 'src/types'
+
+describe('queryBuilder', () => {
+  describe('buildFindMeasurementQuery', () => {
+    it('can build a query for a given namespace', () => {
+      const namespace: Namespace = {
+        database: 'my db',
+        retentionPolicy: 'autogen',
+      }
+      const actual = buildFindMeasurementQuery(namespace, 'test-123_abc')
+      const expected =
+        'SHOW MEASUREMENTS ON "my db" WITH measurement = "test-123_abc"'
+
+      expect(expected).toEqual(actual)
+    })
+  })
+})


### PR DESCRIPTION
Closes #4851

_Briefly describe your proposed changes:_
Add quotes in meta query building that checks for syslog measurement  
_What was the problem?_
Missing quotes in a query caused an unhandled error that made the log viewer appear to be stuck querying when it was not.
_What was the solution?_
Update the query building to have quotes and the thunk action to handle the error with a status update so the log viewer doesn't appear to be stuck loading.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass