### PR TITLE
fix: use influxdata url that happens to have the correct cors headers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -101,7 +101,7 @@ type Server struct {
 	Auth0Organizations []string `long:"auth0-organizations" description:"Auth0 organizations permitted to access Chronograf (comma separated)" env:"AUTH0_ORGS" env-delim:","`
 	Auth0SuperAdminOrg string   `long:"auth0-superadmin-org" description:"Auth0 organization from which users are automatically granted SuperAdmin status" env:"AUTH0_SUPERADMIN_ORG"`
 
-	StatusFeedURL          string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://www.influxdata.com/feed/json" env:"STATUS_FEED_URL"`
+	StatusFeedURL          string            `long:"status-feed-url" description:"URL of a JSON Feed to display as a News Feed on the client Status page." default:"https://influxdata.com/feed/json" env:"STATUS_FEED_URL"`
 	CustomLinks            map[string]string `long:"custom-link" description:"Custom link to be added to the client User menu. Multiple links can be added by using multiple of the same flag with different 'name:url' values, or as an environment variable with comma-separated 'name:url' values. E.g. via flags: '--custom-link=InfluxData:https://www.influxdata.com --custom-link=Chronograf:https://github.com/influxdata/chronograf'. E.g. via environment variable: 'export CUSTOM_LINKS=InfluxData:https://www.influxdata.com,Chronograf:https://github.com/influxdata/chronograf'" env:"CUSTOM_LINKS" env-delim:","`
 	TelegrafSystemInterval time.Duration     `long:"telegraf-system-interval" default:"1m" description:"Duration used in the GROUP BY time interval for the hosts list" env:"TELEGRAF_SYSTEM_INTERVAL"`
 

--- a/ui/test/resources.ts
+++ b/ui/test/resources.ts
@@ -482,7 +482,7 @@ export const authLinks = {
   dashboards: '/chronograf/v1/dashboards',
   environment: '/chronograf/v1/env',
   external: {
-    statusFeed: 'https://www.influxdata.com/feed/json',
+    statusFeed: 'https://influxdata.com/feed/json',
   },
   layouts: '/chronograf/v1/layouts',
   logout: '/oauth/logout',

--- a/ui/test/shared/parsing/constants.ts
+++ b/ui/test/shared/parsing/constants.ts
@@ -387,7 +387,7 @@ export const config = {
     links: [],
   },
   external: {
-    statusFeed: 'https://www.influxdata.com/feed/json',
+    statusFeed: 'https://influxdata.com/feed/json',
   },
   meLink: '/chronograf/v1/me',
 }
@@ -858,7 +858,7 @@ export const emptyConfig = {
     links: [],
   },
   external: {
-    statusFeed: 'https://www.influxdata.com/feed/json',
+    statusFeed: 'https://influxdata.com/feed/json',
   },
   meLink: '/chronograf/v1/me',
 }


### PR DESCRIPTION
Addresses #5315

The headers should still be addressed so all other versions of chronograf can work, but this has Fixed It For Me:tm: 
