### PR TITLE
fix(schema-explorer): update the flux schema explorer to use v1 package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.7.16
+
+### Bug Fixes
+
+1. [#5265](https://github.com/influxdata/chronograf/pull/5323): fix(schema-explorer): update the flux schema explorer to use v1 package
+
+### Features
+
 ## v1.7.15
 
 ### Bug Fixes


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/5316

_What was the problem?_
Flux started erroring on a query that used to work.

_What was the solution?_
Use the v1 package.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)