### PR TITLE
fix(data-explorer): always include upper dashboard time in query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5265](https://github.com/influxdata/chronograf/pull/5265): fix github org pagination when user has > 10 orgs
 1. [#5306](https://github.com/influxdata/chronograf/pull/5306): making http requests on https server results in http 400
 1. [#5305](https://github.com/influxdata/chronograf/pull/5305): Upgrade to flux v0.50.2
+1. [#5309](https://github.com/influxdata/chronograf/pull/5309): fix date range picker in data explorer
 
 ### Features
 

--- a/ui/src/tempVars/constants/index.ts
+++ b/ui/src/tempVars/constants/index.ts
@@ -1,7 +1,10 @@
 import uuid from 'uuid'
 
 import {TimeRange} from 'src/types/queries'
-import {TEMP_VAR_DASHBOARD_TIME} from 'src/shared/constants'
+import {
+  TEMP_VAR_DASHBOARD_TIME,
+  TEMP_VAR_UPPER_DASHBOARD_TIME,
+} from 'src/shared/constants'
 import {Template, TemplateType, TemplateValueType} from 'src/types'
 
 interface TemplateTypesListItem {
@@ -216,7 +219,7 @@ export const unMask = query => {
   return query.replace(/😸/g, ':')
 }
 export const TEMPLATE_RANGE: TimeRange = {
-  upper: null,
+  upper: TEMP_VAR_UPPER_DASHBOARD_TIME,
   lower: TEMP_VAR_DASHBOARD_TIME,
 }
 


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/5297