### PR TITLE
feat: add time zone selector to data explorer

### DIFF
--- a/ui/src/data_explorer/components/DEHeader.tsx
+++ b/ui/src/data_explorer/components/DEHeader.tsx
@@ -5,6 +5,7 @@ import React, {Component} from 'react'
 import {Page, Radio, ButtonShape} from 'src/reusable_ui'
 import GraphTips from 'src/shared/components/GraphTips'
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
+import TimeZoneToggle from 'src/shared/components/time_zones/TimeZoneToggle'
 
 // Constants
 import {CEOTabs} from 'src/dashboards/constants'
@@ -13,11 +14,14 @@ import {CEOTabs} from 'src/dashboards/constants'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {TimeRange} from 'src/types'
+import {TimeRange, TimeZones} from 'src/types'
+import {setTimeZone} from 'src/shared/actions/app'
 
 interface Props {
+  timeZone: TimeZones
   timeRange: TimeRange
   activeEditorTab: CEOTabs
+  onSetTimeZone: typeof setTimeZone
   onOpenWriteData: () => void
   toggleSendToDashboard: () => void
   onSetActiveEditorTab: (activeEditorTab: CEOTabs) => void
@@ -27,6 +31,8 @@ interface Props {
 class DEHeader extends Component<Props> {
   public render() {
     const {
+      timeZone,
+      onSetTimeZone,
       onOpenWriteData,
       activeEditorTab,
       onSetActiveEditorTab,
@@ -62,6 +68,7 @@ class DEHeader extends Component<Props> {
         </Page.Header.Center>
         <Page.Header.Right>
           <GraphTips />
+          <TimeZoneToggle timeZone={timeZone} onSetTimeZone={onSetTimeZone} />
           <button
             onClick={onOpenWriteData}
             data-test="write-data-button"

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -196,13 +196,13 @@ export class DataExplorer extends PureComponent<Props, State> {
           >
             {(activeEditorTab, onSetActiveEditorTab) => (
               <DEHeader
-                timeRange={timeRange}
                 timeZone={timeZone}
+                timeRange={timeRange}
                 onSetTimeZone={onSetTimeZone}
                 activeEditorTab={activeEditorTab}
                 onOpenWriteData={this.handleOpenWriteData}
-                toggleSendToDashboard={this.toggleSendToDashboard}
                 onSetActiveEditorTab={onSetActiveEditorTab}
+                toggleSendToDashboard={this.toggleSendToDashboard}
               />
             )}
           </TimeMachine>

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -1,7 +1,6 @@
 // Libraries
 import React, {PureComponent} from 'react'
 import {connect} from 'react-redux'
-import {bindActionCreators} from 'redux'
 import {withRouter, InjectedRouter, WithRouterProps} from 'react-router'
 import {Location} from 'history'
 import qs from 'qs'
@@ -36,6 +35,7 @@ import {
 import {writeLineProtocolAsync} from 'src/data_explorer/actions/view/write'
 import {updateSourceLink as updateSourceLinkAction} from 'src/data_explorer/actions/queries'
 import {editQueryStatus as editQueryStatusAction} from 'src/data_explorer/actions/queries'
+import {setTimeZone as setTimeZoneAction} from 'src/shared/actions/app'
 
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
@@ -88,6 +88,7 @@ interface PassedProps {
   fluxLinks: Links
   notify: (message: Notification) => void
   sourceLink: string
+  onSetTimeZone: typeof setTimeZoneAction
 }
 
 interface ConnectedProps {
@@ -157,13 +158,15 @@ export class DataExplorer extends PureComponent<Props, State> {
   public render() {
     const {
       source,
-      sources,
-      editQueryStatus,
-      queryStatus,
-      fluxLinks,
       notify,
-      updateSourceLink,
+      sources,
+      timeZone,
       timeRange,
+      fluxLinks,
+      queryStatus,
+      editQueryStatus,
+      updateSourceLink,
+      onSetTimeZone,
     } = this.props
 
     const {isStaticLegend, isComponentMounted} = this.state
@@ -194,6 +197,8 @@ export class DataExplorer extends PureComponent<Props, State> {
             {(activeEditorTab, onSetActiveEditorTab) => (
               <DEHeader
                 timeRange={timeRange}
+                timeZone={timeZone}
+                onSetTimeZone={onSetTimeZone}
                 activeEditorTab={activeEditorTab}
                 onOpenWriteData={this.handleOpenWriteData}
                 toggleSendToDashboard={this.toggleSendToDashboard}
@@ -450,7 +455,7 @@ const ConnectedDataExplorer = (props: PassedProps & WithRouterProps) => {
 const mstp = state => {
   const {
     app: {
-      persisted: {autoRefresh},
+      persisted: {autoRefresh, timeZone},
     },
     dataExplorer: {timeRange, queryStatus, sourceLink},
     dashboardUI: {dashboards},
@@ -459,6 +464,7 @@ const mstp = state => {
   } = state
 
   return {
+    timeZone,
     fluxLinks: links.flux,
     autoRefresh,
     timeRange,
@@ -469,17 +475,16 @@ const mstp = state => {
   }
 }
 
-const mdtp = dispatch => {
-  return {
-    handleChooseAutoRefresh: bindActionCreators(setAutoRefresh, dispatch),
-    errorThrownAction: bindActionCreators(errorThrown, dispatch),
-    writeLineProtocol: bindActionCreators(writeLineProtocolAsync, dispatch),
-    handleGetDashboards: bindActionCreators(getDashboardsAsync, dispatch),
-    sendDashboardCell: bindActionCreators(sendDashboardCellAsync, dispatch),
-    editQueryStatus: bindActionCreators(editQueryStatusAction, dispatch),
-    notify: bindActionCreators(notifyAction, dispatch),
-    updateSourceLink: bindActionCreators(updateSourceLinkAction, dispatch),
-  }
+const mdtp = {
+  handleChooseAutoRefresh: setAutoRefresh,
+  errorThrownAction: errorThrown,
+  writeLineProtocol: writeLineProtocolAsync,
+  handleGetDashboards: getDashboardsAsync,
+  sendDashboardCell: sendDashboardCellAsync,
+  editQueryStatus: editQueryStatusAction,
+  notify: notifyAction,
+  updateSourceLink: updateSourceLinkAction,
+  onSetTimeZone: setTimeZoneAction,
 }
 
 export default connect(mstp, mdtp)(withRouter(ConnectedDataExplorer))

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -60,6 +60,7 @@ import {
   QueryType,
   CellQuery,
   TimeRange,
+  TimeZones,
 } from 'src/types'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Links} from 'src/types/flux'
@@ -89,12 +90,14 @@ interface PassedProps {
   notify: (message: Notification) => void
   sourceLink: string
   onSetTimeZone: typeof setTimeZoneAction
+  timeZone: TimeZones
 }
 
 interface ConnectedProps {
   queryType: QueryType
   queryDrafts: CellQuery[]
   timeRange: TimeRange
+  timeZone: TimeZones
   draftScript: string
   script: string
   onUpdateQueryDrafts: (queryDrafts: CellQuery[]) => void

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -38,7 +38,7 @@ import {
   DecimalPlaces,
   Sort,
 } from 'src/types/dashboards'
-import {QueryUpdateState} from 'src/types'
+import {QueryUpdateState, TimeZones} from 'src/types'
 
 import {FormattedTableData} from 'src/shared/components/TableGraphFormat'
 
@@ -66,6 +66,7 @@ interface Props {
   dataType: DataType
   tableOptions: TableOptions
   timeFormat: string
+  timeZone: TimeZones
   decimalPlaces: DecimalPlaces
   fieldOptions: FieldOption[]
   hoverTime: string
@@ -132,21 +133,21 @@ class TableGraph extends PureComponent<Props, State> {
                   registerChild,
                 }: SizedColumnProps) => (
                   <MultiGrid
-                    onMount={this.handleMultiGridMount}
+                    height={height}
+                    fixedRowCount={1}
                     ref={registerChild}
+                    rowCount={rowCount}
+                    width={adjustedWidth}
+                    rowHeight={ROW_HEIGHT}
                     columnCount={columnCount}
-                    columnWidth={this.calculateColumnWidth(columnWidth)}
                     scrollToRow={scrollToRow}
                     scrollToColumn={scrollToColumn}
-                    rowCount={rowCount}
-                    rowHeight={ROW_HEIGHT}
-                    height={height}
-                    width={adjustedWidth}
-                    fixedColumnCount={fixedColumnCount}
-                    fixedRowCount={1}
-                    cellRenderer={this.cellRenderer}
-                    classNameBottomRightGrid="table-graph--scroll-window"
                     externalScroll={externalScroll}
+                    cellRenderer={this.cellRenderer}
+                    onMount={this.handleMultiGridMount}
+                    fixedColumnCount={fixedColumnCount}
+                    classNameBottomRightGrid="table-graph--scroll-window"
+                    columnWidth={this.calculateColumnWidth(columnWidth)}
                   />
                 )}
               </ColumnSizer>
@@ -445,9 +446,15 @@ class TableGraph extends PureComponent<Props, State> {
     isTimeData: boolean,
     isFieldName: boolean
   ): string => {
-    const {timeFormat, decimalPlaces} = this.props
+    const {timeFormat, timeZone, decimalPlaces} = this.props
 
     if (isTimeData) {
+      if (timeZone === TimeZones.UTC) {
+        return moment(cellData)
+          .utc()
+          .format(timeFormat)
+      }
+
       return moment(cellData).format(timeFormat)
     }
 
@@ -588,8 +595,9 @@ class TableGraph extends PureComponent<Props, State> {
   }
 }
 
-const mstp = ({dashboardUI}) => ({
+const mstp = ({dashboardUI, app}) => ({
   hoverTime: dashboardUI.hoverTime,
+  timeZone: app.persisted.timeZone,
 })
 
 export default connect(mstp)(TableGraph)


### PR DESCRIPTION
### Note
UTC / Local time zone selection works for both tables and all dygraph based visualizations.  

![Kapture 2019-07-03 at 9 51 20](https://user-images.githubusercontent.com/7582765/60610260-44f42c80-9d78-11e9-9cf9-ddc3213229cd.gif)
