### PR TITLE
Use v4 instead of v1 uuids

### DIFF
--- a/ui/src/kapacitor/components/RuleGraph.tsx
+++ b/ui/src/kapacitor/components/RuleGraph.tsx
@@ -69,7 +69,7 @@ class RuleGraph extends PureComponent<Props> {
             source={source}
             queries={this.queries}
             templates={this.templates}
-            uuid={uuid.v1()}
+            uuid={uuid.v4()}
           >
             {data => {
               return (

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -219,7 +219,7 @@ class TimeSeries extends PureComponent<Props, State> {
     let responseUUID: string
     let loading: RemoteDataState = null
 
-    const latestUUID = uuid.v1()
+    const latestUUID = uuid.v4()
 
     this.setState({
       loading: RemoteDataState.Loading,

--- a/ui/src/worker/utils/index.ts
+++ b/ui/src/worker/utils/index.ts
@@ -16,7 +16,7 @@ export const fetchData = async (msg: Message): Promise<any> => {
 }
 
 export const error = (msg: Message, err: Error) => {
-  const id = uuid.v1()
+  const id = uuid.v4()
 
   postMessage({
     id,
@@ -27,7 +27,7 @@ export const error = (msg: Message, err: Error) => {
 }
 
 export const success = async (msg: Message, payload: any) => {
-  const id = uuid.v1()
+  const id = uuid.v4()
 
   await DB.put(id, payload)
 


### PR DESCRIPTION
_Mostly copied over from https://github.com/influxdata/influxdb/pull/14374_

I'm a co-author of the [uuid npm module](https://github.com/kelektiv/node-uuid) which is being used in some places within the code base of influxdb.

I'm currently trying to understand real-world use cases of [time-based UUIDs ("v1 UUIDs")](https://en.wikipedia.org/wiki/Universally_unique_identifier#Version_1_(date-time_and_MAC_address)).

I found two occurrence where `v1` UUIDs were being used instead of `v4` UUIDs and I was wondering if this case really requires the semantically much more complex `v1` UUIDs or whether we could live equally well with purely random `v4` UUIDs? Please see my commit messages for more details.

At least the test suite still passes after my changes, so apparently this doesn't seem to introduce any known regressions.

I'd be really curious to understand the motivation for choosing `v1` over `v4` UUIDs in the first place, so any feedback on this would be highly appreciated!

@bthesorceror as far as I can tell from the git history it seems like you have introduced both usages of `v1` UUIDs so I'd be particularly interested in your feedback.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)