### PR TITLE
Stop cells with raw/no format selected from getting changed to base 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Bug Fixes
 1. [#5068](https://github.com/influxdata/chronograf/pull/5068): Escape injected meta query values
 1. [#5073](https://github.com/influxdata/chronograf/pull/5073): Fix out of range decimal places
+1. [#5076](https://github.com/influxdata/chronograf/pull/5076): Stop raw yaxis format from getting updated to 10
 
 ## v1.7.7 [2018-01-16]
 

--- a/server/cells.go
+++ b/server/cells.go
@@ -121,7 +121,7 @@ func HasCorrectAxes(c *chronograf.DashboardCell) error {
 			return chronograf.ErrInvalidAxis
 		}
 
-		if !oneOf(axis.Base, "10", "2", "") {
+		if !oneOf(axis.Base, "10", "2", "", "raw") {
 			return chronograf.ErrInvalidAxis
 		}
 	}

--- a/ui/src/dashboards/components/AxesOptions.tsx
+++ b/ui/src/dashboards/components/AxesOptions.tsx
@@ -22,7 +22,7 @@ import {Axes, CellType} from 'src/types'
 import {DecimalPlaces} from 'src/types/dashboards'
 import {ColorString} from 'src/types/colors'
 
-const {LINEAR, LOG, BASE_2, BASE_10} = AXES_SCALE_OPTIONS
+const {LINEAR, LOG, BASE_2, BASE_10, BASE_RAW} = AXES_SCALE_OPTIONS
 const getInputMin = scale => (scale === LOG ? '0' : null)
 
 interface Props {
@@ -228,8 +228,8 @@ class AxesOptions extends PureComponent<Props, State> {
         <Radio shape={ButtonShape.StretchToFit}>
           <Radio.Button
             id="y-values-format-tab--raw"
-            value=""
-            active={base === ''}
+            value={BASE_RAW}
+            active={base === '' || base === BASE_RAW}
             titleText="Don't format values"
             onClick={this.handleSetBase}
           >

--- a/ui/src/dashboards/constants/cellEditor.ts
+++ b/ui/src/dashboards/constants/cellEditor.ts
@@ -17,6 +17,7 @@ export const AXES_SCALE_OPTIONS = {
   LOG: 'log',
   BASE_2: '2',
   BASE_10: '10',
+  BASE_RAW: 'raw',
 }
 
 type DefaultAxis = Pick<Axis, Exclude<keyof Axis, 'bounds'>>


### PR DESCRIPTION
Closes #4168

_Briefly describe your proposed changes:_
_What was the problem?_
When unmarshalling a dashboard, the axis base was getting set to `10` if the value was `""`. This was a legacy feature from before raw was a y axis format option. Once raw (or "") became an option, this value was getting overwritten when saved into bolt.

_What was the solution?_
Update the value for raw from `""` to `raw` so that it does not get changed to `10`. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)