### PR TITLE
fix: active kapacitor updating and ui defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#5073](https://github.com/influxdata/chronograf/pull/5073): Fix out of range decimal places
 1. [#5076](https://github.com/influxdata/chronograf/pull/5076): Stop raw yaxis format from getting updated to 10
 1. [#5077](https://github.com/influxdata/chronograf/pull/5077): Correct autoInterval calculations
+1. [#5079](https://github.com/influxdata/chronograf/pull/5079): Fix multiple organizations not showing configured kapacitors
 
 ## v1.7.7 [2018-01-16]
 

--- a/bolt/servers_test.go
+++ b/bolt/servers_test.go
@@ -79,21 +79,6 @@ func TestServerStore(t *testing.T) {
 		t.Fatalf("server 1 update error: got %v, expected %v", src.Organization, "1234")
 	}
 
-	// Attempt to make two active sources
-	srcs[0].Active = true
-	srcs[1].Active = true
-	if err := s.Update(ctx, srcs[0]); err != nil {
-		t.Fatal(err)
-	} else if err := s.Update(ctx, srcs[1]); err != nil {
-		t.Fatal(err)
-	}
-
-	if actual, err := s.Get(ctx, srcs[0].ID); err != nil {
-		t.Fatal(err)
-	} else if actual.Active == true {
-		t.Fatal("Able to set two active servers when only one should be permitted")
-	}
-
 	// Delete an server.
 	if err := s.Delete(ctx, srcs[0]); err != nil {
 		t.Fatal(err)

--- a/organizations/servers_test.go
+++ b/organizations/servers_test.go
@@ -123,6 +123,9 @@ func TestServers_Add(t *testing.T) {
 							Organization: "1337",
 						}, nil
 					},
+					AllF: func(ctx context.Context) ([]chronograf.Server, error) {
+						return []chronograf.Server{}, nil
+					},
 				},
 			},
 			args: args{
@@ -301,6 +304,9 @@ func TestServers_Update(t *testing.T) {
 							Name:         "doody",
 							Organization: "1337",
 						}, nil
+					},
+					AllF: func(ctx context.Context) ([]chronograf.Server, error) {
+						return []chronograf.Server{}, nil
 					},
 				},
 			},

--- a/ui/src/kapacitor/utils/ActiveKapacitorFromSources.ts
+++ b/ui/src/kapacitor/utils/ActiveKapacitorFromSources.ts
@@ -13,7 +13,8 @@ const ActiveKapacitorFromSources = (
     return null
   }
 
-  return ActiveSource.kapacitors.find(k => k.active)
+  const {kapacitors} = ActiveSource
+  return kapacitors.find(k => k.active) || kapacitors[0]
 }
 
 export default ActiveKapacitorFromSources

--- a/ui/src/sources/components/KapacitorDropdown.tsx
+++ b/ui/src/sources/components/KapacitorDropdown.tsx
@@ -141,7 +141,9 @@ class KapacitorDropdown extends PureComponent<Props & WithRouterProps> {
   }
 
   private get activeKapacitor(): Kapacitor {
-    return this.props.kapacitors.find(k => k.active)
+    const {kapacitors} = this.props
+
+    return kapacitors.find(k => k.active) || kapacitors[0]
   }
 
   private get selected(): string {

--- a/ui/test/kapacitor/utils/ActiveKapacitorFromSources.ts
+++ b/ui/test/kapacitor/utils/ActiveKapacitorFromSources.ts
@@ -1,0 +1,48 @@
+import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+import {source, kapacitor} from 'mocks/dummy'
+
+describe('ActiveKapacitorFromSources', () => {
+  const createSource = attrs => ({...source, ...attrs})
+  const createKapacitor = attrs => ({...kapacitor, ...attrs})
+
+  const setup = overrides => {
+    const activeSource = createSource({id: 1, ...overrides})
+
+    const sources = [
+      createSource({id: '1'}),
+      createSource({id: '2'}),
+      createSource({id: '3'}),
+      activeSource,
+    ]
+
+    return {sources, activeSource}
+  }
+
+  it('can return first when no active is present in collection', () => {
+    const expectedKap = createKapacitor({name: 'foo', active: false})
+
+    const {activeSource, sources} = setup({
+      kapacitors: [expectedKap, createKapacitor({name: 'bar', active: false})],
+    })
+
+    const actualKap = ActiveKapacitorFromSources(activeSource, sources)
+
+    expect(actualKap).toBe(expectedKap)
+  })
+
+  it('can return an active kapacitor from a collection', () => {
+    const expectedKap = createKapacitor({name: 'foo', active: true})
+
+    const {activeSource, sources} = setup({
+      kapacitors: [
+        createKapacitor({name: 'beep', active: false}),
+        expectedKap,
+        createKapacitor({name: 'bop', active: false}),
+      ],
+    })
+
+    const actualKap = ActiveKapacitorFromSources(activeSource, sources)
+
+    expect(actualKap).toBe(expectedKap)
+  })
+})


### PR DESCRIPTION
Closes #5061 

_Briefly describe your proposed changes:_
Use the first kapacitor present in a collection if none is active and only set the current organization kapacitors to active false.
_What was the problem?_
When all kapacitors were active false the behavior was to render an empty page. Adding or updating a kapacitor connection would set active false for all other kapacitor connections without regard to org.
_What was the solution?_
Use the first kapacitor connection as the active connection in collection when none are active. Scope reseting active fields to false to the current org.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)