### PR TITLE
Properly set scroll to row for table graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.7.6 [unreleased]
 
 ### Bug Fixes
+1. [4895](https://github.com/influxdata/chronograf/pull/4895): Properly set scroll to row for table graph
 
 ## v1.7.5 [2018-12-14]
 

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -59,17 +59,20 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
     const maxScrollTop = (rowCount + 1) * ROW_HEIGHT - (height + ROW_HEIGHT)
     const maxRow = rowCount - Math.floor(height / ROW_HEIGHT) / 2
 
-    if (scrollTop <= 0) {
+    if (scrollTop < 0) {
       return {scrollToRow}
     }
+    if (scrollToRow > maxRow) {
+      return {scrollToRow: rowCount}
+    }
 
-    if (scrollTop > maxScrollTop || scrollToRow > maxRow) {
-      return null
+    if (scrollTop > maxScrollTop) {
+      return {scrollTop: maxScrollTop}
     }
 
     return {
       scrollToRow,
-      scrollTop: Math.max(scrollTop - height / 2, height / 2),
+      scrollTop: scrollToRow * ROW_HEIGHT - ROW_HEIGHT,
     }
   }
 
@@ -359,7 +362,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
             setScrollTop={this.onScrollbarsScroll}
           >
             <Grid
-              {..._.omit(props, ['scrollToColumn'])}
+              {..._.omit(props, ['scrollToColumn', 'scrollTop'])}
               cellRenderer={this.cellRendererBottomRightGrid}
               className={this.props.classNameBottomRightGrid}
               columnCount={Math.max(0, columnCount - fixedColumnCount)}


### PR DESCRIPTION
- Omit scrollTop to grid properties

Co-authored-by: Palak Bhoojani <palak@influxdata.com>

Closes #4891 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)