### PR TITLE
fix: pass insecure cert settings to flux client

### DIFF
--- a/flux/client.go
+++ b/flux/client.go
@@ -77,7 +77,9 @@ func (c *Client) FluxEnabled() (bool, error) {
 	}
 	defer resp.Body.Close()
 
-	// TODO(goller): add comments about why you and watts did this.
+	// When flux is enabled, the response has 'Content-Type' set to 'application/json' and a body
+	// of `{"error":"mime: no media type"}`. Otherwise it is 'text/plain; charset=utf-8' with
+	// `Flux query service disabled.` in the body.
 	contentType := resp.Header.Get("Content-Type")
 	return contentType == "application/json", nil
 }

--- a/server/sources.go
+++ b/server/sources.go
@@ -85,8 +85,9 @@ func hasFlux(ctx context.Context, src chronograf.Source) (bool, error) {
 	}
 
 	cli := &flux.Client{
-		URL:     url,
-		Timeout: 500 * time.Millisecond,
+		URL:                url,
+		InsecureSkipVerify: src.InsecureSkipVerify,
+		Timeout:            500 * time.Millisecond,
 	}
 
 	return cli.FluxEnabled()


### PR DESCRIPTION
Closes #5357

Chronograf would fail to check for flux support if the influx was using self signed certs. Solved by passing the source's insecureSkipVerify setting to the flux client to be used in the checks.
