### PR TITLE
Bs source variable polish

### DIFF
--- a/ui/src/flux/components/SourceDropdown.tsx
+++ b/ui/src/flux/components/SourceDropdown.tsx
@@ -19,6 +19,7 @@ interface Props {
   onSelectDynamicSource?: () => void
   onChangeSource: (source: Source, type: QueryType) => void
   widthPixels?: number
+  zIndex?: number
 }
 
 interface SourceDropdownItem {
@@ -33,6 +34,7 @@ class SourceDropdown extends PureComponent<Props> {
         onChange={this.handleSelect}
         selectedID={this.selectedID}
         widthPixels={this.props.widthPixels}
+        zIndex={this.props.zIndex}
       >
         {this.dropdownItems}
       </Dropdown>

--- a/ui/src/flux/components/SourceDropdown.tsx
+++ b/ui/src/flux/components/SourceDropdown.tsx
@@ -19,7 +19,7 @@ interface Props {
   onSelectDynamicSource?: () => void
   onChangeSource: (source: Source, type: QueryType) => void
   widthPixels?: number
-  zIndex?: number
+  zIndex?: string
 }
 
 interface SourceDropdownItem {

--- a/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
@@ -40,6 +40,7 @@ interface Props {
   maxMenuHeight?: number
   mode?: DropdownMode
   titleText?: string
+  zIndex?: number | string
 }
 
 interface State {
@@ -58,6 +59,7 @@ class Dropdown extends Component<Props, State> {
     mode: DropdownMode.Radio,
     titleText: '',
     selectedID: '',
+    zIndex: 'auto'
   }
 
   public static Button = DropdownButton
@@ -73,15 +75,16 @@ class Dropdown extends Component<Props, State> {
   }
 
   public render() {
-    const {widthPixels} = this.props
+    const {widthPixels, zIndex} = this.props
     const width = widthPixels ? `${widthPixels}px` : '100%'
+    const style = {width, zIndex}
 
     this.validateChildCount()
     this.validateMode()
 
     return (
       <ClickOutside onClickOutside={this.collapseMenu}>
-        <div className={this.containerClassName} style={{width}}>
+        <div className={this.containerClassName} style={style}>
           {this.button}
           {this.menuItems}
         </div>

--- a/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
+++ b/ui/src/reusable_ui/components/dropdowns/Dropdown.tsx
@@ -40,7 +40,7 @@ interface Props {
   maxMenuHeight?: number
   mode?: DropdownMode
   titleText?: string
-  zIndex?: number | string
+  zIndex?: string
 }
 
 interface State {
@@ -59,7 +59,7 @@ class Dropdown extends Component<Props, State> {
     mode: DropdownMode.Radio,
     titleText: '',
     selectedID: '',
-    zIndex: 'auto'
+    zIndex: 'auto',
   }
 
   public static Button = DropdownButton
@@ -77,7 +77,7 @@ class Dropdown extends Component<Props, State> {
   public render() {
     const {widthPixels, zIndex} = this.props
     const width = widthPixels ? `${widthPixels}px` : '100%'
-    const style = {width, zIndex}
+    const style = {width, zIndex} as React.CSSProperties
 
     this.validateChildCount()
     this.validateMode()

--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -168,6 +168,7 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
                 allowDynamicSource={true}
                 type={QueryType.InfluxQL}
                 widthPixels={0}
+                zIndex={9999}
               />
             </div>
             <div className="form-group col-sm-4">

--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -98,6 +98,9 @@ const DEFAULT_SOURCE_DATABASE_ID = '0'
 
 @ErrorHandling
 class TemplateVariableEditor extends PureComponent<Props, State> {
+  // See comment in source changing handler functions at the bottom of the file
+  private key = +new Date()
+
   constructor(props) {
     super(props)
     const defaultState = {
@@ -168,7 +171,7 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
                 allowDynamicSource={true}
                 type={QueryType.InfluxQL}
                 widthPixels={0}
-                zIndex={9999}
+                zIndex={'9999'}
               />
             </div>
             <div className="form-group col-sm-4">
@@ -194,6 +197,7 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
               />
             </div>
             <TemplateBuilder
+              key={this.key}
               template={nextTemplate}
               templates={templates}
               source={selectedSource}
@@ -419,20 +423,25 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
     return 'Save'
   }
 
-  // When we change the source database here and below, we want to reset the template complete
   private handleSelectDynamicSource = () => {
     this.setState({
       isDynamicSourceSelected: true,
-      nextTemplate: DEFAULT_TEMPLATE(),
     })
+    // Changing this key to be the current timestamp then passing it to the current templateBuilder
+    // forces a re-mount, which re-runs its query, which gets the proper data when we change the source.
+    // A bit of a hack, sorry.
+    this.key = +new Date()
   }
 
   private handleChangeSource = (source: Source) => {
     this.setState({
       isDynamicSourceSelected: false,
       selectedSource: source,
-      nextTemplate: DEFAULT_TEMPLATE(),
     })
+    // Changing this key to be the current timestamp then passing it to the current templateBuilder
+    // forces a re-mount, which re-runs its query, which gets the proper data when we change the source.
+    // A bit of a hack, sorry.
+    this.key = +new Date()
   }
 
   private handleDelete = (): void => {


### PR DESCRIPTION
Connects #5381

Fixes 75% of the issues above for a solid, passing, average C.

* Fixes z-index of source dropdown when the type is map or CSV
* Switching a source now re-runs the query but doesn't blow away current options.
* **Still left to do (but don't let it block this pr):** make query run on modal opening.

<img width="645" alt="Screen Shot 2020-02-13 at 11 59 07 AM" src="https://user-images.githubusercontent.com/146112/74473413-66fa7500-4e58-11ea-93ec-fca51fbdd659.png">

![in](https://user-images.githubusercontent.com/146112/74473417-695ccf00-4e58-11ea-89ad-eeb84d5c47ba.gif)


  - [x] Rebased/mergeable
  - [x] Tests pass