### PR TITLE
Fix error when editing kapacitor info in onboarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5076](https://github.com/influxdata/chronograf/pull/5076): Stop raw yaxis format from getting updated to 10
 1. [#5077](https://github.com/influxdata/chronograf/pull/5077): Correct autoInterval calculations
 1. [#5079](https://github.com/influxdata/chronograf/pull/5079): Fix multiple organizations not showing configured kapacitors
+1. [#5078](https://github.com/influxdata/chronograf/pull/5078): Fix the inability to edit kapacitor info in the onboarding wizard
 
 ## v1.7.7 [2018-01-16]
 

--- a/ui/src/sources/components/KapacitorStep.tsx
+++ b/ui/src/sources/components/KapacitorStep.tsx
@@ -42,7 +42,7 @@ interface Props {
   setActiveKapacitor: sourcesActions.SetActiveKapacitor
   fetchKapacitors: sourcesActions.FetchKapacitorsAsync
   showNewKapacitor?: boolean
-  setKapacitorDraft: (kapacitor: Kapacitor) => void
+  setKapacitorDraft?: (kapacitor: Kapacitor) => void
 }
 
 interface State {
@@ -151,7 +151,9 @@ class KapacitorStep extends Component<Props, State> {
     const {kapacitor} = this.state
 
     this.setState({kapacitor: {...kapacitor, [key]: value}}, () => {
-      setKapacitorDraft(this.state.kapacitor)
+      if (setKapacitorDraft) {
+        setKapacitorDraft(this.state.kapacitor)
+      }
     })
 
     setError(false)


### PR DESCRIPTION
Closes #5060

_Briefly describe your proposed changes:_

_What was the problem?_
`setKapacitorDraft` was added as a prop to the KapacitorStep which is used in both the OnboardingWizard and the ConnectionWizard. The ConnectionWizard passes in the prop whereas the OnboardingWizard does not. Any time a user would edit info in the Kapacitor Form from the onboarding flow, they would get an error message.

_What was the solution?_
Make it an optional prop and only use call that function if the function is passed in.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)