### PR TITLE
fix(package): create chronograf user before install

### DIFF
--- a/etc/build.py
+++ b/etc/build.py
@@ -31,6 +31,7 @@ RESOURCES_DIR = "/usr/share/chronograf/resources"
 
 INIT_SCRIPT = "etc/scripts/init.sh"
 SYSTEMD_SCRIPT = "etc/scripts/chronograf.service"
+PREINST_SCRIPT = "etc/scripts/pre-install.sh"
 POSTINST_SCRIPT = "etc/scripts/post-install.sh"
 POSTUNINST_SCRIPT = "etc/scripts/post-uninstall.sh"
 LOGROTATE_SCRIPT = "etc/scripts/logrotate"
@@ -57,6 +58,7 @@ optional_prereqs = [ 'fpm', 'rpmbuild', 'gpg' ]
 fpm_common_args = "-f -s dir --log error \
 --vendor {} \
 --url {} \
+--before-install {} \
 --after-install {} \
 --after-remove {} \
 --license {} \
@@ -68,6 +70,7 @@ fpm_common_args = "-f -s dir --log error \
 --description \"{}\"".format(
      VENDOR,
      PACKAGE_URL,
+     PREINST_SCRIPT,
      POSTINST_SCRIPT,
      POSTUNINST_SCRIPT,
      PACKAGE_LICENSE,

--- a/etc/scripts/post-install.sh
+++ b/etc/scripts/post-install.sh
@@ -28,11 +28,6 @@ function install_chkconfig {
     chkconfig --add chronograf
 }
 
-id chronograf &>/dev/null
-if [[ $? -ne 0 ]]; then
-    useradd --system -U -M chronograf -s /bin/false -d $DATA_DIR
-fi
-
 # Remove legacy symlink, if it exists
 if [[ -L /etc/init.d/chronograf ]]; then
     rm -f /etc/init.d/chronograf

--- a/etc/scripts/pre-install.sh
+++ b/etc/scripts/pre-install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+DATA_DIR=/var/lib/chronograf
+
+# create user
+if ! id chronograf >/dev/null 2>&1; then
+    useradd --system -U -M chronograf -s /bin/false -d $DATA_DIR
+fi


### PR DESCRIPTION
This solves an issue with CentOS installation where the `chronograf` user is not existing when `fpm` is installing and setting ownership on directories.

The same issue was fixed in other projects, see:

 - kapacitor: https://github.com/influxdata/kapacitor/pull/2205
 - influxDB: https://github.com/influxdata/influxdb/pull/13397
 - telegraf: https://github.com/influxdata/telegraf/pull/5783

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)