### PR TITLE
fix github org pagination when user has > 10 orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,3 @@
-## v1.7.13
-### Bug Fixes
-1. [#5217](https://github.com/influxdata/chronograf/pull/5217): Fix scroll to row bug on table graphs
-1. [#5170](https://github.com/influxdata/chronograf/pull/5170): Wrap inline commas in quotes to distinguish from csv delimiters
-1. [#5225](https://github.com/influxdata/chronograf/pull/5225): Fix tickscript editor syntax coloring
-1. [#5227](https://github.com/influxdata/chronograf/pull/5227): Fix Fix JWK check when using login_id
-1. [#5249](https://github.com/influxdata/chronograf/pull/5249): Fix dashboard typos
 ## v1.7.14
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5265](https://github.com/influxdata/chronograf/pull/5265): fix github org pagination when user has > 10 orgs
+
 ### Features
 
 ## v1.7.13 [2019-08-20]

--- a/oauth2/github.go
+++ b/oauth2/github.go
@@ -140,10 +140,10 @@ func getOrganizations(client *github.Client, log chronograf.Logger) ([]*github.O
 	// Get all pages of results
 	var allOrgs []*github.Organization
 	ctx := context.Background()
+	opt := &github.ListOptions{
+		PerPage: 10,
+	}
 	for {
-		opt := &github.ListOptions{
-			PerPage: 10,
-		}
 		// Get the organizations for the current authenticated user.
 		orgs, resp, err := client.Organizations.List(ctx, "", opt)
 		if err != nil {


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_

When using github oauth, and the user has authorized access to > 10 orgs, a logic error is triggered where the first 10 orgs the user is a member of is retrieved over and over again until the api rate limit is hit. This prevents such a user from being able to login and leaves them with an exhausted github API rate limit.  There is also a secondary issue in that the error message is wrong (will fix on a separate PR).

```
time="2019-08-22T23:15:54Z" level=error msg="OAuth access to email address forbidden GET https://api.github.com/user/orgs?per_page=10: 403 API rate limit of 5000 still exceeded until 2019-08-23 00:11:18 +0000 UTC, not making remote request. [rate reset in 55m24s]"
time="2019-08-22T23:15:54Z" level=error msg="Unable to get principal identifier GET https://api.github.com/user/orgs?per_page=10: 403 API rate limit of 5000 still exceeded until 2019-08-23 00:11:18 +0000 UTC, not making remote request. [rate reset in 55m24s]" component=auth method=GET remote_addr="10.56.3.42:39288" url=/oauth/github/callback?code=8a13f28d28af5a3db3bf&state=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE1NjY1MTYxNDIsImlhdCI6MTU2NjUxNTU0MiwibmJmIjoxNTY2NTE1NTQyLCJzdWIiOiJlRzNhZjRlUS9xemJZblJLSVBONHY1Vi9USGtwVE4yWjdLSTN3K2hCNWM4PSJ9.ARu5ep0KC7c28R6YHSjdu7iBjXNurlMgFFbV0UCHHOQ
```

_What was the solution?_

Move the `opt` var outside of the `for` loop to prevent it from being re-initialized on every iteration.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)