### PR TITLE
chore: pin go to latest minor go version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ version: 2
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20191105
+      DOCKER_TAG: chronograf-20191121
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -57,7 +57,7 @@ jobs:
 
   deploy-nightly:
     environment:
-      DOCKER_TAG: chronograf-20191105
+      DOCKER_TAG: chronograf-20191121
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -85,7 +85,7 @@ jobs:
 
   deploy-pre-release:
     environment:
-      DOCKER_TAG: chronograf-20191105
+      DOCKER_TAG: chronograf-20191121
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -115,7 +115,7 @@ jobs:
 
   deploy-release:
     environment:
-      DOCKER_TAG: chronograf-20191105
+      DOCKER_TAG: chronograf-20191121
       GO111MODULE: "ON"
     machine: true
     steps:

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -7,5 +7,6 @@ _What was the solution?_
   - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
   - [ ] Rebased/mergeable
   - [ ] Tests pass
+  - [ ] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
   - [ ] swagger.json updated (if modified Go structs or API)
   - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## v1.7.15
 
+### Features
+1. [5324](https://github.com/influxdata/chronograf/pull/5324): Pin to latest minor go version; make Docker build process more robust
+
+## v1.7.15
+
 ### Bug Fixes
 
 1. [#5265](https://github.com/influxdata/chronograf/pull/5265): fix github org pagination when user has > 10 orgs

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ server/swagger_gen.go: server/swagger.json
 
 canned/bin_gen.go: canned/*.json
 	go generate -x ./canned
-	
+
 protoboards/bin_gen.go: protoboards/*.json
 	go generate -x ./protoboards
 
@@ -78,7 +78,7 @@ endif
 
 .jsdep: ui/yarn.lock
 ifndef YARN
-	$(error Please install yarn 0.19.1+)
+	$(error Please install yarn 1.19.1+)
 else
 	cd ui && yarn --no-progress --no-emoji
 	@touch .jsdep

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -31,7 +31,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.12.10
+ENV GO_VERSION 1.12
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/README.md
+++ b/etc/README.md
@@ -12,4 +12,4 @@ and push to quay with:
 `docker push quay.io/influxdb/builder:chronograf-$(date "+%Y%m%d")`
 
 ### Update circle
-Update DOCKER_TAG in circle.yml to the new container.
+Update DOCKER_TAG in .circleci/config.yml to the new container.

--- a/etc/build.py
+++ b/etc/build.py
@@ -189,7 +189,7 @@ def go_get(branch, update=False, no_uncommitted=False):
     if local_changes() and no_uncommitted:
         logging.error("There are uncommitted changes in the current directory.")
         return False
-    run("make dep", shell=True, print_output=True)
+    run("make dep -B", shell=True, print_output=True)
     end_time = datetime.utcnow()
     logging.info("Time taken: {}s".format((end_time - start_time).total_seconds()))
     return True


### PR DESCRIPTION
Closes #5320

- Pins go to latest minor revision (e.g. `1.12.x` where `x` is currently `13`, but will soon be `14`)

- Updates the Python build script to always run `make dep` (passes `-B` to `make`). I was having issues where `go-bindata` wasn't being installed properly, and it looks like it's because `make` thought that there was nothing to run with `dep`

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass