### PR TITLE
feat: add ability to authenticate single superadmin user

### DIFF
--- a/cmd/chronoctl/genKey.go
+++ b/cmd/chronoctl/genKey.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+func init() {
+	parser.AddCommand("gen-keypair",
+		"Generate RSA keypair.",
+		"Generate RSA keypair and write to filesystem.",
+		&genKeyCommand{})
+}
+
+type genKeyCommand struct {
+	Out  flags.Filename `long:"out" description:"File to save keys to. The public key is stored in a file with the same name with \".pub\" appended." default:"chronograf-rsa"`
+	Bits int            `long:"bits" description:"Generate RSA keypair with the specified number of bits." default:"4096"`
+}
+
+func (t *genKeyCommand) Execute(args []string) error {
+	_, err := os.Stat(string(t.Out))
+	if err == nil {
+		errExit(errors.New("Specify non-existant file to write to."))
+	}
+
+	_, err = os.Stat(string(t.Out) + ".pub")
+	if err == nil {
+		errExit(errors.New("Specify non-existant file.pub to write to."))
+	}
+
+	key, err := rsa.GenerateKey(rand.Reader, t.Bits)
+	if err != nil {
+		errExit(err)
+	}
+
+	ioutil.WriteFile(string(t.Out), pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	}), 0600)
+
+	ioutil.WriteFile(string(t.Out)+".pub", pem.EncodeToMemory(&pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: x509.MarshalPKCS1PublicKey(key.Public().(*rsa.PublicKey)),
+	}), 0644)
+
+	fmt.Printf("Key pair generated and saved at %s and %s.pub\n", t.Out, t.Out)
+	return nil
+}

--- a/cmd/chronoctl/token.go
+++ b/cmd/chronoctl/token.go
@@ -49,19 +49,19 @@ func (t *tokenCommand) Execute(args []string) error {
 
 func parsePrivKey(privKeyFile string) (*rsa.PrivateKey, error) {
 	if privKeyFile == "" {
-		errExit(errors.New("No private key file specified"))
+		return nil, errors.New("No private key file specified")
 	}
 
 	pemBytes, err := ioutil.ReadFile(string(privKeyFile))
 	if err != nil {
-		errExit(fmt.Errorf("Failed to read file: %s", err.Error()))
+		return nil, fmt.Errorf("Failed to read file: %s", err.Error())
 	}
 
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
-		errExit(errors.New("No PEM formatted key found"))
+		return nil, errors.New("No PEM formatted key found")
 	} else if block.Type != "RSA PRIVATE KEY" {
-		errExit(fmt.Errorf("Unsupported key type %q", block.Type))
+		return nil, fmt.Errorf("Unsupported key type %q", block.Type)
 	}
 
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -70,12 +70,12 @@ func parsePrivKey(privKeyFile string) (*rsa.PrivateKey, error) {
 func getNonceMsg(url string) ([]byte, error) {
 	req, err := http.NewRequest("GET", url+"/nonce", nil)
 	if err != nil {
-		errExit(fmt.Errorf("Failed to create request: %s", err.Error()))
+		return nil, fmt.Errorf("Failed to create request: %s", err.Error())
 	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		errExit(fmt.Errorf("Failed to get nonce: %s", err.Error()))
+		return nil, fmt.Errorf("Failed to get nonce: %s", err.Error())
 	}
 	defer resp.Body.Close()
 

--- a/cmd/chronoctl/token.go
+++ b/cmd/chronoctl/token.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+func init() {
+	parser.AddCommand("token",
+		"Get current token for superadmin user (if configured)",
+		"Token gets and signs the nonce, providing an expiring token to use in the header: 'Authorization: CHRONOGRAF-SHA256 xxx'",
+		&tokenCommand{})
+}
+
+type tokenCommand struct {
+	ChronoURL   string         `long:"chronograf-url" default:"http://localhost:8888" description:"Chronograf's URL." env:"CHRONOGRAF_URL"`
+	PrivKeyFile flags.Filename `long:"priv-key-file" description:"File location of private key for superadmin token authentication." env:"PRIV_KEY_FILE"`
+}
+
+func (t *tokenCommand) Execute(args []string) error {
+	key, err := parsePrivKey(string(t.PrivKeyFile))
+	if err != nil {
+		errExit(fmt.Errorf("Failed to parse RSA key: %s", err.Error()))
+	}
+
+	msg, err := getNonceMsg(t.ChronoURL)
+	if err != nil {
+		errExit(err)
+	}
+
+	dgst, err := signMsg(msg, key)
+	if err != nil {
+		errExit(fmt.Errorf("Failed to sign: %s", err.Error()))
+	}
+
+	fmt.Println(base64.StdEncoding.EncodeToString(dgst))
+	return nil
+}
+
+func parsePrivKey(privKeyFile string) (*rsa.PrivateKey, error) {
+	if privKeyFile == "" {
+		errExit(errors.New("No private key file specified"))
+	}
+
+	pemBytes, err := ioutil.ReadFile(string(privKeyFile))
+	if err != nil {
+		errExit(fmt.Errorf("Failed to read file: %s", err.Error()))
+	}
+
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		errExit(errors.New("No PEM formatted key found"))
+	} else if block.Type != "RSA PRIVATE KEY" {
+		errExit(fmt.Errorf("Unsupported key type %q", block.Type))
+	}
+
+	return x509.ParsePKCS1PrivateKey(block.Bytes)
+}
+
+func getNonceMsg(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url+"/nonce", nil)
+	if err != nil {
+		errExit(fmt.Errorf("Failed to create request: %s", err.Error()))
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		errExit(fmt.Errorf("Failed to get nonce: %s", err.Error()))
+	}
+	defer resp.Body.Close()
+
+	return ioutil.ReadAll(resp.Body)
+}
+
+func signMsg(msg []byte, key *rsa.PrivateKey) ([]byte, error) {
+	h := crypto.SHA256.New()
+	h.Write(msg)
+	d := h.Sum(nil)
+
+	return rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, d)
+}

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/golang/protobuf v1.3.3 // indirect
 	github.com/google/go-cmp v0.3.0
 	github.com/google/go-github v17.0.0+incompatible
