### PR TITLE
Fix scroll to row bug on table graphs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.7.13
+### Bug Fixes
+1. [#5217](https://github.com/influxdata/chronograf/pull/5217): Fix scroll to row bug on table graphs
+
+### Features
+
 ## v1.7.12 [2019-06-20]
 ### Bug Fixes
 1. [#5208](https://github.com/influxdata/chronograf/pull/5208): Clarify wording of PagerDuty v1 deprecation message

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -76,7 +76,6 @@ interface Props {
 }
 
 interface State {
-  sortedTimeVals: TimeSeriesValue[]
   sortedLabels: Label[]
   hoveredColumnIndex: number
   hoveredRowIndex: number
@@ -95,7 +94,6 @@ class TableGraph extends PureComponent<Props, State> {
 
     this.state = {
       shouldResize: false,
-      sortedTimeVals: [],
       sortedLabels: [],
       hoveredColumnIndex: NULL_ARRAY_INDEX,
       hoveredRowIndex: NULL_ARRAY_INDEX,
@@ -179,7 +177,6 @@ class TableGraph extends PureComponent<Props, State> {
 
   public async componentDidMount() {
     const {
-      data: {sortedTimeVals},
       fieldOptions,
     } = this.props
 
@@ -191,7 +188,6 @@ class TableGraph extends PureComponent<Props, State> {
 
     this.setState(
       {
-        sortedTimeVals,
         hoveredColumnIndex: NULL_ARRAY_INDEX,
         hoveredRowIndex: NULL_ARRAY_INDEX,
         isTimeVisible,
@@ -322,7 +318,10 @@ class TableGraph extends PureComponent<Props, State> {
     scrollToColumn: number | null
     externalScroll: boolean
   } {
-    const {sortedTimeVals, hoveredColumnIndex, isTimeVisible} = this.state
+    const {
+      data: { sortedTimeVals },
+    } = this.props
+    const { hoveredColumnIndex, isTimeVisible} = this.state
     const {hoverTime} = this.props
     const hoveringThisTable = hoveredColumnIndex !== NULL_ARRAY_INDEX
     const notHovering = hoverTime === NULL_HOVER_TIME
@@ -373,7 +372,10 @@ class TableGraph extends PureComponent<Props, State> {
   private handleHover = (e: React.MouseEvent<HTMLElement>) => {
     const {dataset} = e.target as HTMLElement
     const {handleSetHoverTime} = this.props
-    const {sortedTimeVals, isTimeVisible} = this.state
+    const {
+      data: { sortedTimeVals },
+    } = this.props
+    const { isTimeVisible} = this.state
     if (this.isVerticalTimeAxis && +dataset.rowIndex === 0) {
       return
     }

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -176,9 +176,7 @@ class TableGraph extends PureComponent<Props, State> {
   }
 
   public async componentDidMount() {
-    const {
-      fieldOptions,
-    } = this.props
+    const {fieldOptions} = this.props
 
     window.addEventListener('resize', this.handleResize)
 
@@ -319,9 +317,9 @@ class TableGraph extends PureComponent<Props, State> {
     externalScroll: boolean
   } {
     const {
-      data: { sortedTimeVals },
+      data: {sortedTimeVals},
     } = this.props
-    const { hoveredColumnIndex, isTimeVisible} = this.state
+    const {hoveredColumnIndex, isTimeVisible} = this.state
     const {hoverTime} = this.props
     const hoveringThisTable = hoveredColumnIndex !== NULL_ARRAY_INDEX
     const notHovering = hoverTime === NULL_HOVER_TIME
@@ -373,9 +371,9 @@ class TableGraph extends PureComponent<Props, State> {
     const {dataset} = e.target as HTMLElement
     const {handleSetHoverTime} = this.props
     const {
-      data: { sortedTimeVals },
+      data: {sortedTimeVals},
     } = this.props
-    const { isTimeVisible} = this.state
+    const {isTimeVisible} = this.state
     if (this.isVerticalTimeAxis && +dataset.rowIndex === 0) {
       return
     }


### PR DESCRIPTION
Closes #5112

Table graphs were calculating the table index for hoverTime based on stale sortedTimeVals copied to state once on the componentDidMount method, instead of updated sortedTimeVals that reflected user sort selections. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)