### PR TITLE
Prevent cell renaming widget from pushing other header elements offscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [4861](https://github.com/influxdata/chronograf/pull/4861): Fix logs stuck in loading state
 1. [4847](https://github.com/influxdata/chronograf/pull/4847): Improve display of Flux Wizard on small screens
 1. [4863](https://github.com/influxdata/chronograf/pull/4863): Update logs histogram data on click and new search
+1. [4872](https://github.com/influxdata/chronograf/pull/4872): Prevent cell renaming widget from pushing other header elements offscreen
 
 ### UI Improvements
 1. [#4809](https://github.com/influxdata/chronograf/pull/4809): Add loading spinners while fetching protoboards

--- a/ui/src/dashboards/components/rename_dashboard/RenameDashboard.scss
+++ b/ui/src/dashboards/components/rename_dashboard/RenameDashboard.scss
@@ -7,8 +7,8 @@ $rename-dash-title-padding: 7px;
 
 .rename-dashboard {
   height: $form-sm-height;
-  min-width: 0;
-  width: 100%;;
+  width: 100%;
+  max-width: 40vw;
 }
 .dashboard-switcher + .rename-dashboard {
   width: calc(100% - 38px);

--- a/ui/src/reusable_ui/components/page_layout/Page.scss
+++ b/ui/src/reusable_ui/components/page_layout/Page.scss
@@ -87,7 +87,6 @@
   align-items: center;
 }
 .page-header--left {
-  flex: 1 0 0;
   justify-content: flex-start;
   > * {
     margin: 0;
@@ -119,6 +118,9 @@
   vertical-align: middle;
   @include no-user-select();
   cursor: default;
+  max-width: 42vw;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 // TODO: Refactor this to be a part of overlay styles

--- a/ui/src/reusable_ui/components/page_layout/PageHeaderLeft.tsx
+++ b/ui/src/reusable_ui/components/page_layout/PageHeaderLeft.tsx
@@ -41,9 +41,7 @@ class PageHeaderLeft extends Component<Props> {
     const {offsetPixels} = this.props
 
     if (offsetPixels === DEFAULT_OFFSET) {
-      return {
-        flex: `1 0 ${offsetPixels}`,
-      }
+      return
     }
 
     return {

--- a/ui/src/reusable_ui/components/page_layout/PageHeaderRight.tsx
+++ b/ui/src/reusable_ui/components/page_layout/PageHeaderRight.tsx
@@ -42,9 +42,7 @@ class PageHeaderRight extends Component<Props> {
     const {offsetPixels} = this.props
 
     if (offsetPixels === DEFAULT_OFFSET) {
-      return {
-        flex: `1 0 ${offsetPixels}`,
-      }
+      return
     }
 
     return {


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/4870

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass