### PR TITLE
Fix flux editor scrollbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [4861](https://github.com/influxdata/chronograf/pull/4861): Fix logs stuck in loading state
 1. [4847](https://github.com/influxdata/chronograf/pull/4847): Improve display of Flux Wizard on small screens
 1. [4863](https://github.com/influxdata/chronograf/pull/4863): Update logs histogram data on click and new search
+1. [4877](https://github.com/influxdata/chronograf/pull/4877): Fix flux editor scrollbars
 
 ### UI Improvements
 1. [#4809](https://github.com/influxdata/chronograf/pull/4809): Add loading spinners while fetching protoboards

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -42,7 +42,10 @@ interface EditorInstance extends IInstance {
 class FluxScriptEditor extends PureComponent<Props, State> {
   private editor: EditorInstance
   private lineWidgets: Widget[] = []
-  private containerDimensions: {width: number; height: number}
+  private containerDimensions: {width: number; height: number} = {
+    height: 0,
+    width: 0,
+  }
 
   public constructor(props: Props) {
     super(props)

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -43,7 +43,7 @@ interface EditorInstance extends IInstance {
 class FluxScriptEditor extends PureComponent<Props, State> {
   private editor: EditorInstance
   private lineWidgets: Widget[] = []
-  private containerWidth: number
+  private containerDimensions: {width: number; height: number}
 
   public constructor(props: Props) {
     super(props)
@@ -113,13 +113,14 @@ class FluxScriptEditor extends PureComponent<Props, State> {
   }
 
   private handleMouseEnter = (e: MouseEvent<HTMLDivElement>) => {
-    const {width} = e.currentTarget.getBoundingClientRect()
+    const {width, height} = e.currentTarget.getBoundingClientRect()
+    const {width: prevWidth, height: prevHeight} = this.containerDimensions
 
-    if (width !== this.containerWidth) {
+    if (prevWidth !== width || prevHeight !== height) {
       this.editor.refresh()
     }
 
-    this.containerWidth = width
+    this.containerDimensions = {width, height}
   }
 
   private makeError(): void {

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -1,4 +1,3 @@
-import _ from 'lodash'
 import React, {PureComponent, MouseEvent} from 'react'
 import {Controlled as ReactCodeMirror, IInstance} from 'react-codemirror2'
 import {EditorChange, LineWidget} from 'codemirror'

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -1,5 +1,5 @@
 import _ from 'lodash'
-import React, {PureComponent} from 'react'
+import React, {PureComponent, MouseEvent} from 'react'
 import {Controlled as ReactCodeMirror, IInstance} from 'react-codemirror2'
 import {EditorChange, LineWidget} from 'codemirror'
 import {ShowHintOptions} from 'src/types/codemirror'
@@ -43,6 +43,7 @@ interface EditorInstance extends IInstance {
 class FluxScriptEditor extends PureComponent<Props, State> {
   private editor: EditorInstance
   private lineWidgets: Widget[] = []
+  private containerWidth: number
 
   public constructor(props: Props) {
     super(props)
@@ -94,7 +95,7 @@ class FluxScriptEditor extends PureComponent<Props, State> {
     }
 
     return (
-      <div className="flux-script-editor">
+      <div className="flux-script-editor" onMouseEnter={this.handleMouseEnter}>
         <ReactCodeMirror
           autoFocus={true}
           autoCursor={true}
@@ -109,6 +110,16 @@ class FluxScriptEditor extends PureComponent<Props, State> {
         {children}
       </div>
     )
+  }
+
+  private handleMouseEnter = (e: MouseEvent<HTMLDivElement>) => {
+    const {width} = e.currentTarget.getBoundingClientRect()
+
+    if (width !== this.containerWidth) {
+      this.editor.refresh()
+    }
+
+    this.containerWidth = width
   }
 
   private makeError(): void {

--- a/ui/src/style/components/code-mirror/_time-machine.scss
+++ b/ui/src/style/components/code-mirror/_time-machine.scss
@@ -54,6 +54,9 @@
 
   .CodeMirror-vscrollbar,
   .CodeMirror-hscrollbar {
-    @include custom-scrollbar-round($g1-raven, $g6-smoke);
+    @include custom-scrollbar-round($g1-raven, $c-pool);
+    &::-webkit-scrollbar-thumb {
+      border-width: 5px;
+    }
   }
 }

--- a/ui/src/style/components/threesizer.scss
+++ b/ui/src/style/components/threesizer.scss
@@ -133,6 +133,8 @@ $threesizer-shadow-stop: fade-out($g0-obsidian, 1);
 }
 
 // Header
+$threesizer-header-height: 44px;
+$threesizer-header-width: 44px;
 .threesizer--header {
   display: flex;
   align-items: center;
@@ -140,11 +142,11 @@ $threesizer-shadow-stop: fade-out($g0-obsidian, 1);
   padding: 0 11px;
   background-color: $g2-kevlar;
   .horizontal>& {
-    width: 44px;
+    width: $threesizer-header-width;
     border-right: 2px solid $g4-onyx;
   }
   .vertical>& {
-    height: 44px;
+    height: $threesizer-header-height;
     border-bottom: 2px solid $g4-onyx;
   }
 }

--- a/ui/src/style/components/time-machine/flux-editor.scss
+++ b/ui/src/style/components/time-machine/flux-editor.scss
@@ -33,5 +33,5 @@ height: 100%;
 }
 
 .flux-query-maker--script .threesizer--body {
-  overflow: scroll;
+  height: calc(100% - #{$threesizer-header-height});
 }


### PR DESCRIPTION
Closes #https://github.com/influxdata/chronograf/issues/4871

_Briefly describe your proposed changes:_
Remove overflow scroll strategy for code mirror threesizer contents wrapper 
Show scrollbars on mouse enter after width change
_What was the problem?_
Multiple scrollbars were being rendered one for the threesizer contents overflow and one for code mirror overflow
CodeMirror scrollbars were not aware of resizes of the threesizer
_What was the solution?_
 - Update styling of the threesizer contents to be the full height of the vertical minus the height of threesize header 
- Add a mouse enter listener that checks for width/height changes

![kapture 2018-12-11 at 15 31 14](https://user-images.githubusercontent.com/4994741/49828424-e1fa6400-fd59-11e8-975e-99b920585a90.gif)


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass