### PR TITLE
Update hostname for meta urls for new sources only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#4895](https://github.com/influxdata/chronograf/pull/4895): Properly set scroll to row for table graph
 1. [#4906](https://github.com/influxdata/chronograf/pull/4906): Prevent Kapacitor URLs from being overwritten in Connection Wizard.
 1. [#4862](https://github.com/influxdata/chronograf/pull/4909): Fix logs intermitently show empty on first load
+1. [#5034](https://github.com/influxdata/chronograf/pull/5034): Prevent meta node URLs from being overwritten in Connection Wizard.
 
 ## v1.7.5 [2018-12-14]
 

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -216,10 +216,10 @@ class SourceStep extends PureComponent<Props, State> {
     const {source} = this.state
     const metaserviceURL = new URL(source.metaUrl || DEFAULT_SOURCE.metaUrl)
     const sourceURL = new URL(sourceURLstring || DEFAULT_SOURCE.url)
-    metaserviceURL.hostname = sourceURL.hostname
 
     if (isNewSource(source)) {
       try {
+        metaserviceURL.hostname = sourceURL.hostname
         let sourceFromServer = await createSource(source)
         sourceFromServer = {...sourceFromServer, metaUrl: metaserviceURL.href}
         this.props.addSource(sourceFromServer)


### PR DESCRIPTION
Closes #4893 

_What was the problem?_
When editing an enterprise source in the connection wizard, the meta node URL was overwritten with the default URL every time the source URL was updated.

_What was the solution?_
Only update the meta node URL with the default URL if the source connection is new. Otherwise, if it is an existing connection being updated, use the URL from state.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
