### PR TITLE
update non_negative_derivative calls to fix #5358

### DIFF
--- a/canned/apache.json
+++ b/canned/apache.json
@@ -49,7 +49,7 @@
       "name": "Apache - Total Accesses",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"TotalAccesses\")) AS \"tot_access\" FROM \":db:\".\":rp:\".\"apache\"",
+          "query": "SELECT non_negative_derivative(max(\"TotalAccesses\"), 1s) AS \"tot_access\" FROM \":db:\".\":rp:\".\"apache\"",
           "label": "accesses/s",
           "groupbys": [
             "\"server\""

--- a/canned/haproxy.json
+++ b/canned/haproxy.json
@@ -88,7 +88,7 @@
       "name": "HAProxy – Frontend Sessions/Second ",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"rate\")) AS \"sessions_per_second\" FROM \":db:\".\":rp:\".\"haproxy\"",
+          "query": "SELECT non_negative_derivative(max(\"rate\"), 1s) AS \"sessions_per_second\" FROM \":db:\".\":rp:\".\"haproxy\"",
           "groupbys": [],
           "wheres": []
         }
@@ -118,7 +118,7 @@
       "name": "HAProxy – Frontend Security Denials/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"dreq\")) AS \"denials_per_second\" FROM \":db:\".\":rp:\".\"haproxy\"",
+          "query": "SELECT non_negative_derivative(max(\"dreq\"), 1s) AS \"denials_per_second\" FROM \":db:\".\":rp:\".\"haproxy\"",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/influxdb_httpd.json
+++ b/canned/influxdb_httpd.json
@@ -13,7 +13,7 @@
       "name": "InfluxDB - Write HTTP Requests",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"writeReq\")) AS \"http_requests\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
+          "query": "SELECT non_negative_derivative(max(\"writeReq\"), 1s) AS \"http_requests\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
           "label": "count/s",
           "groupbys": [],
           "wheres": []
@@ -29,7 +29,7 @@
       "name": "InfluxDB - Query Requests",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"queryReq\")) AS \"query_requests\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
+          "query": "SELECT non_negative_derivative(max(\"queryReq\"), 1s) AS \"query_requests\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
           "label": "count/s",
           "groupbys": [],
           "wheres": []
@@ -46,7 +46,7 @@
       "name": "InfluxDB - Client Failures",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"clientError\")) AS \"client_errors\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
+          "query": "SELECT non_negative_derivative(max(\"clientError\"), 1s) AS \"client_errors\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
           "label": "count/s",
           "groupbys": [],
           "wheres": []

--- a/canned/influxdb_write.json
+++ b/canned/influxdb_write.json
@@ -13,7 +13,7 @@
       "name": "InfluxDB - Write Points",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"pointReq\")) AS \"points_written\" FROM \":db:\".\":rp:\".\"influxdb_write\"",
+          "query": "SELECT non_negative_derivative(max(\"pointReq\"), 1s) AS \"points_written\" FROM \":db:\".\":rp:\".\"influxdb_write\"",
           "label": "points/s",
           "groupbys": [],
           "wheres": []
@@ -29,13 +29,13 @@
       "name": "InfluxDB - Write Errors",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"writeError\")) AS \"shard_write_error\" FROM \":db:\".\":rp:\".\"influxdb_write\"",
+          "query": "SELECT non_negative_derivative(max(\"writeError\"), 1s) AS \"shard_write_error\" FROM \":db:\".\":rp:\".\"influxdb_write\"",
           "label": "errors/s",
           "groupbys": [],
           "wheres": []
         },
         {
-          "query": "SELECT non_negative_derivative(max(\"serveError\")) AS \"http_error\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
+          "query": "SELECT non_negative_derivative(max(\"serveError\"), 1s) AS \"http_error\" FROM \":db:\".\":rp:\".\"influxdb_httpd\"",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/kubernetes_pod_network.json
+++ b/canned/kubernetes_pod_network.json
@@ -13,7 +13,7 @@
       "name": "K8s - Pod TX Bytes/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"tx_bytes\")) AS \"tx_bytes_per_second\" FROM \":db:\".\":rp:\".\"kubernetes_pod_network\"",
+          "query": "SELECT non_negative_derivative(max(\"tx_bytes\"), 1s) AS \"tx_bytes_per_second\" FROM \":db:\".\":rp:\".\"kubernetes_pod_network\"",
           "groupbys": [
             "\"pod_name\"",
             "\"host\""
@@ -31,7 +31,7 @@
       "name": "K8s - Pod RX Bytes/Second ",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"rx_bytes\")) AS \"rx_bytes_per_second\" FROM \":db:\".\":rp:\".\"kubernetes_pod_network\"",
+          "query": "SELECT non_negative_derivative(max(\"rx_bytes\"), 1s) AS \"rx_bytes_per_second\" FROM \":db:\".\":rp:\".\"kubernetes_pod_network\"",
           "groupbys": [
             "\"pod_name\"",
             "\"host\""

--- a/canned/memcached.json
+++ b/canned/memcached.json
@@ -29,7 +29,7 @@
       "name": "Memcached - Get Hits/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"get_hits\")) AS \"get_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"get_hits\"), 1s) AS \"get_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "hits/s",
           "groupbys": [],
           "wheres": []
@@ -45,7 +45,7 @@
       "name": "Memcached - Get Misses/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"get_misses\")) AS \"get_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"get_misses\"), 1s) AS \"get_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "misses/s",
           "groupbys": [],
           "wheres": []
@@ -61,7 +61,7 @@
       "name": "Memcached - Delete Hits/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"delete_hits\")) AS \"delete_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"delete_hits\"), 1s) AS \"delete_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "deletes/s",
           "groupbys": [],
           "wheres": []
@@ -77,7 +77,7 @@
       "name": "Memcached - Delete Misses/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"delete_misses\")) AS \"delete_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"delete_misses\"), 1s) AS \"delete_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "delete misses/s",
           "groupbys": [],
           "wheres": []
@@ -93,7 +93,7 @@
       "name": "Memcached - Incr Hits/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"incr_hits\")) AS \"incr_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"incr_hits\"), 1s) AS \"incr_hits\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "incr hits/s",
           "groupbys": [],
           "wheres": []
@@ -109,7 +109,7 @@
       "name": "Memcached - Incr Misses/Second",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"incr_misses\")) AS \"incr_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"incr_misses\"), 1s) AS \"incr_misses\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "incr misses/s",
           "groupbys": [],
           "wheres": []
@@ -173,7 +173,7 @@
       "name": "Memcached - Bytes Read/Sec",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"bytes_read\")) AS \"bytes_read\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"bytes_read\"), 1s) AS \"bytes_read\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "bytes/s",
           "groupbys": [],
           "wheres": []
@@ -189,7 +189,7 @@
       "name": "Memcached - Bytes Written/Sec",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"bytes_written\")) AS \"bytes_written\" FROM \":db:\".\":rp:\".\"memcached\"",
+          "query": "SELECT non_negative_derivative(max(\"bytes_written\"), 1s) AS \"bytes_written\" FROM \":db:\".\":rp:\".\"memcached\"",
           "label": "bytes/s",
           "groupbys": [],
           "wheres": []

--- a/canned/netstat.json
+++ b/canned/netstat.json
@@ -33,12 +33,12 @@
       "name": "System - Sockets Created/Second ",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"tcp_established\")) AS \"tcp_established\" FROM \":db:\".\":rp:\".\"netstat\"",
+          "query": "SELECT non_negative_derivative(max(\"tcp_established\"), 1s) AS \"tcp_established\" FROM \":db:\".\":rp:\".\"netstat\"",
           "groupbys": [],
           "wheres": []
         },
         {
-          "query": "SELECT non_negative_derivative(max(\"udp_socket\")) AS \"udp_socket\" FROM \":db:\".\":rp:\".\"netstat\"",
+          "query": "SELECT non_negative_derivative(max(\"udp_socket\"), 1s) AS \"udp_socket\" FROM \":db:\".\":rp:\".\"netstat\"",
           "groupbys": [],
           "wheres": []
         }

--- a/canned/nginx.json
+++ b/canned/nginx.json
@@ -30,7 +30,7 @@
       "name": "NGINX – Client Errors",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"accepts\")) - non_negative_derivative(max(\"handled\")) FROM \":db:\".\":rp:\".\"nginx\"",
+          "query": "SELECT non_negative_derivative(max(\"accepts\"), 1s) - non_negative_derivative(max(\"handled\"), 1s) FROM \":db:\".\":rp:\".\"nginx\"",
           "groupbys": [
             "\"server\""
           ],

--- a/canned/nsq_topic.json
+++ b/canned/nsq_topic.json
@@ -47,7 +47,7 @@
       "name": "NSQ - Topic Ingress",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"message_count\")) AS \"messages_per_second\" FROM \":db:\".\":rp:\".\"nsq_topic\"",
+          "query": "SELECT non_negative_derivative(max(\"message_count\"), 1s) AS \"messages_per_second\" FROM \":db:\".\":rp:\".\"nsq_topic\"",
           "groupbys": [
             "\"topic\"",
             "\"host\""

--- a/canned/phpfpm.json
+++ b/canned/phpfpm.json
@@ -13,7 +13,7 @@
       "name": "phpfpm – Accepted Connections",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(\"accepted_conn\"),1s) FROM \":db:\".\":rp:\".\"phpfpm\"",
+          "query": "SELECT non_negative_derivative(mean(\"accepted_conn\"), 1s) FROM \":db:\".\":rp:\".\"phpfpm\"",
           "label": "count",
           "groupbys": [
             "\"pool\""
@@ -47,7 +47,7 @@
       "name": "phpfpm – Slow Requests",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(mean(\"slow_requests\"),1s) FROM \":db:\".\":rp:\".\"phpfpm\"",
+          "query": "SELECT non_negative_derivative(mean(\"slow_requests\"), 1s) FROM \":db:\".\":rp:\".\"phpfpm\"",
           "label": "count",
           "groupbys": [
             "\"pool\""

--- a/canned/redis.json
+++ b/canned/redis.json
@@ -41,7 +41,7 @@
       "name": "Redis - CPU",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"used_cpu_user\")) AS \"used_cpu_per_second\" FROM \":db:\".\":rp:\".\"redis\"",
+          "query": "SELECT non_negative_derivative(max(\"used_cpu_user\"), 1s) AS \"used_cpu_per_second\" FROM \":db:\".\":rp:\".\"redis\"",
           "groupbys": []
         }
       ]
@@ -55,7 +55,7 @@
       "name": "Redis - Memory",
       "queries": [
         {
-          "query": "SELECT non_negative_derivative(max(\"used_memory\")) AS \"used_memory_per_second\" FROM \":db:\".\":rp:\".\"redis\"",
+          "query": "SELECT non_negative_derivative(max(\"used_memory\"), 1s) AS \"used_memory_per_second\" FROM \":db:\".\":rp:\".\"redis\"",
           "groupbys": []
         }
       ]


### PR DESCRIPTION
Closes #5358

changes non_negative_derivative calls in the json files in canned directory to include the 1s

`- non_negative_derivative(max("tcp_established"))
+ non_negative_derivative(max("tcp_established"), 1s)`
