### PR TITLE
fix(explorer): add type checking to AxesOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [#5079](https://github.com/influxdata/chronograf/pull/5079): Fix multiple organizations not showing configured kapacitors
 1. [#5078](https://github.com/influxdata/chronograf/pull/5078): Fix the inability to edit kapacitor info in the onboarding wizard
 1. [#5083](https://github.com/influxdata/chronograf/pull/5083): Fix the column names in the Window function example
+1. [#5110](https://github.com/influxdata/chronograf/pull/5110): Fix the input for line controls in visualization options.
 
 ## v1.7.7 [2018-01-16]
 

--- a/ui/src/shared/components/OptIn.tsx
+++ b/ui/src/shared/components/OptIn.tsx
@@ -129,12 +129,14 @@ export default class OptIn extends Component<Props, State> {
   private handleChangeCustomValue = (
     e: ChangeEvent<HTMLInputElement>
   ): void => {
-    const {min, max} = this.props
+    const {min, max, type} = this.props
     const {value} = e.target
 
     if (value === '') {
       this.setCustomValue('')
-    } else {
+    } else if (type === 'text') {
+      this.setCustomValue(value)
+    } else if (type === 'number') {
       this.setCustomValue(toValueInRange(value, min, max))
     }
   }


### PR DESCRIPTION
Closes #5099

_What was the problem?_
There was a bug with visualization options in the data explorer/cell editor overlay in which typing into the "title" input for Line Controls did not update the field.

_What was the solution?_
Add a type check in the `OptIn` component, so that the input value is only fit to a max/min if it is of type number.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass