### PR TITLE
Update functions.ts

### DIFF
--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -942,7 +942,7 @@ export const FUNCTIONS: FluxToolbarFunction[] = [
       },
     ],
     desc: 'Applies a function to each record in the input tables.',
-    example: 'map(fn: (r) => r._value * r._value), mergeKey: true)',
+    example: 'map(fn: (r) => r._value * r._value, mergeKey: true)',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/flux/latest/functions/transformations/map',


### PR DESCRIPTION
Closes #5176 

_Briefly describe your proposed changes:_
Removed errant parenthesis in `map()` example.

_What was the problem?_
This was causing queries created by selecting `map()` from the function list to fail due to bad syntax.

_What was the solution?_
Remove the extra parenthesis