### PR TITLE
fix: use auth settings when pinging source

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -221,6 +221,13 @@ func (c *Client) ping(u *url.URL) (string, string, error) {
 		return "", "", err
 	}
 
+	if c.Authorizer != nil {
+		err = c.Authorizer.Set(req)
+		if err != nil {
+			return "", "", err
+		}
+	}
+
 	hc := &http.Client{}
 	if c.InsecureSkipVerify {
 		hc.Transport = skipVerifyTransport


### PR DESCRIPTION
Closes #5423

If influxdb (>=1.7.9) was configured with `ping-auth-enabled`, chronograf would get 401's when pinging the source. This adds configured authentication to the request to resolve that.
