### PR TITLE
Update the toolbar doc and example for keyValues() function

### DIFF
--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -738,7 +738,7 @@ export const FUNCTIONS: FluxToolbarFunction[] = [
     name: 'keyValues',
     args: [
       {
-        name: 'keyCols',
+        name: 'keyColumns',
         desc:
           'A list of columns from which values are extracted. All columns indicated must be of the same type.',
         type: 'Array of Strings',
@@ -752,7 +752,7 @@ export const FUNCTIONS: FluxToolbarFunction[] = [
     ],
     desc:
       "Returns a table with the input table's group key plus two columns, `_key` and `_value`, that correspond to unique column + value pairs from the input table.",
-    example: 'keyValues(keyCols: ["usage_idle", "usage_user"])',
+    example: 'keyValues(keyColumns: ["usage_idle", "usage_user"])',
     category: 'Transformations',
     link:
       'https://docs.influxdata.com/flux/latest/functions/transformations/keyvalues',


### PR DESCRIPTION
_What was the problem?_

The Chronograf UI toolbar help documentation for the Flux `keyValues()` function said that there's an argument called `keyCols`. That's wrong, the argument name is `keyColumns` ([documentation reference](https://docs.influxdata.com/flux/v0.24/functions/built-in/transformations/keyvalues/)).

Same for the injected example usage. When clicking on the 'Click to add', it injects this:
```
|> keyValues(keyCols: ["usage_idle", "usage_user"])
```
where it should be
```
|> keyValues(keyColumns: ["usage_idle", "usage_user"])
```


_What was the solution?_

I've replaced `keyCols` with `keyColumns` in both the argument name doc and example usage.

  - [n/a] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [n/a] Rebased/mergeable
  - [n/a] Tests pass
  - [n/a] swagger.json updated (if modified Go structs or API)
  - [Yes] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)