### PR TITLE
Set kapacitor in ConnectionWizard and call syncHostnames for new kapacitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [4895](https://github.com/influxdata/chronograf/pull/4895): Properly set scroll to row for table graph
+1. [4906](https://github.com/influxdata/chronograf/pull/4906): Prevent Kapacitor URLs from being overwritten in Connection Wizard.
 
 ## v1.7.5 [2018-12-14]
 

--- a/ui/src/sources/components/ConnectionWizard.tsx
+++ b/ui/src/sources/components/ConnectionWizard.tsx
@@ -134,6 +134,7 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
             setError={this.handleSetKapacitorError}
             kapacitor={kapacitor}
             showNewKapacitor={showNewKapacitor}
+            setKapacitorDraft={this.setKapacitorDraft}
           />
         </WizardStep>
         <WizardStep
@@ -221,6 +222,10 @@ class ConnectionWizard extends PureComponent<Props & WithRouterProps, State> {
       kapacitorError: response.error,
     })
     return response
+  }
+
+  private setKapacitorDraft = (kapacitor: Kapacitor) => {
+    this.setState({kapacitor})
   }
 
   private handleKapacitorPrev = () => {}


### PR DESCRIPTION
Closes #4894

_What was the problem?_
Kapacitor URLs were overwritten when moving between steps in the Connection Wizard.

_What was the solution?_
Only sync the Kapacitor URL with the source URL when first adding a new Kapacitor. After that, keep the updated Kapacitor URL in the Connection Wizard.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass