### PR TITLE
fix: handle change to news feed data structure

### DIFF
--- a/ui/src/status/components/JSONFeedReader.tsx
+++ b/ui/src/status/components/JSONFeedReader.tsx
@@ -17,7 +17,7 @@ const JSONFeedReader: SFC<Props> = ({data}) =>
               date_published: datePublished,
               url,
               title,
-              author: {name},
+              authors,
               image,
               content_text: contentText,
             }) => (
@@ -29,7 +29,7 @@ const JSONFeedReader: SFC<Props> = ({data}) =>
                   <a href={url} target="_blank">
                     <h6>{title}</h6>
                   </a>
-                  <span>by {name}</span>
+                  <span>by {authors.map(author => author.name).join(" & ")}</span>
                 </div>
                 <div className="newsfeed--content">
                   {image ? <img src={image} /> : null}

--- a/ui/src/status/components/JSONFeedReader.tsx
+++ b/ui/src/status/components/JSONFeedReader.tsx
@@ -29,7 +29,9 @@ const JSONFeedReader: SFC<Props> = ({data}) =>
                   <a href={url} target="_blank">
                     <h6>{title}</h6>
                   </a>
-                  <span>by {authors.map(author => author.name).join(" & ")}</span>
+                  <span>
+                    by {authors.map(author => author.name).join(' & ')}
+                  </span>
                 </div>
                 <div className="newsfeed--content">
                   {image ? <img src={image} /> : null}

--- a/ui/src/types/status.ts
+++ b/ui/src/types/status.ts
@@ -1,3 +1,6 @@
+interface Authors {
+  name: string
+}
 interface JSONFeedDataItem {
   id: string
   url: string
@@ -6,9 +9,7 @@ interface JSONFeedDataItem {
   date_published: string
   date_modified: string
   image: string
-  author: {
-    name: string
-  }
+  authors: Authors[]
 }
 
 export interface JSONFeedData {

--- a/ui/src/types/status.ts
+++ b/ui/src/types/status.ts
@@ -1,6 +1,7 @@
 interface Authors {
   name: string
 }
+
 interface JSONFeedDataItem {
   id: string
   url: string


### PR DESCRIPTION
Closes #5416 

It seems the feed data structure has changed from having a single `author` to multiple `authors`, this accounts for that.
