### PR TITLE
fix(alert): message validation

### DIFF
--- a/ui/src/kapacitor/constants/index.ts
+++ b/ui/src/kapacitor/constants/index.ts
@@ -171,6 +171,14 @@ export const RULE_MESSAGE_TEMPLATES: RuleMessageTemplate = {
     label: '{{.Time}}',
     text: 'The time of the point that triggered the event',
   },
+  else: {
+    label: '{{else}}',
+    text: 'Start of else block',
+  },
+  end: {
+    label: '{{end}}',
+    text: 'End of block',
+  },
 }
 
 export const RULE_MESSAGE_TEMPLATE_TEXTS = _.map(RULE_MESSAGE_TEMPLATES, t => {

--- a/ui/src/kapacitor/utils/alertMessageValidation.ts
+++ b/ui/src/kapacitor/utils/alertMessageValidation.ts
@@ -5,7 +5,19 @@ export const isValidTemplate = (template: string): boolean => {
   const exactMatch = !!_.find(RULE_MESSAGE_TEMPLATE_TEXTS, t => t === template)
   const fieldsRegex = /(index .Fields ".+")/
   const tagsRegex = /(index .Tags ".+")/
-  const fuzzyMatch = fieldsRegex.test(template) || tagsRegex.test(template)
+  const ifRegex = /(if .+)/
+  const rangeRegex = /(range .+)/
+  const blockRegex = /(block .+)/
+  const withRegex = /(with .+)/
+
+  const fuzzyMatch =
+    fieldsRegex.test(template) ||
+    tagsRegex.test(template) ||
+    ifRegex.test(template) ||
+    rangeRegex.test(template) ||
+    blockRegex.test(template) ||
+    withRegex.test(template)
+
   return exactMatch || fuzzyMatch
 }
 
@@ -35,6 +47,7 @@ export const isValidMessage = (message: string): boolean => {
   if (message[message.length] === '}') {
     message = message + ' '
   }
+
   const malformedTemplateRegexp1 = RegExp('(({{)([^{}]*)(})([^}]+))') // matches {{*} where star does not contain '{' or '}'
 
   if (malformedTemplateRegexp1.test(message)) {
@@ -52,7 +65,10 @@ export const isValidMessage = (message: string): boolean => {
     matches[matches.length] = match[2].trim()
     match = templateRegexp.exec(message)
   }
-  return _.every(matches, m => isValidTemplate(m))
+
+  const isValid = _.every(matches, m => isValidTemplate(m))
+
+  return isValid
 }
 
 export default isValidMessage

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -233,6 +233,8 @@ export interface RuleMessageTemplate {
   fields: RuleMessage
   field: RuleMessage
   time: RuleMessage
+  else: RuleMessage
+  end: RuleMessage
 }
 
 export interface RuleMessage {

--- a/ui/test/kapacitor/utils/alertMessageValidation.test.ts
+++ b/ui/test/kapacitor/utils/alertMessageValidation.test.ts
@@ -5,8 +5,42 @@ import {
 } from 'src/kapacitor/utils/alertMessageValidation'
 import {RULE_MESSAGE_TEMPLATE_TEXTS} from 'src/kapacitor/constants'
 
+// for a full list of valid go templates consult: https://golang.org/pkg/text/template/
+
 describe('kapacitor.utils.alertMessageValidation', () => {
   describe('isValidMessage', () => {
+    it('accepts message containing a "with" block', () => {
+      const template = `{{ with eq.Tags "something" }} alert is under threshold{{ else }} alert is over threshold{{ end }}`
+
+      const isValid = isValidMessage(template)
+
+      expect(isValid).toBe(true)
+    })
+
+    it('accepts message containing a "block" block', () => {
+      const template = `{{ block eq.Tags "something" }} alert is under threshold{{ else }} alert is over threshold{{ end }}`
+
+      const isValid = isValidMessage(template)
+
+      expect(isValid).toBe(true)
+    })
+
+    it('accepts message containing a "range" block', () => {
+      const template = `{{ range eq.Tags "something" }} alert is under threshold{{ else }} alert is over threshold{{ end }}`
+
+      const isValid = isValidMessage(template)
+
+      expect(isValid).toBe(true)
+    })
+
+    it('accepts message containing an "if" block', () => {
+      const template = `{{ if eq.Tags "something" }} alert is under threshold{{ else }} alert is over threshold{{ end }}`
+
+      const isValid = isValidMessage(template)
+
+      expect(isValid).toBe(true)
+    })
+
     it('accepts message containing one simple template', () => {
       const isValid = isValidMessage('{{.ID}}')
 
@@ -75,16 +109,19 @@ describe('kapacitor.utils.alertMessageValidation', () => {
 
       expect(isValid).toEqual(true)
     })
+
     it('is False for a jibberish input', () => {
       const isValid = isValidTemplate('laslkj;owaiu0294u,mxn')
 
       expect(isValid).toEqual(false)
     })
+
     it('is True for a fuzzy match to tags', () => {
       const isValid = isValidTemplate('(index .Tags "lalala")')
 
       expect(isValid).toEqual(true)
     })
+
     it('is False for distorted version of tags', () => {
       const isValid = isValidTemplate('(indeasdfx .Tags "lalala")')
 


### PR DESCRIPTION
Closes #5090 

Alert rule message validation did not handle each kind of template block as described in the [go templating docs](https://golang.org/pkg/text/template/)

I fixed validation of `if/else` constructs and added validation for range, while, block and with.

###Notes
What this doesn't validate for is that all of the above mentioned blocks don't validate that they include an `end`.
