### PR TITLE
fix cursor location after adding a function with a new line

### DIFF
--- a/ui/src/flux/helpers/scriptInsertion.ts
+++ b/ui/src/flux/helpers/scriptInsertion.ts
@@ -37,21 +37,36 @@ const getInsertLineNumber = (
   return currentLineNumber + 1
 }
 
-const formatFunctionForInsert = (funcName: string, fluxFunction: string) => {
+const functionRequiresNewLine = (funcName: string): boolean => {
   switch (funcName) {
     case FROM.name:
     case UNION.name: {
-      return `\n${fluxFunction}`
+      return true
     }
     default:
-      return `  |> ${fluxFunction}`
+      return false
   }
 }
 
-const getCursorPosition = (insertLineNumber, formattedFunction): Position => {
-  const endOfLine = formattedFunction.length - 1
+const formatFunctionForInsert = (funcName: string, fluxFunction: string) => {
+  if (functionRequiresNewLine(funcName)) {
+    return `\n${fluxFunction}`
+  }
 
-  return {line: insertLineNumber, ch: endOfLine}
+  return `  |> ${fluxFunction}`
+}
+
+const getCursorPosition = (
+  insertLineNumber,
+  formattedFunction,
+  funcName
+): Position => {
+  const ch = formattedFunction.length - 1
+  const line = functionRequiresNewLine(funcName)
+    ? insertLineNumber + 1
+    : insertLineNumber
+
+  return {line, ch}
 }
 
 export const insertFluxFunction = (
@@ -75,7 +90,8 @@ export const insertFluxFunction = (
 
   const updatedCursorPosition = getCursorPosition(
     insertLineNumber,
-    formattedFunction
+    formattedFunction,
+    functionName
   )
 
   return {updatedScript, cursorPosition: updatedCursorPosition}


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_
when adding a from or union function from the functions toolbar and then another one, it did not update the cursor for the next insert to the correct line.
_What was the solution?_
account for the extra new line entered when inserting a from or union

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)