### PR TITLE
fix(defaultQueryConfig): if in rule remove upper dashboard time

### DIFF
--- a/ui/src/utils/defaultQueryConfig.ts
+++ b/ui/src/utils/defaultQueryConfig.ts
@@ -28,7 +28,7 @@ const defaultQueryConfig = (
     status: null,
     shifts: [],
     fill: null,
-    range: TEMPLATE_RANGE,
+    range: isKapacitorRule ? {...TEMPLATE_RANGE, upper: null} : TEMPLATE_RANGE,
     originalQuery: null,
   }
 


### PR DESCRIPTION
Previously used the same template range for both kapacitor rules and data explorer. When we introduced upperDashboardTime to DE, we accidentally broke kapacitor rules. This fix, conditionally checks to see that the query config we are creating is a kapacitor rule query config and removed upperDashboardTime.