### PR TITLE
WIP: feat(hostlist): add env variable to disable host list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5352](https://github.com/influxdata/chronograf/pull/5352): Add etcd as an alternate backend store
 1. [#5367](https://github.com/influxdata/chronograf/pull/5367): Template variables can now select their source database
 1. [#5362](https://github.com/influxdata/chronograf/pull/5362): Add migrate command to chronoctl
+1. [#5308](https://github.com/influxdata/chronograf/pull/5308): The hosts page can be disabled by setting the new environment variable `HOST_PAGE_DISABLED` to `true`, or by passing in `--host-page-disabled` or `-H` flags
 
 ### Other
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -958,6 +958,7 @@ type BuildStore interface {
 // that were set on the server
 type Environment struct {
 	TelegrafSystemInterval time.Duration `json:"telegrafSystemInterval"`
+	HostPageDisabled       bool          `json:"HostPageDisabled"`
 }
 
 // KVClient defines what each kv store should be capable of.

--- a/dist/dist.go
+++ b/dist/dist.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/elazarl/go-bindata-assetfs"
+	assetfs "github.com/elazarl/go-bindata-assetfs"
 )
 
 // DebugAssets serves assets via a specified directory

--- a/server/env.go
+++ b/server/env.go
@@ -9,6 +9,7 @@ import (
 type envResponse struct {
 	Links                  selfLinks `json:"links"`
 	TelegrafSystemInterval string    `json:"telegrafSystemInterval"`
+	HostPageDisabled       bool      `json:"hostPageDisabled"`
 }
 
 func newEnvResponse(env chronograf.Environment) *envResponse {
@@ -17,6 +18,7 @@ func newEnvResponse(env chronograf.Environment) *envResponse {
 			Self: "/chronograf/v1/env",
 		},
 		TelegrafSystemInterval: env.TelegrafSystemInterval.String(),
+		HostPageDisabled:       env.HostPageDisabled,
 	}
 }
 

--- a/server/env_test.go
+++ b/server/env_test.go
@@ -35,7 +35,7 @@ func TestEnvironment(t *testing.T) {
 			wants: wants{
 				statusCode:  200,
 				contentType: "application/json",
-				body:        `{"links":{"self":"/chronograf/v1/env"},"telegrafSystemInterval":"1m0s"}`,
+				body:        `{"links":{"self":"/chronograf/v1/env"},"telegrafSystemInterval":"1m0s","hostPageDisabled":false}`,
 			},
 		},
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -105,6 +105,7 @@ type Server struct {
 	CustomLinks            map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`
 	TelegrafSystemInterval time.Duration     `long:"telegraf-system-interval" default:"1m" description:"Duration used in the GROUP BY time interval for the hosts list" env:"TELEGRAF_SYSTEM_INTERVAL"`
 
+	HostPageDisabled  bool   `short:"H" long:"host-page-disabled" description:"Disable the host list page" env:"HOST_PAGE_DISABLED"`
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
 	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
 	Basepath          string `short:"p" long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted. (Note: PREFIX_ROUTES has been deprecated. Now, if basepath is set, all routes will be prefixed with it.)" env:"BASE_PATH"`
@@ -376,6 +377,7 @@ func (s *Server) Serve(ctx context.Context) {
 	}
 	service.Env = chronograf.Environment{
 		TelegrafSystemInterval: s.TelegrafSystemInterval,
+		HostPageDisabled:       s.HostPageDisabled,
 	}
 
 	if !validBasepath(s.Basepath) {

--- a/ui/mocks/shared/apis/env.ts
+++ b/ui/mocks/shared/apis/env.ts
@@ -1,1 +1,2 @@
-export const getEnv = () => Promise.resolve({telegrafSystemInterval: '1m0s'})
+export const getEnv = () =>
+  Promise.resolve({telegrafSystemInterval: '1m0s', hostPageDisabled: false})

--- a/ui/src/shared/actions/env.ts
+++ b/ui/src/shared/actions/env.ts
@@ -1,0 +1,31 @@
+import {
+  ActionTypes,
+  SetTelegrafSystemIntervalAction,
+  SetHostPageDisplayStatusAction,
+} from 'src/types/actions/app'
+
+export type SetTelegrafSystemIntervalActionCreator = (
+  telegrafSystemInterval: string
+) => SetTelegrafSystemIntervalAction
+
+export type SetHostPageDisplayStatusActionCreator = (
+  isHostPageDisabled: boolean
+) => SetHostPageDisplayStatusAction
+
+export const setTelegrafSystemInterval: SetTelegrafSystemIntervalActionCreator = (
+  telegrafSystemInterval
+): SetTelegrafSystemIntervalAction => ({
+  type: ActionTypes.SetTelegrafSystemInterval,
+  payload: {
+    telegrafSystemInterval,
+  },
+})
+
+export const setHostPageDisplayStatus: SetHostPageDisplayStatusActionCreator = (
+  hostPageDisabled
+): SetHostPageDisplayStatusAction => ({
+  type: ActionTypes.SetHostPageDisplayStatus,
+  payload: {
+    hostPageDisabled,
+  },
+})

--- a/ui/src/shared/apis/env.ts
+++ b/ui/src/shared/apis/env.ts
@@ -2,6 +2,7 @@ import AJAX from 'src/utils/ajax'
 
 const DEFAULT_ENVS = {
   telegrafSystemInterval: '1m',
+  hostPageDisabled: false,
 }
 
 export const getEnv = async url => {

--- a/ui/src/shared/reducers/env.ts
+++ b/ui/src/shared/reducers/env.ts
@@ -1,0 +1,32 @@
+import {ActionTypes, Action} from 'src/types/actions/app'
+import {Env} from 'src/types/'
+
+const initialState: Env = {
+  telegrafSystemInterval: '1m',
+  hostPageDisabled: false,
+}
+
+const envReducer = (state = initialState, action: Action) => {
+  switch (action.type) {
+    case ActionTypes.SetTelegrafSystemInterval: {
+      const {telegrafSystemInterval} = action.payload
+      return {
+        ...state,
+        telegrafSystemInterval,
+      }
+    }
+
+    case ActionTypes.SetHostPageDisplayStatus: {
+      const {hostPageDisabled} = action.payload
+      return {
+        ...state,
+        hostPageDisabled,
+      }
+    }
+
+    default:
+      return state
+  }
+}
+
+export default envReducer

--- a/ui/src/shared/reducers/index.js
+++ b/ui/src/shared/reducers/index.js
@@ -1,5 +1,6 @@
 import app from './app'
 import auth from './auth'
+import env from './env'
 import config from './config'
 import errors from './errors'
 import links from './links'
@@ -10,6 +11,7 @@ import annotations from './annotations'
 export default {
   app,
   auth,
+  env,
   links,
   config,
   errors,

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -17,7 +17,7 @@ import {DEFAULT_HOME_PAGE} from 'src/shared/constants'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 import {Params, Location, Links, Me} from 'src/types/sideNav'
-import {Source} from 'src/types'
+import {Env, Source} from 'src/types'
 
 interface Props {
   sources: Source[]
@@ -28,6 +28,7 @@ interface Props {
   logoutLink?: string
   links?: Links
   me: Me
+  env: Env
 }
 
 @ErrorHandling
@@ -45,6 +46,7 @@ class SideNav extends PureComponent<Props> {
       logoutLink,
       links,
       me,
+      env,
       sources = [],
     } = this.props
 
@@ -55,6 +57,8 @@ class SideNav extends PureComponent<Props> {
     const dataExplorerLink = `${sourcePrefix}/chronograf/data-explorer`
 
     const isDefaultPage = location.split('/').includes(DEFAULT_HOME_PAGE)
+
+    const hostPageIsEnabled = !env.hostPageDisabled
 
     return isHidden ? null : (
       <nav className="sidebar">
@@ -68,14 +72,16 @@ class SideNav extends PureComponent<Props> {
             <span className="sidebar--icon icon cubo-uniform" />
           </Link>
         </div>
-        <NavBlock
-          highlightWhen={['hosts']}
-          icon="eye"
-          link={`${sourcePrefix}/hosts`}
-          location={location}
-        >
-          <NavHeader link={`${sourcePrefix}/hosts`} title="Host List" />
-        </NavBlock>
+        {hostPageIsEnabled && (
+          <NavBlock
+            highlightWhen={['hosts']}
+            icon="eye"
+            link={`${sourcePrefix}/hosts`}
+            location={location}
+          >
+            <NavHeader link={`${sourcePrefix}/hosts`} title="Host List" />
+          </NavBlock>
+        )}
         <NavBlock
           highlightWhen={['data-explorer']}
           icon="graphline-2"
@@ -163,14 +169,14 @@ class SideNav extends PureComponent<Props> {
             title="Configuration"
           />
         </NavBlock>
-        {isUsingAuth ? (
+        {isUsingAuth && (
           <UserNavBlock
             logoutLink={logoutLink}
             links={links}
             me={me}
             sourcePrefix={sourcePrefix}
           />
-        ) : null}
+        )}
       </nav>
     )
   }
@@ -183,12 +189,14 @@ const mapStateToProps = ({
     ephemeral: {inPresentationMode},
   },
   links,
+  env,
 }) => ({
   sources,
   isHidden: inPresentationMode,
   isUsingAuth,
   logoutLink,
   links,
+  env,
   me,
 })
 

--- a/ui/src/store/configureStore.js
+++ b/ui/src/store/configureStore.js
@@ -17,6 +17,7 @@ import cellEditorOverlay from 'src/dashboards/reducers/cellEditorOverlay'
 import dashTimeV1 from 'src/dashboards/reducers/dashTimeV1'
 import persistStateEnhancer from './persistStateEnhancer'
 import servicesReducer from 'src/shared/reducers/services'
+import envReducer from 'src/shared/reducers/env'
 
 const rootReducer = combineReducers({
   ...statusReducers,
@@ -27,6 +28,7 @@ const rootReducer = combineReducers({
   dashboardUI,
   cellEditorOverlay,
   dashTimeV1,
+  envReducer,
   logs: logsReducer,
   routing: routerReducer,
   services: servicesReducer,

--- a/ui/src/types/actions/app.ts
+++ b/ui/src/types/actions/app.ts
@@ -8,6 +8,8 @@ export enum ActionTypes {
   ToggleTemplateVariableControlBar = 'TOGGLE_TEMPLATE_VARIABLE_CONTROL_BAR',
   Noop = 'NOOP',
   SetTimeZone = 'SET_TIME_ZONE',
+  SetTelegrafSystemInterval = 'SET_TELEGRAF_SYSTEM_INTERVAL',
+  SetHostPageDisplayStatus = 'SET_HOST_PAGE_DISPLAY_STATUS',
 }
 
 export type Action =
@@ -16,6 +18,8 @@ export type Action =
   | SetAutoRefreshAction
   | ToggleTemplateVariableControlBarAction
   | SetTimeZoneAction
+  | SetTelegrafSystemIntervalAction
+  | SetHostPageDisplayStatusAction
 
 export type EnablePresentationModeActionCreator = () => EnablePresentationModeAction
 
@@ -52,5 +56,19 @@ export interface SetTimeZoneAction {
   type: ActionTypes.SetTimeZone
   payload: {
     timeZone: TimeZones
+  }
+}
+
+export interface SetTelegrafSystemIntervalAction {
+  type: ActionTypes.SetTelegrafSystemInterval
+  payload: {
+    telegrafSystemInterval: string
+  }
+}
+
+export interface SetHostPageDisplayStatusAction {
+  type: ActionTypes.SetHostPageDisplayStatus
+  payload: {
+    hostPageDisabled: boolean
   }
 }

--- a/ui/src/types/env.ts
+++ b/ui/src/types/env.ts
@@ -1,0 +1,4 @@
+export interface Env {
+  telegrafSystemInterval: string
+  hostPageDisabled: boolean
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -66,9 +66,11 @@ import {JSONFeedData} from './status'
 import {Annotation} from './annotations'
 import {WriteDataMode, QueryUpdateState} from './dataExplorer'
 import {Host, Layout} from './hosts'
+import {Env} from './env'
 
 export {
   Me,
+  Env,
   Links,
   Role,
   User,

--- a/ui/src/types/localStorage.ts
+++ b/ui/src/types/localStorage.ts
@@ -8,6 +8,8 @@ export interface LocalStorage {
   timeRange: TimeRange
   script: string
   logs: LogsState
+  telegrafSystemInterval: string
+  hostPageDisabled: boolean
 }
 
 export type VERSION = string

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1022,7 +1022,7 @@ ajv-keywords@^3.0.0:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.2.0.tgz#e86b819c602cf8821ad637413698f1dec021847a"
   integrity sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=
 
-ajv@^5.1.0, ajv@^5.2.3, ajv@^5.3.0:
+ajv@^5.2.3, ajv@^5.3.0:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   integrity sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=
@@ -1299,7 +1299,7 @@ aws-sign2@~0.7.0:
   resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
-aws4@^1.6.0, aws4@^1.8.0:
+aws4@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
@@ -2232,7 +2232,7 @@ combined-stream@1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-combined-stream@~1.0.5, combined-stream@~1.0.6:
+combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
   integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
@@ -3729,7 +3729,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.1, extend@~3.0.2:
+extend@^3.0.0, extend@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
@@ -4013,7 +4013,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.1, form-data@~2.3.2:
+form-data@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.2.tgz#4970498be604c20c005d4f5c23aecd21d6b49099"
   integrity sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=
@@ -4257,14 +4257,6 @@ har-schema@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
-
-har-validator@~5.0.3:
-  version "5.0.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.0.3.tgz#ba402c266194f15956ef15e0fcf242993f6a7dfd"
-  integrity sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=
-  dependencies:
-    ajv "^5.1.0"
-    har-schema "^2.0.0"
 
 har-validator@~5.1.0:
   version "5.1.0"
@@ -5827,20 +5819,10 @@ lodash-es@^4.2.1:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.11.tgz#145ab4a7ac5c5e52a3531fb4f310255a152b4be0"
   integrity sha512-DHb1ub+rMjjrxqlB3H56/6MXtm1lSksDp2rA2cNWjG8mlDUYFhUj3Di2Zn5IwSU87xLv8tNIQ7sSwE/YOX/D/Q==
 
-lodash.assign@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/lodash.assign/-/lodash.assign-4.2.0.tgz#0d99f3ccd7a6d261d19bdaeb9245005d285808e7"
-  integrity sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=
-
 lodash.clone@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
-
-lodash.clonedeep@^4.3.2:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz#e23f3f9c4f8fbdde872529c1071857a086e5ccef"
-  integrity sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=
 
 lodash.debounce@^4.0.8:
   version "4.0.8"
@@ -5872,11 +5854,6 @@ lodash.memoize@^4.1.2:
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
   integrity sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=
 
-lodash.mergewith@^4.6.0:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
-  integrity sha512-eWw5r+PYICtEBgrBE5hhlT6aAa75f411bgDz/ZL2KZqYV03USvucsxcHUIlGTDTECs1eunpI7HOV7U+WLDvNdQ==
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -5897,7 +5874,7 @@ lodash@^4.0.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.4, 
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
 
-lodash@^4.17.13:
+lodash@^4.17.13, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
@@ -6139,7 +6116,7 @@ mime-db@~1.36.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.36.0.tgz#5020478db3c7fe93aad7bbcc4dcf869c43363397"
   integrity sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw==
 
-mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.18, mime-types@~2.1.19:
+mime-types@^2.1.12, mime-types@~2.1.18, mime-types@~2.1.19:
   version "2.1.20"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.20.tgz#930cb719d571e903738520f8470911548ca2cc19"
   integrity sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==
@@ -6243,10 +6220,15 @@ mute-stream@0.0.7:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
   integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
-nan@^2.0.7, nan@^2.10.0, nan@^2.9.2:
+nan@^2.0.7, nan@^2.9.2:
   version "2.11.1"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
+
+nan@^2.13.2:
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
+  integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
 
 nano-date@^2.0.1:
   version "2.1.0"
@@ -6412,10 +6394,10 @@ node-releases@^1.0.0-alpha.12:
   dependencies:
     semver "^5.3.0"
 
-node-sass@^4.9.0:
-  version "4.9.3"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.3.tgz#f407cf3d66f78308bb1e346b24fa428703196224"
-  integrity sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==
+node-sass@^4.13.0:
+  version "4.13.1"
+  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.13.1.tgz#9db5689696bb2eec2c32b98bfea4c7a2e992d0a3"
+  integrity sha512-TTWFx+ZhyDx1Biiez2nB0L3YrCZ/8oHagaDalbuBSlqXgUPsdkUSzJsVxeDO9LtPB49+Fh3WQl3slABo6AotNw==
   dependencies:
     async-foreach "^0.1.3"
     chalk "^1.1.1"
@@ -6424,15 +6406,13 @@ node-sass@^4.9.0:
     get-stdin "^4.0.1"
     glob "^7.0.3"
     in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
+    lodash "^4.17.15"
     meow "^3.7.0"
     mkdirp "^0.5.1"
-    nan "^2.10.0"
+    nan "^2.13.2"
     node-gyp "^3.8.0"
     npmlog "^4.0.0"
-    request "2.87.0"
+    request "^2.88.0"
     sass-graph "^2.2.4"
     stdout-stream "^1.4.0"
     "true-case-path" "^1.0.2"
@@ -6553,11 +6533,6 @@ nwsapi@^2.0.7:
   version "2.0.9"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.0.9.tgz#77ac0cdfdcad52b6a1151a84e73254edc33ed016"
   integrity sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==
-
-oauth-sign@~0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
-  integrity sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=
 
 oauth-sign@~0.9.0:
   version "0.9.0"
@@ -7766,7 +7741,7 @@ qs@6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@^6.5.2, qs@~6.5.1, qs@~6.5.2:
+qs@^6.5.2, qs@~6.5.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
@@ -8397,33 +8372,7 @@ request-promise-native@^1.0.5:
     stealthy-require "^1.1.0"
     tough-cookie ">=2.3.3"
 
-request@2.87.0:
-  version "2.87.0"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.87.0.tgz#32f00235cd08d482b4d0d68db93a829c0ed5756e"
-  integrity sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.6.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.5"
-    extend "~3.0.1"
-    forever-agent "~0.6.1"
-    form-data "~2.3.1"
-    har-validator "~5.0.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.17"
-    oauth-sign "~0.8.2"
-    performance-now "^2.1.0"
-    qs "~6.5.1"
-    safe-buffer "^5.1.1"
-    tough-cookie "~2.3.3"
-    tunnel-agent "^0.6.0"
-    uuid "^3.1.0"
-
-request@^2.79.0, request@^2.87.0:
+request@^2.79.0, request@^2.87.0, request@^2.88.0:
   version "2.88.0"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.0.tgz#9c2fca4f7d35b592efe57c7f0a55e81052124fef"
   integrity sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==
@@ -9475,13 +9424,6 @@ tough-cookie@>=2.3.3, tough-cookie@^2.3.2, tough-cookie@^2.3.4, tough-cookie@~2.
     psl "^1.1.24"
     punycode "^1.4.1"
 
-tough-cookie@~2.3.3:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
-  integrity sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==
-  dependencies:
-    punycode "^1.4.1"
-
 tr46@^1.0.0, tr46@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-1.0.1.tgz#a8b13fd6bfd2489519674ccde55ba3693b706d09"
@@ -9881,7 +9823,7 @@ uuid@3.2.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
   integrity sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==
 
-uuid@^3.1.0, uuid@^3.2.1, uuid@^3.3.2:
+uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==


### PR DESCRIPTION
Closes #5370

Introduces a new option to disable rendering and serving of the hosts page.

`chronograf -H`, `chronograf --host-page-disabled`, or setting the following environment variable:
```sh
HOST_PAGE_DISABLED=true
```

### No Hosts page sidebar nav
<img width="231" alt="Screen Shot 2020-02-07 at 4 06 04 PM" src="https://user-images.githubusercontent.com/146112/74074627-d1786480-49c3-11ea-99ad-104abea35c1f.png">

### 404 when hitting `sources/$sourceId/hosts`
<img width="1012" alt="Screen Shot 2020-02-07 at 4 06 16 PM" src="https://user-images.githubusercontent.com/146112/74074628-d210fb00-49c3-11ea-90af-2891b7315c85.png">

## Testing Instructions
* Start the chronograf go server with the envvar `HOST_PAGE_DISABLED` set to true.
  * Simple way to do it: `HOST_PAGE_DISABLED=true go run ./cmd/chronograf/ -d`
* Go to any page in the app - the hosts page should be missing from the side nav
* Hit the hosts page directly `/sources/$sourceId/hosts`

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
