### PR TITLE
fix: allow backwards compatibility with filestore .dashboard files

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ In order to upgrade from a Chronograf older than 1.4.0 (<=1.3.10) to 1.8 or newe
 
 ### Compatibility
 
-Chronograf 1.8 introduces a breaking change in the dashboards API (`/chronograf/v1/dashboards`) which may affect certain clients. The `id` previously was being returned as an integer. Since javascript can't cleanly handle numbers with more than 16 digits (`console.log(12345678901234567890)` yields `12345678901234567000`), integer ids have been exposed as strings. As with other resource ids, they will remain stored internally as integers, so no database migration is required.
+Chronograf 1.8 introduces a breaking change in the dashboards API (`/chronograf/v1/dashboards`) which may affect certain clients. The `id` previously was being returned as an integer. Since javascript can't cleanly handle numbers with more than 16 digits (`console.log(12345678901234567890)` yields `12345678901234567000`), integer ids have been exposed as strings. As with other resource ids, they will remain stored internally as integers, so no database migration is required. If using `.dashboard` files to pre-populate available dashboards, those files should be updated and the `id` should be converted to a string value.
 
 ## Documentation
 

--- a/canned/bin.go
+++ b/canned/bin.go
@@ -3,7 +3,6 @@ package canned
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 
 	"github.com/influxdata/chronograf"
 )
@@ -43,16 +42,6 @@ func (s *BinLayoutsStore) All(ctx context.Context) ([]chronograf.Layout, error) 
 	return layouts, nil
 }
 
