### PR TITLE
fix(ui): use the the available y-axis label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#5265](https://github.com/influxdata/chronograf/pull/5323): fix(schema-explorer): update the flux schema explorer to use v1 package
+1. [5326](https://github.com/influxdata/chronograf/pull/5326): fix(ui): use a fallback label for y-axis if it's available
 
 ### Features
 

--- a/ui/src/shared/components/Dygraph.tsx
+++ b/ui/src/shared/components/Dygraph.tsx
@@ -459,8 +459,12 @@ class Dygraph extends Component<Props, State> {
   }
 
   private getLabel = (axis: string): string => {
-    const {axes, queries} = this.props
-    const label = getDeep<string>(axes, `${axis}.label`, '')
+    const {axes, labels, queries} = this.props
+
+    // if label comes back as '', use the y axis label from props.labels, if it exists
+    // see https://github.com/influxdata/chronograf/issues/5314
+    const fallbackLabel = labels[1] || ''
+    const label = getDeep<string>(axes, `${axis}.label`, '') || fallbackLabel
     const queryConfig = getDeep(queries, '0.queryConfig', false)
 
     if (label || !queryConfig) {


### PR DESCRIPTION
Closes #5314

y-axis labels were disappearing. This is a band-aid to fall back to a known value for the y-axis
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass