### PR TITLE
fix(kapacitor): use better heuristic than string contains `batch` when creating tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### Bug Fixes
 
 1. [#5265](https://github.com/influxdata/chronograf/pull/5323): fix(schema-explorer): update the flux schema explorer to use v1 package
-1. [5326](https://github.com/influxdata/chronograf/pull/5326): fix(ui): use a fallback label for y-axis if it's available
+1. [#5326](https://github.com/influxdata/chronograf/pull/5326): fix(ui): use a fallback label for y-axis if it's available
+1. [#5335](https://github.com/influxdata/chronograf/pull/5335): fix(kapacitor): use better heuristic than string contains `batch` when creating tasks
 
 ### Features
 

--- a/kapacitor/validate.go
+++ b/kapacitor/validate.go
@@ -38,9 +38,13 @@ func validateTick(script chronograf.TICKScript) error {
 	return err
 }
 
+func isBatchTask(script string) bool {
+	return strings.Contains(script, "batch ") || strings.Contains(script, "batch|") || strings.Contains(script, "batch\n")
+}
+
 func newPipeline(script chronograf.TICKScript) (*pipeline.Pipeline, error) {
 	edge := pipeline.StreamEdge
-	if strings.Contains(string(script), "batch") {
+	if isBatchTask(string(script)) {
 		edge = pipeline.BatchEdge
 	}
 

--- a/kapacitor/validate_test.go
+++ b/kapacitor/validate_test.go
@@ -1,7 +1,10 @@
 package kapacitor
 
-import "testing"
-import "github.com/influxdata/chronograf"
+import (
+	"testing"
+
+	"github.com/influxdata/chronograf"
+)
 
 func TestValidateAlert(t *testing.T) {
 	tests := []struct {
@@ -36,6 +39,16 @@ func Test_validateTick(t *testing.T) {
 		{
 			name:    "Valid Script",
 			script:  "stream|from()",
+			wantErr: false,
+		},
+		{
+			name:    "Valid stream Script with batch string",
+			script:  "stream|from().database('batch')",
+			wantErr: false,
+		},
+		{
+			name:    "Valid batch Script",
+			script:  "batch|query('select * from bar')",
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/5332

_Briefly describe your proposed changes:_
Previously we used the heuristic of checking if `batch` was a substring of the tickscript. This caused an issue where the user had a regular script `batchsvc` in their tickscript. We instead use a slightly better heuristic which is to check for `batch|`, `batch `, or `batch\n`. This is not perfect, but should suffice. I had attempted to parse and walk the kapacitor ast, but the walk function exposed does not make this easy.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
