### PR TITLE
ensure flux function gets added when no cursor

### DIFF
--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -58,7 +58,7 @@ interface State {
 class FluxQueryMaker extends PureComponent<Props, State> {
   private debouncer: Debouncer = new DefaultDebouncer()
   private getAST = restartable(getAST)
-  private cursorPosition: Position
+  private cursorPosition: Position = {line: 0, ch: 0}
 
   public constructor(props: Props) {
     super(props)


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_
if you go to the flux script editor section without clicking the actual editor and then try to add a funciton by click on the tool bar, it will not get added to the script.
_What was the solution?_
give an initial cursor position if none is provided by the editor.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)