### PR TITLE
chore: update docs to be more clear about node and go versions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,12 @@ To assist in review for the PR, please add the following to your pull request co
 If you are going to be contributing back to Chronograf please take a second to sign our CLA, which can be found
 [on our website](https://influxdata.com/community/cla/).
 
+## Installing & Using Node
+
+You'll need to install Node 10.13.0 to run the frontend chronograf application.
+
+* [Install Node 10.13.0 LTS](https://nodejs.org/en/blog/release/v10.13.0/)
+
 ## Installing & Using Yarn
 
 You'll need to install Yarn to manage the frontend (JavaScript) dependencies.
@@ -53,7 +59,7 @@ To add a dependency via Yarn, for example, run `yarn add <dependency>` from with
 
 ## Installing Go
 
-Chronograf requires Go 1.10 or higher.
+Chronograf requires Go 1.13 or higher.
 
 ## Installing & Using Dep
 

--- a/README.md
+++ b/README.md
@@ -182,12 +182,12 @@ docker pull chronograf:latest
 
 ### From Source
 
-* Chronograf works with go 1.11+, node LTS, and yarn 1.7+.
+* Chronograf works with go 1.13+, node 10.13.0 LTS, and yarn 1.7+.
 * Chronograf requires [Kapacitor](https://github.com/influxdata/kapacitor)
   1.5.x+ to create and store alerts.
 
 1. [Install Go](https://golang.org/doc/install)
-1. [Install Node and NPM](https://nodejs.org/en/download/)
+1. [Install Node (version 10.13.0 LTS) and NPM](https://nodejs.org/ru/blog/release/v10.13.0/)
 1. [Install yarn](https://yarnpkg.com/docs/install)
 1. [Setup your GOPATH](https://golang.org/doc/code.html#GOPATH)
 1. Build the Chronograf package:


### PR DESCRIPTION
Updates versions in docs, and specifically link to node 10.13.0 lts

  - [x] Rebased/mergeable
  - [x] Tests pass