### PR TITLE
fix(package): make rpm verify pass after installation

### DIFF
--- a/etc/build.py
+++ b/etc/build.py
@@ -18,6 +18,8 @@ import json
 
 # Packaging variables
 PACKAGE_NAME = "chronograf"
+USER = "chronograf"
+GROUP = "chronograf"
 INSTALL_ROOT_DIR = "/usr/bin"
 LOG_DIR = "/var/log/chronograf"
 DATA_DIR = "/var/lib/chronograf"
@@ -61,6 +63,8 @@ fpm_common_args = "-f -s dir --log error \
 --maintainer {} \
 --directories {} \
 --directories {} \
+--rpm-attr 755,{},{}:{} \
+--rpm-attr 755,{},{}:{} \
 --description \"{}\"".format(
      VENDOR,
      PACKAGE_URL,
@@ -70,6 +74,8 @@ fpm_common_args = "-f -s dir --log error \
      MAINTAINER,
      LOG_DIR,
      DATA_DIR,
+     USER, GROUP, LOG_DIR,
+     USER, GROUP, DATA_DIR,
      DESCRIPTION)
 
 for f in CONFIGURATION_FILES:

--- a/etc/scripts/post-install.sh
+++ b/etc/scripts/post-install.sh
@@ -33,13 +33,6 @@ if [[ $? -ne 0 ]]; then
     useradd --system -U -M chronograf -s /bin/false -d $DATA_DIR
 fi
 
-test -d $LOG_DIR || mkdir -p $DATA_DIR
-test -d $DATA_DIR || mkdir -p $DATA_DIR
-chown -R -L chronograf:chronograf $LOG_DIR
-chown -R -L chronograf:chronograf $DATA_DIR
-chmod 755 $LOG_DIR
-chmod 755 $DATA_DIR
-
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/chronograf ]]; then
     rm -f /etc/init.d/chronograf
@@ -63,6 +56,17 @@ if [[ -f /etc/redhat-release ]]; then
     fi
 elif [[ -f /etc/debian_version ]]; then
     # Debian/Ubuntu logic
+
+    # Ownership for RH-based platforms is set in build.py via the `rmp-attr` option.
+    # We perform ownership change only for Debian-based systems.
+    # Moving these lines out of this if statement would make `rmp -V` fail after installation.
+    test -d $LOG_DIR || mkdir -p $DATA_DIR
+    test -d $DATA_DIR || mkdir -p $DATA_DIR
+    chown -R -L chronograf:chronograf $LOG_DIR
+    chown -R -L chronograf:chronograf $DATA_DIR
+    chmod 755 $LOG_DIR
+    chmod 755 $DATA_DIR
+
     which systemctl &>/dev/null
     if [[ $? -eq 0 ]]; then
     	install_systemd


### PR DESCRIPTION
This change sets the ownership of directories on package generation with fpm instead that in post-install to make `rmp -V` pass.

For more details, see: influxdata/EAR#716

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)