### PR TITLE
Fix rpm install systemv version instead of systemd on Amazon Linux 2

### DIFF
--- a/etc/scripts/post-install.sh
+++ b/etc/scripts/post-install.sh
@@ -77,7 +77,13 @@ elif [[ -f /etc/os-release ]]; then
     source /etc/os-release
     if [[ $ID = "amzn" ]]; then
     	# Amazon Linux logic
-    	install_init
-    	install_chkconfig
+    	which systemctl &>/dev/null
+        if [[ $? -eq 0 ]]; then
+        	install_systemd
+        else
+        	# Assuming sysv
+        	install_init
+        	install_chkconfig
+        fi
     fi
 fi


### PR DESCRIPTION
Closes #

_Briefly describe your proposed changes:_
rpm install systemd version instead of  systemv on Amazon Linux 2
_What was the problem?_
_What was the solution?_

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)