-// Add is not support by BinLayoutsStore
-func (s *BinLayoutsStore) Add(ctx context.Context, layout chronograf.Layout) (chronograf.Layout, error) {
-	return chronograf.Layout{}, fmt.Errorf("Add to BinLayoutsStore not supported")
-}
-
-// Delete is not support by BinLayoutsStore
-func (s *BinLayoutsStore) Delete(ctx context.Context, layout chronograf.Layout) error {
-	return fmt.Errorf("Delete to BinLayoutsStore not supported")
-}
-
 // Get retrieves Layout if `ID` exists.
 func (s *BinLayoutsStore) Get(ctx context.Context, ID string) (chronograf.Layout, error) {
 	layouts, err := s.All(ctx)
@@ -75,9 +64,4 @@ func (s *BinLayoutsStore) Get(ctx context.Context, ID string) (chronograf.Layout
 		WithField("name", ID).
 		Error("Layout not found")
 	return chronograf.Layout{}, chronograf.ErrLayoutNotFound
-}
-
-// Update not supported
-func (s *BinLayoutsStore) Update(ctx context.Context, layout chronograf.Layout) error {
-	return fmt.Errorf("Update to BinLayoutsStore not supported")
 }

--- a/chronograf.go
+++ b/chronograf.go
@@ -598,7 +598,7 @@ func (d *Dashboard) UnmarshalJSON(data []byte) error {
 	type Alias Dashboard
 
 	aux := &struct {
-		ID *string `json:"id,omitempty"`
+		ID interface{} `json:"id,omitempty"`
 		*Alias
 	}{
 		Alias: (*Alias)(d),
@@ -609,11 +609,27 @@ func (d *Dashboard) UnmarshalJSON(data []byte) error {
 	}
 
 	if aux.ID != nil {
-		ID, err := strconv.ParseInt(*aux.ID, 10, 64)
-		if err != nil {
-			return err
+		// Allows backwards compatibility with filestore `.dashboard` files.
+		switch id := aux.ID.(type) {
+		case int:
+			d.ID = DashboardID(id)
+		case int32:
+			d.ID = DashboardID(id)
+		case int64:
+			d.ID = DashboardID(id)
+		case float32:
+			d.ID = DashboardID(id)
+		case float64:
+			d.ID = DashboardID(id)
+		case string:
+			ID, err := strconv.ParseInt(id, 10, 64)
+			if err != nil {
+				return err
+			}
+			d.ID = DashboardID(ID)
+		default:
+			return fmt.Errorf("invalid id type %T", id)
 		}
-		d.ID = DashboardID(ID)
 	}
 
 	return nil

--- a/filestore/dashboards.go
+++ b/filestore/dashboards.go
@@ -21,17 +21,15 @@ type Dashboards struct {
 	Dir     string                                      // Dir is the directory containing the dashboards.
 	ReadDir func(dirname string) ([]os.FileInfo, error) // ReadDir reads the directory named by dirname and returns a list of directory entries sorted by filename.
 	Remove  func(name string) error                     // Remove file
-	IDs     chronograf.ID                               // IDs generate unique ids for new dashboards
 	Logger  chronograf.Logger
 }
 
 // NewDashboards constructs a dashboard store wrapping a file system directory
-func NewDashboards(dir string, ids chronograf.ID, logger chronograf.Logger) chronograf.DashboardsStore {
+func NewDashboards(dir string, logger chronograf.Logger) chronograf.DashboardsStore {
 	return &Dashboards{
 		Dir:     dir,
 		ReadDir: ioutil.ReadDir,
 		Remove:  os.Remove,
-		IDs:     ids,
 		Logger:  logger,
 	}
 }

--- a/filestore/dashboards_test.go
+++ b/filestore/dashboards_test.go
@@ -1,0 +1,169 @@
+package filestore_test
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/filestore"
+	"github.com/influxdata/chronograf/mocks"
+	"github.com/stretchr/testify/require"
+)
+
+type dashAllTest struct {
+	boards []string
+	err    bool
+}
+
+func TestDashboardsAll(t *testing.T) {
+	var tests = []dashAllTest{
+		{
+			boards: []string{
+				`{
+	"id": 1,
+	"cells": [],
+	"templates": [],
+	"name": "test-int-id",
+	"organization": "default"
+}`,
+				`{
+	"id": "2",
+	"cells": [],
+	"templates": [],
+	"name": "test-string-id",
+	"organization": "default"
+}`,
+			},
+			err: false,
+		},
+		{
+			boards: []string{
+				`{
+	"id": "abc123",
+	"cells": [],
+	"templates": [],
+	"name": "test-string-id",
+	"organization": "default"
+}`,
+			},
+			err: true,
+		},
+	}
+
+	for i, test := range tests {
+		testDashboardAll(t, i, test)
+	}
+}
+
+func testDashboardAll(t *testing.T, i int, test dashAllTest) {
+	dir, err := ioutil.TempDir("", "dashboard-all")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	for j, b := range test.boards {
+		require.NoError(t, ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%d-%d.dashboard", i, j)), []byte(b), 0644))
+	}
+
+	dboards, err := filestore.NewDashboards(dir, mocks.NewLogger()).All(context.TODO())
+	require.NoError(t, err)
+
+	if test.err {
+		require.Equal(t, 0, len(dboards))
+	} else {
+		require.Equal(t, len(test.boards), len(dboards))
+	}
+}
+
+type dashUpdateTest struct {
+	pre  []string
+	post []chronograf.Dashboard
+	err  bool
+}
+
+func TestDashboardsUpdate(t *testing.T) {
+	var tests = []dashUpdateTest{
+		{
+			pre: []string{
+				`{
+	"id": 1,
+	"cells": [],
+	"templates": [],
+	"name": "test-int-id",
+	"organization": "default"
+}`,
+				`{
+	"id": "2",
+	"cells": [],
+	"templates": [],
+	"name": "test-string-id",
+	"organization": "default"
+}`,
+			},
+			post: []chronograf.Dashboard{
+				{
+					ID:           chronograf.DashboardID(1),
+					Name:         "test-int-id-1",
+					Organization: "default",
+				},
+				{
+					ID:           chronograf.DashboardID(2),
+					Name:         "test-string-id-1",
+					Organization: "default",
+				},
+			},
+			err: false,
+		},
+		{
+			pre: []string{
+				`{
+	"id": "abc123",
+	"cells": [],
+	"templates": [],
+	"name": "test-string-id",
+	"organization": "default"
+}`,
+			},
+			post: []chronograf.Dashboard{
+				{
+					ID:           chronograf.DashboardID(1),
+					Name:         "test-string-id",
+					Organization: "default",
+				},
+			},
+			err: true,
+		},
+	}
+
+	for i, test := range tests {
+		testDashboardUpdate(t, i, test)
+	}
+}
+
+func testDashboardUpdate(t *testing.T, i int, test dashUpdateTest) {
+	dir, err := ioutil.TempDir("", "dashboard-all")
+	require.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	for j, b := range test.pre {
+		require.NoError(t, ioutil.WriteFile(path.Join(dir, fmt.Sprintf("%d-%d.dashboard", i, j)), []byte(b), 0644))
+	}
+
+	dash := filestore.NewDashboards(dir, mocks.NewLogger())
+	for _, b := range test.post {
+		require.Equal(t, test.err, dash.Update(context.TODO(), b) != nil)
+	}
+
+	dboards, err := dash.All(context.TODO())
+	require.NoError(t, err)
+
+	if test.err {
+		require.Equal(t, 0, len(dboards))
+	} else {
+		require.Equal(t, len(test.pre), len(dboards))
+		require.Equal(t, test.post, dboards)
+	}
+}

--- a/server/builders.go
+++ b/server/builders.go
@@ -91,7 +91,7 @@ type MultiDashboardBuilder struct {
 // Build will construct a Dashboard store of filesystem and db-backed dashboards
 func (builder *MultiDashboardBuilder) Build(db chronograf.DashboardsStore) (*multistore.DashboardsStore, error) {
 	// These dashboards are those handled from a directory
-	files := filestore.NewDashboards(builder.Path, builder.ID, builder.Logger)
+	files := filestore.NewDashboards(builder.Path, builder.Logger)
 	// Acts as a front-end to both the bolt dashboard and filesystem dashboards.
 	// The idea here is that these stores form a hierarchy in which each is tried sequentially until
 	// the operation has success.  So, the database is preferred over filesystem


### PR DESCRIPTION
Closes #5364

This change allows .dashboard files with integer ids to be used without modification in chronograf 1.8