### PR TITLE
fix: log viewer uses a default if the mapped severity doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## v1.8.0
 
+### Bug Fixes
+
+1. [#5345](https://github.com/influxdata/chronograf/pull/5345): Log Viewer uses a default if the mapped severity doesn't exist
+
 ## v1.7.17 [2020-01-08]
 
 ### Bug Fixes

--- a/ui/jest.config.js
+++ b/ui/jest.config.js
@@ -25,14 +25,5 @@ module.exports = {
       displayName: 'eslint',
       testMatch: ['<rootDir>/test/**/*.test.js'],
     },
-    {
-      runner: 'jest-runner-tslint',
-      displayName: 'tslint',
-      moduleFileExtensions: ['ts', 'tsx'],
-      testMatch: [
-        '<rootDir>/test/**/*.test.ts',
-        '<rootDir>/test/**/*.test.tsx',
-      ],
-    },
   ],
 }

--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -481,7 +481,9 @@ class LogsTable extends Component<Props, State> {
 
     if (column === 'severity' && isDotNeeded) {
       title = value
-      const colorLevel = severityLevelColors.find(lc => lc.level === value)
+      const colorLevel =
+        severityLevelColors.find(lc => lc.level === value) ||
+        severityLevelColors[0]
       formattedValue = (
         <>
           <div


### PR DESCRIPTION
Closes #5337

This passes a default value to `colorLevel` to guard against an incorrect key being used.

This doesn't fix the underlying issue that the error reporter is wonky on the log viewer. I was able to tweak it so the error reporter looked good, but it involved moving `FancyScrollbars` to a different parent so it became the parent of an `AutoSizer` and that frankly made me very worried and uncomfortable. I'm very hesitant to change the structure of an application I don't understand well. So we're slapping the easy fix on this and if we see more issues of this cropping up, we'll address it then.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
