### PR TITLE
Fix erroneous query manipulation

### DIFF
--- a/ui/src/dashboards/components/Dashboard.js
+++ b/ui/src/dashboards/components/Dashboard.js
@@ -30,6 +30,10 @@ const Dashboard = ({
       ...q,
       database: q.db,
       text: q.query,
+      queryConfig: {
+        ...q.queryConfig,
+        rawText: q.query,
+      },
     }))
     return dashboardCell
   })


### PR DESCRIPTION
When a user creates a cell, they can create an InfluxQL query with the visual query builder. In this case, the query to execute is derived from the cell's query config. They can also enter a query manually, in which case the query config should be ignored.

If a user enters a query manually, we attempt to parse that query into a query config. If we are successful, then it doesn't matter whether we execute the query that was entered manually, or the query derived from the query config.

We can't always parse a query back into a query config, but we nonetheless have always been executing cell queries derived from a query config. This created the issue witnessed in #5131.

This commit changes that behavior; if a query has been entered manually, we will always respect it.

Closes #5131
