### PR TITLE
chore: upgrade go and node-sass dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,3 +29,5 @@ require (
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	google.golang.org/api v0.7.0
 )
+
+go 1.13

--- a/ui/package.json
+++ b/ui/package.json
@@ -80,7 +80,7 @@
     "jest-runner-eslint": "^0.6.0",
     "jest-runner-tslint": "^1.0.4",
     "jsdom": "^9.0.0",
-    "node-sass": "^4.9.0",
+    "node-sass": "^4.13.0",
     "parcel": "^1.10.1",
     "prettier": "1.12.1",
     "ts-jest": "^23.10.3",


### PR DESCRIPTION
Upgrade go to 1.13 in go.mod
Upgrade node-sass dependency to 4.13.0

  - [x] Rebased/mergeable
  - [x] Tests pass