-	github.com/google/uuid v1.1.1 // indirect
+	github.com/google/uuid v1.1.1
 	github.com/goreleaser/goreleaser v0.97.0 // indirect
 	github.com/gorilla/websocket v1.4.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.1.0 // indirect

--- a/server/auth.go
+++ b/server/auth.go
@@ -141,17 +141,17 @@ func validSignature(log chronograf.Logger, authHeader string) bool {
 
 	data, err := base64.StdEncoding.DecodeString(sig)
 	if err != nil {
-		log.Error("Failed to base64 decode signature")
+		log.Debug("Failed to base64 decode signature")
 		return false
 	}
 
 	err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, d, data)
 	if err != nil {
-		log.Error("Failed to verify signature: ", err)
+		log.Debug("Failed to verify signature: ", err)
 		return false
 	}
 
-	return err == nil
+	return true
 }
 
 // AuthorizedUser extracts the user name and provider from context. If the

--- a/server/auth.go
+++ b/server/auth.go
@@ -2,6 +2,9 @@ package server
 
 import (
 	"context"
+	"crypto"
+	"crypto/rsa"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 
@@ -29,6 +32,11 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 			WithField("remote_addr", r.RemoteAddr).
 			WithField("method", r.Method).
 			WithField("url", r.URL)
+
+		if validSignature(log, r.Header.Get("message"), r.Header.Get("signature")) {
+			next.ServeHTTP(w, r)
+			return
+		}
 
 		ctx := r.Context()
 		// We do not check the authorization of the principal.  Those
@@ -83,6 +91,34 @@ func RawStoreAccess(logger chronograf.Logger, next http.HandlerFunc) http.Handle
 	}
 }
 
+// validSignature validates the message was signed with the private key corresponding
+// to the public key given to chronograf on start. Ideally, we would provide the
+// message to be signed to the user in another call. This would allow old signature/msg
+// pairs to be "expired".
+func validSignature(log chronograf.Logger, msg, sig string) bool {
+	if publicKey == nil || msg == "" || sig == "" {
+		return false
+	}
+
+	h := crypto.SHA256.New()
+	h.Write([]byte(msg))
+	d := h.Sum(nil)
+
+	data, err := base64.StdEncoding.DecodeString(sig)
+	if err != nil {
+		log.Error("Failed to base64 decode signature")
+		return false
+	}
+
+	err = rsa.VerifyPKCS1v15(publicKey, crypto.SHA256, d, data)
+	if err != nil {
+		log.Error("Failed to verify signature: ", err)
+		return false
+	}
+
+	return err == nil
+}
+
 // AuthorizedUser extracts the user name and provider from context. If the
 // user and provider can be found on the context, we look up the user by their
 // name and provider. If the user is found, we verify that the user has at at
@@ -108,6 +144,18 @@ func AuthorizedUser(
 		if err != nil {
 			log.Error(fmt.Sprintf("Failed to retrieve the default organization: %v", err))
 			Error(w, http.StatusForbidden, "User is not authorized", logger)
+			return
+		}
+
+		if validSignature(log, r.Header.Get("message"), r.Header.Get("signature")) {
+			// If there is super admin auth, then set the organization id to be the deault org id on context
+			// so that calls like hasOrganizationContext as used in Organization Config service
+			// method OrganizationConfig can successfully get the organization id
+			ctx = context.WithValue(ctx, organizations.ContextKey, defaultOrg.ID)
+
+			// And if there is super admin auth, then give the user raw access to the DataStore
+			r = r.WithContext(serverContext(ctx))
+			next(w, r)
 			return
 		}
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	_ "net/http/pprof"
 
@@ -36,6 +37,7 @@ type MuxOpts struct {
 	CustomLinks   []CustomLink // Any custom external links for client's User menu
 	PprofEnabled  bool         // Mount pprof routes for profiling
 	DisableGZip   bool         // Optionally disable gzip.
+	nonceExpire   time.Duration
 }
 
 // NewMux attaches all the route handlers; handler returned servers chronograf.
@@ -149,6 +151,9 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 
 	/* Health */
 	router.GET("/ping", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })
+
+	/* Auth */
+	router.GET("/nonce", nonce(opts.nonceExpire))
 
 	/* API */
 	// Organizations


### PR DESCRIPTION
This short-circuits any configured authentication, allowing a user with the correctly signed message to act against the api.

Closes #5387

--------------------------------------------------

Adds `chronoctl gen-keypair` to generate an rsa keypair.
Adds `chronoctl token --priv-key-file /path/to/private/key` to request and sign a message to authenticate with a chronograf started with a public key.
Adds `chronograf --pub-key-file /path/to/public/key` to enable token authentication for the owner of the keypair.

Start chronograf:
```sh
chronograf --pub-key-file="./chronograf-rsa.pub" # other oauth options
```

Get and use signed message as authorization token:
```sh
# Store signature to use as token until expires (default 10m)
export SIGNATURE=$(chronoctl token --priv-key-file chronograf-rsa)
# Request restricted resources
curl -H "Authorization: CHRONOGRAF-SHA256 ${SIGNATURE}" \
  localhost:8888/chronograf/v1/dashboards
```
