### PR TITLE
fix: allow signing out when using oauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5340](https://github.com/influxdata/chronograf/pull/5340): Allow logging out when using Oauth
+
 ### Features
 
 ## v1.7.16 [2019-12-18]

--- a/ui/src/auth/Login.js
+++ b/ui/src/auth/Login.js
@@ -8,22 +8,8 @@ import SplashPage from 'shared/components/SplashPage'
 
 const VERSION = process.env.npm_package_version
 
-const Login = props => {
-  const {
-    authData: {
-      auth: {links, isAuthLoading},
-    },
-  } = props
-
-  if (isAuthLoading) {
-    return <PageSpinner />
-  }
-
-  const redirectTo = links && links.length === 1 && links[0].login
-
-  if (redirectTo) {
-    window.location.href = redirectTo
-
+const Login = ({authData: {auth}}) => {
+  if (auth.isAuthLoading) {
     return <PageSpinner />
   }
 
@@ -35,8 +21,8 @@ const Login = props => {
         <p>
           <strong>{VERSION}</strong> / Time-Series Data Visualization
         </p>
-        {links &&
-          links.map(({name, login, label}) => (
+        {auth.links &&
+          auth.links.map(({name, login, label}) => (
             <a key={name} className="btn btn-primary" href={login}>
               <span className={`icon ${name}`} />
               Log in with {label}


### PR DESCRIPTION
Closes #5333

Reverts previous change that auto-redirected back to ouath provider's login. You may now get off Mr. Bones' Wild Ride.

Testing instructions:

1. Set up github as an oauth provider for Chronograf: https://developer.github.com/apps/building-oauth-apps/creating-an-oauth-app/
1. Set up the local settings to look like this: ![p](https://user-images.githubusercontent.com/146112/71691160-77003e80-2d5b-11ea-97f7-b10000edb20a.png)
1. Make sure you're on this branch `bs_allow_logouts`
1. Launch chronograf using github as an oauth provider. `TOKEN_SECRET` can be any arbitrary string. I chose song lyrics. Replace the `$CHRONOGRAF_GH_CLIENT_ID` and `CHRONOGRAF_GH_CLIENT_SECRET` with the values that github gives you, or export those values as variables below.
   ```GH_CLIENT_ID=$CHRONOGRAF_GH_CLIENT_ID GH_CLIENT_SECRET=$CHRONOGRAF_GH_CLIENT_SECRET TOKEN_SECRET=$CHRONOGRAF_TOKEN_SECRET go run ./cmd/chronograf/ -d```

Depends on #5339 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
