### PR TITLE
fix(influx): allow upperDashboardTime when generating query config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,15 @@
 ### Bug Fixes
 
 1. [#5265](https://github.com/influxdata/chronograf/pull/5323): fix(schema-explorer): update the flux schema explorer to use v1 package
-1. [5326](https://github.com/influxdata/chronograf/pull/5326): fix(ui): use a fallback label for y-axis if it's available
+1. [#5326](https://github.com/influxdata/chronograf/pull/5326): fix(ui): use a fallback label for y-axis if it's available
+1. [#5334](https://github.com/influxdata/chronograf/pull/5334): fix(influx): allow upperDashboardTime when generating query config
 
 ### Features
 
 ## v1.7.15
 
 ### Features
+
 1. [5324](https://github.com/influxdata/chronograf/pull/5324): Pin to latest minor go version; make Docker build process more robust
 
 ## v1.7.15

--- a/influx/query.go
+++ b/influx/query.go
@@ -62,6 +62,7 @@ func ParseTime(influxQL string, now time.Time) (time.Duration, error) {
 // Convert changes an InfluxQL query to a QueryConfig
 func Convert(influxQL string) (chronograf.QueryConfig, error) {
 	itsDashboardTime := false
+	itsUpperDashboardTime := false
 	intervalTime := false
 
 	if strings.Contains(influxQL, ":interval:") {
@@ -74,6 +75,11 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 		itsDashboardTime = true
 	}
 
+	if strings.Contains(influxQL, ":upperDashboardTime:") {
+		influxQL = strings.Replace(influxQL, ":upperDashboardTime:", "now() - 1m", 1)
+		itsUpperDashboardTime = true
+	}
+
 	query, err := influxql.ParseQuery(influxQL)
 	if err != nil {
 		return chronograf.QueryConfig{}, err
@@ -81,6 +87,10 @@ func Convert(influxQL string) (chronograf.QueryConfig, error) {
 
 	if itsDashboardTime {
 		influxQL = strings.Replace(influxQL, "now() - 15m", ":dashboardTime:", 1)
+	}
+
+	if itsUpperDashboardTime {
+		influxQL = strings.Replace(influxQL, "now() - 1m", ":upperDashboardTime:", 1)
 	}
 
 	if intervalTime {

--- a/influx/query_test.go
+++ b/influx/query_test.go
@@ -48,6 +48,37 @@ func TestConvert(t *testing.T) {
 			},
 		},
 		{
+			name:     "Test upperDashboardTime",
+			influxQL: `SELECT "usage_idle", "usage_guest_nice", "usage_system", "usage_guest" FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime: AND time < :upperDashboardTime:`,
+			want: chronograf.QueryConfig{
+				Database:        "telegraf",
+				Measurement:     "cpu",
+				RetentionPolicy: "autogen",
+				Fields: []chronograf.Field{
+					chronograf.Field{
+						Value: "usage_idle",
+						Type:  "field",
+					},
+					chronograf.Field{
+						Value: "usage_guest_nice",
+						Type:  "field",
+					},
+					chronograf.Field{
+						Value: "usage_system",
+						Type:  "field",
+					},
+					chronograf.Field{
+						Value: "usage_guest",
+						Type:  "field",
+					},
+				},
+				Tags: map[string][]string{},
+				GroupBy: chronograf.GroupBy{
+					Tags: []string{},
+				},
+			},
+		},
+		{
 			name:     "Test field function order",
 			influxQL: `SELECT mean("usage_idle"), median("usage_idle"), count("usage_guest_nice"), mean("usage_guest_nice") FROM "telegraf"."autogen"."cpu" WHERE time > :dashboardTime:`,
 			want: chronograf.QueryConfig{


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/5330

_Briefly describe your proposed changes:_
When we added upperDashboard time to queries, it resulted in an invalid query config. To resolve this we treat dashboardTime and upperDashboardTime the same.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
