### PR TITLE
fix(ui/mapVarsToCSV): double quote map template values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 1. [#5110](https://github.com/influxdata/chronograf/pull/5110): Fix the input for line controls in visualization options.
 1. [#5111](https://github.com/influxdata/chronograf/pull/5111): Stop scrollbars from covering text in flux editor
 1. [#5114](https://github.com/influxdata/chronograf/pull/5114): Insert flux function near cursor in flux editor
+1. [#5118](https://github.com/influxdata/chronograf/pull/5118): Fix double quoting of map template values
 
 ## v1.7.8 [2019-02-08]
 ### Bug Fixes

--- a/ui/src/tempVars/components/MapTemplateBuilder.tsx
+++ b/ui/src/tempVars/components/MapTemplateBuilder.tsx
@@ -114,7 +114,7 @@ class MapTemplateBuilder extends PureComponent<TemplateBuilderProps, State> {
   private constructValuesFromString(templateValuesString: string) {
     const {notify} = this.props
 
-    const {errors, values} =  csvToMap(templateValuesString)
+    const {errors, values} = csvToMap(templateValuesString)
 
     if (errors.length > 0) {
       notify(notifyInvalidMapType())

--- a/ui/src/tempVars/components/MapTemplateBuilder.tsx
+++ b/ui/src/tempVars/components/MapTemplateBuilder.tsx
@@ -1,10 +1,8 @@
 import React, {PureComponent, ChangeEvent} from 'react'
-import {getDeep} from 'src/utils/wrappers'
-import Papa from 'papaparse'
-import _ from 'lodash'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
+import {csvToMap, mapToCSV} from 'src/tempVars/utils'
 import TemplatePreviewList from 'src/tempVars/components/TemplatePreviewList'
 import DragAndDrop from 'src/shared/components/DragAndDrop'
 import {
@@ -12,8 +10,7 @@ import {
   notifyInvalidMapType,
 } from 'src/shared/copy/notifications'
 
-import {TemplateBuilderProps, TemplateValueType} from 'src/types'
-import {trimAndRemoveQuotes} from 'src/tempVars/utils'
+import {TemplateBuilderProps} from 'src/types'
 
 interface State {
   templateValuesString: string
@@ -23,11 +20,7 @@ interface State {
 class MapTemplateBuilder extends PureComponent<TemplateBuilderProps, State> {
   public constructor(props: TemplateBuilderProps) {
     super(props)
-    const templateValues = props.template.values.map(v => v.value)
-    const templateKeys = props.template.values.map(v => v.key)
-    const templateValuesString = templateKeys
-      .map((v, i) => `${v}, ${templateValues[i]}`)
-      .join('\n')
+    const templateValuesString = mapToCSV(props.template.values)
 
     this.state = {
       templateValuesString,
@@ -120,39 +113,8 @@ class MapTemplateBuilder extends PureComponent<TemplateBuilderProps, State> {
 
   private constructValuesFromString(templateValuesString: string) {
     const {notify} = this.props
-    const trimmed = _.trimEnd(templateValuesString, '\n')
-    const parsedTVS = Papa.parse(trimmed)
-    const templateValuesData = getDeep<string[][]>(parsedTVS, 'data', [[]])
 
-    if (templateValuesData.length === 0) {
-      return
-    }
-
-    let arrayOfKeys = []
-    let values = []
-    _.forEach(templateValuesData, arr => {
-      if (arr.length === 2 || (arr.length === 3 && arr[2] === '')) {
-        const key = trimAndRemoveQuotes(arr[0])
-        const value = trimAndRemoveQuotes(arr[1])
-
-        if (!arrayOfKeys.includes(key) && key !== '') {
-          values = [
-            ...values,
-            {
-              type: TemplateValueType.Map,
-              value,
-              key,
-              selected: false,
-              localSelected: false,
-            },
-          ]
-          arrayOfKeys = [...arrayOfKeys, key]
-        }
-      } else {
-        notify(notifyInvalidMapType())
-      }
-    })
-    return values
+    return csvToMap(templateValuesString, () => notify(notifyInvalidMapType()))
   }
 }
 

--- a/ui/src/tempVars/components/MapTemplateBuilder.tsx
+++ b/ui/src/tempVars/components/MapTemplateBuilder.tsx
@@ -114,7 +114,13 @@ class MapTemplateBuilder extends PureComponent<TemplateBuilderProps, State> {
   private constructValuesFromString(templateValuesString: string) {
     const {notify} = this.props
 
-    return csvToMap(templateValuesString, () => notify(notifyInvalidMapType()))
+    const {errors, values} =  csvToMap(templateValuesString)
+
+    if (errors.length > 0) {
+      notify(notifyInvalidMapType())
+    }
+
+    return values
   }
 }
 

--- a/ui/test/tempVars/utils/csvToMap.test.ts
+++ b/ui/test/tempVars/utils/csvToMap.test.ts
@@ -1,0 +1,204 @@
+import {csvToMap, mapToCSV} from 'src/tempVars/utils'
+
+import {TemplateValueType} from 'src/types'
+
+describe('MapVars', () => {
+  const mapDefaults = {
+    type: TemplateValueType.Map,
+    value: '',
+    key: '',
+    selected: false,
+    localSelected: false,
+  }
+
+  describe('csvToMap', () => {
+    it('can parse key values', () => {
+      const csv = 'a,1\nb,2\nc,3\n'
+
+      const actual = csvToMap(csv, jest.fn())
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: '1',
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: '2',
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: '3',
+        },
+      ])
+    })
+
+    it('can parse single quoted values', () => {
+      const csv = `a,'1'\nb,'2'\nc,'3'\n`
+
+      const actual = csvToMap(csv, jest.fn())
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: `'1'`,
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: `'2'`,
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: `'3'`,
+        },
+      ])
+    })
+
+    it('can parse single quoted values with commas and spaces', () => {
+      const csv = `a,"'1, 2'"\nb,"'2, 3'"\nc,"'3, 4'"\n`
+
+      const actual = csvToMap(csv, jest.fn())
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: `'1, 2'`,
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: `'2, 3'`,
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: `'3, 4'`,
+        },
+      ])
+    })
+
+    it('can parse double quoted values', () => {
+      const csv = `a,"1"\nb,"2"\nc,"3"\n`
+
+      const actual = csvToMap(csv, jest.fn())
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: '1',
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: '2',
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: '3',
+        },
+      ])
+    })
+
+    it('can parse double quoted values with commas', () => {
+      const csv = `a,"1, 2"\nb,"2, 3"\nc,"3, 4"\n`
+
+      const actual = csvToMap(csv, jest.fn())
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: '1, 2',
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: '2, 3',
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: '3, 4',
+        },
+      ])
+    })
+  })
+
+  describe('mapToCSV', () => {
+    it('can create a CSV', () => {
+      const actual = mapToCSV([
+        {
+          ...mapDefaults,
+          key: 'a',
+          value: '1',
+        },
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: '2',
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: '3',
+        },
+      ])
+
+      const expected = 'a,"1"\nb,"2"\nc,"3"'
+
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  it('can double quote single quoted values', () => {
+    const actual = mapToCSV([
+      {
+        ...mapDefaults,
+        key: 'a',
+        value: `'1, 2'`,
+      },
+      {
+        ...mapDefaults,
+        key: 'b',
+        value: `'2, 3'`,
+      },
+      {
+        ...mapDefaults,
+        key: 'c',
+        value: `'3, 4'`,
+      },
+    ])
+
+    const expected = `a,"'1, 2'"\nb,"'2, 3'"\nc,"'3, 4'"`
+
+    expect(actual).toEqual(expected)
+  })
+
+  it('can double quote keys with CSV values', () => {
+    const actual = mapToCSV([
+      {
+        ...mapDefaults,
+        key: 'a',
+        value: '1, 2',
+      },
+      {
+        ...mapDefaults,
+        key: 'b',
+        value: '2, 3',
+      },
+      {
+        ...mapDefaults,
+        key: 'c',
+        value: '3, 4',
+      },
+    ])
+
+    const expected = `a,"1, 2"\nb,"2, 3"\nc,"3, 4"`
+
+    expect(actual).toEqual(expected)
+  })
+})

--- a/ui/test/tempVars/utils/csvToMap.test.ts
+++ b/ui/test/tempVars/utils/csvToMap.test.ts
@@ -15,7 +15,7 @@ describe('MapVars', () => {
     it('can parse key values', () => {
       const csv = 'a,1\nb,2\nc,3\n'
 
-      const actual = csvToMap(csv, jest.fn())
+      const {values: actual} = csvToMap(csv)
       expect(actual).toEqual([
         {
           ...mapDefaults,
@@ -35,10 +35,30 @@ describe('MapVars', () => {
       ])
     })
 
+    it('records invalid keys', () => {
+      const csv = 'a,1,2\nb,2\nc,3\n'
+
+      const {values: actual, errors} = csvToMap(csv)
+      expect(actual).toEqual([
+        {
+          ...mapDefaults,
+          key: 'b',
+          value: '2',
+        },
+        {
+          ...mapDefaults,
+          key: 'c',
+          value: '3',
+        },
+      ])
+
+      expect(errors).toEqual(['a'])
+    })
+
     it('can parse single quoted values', () => {
       const csv = `a,'1'\nb,'2'\nc,'3'\n`
 
-      const actual = csvToMap(csv, jest.fn())
+      const {values: actual} = csvToMap(csv)
       expect(actual).toEqual([
         {
           ...mapDefaults,
@@ -61,7 +81,7 @@ describe('MapVars', () => {
     it('can parse single quoted values with commas and spaces', () => {
       const csv = `a,"'1, 2'"\nb,"'2, 3'"\nc,"'3, 4'"\n`
 
-      const actual = csvToMap(csv, jest.fn())
+      const {values: actual} = csvToMap(csv)
       expect(actual).toEqual([
         {
           ...mapDefaults,
@@ -84,7 +104,7 @@ describe('MapVars', () => {
     it('can parse double quoted values', () => {
       const csv = `a,"1"\nb,"2"\nc,"3"\n`
 
-      const actual = csvToMap(csv, jest.fn())
+      const {values: actual} = csvToMap(csv)
       expect(actual).toEqual([
         {
           ...mapDefaults,
@@ -107,7 +127,8 @@ describe('MapVars', () => {
     it('can parse double quoted values with commas', () => {
       const csv = `a,"1, 2"\nb,"2, 3"\nc,"3, 4"\n`
 
-      const actual = csvToMap(csv, jest.fn())
+      const {values: actual} = csvToMap(csv)
+
       expect(actual).toEqual([
         {
           ...mapDefaults,


### PR DESCRIPTION
Closes #5104 

_Briefly describe your proposed changes:_
Double quote the map values so that they can safely be parsed again.
_What was the problem?_
We trim double quotes on map template values, but don't add double quotes back to the regenerated CSV to ensure it can be parsed.
_What was the solution?_
Add test coverage for map values that are unquoted, single quoted and double quoted. One test case in particular demonstrates how single quoted values containing commas will need to be double quoted for correct parsing.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

![Kapture 2019-03-18 at 14 10 37](https://user-images.githubusercontent.com/4994741/54556747-edc87880-498f-11e9-9da9-345ca7da4d28.gif)
