### PR TITLE
fix(server): timeout and fetch version concurrently

### DIFF
--- a/flux/client.go
+++ b/flux/client.go
@@ -62,8 +62,9 @@ func (c *Client) FluxEnabled() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-
-	hc := &http.Client{}
+	hc := &http.Client{
+		Timeout: c.Timeout,
+	}
 	if c.InsecureSkipVerify {
 		hc.Transport = skipVerifyTransport
 	} else {


### PR DESCRIPTION
Closes #5197

_Briefly describe your proposed changes:_
Fixes an issue with fetching source versions not timing out
_What was the problem?_
Source version's were not fetched concurrently and did not timeout. This caused the browser to hang when one of many sources was experiencing connection delays.
_What was the solution?_
Add a timeout to each source version fetch and timeout with a default of `"unknown"` after 1 second. 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)