### PR TITLE
feat(ui): add query parameter for autofresh option in dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#5345](https://github.com/influxdata/chronograf/pull/5345): Log Viewer uses a default if the mapped severity doesn't exist
 
+### Features
+
+1. [#5348](https://github.com/influxdata/chronograf/pull/5348): Add query parameter for dashboard auto refresh
+
 ## v1.7.17 [2020-01-08]
 
 ### Bug Fixes
@@ -27,7 +31,7 @@
 
 ### Features
 
-1. [5324](https://github.com/influxdata/chronograf/pull/5324): Pin to latest minor go version; make Docker build process more robust
+1. [#5324](https://github.com/influxdata/chronograf/pull/5324): Pin to latest minor go version; make Docker build process more robust
 
 ## v1.7.15
 

--- a/ui/src/dashboards/actions/index.ts
+++ b/ui/src/dashboards/actions/index.ts
@@ -55,6 +55,7 @@ import {
   TemplateValue,
   TemplateType,
   Status,
+  RefreshRate,
 } from 'src/types'
 import {NewDefaultCell} from 'src/types/dashboards'
 
@@ -76,7 +77,9 @@ export enum ActionType {
   SetHoverTime = 'SET_HOVER_TIME',
   SetActiveCell = 'SET_ACTIVE_CELL',
   SetDashboardTimeV1 = 'SET_DASHBOARD_TIME_V1',
+  SetDashboardRefresh = 'SET_DASHBOARD_REFRESH',
   RetainRangesDashboardTimeV1 = 'RETAIN_RANGES_DASHBOARD_TIME_V1',
+  RetainDashboardRefresh = 'RETAIN_DASHBOARD_REFRESH',
 }
 
 interface LoadDashboardsAction {
@@ -96,6 +99,13 @@ interface LoadDashboardAction {
 
 interface RetainRangesDashTimeV1Action {
   type: ActionType.RetainRangesDashboardTimeV1
+  payload: {
+    dashboardIDs: number[]
+  }
+}
+
+interface RetainDashRefreshAction {
+  type: ActionType.RetainDashboardRefresh
   payload: {
     dashboardIDs: number[]
   }
@@ -213,10 +223,19 @@ interface SetDashTimeV1Action {
   }
 }
 
+interface SetDashRefreshAction {
+  type: ActionType.SetDashboardRefresh
+  payload: {
+    dashboardID: number
+    refreshRate: RefreshRate
+  }
+}
+
 export type Action =
   | LoadDashboardsAction
   | LoadDashboardAction
   | RetainRangesDashTimeV1Action
+  | RetainDashRefreshAction
   | SetTimeRangeAction
   | SetZoomedTimeRangeAction
   | UpdateDashboardAction
@@ -232,6 +251,7 @@ export type Action =
   | SetHoverTimeAction
   | SetActiveCellAction
   | SetDashTimeV1Action
+  | SetDashRefreshAction
 
 export const loadDashboards = (
   dashboards: Dashboard[],
@@ -257,10 +277,25 @@ export const setDashTimeV1 = (
   payload: {dashboardID, timeRange},
 })
 
+export const setDashRefresh = (
+  dashboardID: number,
+  refreshRate: RefreshRate
+): SetDashRefreshAction => ({
+  type: ActionType.SetDashboardRefresh,
+  payload: {dashboardID, refreshRate},
+})
+
 export const retainRangesDashTimeV1 = (
   dashboardIDs: number[]
 ): RetainRangesDashTimeV1Action => ({
   type: ActionType.RetainRangesDashboardTimeV1,
+  payload: {dashboardIDs},
+})
+
+export const retainDashRefresh = (
+  dashboardIDs: number[]
+): RetainDashRefreshAction => ({
+  type: ActionType.RetainDashboardRefresh,
   payload: {dashboardIDs},
 })
 

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -24,7 +24,7 @@ import {STATIC_LEGEND} from 'src/dashboards/constants/cellEditor'
 // Types
 import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
-import {NotificationAction, TimeRange, CellType} from 'src/types'
+import {NotificationAction, TimeRange, RefreshRate, CellType} from 'src/types'
 import {Template} from 'src/types/tempVars'
 import {
   Cell,
@@ -78,6 +78,7 @@ interface PassedProps {
   dashboardTemplates: Template[]
   cell: Cell | NewDefaultCell
   dashboardTimeRange: TimeRange
+  dashboardRefresh: RefreshRate
 }
 
 type Props = PassedProps & ConnectedProps
@@ -105,11 +106,12 @@ class CellEditorOverlay extends Component<Props, State> {
   }
 
   public componentDidMount() {
-    const {cell, dashboardTimeRange, onResetTimeMachine} = this.props
+    const {cell, dashboardTimeRange, dashboardRefresh, onResetTimeMachine} = this.props
 
     const initialState = {
       ...initialStateFromCell(cell),
       timeRange: dashboardTimeRange,
+      refresh: dashboardRefresh,
     }
 
     onResetTimeMachine(initialState)
@@ -126,6 +128,7 @@ class CellEditorOverlay extends Component<Props, State> {
       source,
       sources,
       queryStatus,
+      dashboardRefresh,
     } = this.props
 
     const {isStaticLegend} = this.state
@@ -150,6 +153,7 @@ class CellEditorOverlay extends Component<Props, State> {
           isStaticLegend={isStaticLegend}
           queryStatus={queryStatus}
           onUpdateScriptStatus={this.handleUpdateScriptStatus}
+          refresh={dashboardRefresh}
         >
           {(activeEditorTab, onSetActiveEditorTab) => (
             <CEOHeader

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -106,7 +106,12 @@ class CellEditorOverlay extends Component<Props, State> {
   }
 
   public componentDidMount() {
-    const {cell, dashboardTimeRange, dashboardRefresh, onResetTimeMachine} = this.props
+    const {
+      cell,
+      dashboardTimeRange,
+      dashboardRefresh,
+      onResetTimeMachine,
+    } = this.props
 
     const initialState = {
       ...initialStateFromCell(cell),

--- a/ui/src/dashboards/components/CellEditorOverlay.tsx
+++ b/ui/src/dashboards/components/CellEditorOverlay.tsx
@@ -108,8 +108,8 @@ class CellEditorOverlay extends Component<Props, State> {
   public componentDidMount() {
     const {
       cell,
-      dashboardTimeRange,
       dashboardRefresh,
+      dashboardTimeRange,
       onResetTimeMachine,
     } = this.props
 

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -26,6 +26,9 @@ import {setTimeZone} from 'src/shared/actions/app'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import TimeZoneToggle from 'src/shared/components/time_zones/TimeZoneToggle'
 
+// Constants
+import {AutoRefreshOption} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
+
 interface State {
   selected: QueriesModels.TimeRange
 }
@@ -38,7 +41,7 @@ interface Props {
   onSetTimeZone: typeof setTimeZone
   autoRefresh: number
   handleChooseTimeRange: (timeRange: QueriesModels.TimeRange) => void
-  handleChooseAutoRefresh: AppActions.SetAutoRefreshActionCreator
+  handleChooseAutoRefresh: (autoRefreshOption: AutoRefreshOption) => void
   onManualRefresh: () => void
   handleClickPresentationButton: AppActions.DelayEnablePresentationModeDispatcher
   onAddCell: () => void

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -59,7 +59,7 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import * as TempVarsModels from 'src/types/tempVars'
 import {NewDefaultCell} from 'src/types/dashboards'
-import {NotificationAction, TimeZones} from 'src/types'
+import {NotificationAction, TimeZones, RefreshRate} from 'src/types'
 import {AnnotationsDisplaySetting} from 'src/types/annotations'
 import {Links} from 'src/types/flux'
 import {createTimeRangeTemplates} from 'src/shared/utils/templates'
@@ -79,7 +79,7 @@ interface Props extends ManualRefreshProps, WithRouterProps {
   dashboard: DashboardsModels.Dashboard
   dashboards: DashboardsModels.Dashboard[]
   autoRefresh: number
-  refreshRate: number
+  refreshRate: RefreshRate
   timeRange: QueriesModels.TimeRange
   zoomedTimeRange: QueriesModels.TimeRange
   inPresentationMode: boolean
@@ -143,6 +143,8 @@ class DashboardPage extends Component<Props, State> {
 
   public async componentDidMount() {
     const {refreshRate, updateQueryParams} = this.props
+    const compareOptionToRefreshRate = (r: AutoRefreshOption) =>
+      r.milliseconds === refreshRate
     const {location: {search = ''} = {}} = window
     const urlSelectedRefresh = search.match(/refresh=([^&#]*)/i)
     let pollRefreshRate = refreshRate
@@ -157,13 +159,11 @@ class DashboardPage extends Component<Props, State> {
         pollRefreshRate = option.milliseconds
       } else {
         localStorageRefresh = autoRefreshOptions.find(
-          r => r.milliseconds === refreshRate
+          compareOptionToRefreshRate
         )
       }
     } else {
-      localStorageRefresh = autoRefreshOptions.find(
-        r => r.milliseconds === refreshRate
-      )
+      localStorageRefresh = autoRefreshOptions.find(compareOptionToRefreshRate)
     }
 
     if (localStorageRefresh) {

--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -16,6 +16,7 @@ import {
   getChronografVersion,
   importDashboardAsync,
   retainRangesDashTimeV1 as retainRangesDashTimeV1Action,
+  retainDashRefresh as retainDashRefreshAction,
 } from 'src/dashboards/actions'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 
@@ -45,6 +46,7 @@ export interface Props {
   handleImportDashboard: (dashboard: Dashboard) => void
   notify: (message: Notification) => void
   retainRangesDashTimeV1: (dashboardIDs: number[]) => void
+  retainDashRefresh: (dashboardIDs: number[]) => void
   dashboards: Dashboard[]
 }
 
@@ -71,6 +73,7 @@ export class DashboardsPage extends PureComponent<Props, State> {
       const dashboardIDs = dashboards.map(d => d.id)
 
       this.props.retainRangesDashTimeV1(dashboardIDs)
+      this.props.retainDashRefresh(dashboardIDs)
       this.setState({dashboardsStatus: RemoteDataState.Done})
     } catch {
       this.setState({dashboardsStatus: RemoteDataState.Error})
@@ -197,6 +200,7 @@ const mapDispatchToProps = {
   handleImportDashboard: importDashboardAsync,
   notify: notifyAction,
   retainRangesDashTimeV1: retainRangesDashTimeV1Action,
+  retainDashRefresh: retainDashRefreshAction,
 }
 
 export default withRouter(

--- a/ui/src/dashboards/reducers/dashTimeV1.ts
+++ b/ui/src/dashboards/reducers/dashTimeV1.ts
@@ -1,15 +1,11 @@
 import {unionBy} from 'lodash'
 
-import {TimeRange, RefreshRate} from 'src/types'
+import {TimeRange} from 'src/types'
+import {Refresh} from 'src/types/localStorage'
 import {Action, ActionType} from 'src/dashboards/actions'
 
 interface Range extends TimeRange {
   dashboardID: number
-}
-
-interface Refresh {
-  dashboardID: number
-  refreshRate: RefreshRate
 }
 
 export interface State {

--- a/ui/src/dashboards/reducers/dashTimeV1.ts
+++ b/ui/src/dashboards/reducers/dashTimeV1.ts
@@ -29,16 +29,28 @@ export default (state: State = initialState, action: Action) => {
 
     case ActionType.RetainRangesDashboardTimeV1: {
       const {dashboardIDs} = action.payload
-      const ranges = state.ranges.filter(r =>
-        dashboardIDs.includes(r.dashboardID)
-      )
+      let dashboardIDsHash = {}
+      if (Array.isArray(dashboardIDs)) {
+        dashboardIDsHash = dashboardIDs.reduce((accum, id) => {
+          accum[id] = true
+          return accum
+        }, dashboardIDsHash)
+      }
+      const ranges = state.ranges.filter(r => dashboardIDsHash[r.dashboardID])
       return {...state, ranges}
     }
 
     case ActionType.RetainDashboardRefresh: {
       const {dashboardIDs} = action.payload
-      const refreshes = state.refreshes.filter(r =>
-        dashboardIDs.includes(r.dashboardID)
+      let dashboardIDsHash = {}
+      if (Array.isArray(dashboardIDs)) {
+        dashboardIDsHash = dashboardIDs.reduce((accum, id) => {
+          accum[id] = true
+          return accum
+        }, dashboardIDsHash)
+      }
+      const refreshes = state.refreshes.filter(
+        r => dashboardIDsHash[r.dashboardID]
       )
       return {...state, refreshes}
     }

--- a/ui/src/dashboards/reducers/dashTimeV1.ts
+++ b/ui/src/dashboards/reducers/dashTimeV1.ts
@@ -1,18 +1,25 @@
-import _ from 'lodash'
+import {unionBy} from 'lodash'
 
-import {TimeRange} from 'src/types'
+import {TimeRange, RefreshRate} from 'src/types'
 import {Action, ActionType} from 'src/dashboards/actions'
 
 interface Range extends TimeRange {
   dashboardID: number
 }
 
+interface Refresh {
+  dashboardID: number
+  refreshRate: RefreshRate
+}
+
 export interface State {
   ranges: Range[]
+  refreshes: Refresh[]
 }
 
 const initialState: State = {
   ranges: [],
+  refreshes: [],
 }
 
 export default (state: State = initialState, action: Action) => {
@@ -32,12 +39,28 @@ export default (state: State = initialState, action: Action) => {
       return {...state, ranges}
     }
 
+    case ActionType.RetainDashboardRefresh: {
+      const {dashboardIDs} = action.payload
+      const refreshes = state.refreshes.filter(r =>
+        dashboardIDs.includes(r.dashboardID)
+      )
+      return {...state, refreshes}
+    }
+
     case ActionType.SetDashboardTimeV1: {
       const {dashboardID, timeRange} = action.payload
       const newTimeRange = [{dashboardID, ...timeRange}]
-      const ranges = _.unionBy(newTimeRange, state.ranges, 'dashboardID')
+      const ranges = unionBy(newTimeRange, state.ranges, 'dashboardID')
 
       return {...state, ranges}
+    }
+
+    case ActionType.SetDashboardRefresh: {
+      const {dashboardID, refreshRate} = action.payload
+      const newRefresh = [{dashboardID, refreshRate}]
+      const refreshes = unionBy(newRefresh, state.refreshes, 'dashboardID')
+
+      return {...state, refreshes}
     }
   }
 

--- a/ui/src/dashboards/selectors/index.tsx
+++ b/ui/src/dashboards/selectors/index.tsx
@@ -8,9 +8,13 @@ export const getTimeRange = (state: {dashTimeV1: DashTimeState}, dashboardID) =>
     r => r.dashboardID === idNormalizer(TYPE_ID, dashboardID)
   ) || DEFAULT_TIME_RANGE
 
-export const getRefreshRate = (state: {dashTimeV1: DashTimeState}, dashboardID) => {
-  const {refreshRate = DASHBOARD_REFRESH_DEFAULT} = state.dashTimeV1.refreshes.find(
-    refr => refr.dashboardID === idNormalizer(TYPE_ID, dashboardID)
-  ) || {}
+export const getRefreshRate = (
+  state: {dashTimeV1: DashTimeState},
+  dashboardID
+) => {
+  const {refreshRate = DASHBOARD_REFRESH_DEFAULT} =
+    state.dashTimeV1.refreshes.find(
+      refr => refr.dashboardID === idNormalizer(TYPE_ID, dashboardID)
+    ) || {}
   return refreshRate
 }

--- a/ui/src/dashboards/selectors/index.tsx
+++ b/ui/src/dashboards/selectors/index.tsx
@@ -1,4 +1,5 @@
 import {DEFAULT_TIME_RANGE} from 'src/shared/data/timeRanges'
+import {DASHBOARD_REFRESH_DEFAULT} from 'src/shared/constants'
 import idNormalizer, {TYPE_ID} from 'src/normalizers/id'
 import {State as DashTimeState} from 'src/dashboards/reducers/dashTimeV1'
 
@@ -6,3 +7,10 @@ export const getTimeRange = (state: {dashTimeV1: DashTimeState}, dashboardID) =>
   state.dashTimeV1.ranges.find(
     r => r.dashboardID === idNormalizer(TYPE_ID, dashboardID)
   ) || DEFAULT_TIME_RANGE
+
+export const getRefreshRate = (state: {dashTimeV1: DashTimeState}, dashboardID) => {
+  const {refreshRate = DASHBOARD_REFRESH_DEFAULT} = state.dashTimeV1.refreshes.find(
+    refr => refr.dashboardID === idNormalizer(TYPE_ID, dashboardID)
+  ) || {}
+  return refreshRate
+}

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -170,6 +170,7 @@ export class DataExplorer extends PureComponent<Props, State> {
       editQueryStatus,
       updateSourceLink,
       onSetTimeZone,
+      autoRefresh,
     } = this.props
 
     const {isStaticLegend, isComponentMounted} = this.state
@@ -196,6 +197,7 @@ export class DataExplorer extends PureComponent<Props, State> {
             updateSourceLink={updateSourceLink}
             onResetFocus={this.handleResetFocus}
             onToggleStaticLegend={this.handleToggleStaticLegend}
+            refresh={autoRefresh}
           >
             {(activeEditorTab, onSetActiveEditorTab) => (
               <DEHeader

--- a/ui/src/hosts/containers/HostPage.tsx
+++ b/ui/src/hosts/containers/HostPage.tsx
@@ -39,7 +39,7 @@ interface Props {
   autoRefresh: number
   manualRefresh: number
   onManualRefresh: () => void
-  handleChooseAutoRefresh: typeof setAutoRefresh
+  handleChooseTimeRange: typeof setAutoRefresh
   handleClickPresentationButton: typeof delayEnablePresentationMode
 }
 
@@ -58,6 +58,7 @@ class HostPage extends PureComponent<Props, State> {
       hostLinks: EMPTY_LINKS,
       timeRange: timeRanges.find(tr => tr.lower === 'now() - 1h'),
     }
+    this.handleChooseAutoRefresh = this.handleChooseAutoRefresh.bind(this)
   }
 
   public async componentDidMount() {
@@ -103,6 +104,12 @@ class HostPage extends PureComponent<Props, State> {
     GlobalAutoRefresher.stopPolling()
   }
 
+  public handleChooseAutoRefresh = option => {
+    const {handleChooseTimeRange} = this.props
+    const {milliseconds} = option
+    handleChooseTimeRange(milliseconds)
+  }
+
   public render() {
     const {
       autoRefresh,
@@ -110,7 +117,6 @@ class HostPage extends PureComponent<Props, State> {
       onManualRefresh,
       params: {hostID},
       inPresentationMode,
-      handleChooseAutoRefresh,
       handleClickPresentationButton,
       source,
     } = this.props
@@ -127,7 +133,7 @@ class HostPage extends PureComponent<Props, State> {
           autoRefresh={autoRefresh}
           isHidden={inPresentationMode}
           onManualRefresh={onManualRefresh}
-          handleChooseAutoRefresh={handleChooseAutoRefresh}
+          handleChooseAutoRefresh={this.handleChooseAutoRefresh}
           handleChooseTimeRange={this.handleChooseTimeRange}
           handleClickPresentationButton={handleClickPresentationButton}
           dashboardLinks={hostLinks}
@@ -208,7 +214,7 @@ const mstp = ({
 })
 
 const mdtp = {
-  handleChooseAutoRefresh: setAutoRefresh,
+  handleChooseTimeRange: setAutoRefresh,
   handleClickPresentationButton: delayEnablePresentationMode,
 }
 

--- a/ui/src/hosts/containers/HostPage.tsx
+++ b/ui/src/hosts/containers/HostPage.tsx
@@ -104,7 +104,7 @@ class HostPage extends PureComponent<Props, State> {
     GlobalAutoRefresher.stopPolling()
   }
 
-  public handleChooseAutoRefresh = option => {
+  public handleChooseAutoRefresh(option) {
     const {handleChooseTimeRange} = this.props
     const {milliseconds} = option
     handleChooseTimeRange(milliseconds)

--- a/ui/src/hosts/containers/HostsPage.tsx
+++ b/ui/src/hosts/containers/HostsPage.tsx
@@ -43,13 +43,14 @@ import {
   RemoteDataState,
   Host,
   Layout,
+  RefreshRate,
 } from 'src/types'
 
 interface Props extends ManualRefreshProps {
   source: Source
   links: Links
   autoRefresh: number
-  onChooseAutoRefresh: () => void
+  onChooseAutoRefresh: (milliseconds: RefreshRate) => void
   notify: NotificationAction
 }
 
@@ -74,6 +75,7 @@ export class HostsPage extends PureComponent<Props, State> {
       hostsPageStatus: RemoteDataState.NotStarted,
       layouts: [],
     }
+    this.handleChooseAutoRefresh = this.handleChooseAutoRefresh.bind(this)
   }
 
   public async componentDidMount() {
@@ -134,11 +136,7 @@ export class HostsPage extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {
-      source,
-      autoRefresh,
-      onManualRefresh,
-    } = this.props
+    const {source, autoRefresh, onManualRefresh} = this.props
     const {hostsObject, hostsPageStatus} = this.state
     return (
       <Page className="hosts-list-page">
@@ -149,7 +147,7 @@ export class HostsPage extends PureComponent<Props, State> {
           <Page.Header.Right showSourceIndicator={true}>
             <AutoRefreshDropdown
               selected={autoRefresh}
-              onChoose={(option) => this.handleChooseAutoRefresh(option)}
+              onChoose={this.handleChooseAutoRefresh}
               onManualRefresh={onManualRefresh}
             />
           </Page.Header.Right>

--- a/ui/src/hosts/containers/HostsPage.tsx
+++ b/ui/src/hosts/containers/HostsPage.tsx
@@ -127,11 +127,16 @@ export class HostsPage extends PureComponent<Props, State> {
     this.intervalID = null
   }
 
+  public handleChooseAutoRefresh(option) {
+    const {onChooseAutoRefresh} = this.props
+    const {milliseconds} = option
+    onChooseAutoRefresh(milliseconds)
+  }
+
   public render() {
     const {
       source,
       autoRefresh,
-      onChooseAutoRefresh,
       onManualRefresh,
     } = this.props
     const {hostsObject, hostsPageStatus} = this.state
@@ -144,7 +149,7 @@ export class HostsPage extends PureComponent<Props, State> {
           <Page.Header.Right showSourceIndicator={true}>
             <AutoRefreshDropdown
               selected={autoRefresh}
-              onChoose={onChooseAutoRefresh}
+              onChoose={(option) => this.handleChooseAutoRefresh(option)}
               onManualRefresh={onManualRefresh}
             />
           </Page.Header.Right>

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -1,5 +1,6 @@
 import _ from 'lodash'
-import normalizer from 'src/normalizers/dashboardTime'
+import dashBoardTimeNormalizer from 'src/normalizers/dashboardTime'
+import dashBoardRefreshNormalizer from 'src/normalizers/dashboardRefresh'
 import {
   notifyNewVersion,
   notifyLoadLocalSettingsFailed,
@@ -44,12 +45,12 @@ export const loadLocalStorage = (errorsQueue: any[]): LocalStorage | {} => {
 export const saveToLocalStorage = ({
   app,
   timeRange,
-  dashTimeV1: {ranges},
+  dashTimeV1: {ranges, refreshes},
   logs,
   script,
 }: LocalStorage): void => {
   try {
-    const dashTimeV1 = {ranges: normalizer(ranges)}
+    const dashTimeV1 = {ranges: dashBoardTimeNormalizer(ranges), refreshes: dashBoardRefreshNormalizer(refreshes)}
 
     const minimalLogs = _.omit(logs, [
       'tableData',

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -50,7 +50,10 @@ export const saveToLocalStorage = ({
   script,
 }: LocalStorage): void => {
   try {
-    const dashTimeV1 = {ranges: dashBoardTimeNormalizer(ranges), refreshes: dashBoardRefreshNormalizer(refreshes)}
+    const dashTimeV1 = {
+      ranges: dashBoardTimeNormalizer(ranges),
+      refreshes: dashBoardRefreshNormalizer(refreshes),
+    }
 
     const minimalLogs = _.omit(logs, [
       'tableData',

--- a/ui/src/normalizers/dashboardRefresh.js
+++ b/ui/src/normalizers/dashboardRefresh.js
@@ -11,8 +11,9 @@ const dashrefresh = (refreshes) => {
     }
 
     const {dashboardID, refreshRate} = r
+    const isTypeOfRefreshRate = !refreshRate || typeof refreshRate === 'number'
 
-    if (typeof dashboardID !== 'number' || !(!refreshRate || typeof refreshRate === 'number')) {
+    if (typeof dashboardID !== 'number' || !isTypeOfRefreshRate) {
       return false
     }
     return true

--- a/ui/src/normalizers/dashboardRefresh.js
+++ b/ui/src/normalizers/dashboardRefresh.js
@@ -1,0 +1,24 @@
+import {isObject} from 'lodash'
+
+const dashrefresh = (refreshes) => {
+  if (!Array.isArray(refreshes)) {
+    return []
+  }
+
+  const normalized = refreshes.filter(r => {
+    if (!isObject(r)) {
+      return false
+    }
+
+    const {dashboardID, refreshRate} = r
+
+    if (typeof dashboardID !== 'number' || !(!refreshRate || typeof refreshRate === 'number')) {
+      return false
+    }
+    return true
+  })
+
+  return normalized
+}
+
+export default dashrefresh

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -145,7 +145,6 @@ class TimeMachine extends PureComponent<Props, State> {
       timeMachineProportions,
       onSetTimeMachineProportions,
     } = this.props
-    console.log('TM.render: this.props', this.props, 'this.state', this.state)
     const {autoRefreshDuration, isViewingRawData} = this.state
     const [topSize, bottomSize] = timeMachineProportions
 

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -29,10 +29,12 @@ import {updateSourceLink as updateSourceLinkAction} from 'src/data_explorer/acti
 // Constants
 import {HANDLE_HORIZONTAL} from 'src/shared/constants'
 import {CEOTabs} from 'src/dashboards/constants'
+import {AutoRefreshOption} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
 
 // Types
 import {
   TimeRange,
+  RefreshRate,
   QueryConfig,
   Template,
   Source,
@@ -86,6 +88,7 @@ interface PassedProps {
   ) => JSX.Element
   queryStatus: QueryStatus
   onUpdateScriptStatus?: (status: ScriptStatus) => void
+  refresh: RefreshRate
 }
 
 interface State {
@@ -108,7 +111,7 @@ class TimeMachine extends PureComponent<Props, State> {
       activeEditorTab: CEOTabs.Queries,
       selectedSource: null,
       autoRefresher: new AutoRefresher(),
-      autoRefreshDuration: 0,
+      autoRefreshDuration: props.refresh,
       isViewingRawData: false,
     }
   }
@@ -142,6 +145,7 @@ class TimeMachine extends PureComponent<Props, State> {
       timeMachineProportions,
       onSetTimeMachineProportions,
     } = this.props
+    console.log('TM.render: this.props', this.props, 'this.state', this.state)
     const {autoRefreshDuration, isViewingRawData} = this.state
     const [topSize, bottomSize] = timeMachineProportions
 
@@ -522,8 +526,11 @@ class TimeMachine extends PureComponent<Props, State> {
     onDeleteQuery(queryToDelete.id)
   }
 
-  private handleChangeAutoRefreshDuration = (autoRefreshDuration: number) => {
-    this.setState({autoRefreshDuration})
+  private handleChangeAutoRefreshDuration = (
+    autoRefreshOption: AutoRefreshOption
+  ): void => {
+    const {milliseconds} = autoRefreshOption
+    this.setState({autoRefreshDuration: milliseconds})
   }
 
   private handleSetActiveQueryIndex = (activeQueryIndex): void => {
@@ -563,6 +570,7 @@ const ConnectedTimeMachine = (props: PassedProps & ManualRefreshProps) => {
             draftScript={state.draftScript}
             queryDrafts={state.queryDrafts}
             timeRange={state.timeRange}
+            refresh={props.refresh}
             timeMachineProportions={container.state.timeMachineProportions}
             onUpdateQueryType={container.handleUpdateQueryType}
             onUpdateTimeRange={container.handleUpdateTimeRange}

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -16,6 +16,9 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import {Template, QueryType} from 'src/types'
 
+// Constants
+import {AutoRefreshOption} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
+
 interface Props {
   isFluxSelected: boolean
   source: SourcesModels.Source
@@ -25,7 +28,7 @@ interface Props {
   isDynamicSourceSelected: boolean
   onChangeSource: (source: SourcesModels.Source, type: QueryType) => void
   autoRefreshDuration: number
-  onChangeAutoRefreshDuration: (newDuration: number) => void
+  onChangeAutoRefreshDuration: (autoRefreshOption: AutoRefreshOption) => void
   queries: QueriesModels.QueryConfig[]
   templates: Template[]
   sourceSupportsFlux: boolean

--- a/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -70,9 +70,7 @@ class AutoRefreshDropdown extends Component<Props> {
     autoRefreshOption: AutoRefreshOption
   ): void => {
     const {onChoose} = this.props
-    const {milliseconds} = autoRefreshOption
-
-    onChoose(milliseconds)
+    onChoose(autoRefreshOption)
   }
 
   private get isPaused(): boolean {

--- a/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -15,7 +15,7 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   selected: number
-  onChoose: (milliseconds: number) => void
+  onChoose: (autoRefreshOption: AutoRefreshOption) => void
   showManualRefresh?: boolean
   onManualRefresh?: () => void
 }

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -406,6 +406,7 @@ export const HTTP_FORBIDDEN = 403
 export const HTTP_NOT_FOUND = 404
 
 export const AUTOREFRESH_DEFAULT = 0 // in milliseconds
+export const DASHBOARD_REFRESH_DEFAULT = 10000 // in milliseconds
 export const SHOW_TEMP_VAR_CONTROL_BAR_DEFAULT = false
 
 export const GRAPH = 'graph'

--- a/ui/src/types/dashboards.ts
+++ b/ui/src/types/dashboards.ts
@@ -239,3 +239,5 @@ export interface Protoboard {
   meta: ProtoboardMetadata
   data: ProtoboardData
 }
+
+export type RefreshRate = number | null | undefined

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -14,6 +14,7 @@ import {
   CellType,
   Protoboard,
   QueryType,
+  RefreshRate,
 } from './dashboards'
 import {
   Template,

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -104,6 +104,7 @@ export {
   DropdownAction,
   DropdownItem,
   TimeRange,
+  RefreshRate,
   DygraphData,
   DygraphSeries,
   DygraphValue,

--- a/ui/src/types/localStorage.ts
+++ b/ui/src/types/localStorage.ts
@@ -1,4 +1,4 @@
-import {TimeRange, TimeZones} from 'src/types'
+import {TimeRange, TimeZones, RefreshRate} from 'src/types'
 import {LogsState} from 'src/types/logs'
 
 export interface LocalStorage {
@@ -19,6 +19,12 @@ export interface App {
 
 export interface DashTimeV1 {
   ranges: DashboardTimeRange[]
+  refreshes: Refresh[]
+}
+
+export interface Refresh {
+  dashboardID: number
+  refreshRate: RefreshRate
 }
 
 interface DashboardTimeRange {

--- a/ui/test/dashboards/reducers/dashTimeV1.test.js
+++ b/ui/test/dashboards/reducers/dashTimeV1.test.js
@@ -9,7 +9,7 @@ describe('Dashboards.Reducers.DashTimeV1', () => {
   it('can load initial state', () => {
     const noopAction = () => ({type: 'NOOP'})
     const actual = reducer(emptyState, noopAction)
-    const expected = {ranges: []}
+    const expected = {ranges: [], refreshes: []}
 
     expect(actual).toEqual(expected)
   })


### PR DESCRIPTION
Closes https://github.com/influxdata/chronograf/issues/4012

- User selects a refresh rate in the dashboard: the selection is persisted for that dashboard and a query parameter is added to the url.
- A url with custom query parameters is used to directly navigate to a dashboard: the dashboard sets the refresh rate, persists it, and updates the refresh dropdown based on a valid query parameter for refresh.  

- [x] CHANGELOG.md updated with a link to the PR (not the Issue)
- [x] Rebased/mergeable
- [x] Tests pass

