### PR TITLE
Fix/table sizing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-1. [#5442](https://github.com/influxdata/chronograf/pull/5442): Updated table rendering styles to make table rows deterministic
+1. [#5442](https://github.com/influxdata/chronograf/pull/5442): Updated table rendering styles to make table rows consistent
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5442](https://github.com/influxdata/chronograf/pull/5442): Updated table rendering styles to make table rows deterministic
+
 ### Features
 
 ### Other

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -396,10 +396,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
-                height: Math.max(
-                  calculatedRowCount * ROW_HEIGHT + SCROLLBAR_SIZE_BUFFER,
-                  height
-                ),
+                height: Math.max(calculatedRowCount * ROW_HEIGHT, height),
               }}
               width={width - leftWidth}
             />

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -325,11 +325,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               height={height}
               ref={this.bottomLeftGridRef}
               rowCount={calculatedRowCount}
-              rowHeight={ROW_HEIGHT}
+              rowHeight={height/calculatedRowCount}
               columnWidth={columnWidth}
               style={{
                 overflowY: 'hidden',
-                height: calculatedRowCount * ROW_HEIGHT,
                 position: 'absolute',
               }}
               tabIndex={null}
@@ -387,11 +386,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               ref={this.bottomRightGridRef}
               onScroll={this.onGridScroll}
               rowCount={calculatedRowCount}
-              rowHeight={ROW_HEIGHT}
+              rowHeight={height/calculatedRowCount}
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
-                height: calculatedRowCount * ROW_HEIGHT + SCROLLBAR_SIZE_BUFFER,
               }}
               width={width - leftWidth}
             />

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -332,7 +332,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               columnWidth={columnWidth}
               style={{
                 overflowY: 'hidden',
-                position: 'absolute',
+                height: Math.max(calculatedRowCount * ROW_HEIGHT, height),
               }}
               tabIndex={null}
               width={width}
@@ -396,6 +396,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
+                height: Math.max(
+                  calculatedRowCount * ROW_HEIGHT + SCROLLBAR_SIZE_BUFFER,
+                  height
+                ),
               }}
               width={width - leftWidth}
             />

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -305,11 +305,11 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
 
     return (
       <AutoSizer>
-        {({width}) => (
+        {({width, height}) => (
           <FancyScrollbar
             style={{
               width,
-              height: this.props.height,
+              height: this.props.height - ROW_HEIGHT,
             }}
             autoHide={true}
             scrollTop={this.state.scrollTop}
@@ -322,14 +322,14 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               cellRenderer={this.cellRendererBottomLeftGrid}
               className={this.props.classNameBottomLeftGrid}
               columnCount={fixedColumnCount}
-              height={this.props.height}
+              height={height}
               ref={this.bottomLeftGridRef}
               rowCount={calculatedRowCount}
-              rowHeight={this.props.height}
+              rowHeight={ROW_HEIGHT}
               columnWidth={columnWidth}
               style={{
                 overflowY: 'hidden',
-                height: this.props.height,
+                height: calculatedRowCount * ROW_HEIGHT,
                 position: 'absolute',
               }}
               tabIndex={null}
@@ -364,12 +364,12 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
 
     return (
       <AutoSizer>
-        {({width}) => (
+        {({width, height}) => (
           <FancyScrollbar
             style={{
               marginLeft: leftWidth,
               width: this.props.width - leftWidth,
-              height: this.props.height,
+              height: this.props.height - ROW_HEIGHT,
             }}
             autoHide={true}
             scrollTop={scrollTop}
@@ -383,15 +383,15 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               columnCount={Math.max(0, columnCount - fixedColumnCount)}
               columnWidth={this.columnWidthRightGrid}
               overscanRowCount={100}
-              height={this.props.height}
+              height={height}
               ref={this.bottomRightGridRef}
               onScroll={this.onGridScroll}
               rowCount={calculatedRowCount}
-              rowHeight={this.props.height}
+              rowHeight={ROW_HEIGHT}
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
-                height: SCROLLBAR_SIZE_BUFFER + ROW_HEIGHT + this.props.height,
+                height: calculatedRowCount * ROW_HEIGHT + SCROLLBAR_SIZE_BUFFER,
               }}
               width={width - leftWidth}
             />

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -325,7 +325,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               height={height}
               ref={this.bottomLeftGridRef}
               rowCount={calculatedRowCount}
-              rowHeight={height/calculatedRowCount}
+              rowHeight={Math.max(height / calculatedRowCount, ROW_HEIGHT)}
               columnWidth={columnWidth}
               style={{
                 overflowY: 'hidden',
@@ -386,7 +386,7 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               ref={this.bottomRightGridRef}
               onScroll={this.onGridScroll}
               rowCount={calculatedRowCount}
-              rowHeight={height/calculatedRowCount}
+              rowHeight={Math.max(height / calculatedRowCount, ROW_HEIGHT)}
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',

--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -325,7 +325,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               height={height}
               ref={this.bottomLeftGridRef}
               rowCount={calculatedRowCount}
-              rowHeight={Math.max(height / calculatedRowCount, ROW_HEIGHT)}
+              rowHeight={this.getCalculatedRowHeight(
+                height,
+                calculatedRowCount
+              )}
               columnWidth={columnWidth}
               style={{
                 overflowY: 'hidden',
@@ -386,7 +389,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               ref={this.bottomRightGridRef}
               onScroll={this.onGridScroll}
               rowCount={calculatedRowCount}
-              rowHeight={Math.max(height / calculatedRowCount, ROW_HEIGHT)}
+              rowHeight={this.getCalculatedRowHeight(
+                height,
+                calculatedRowCount
+              )}
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
@@ -397,6 +403,15 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
         )}
       </AutoSizer>
     )
+  }
+
+  private getCalculatedRowHeight = (
+    height: number,
+    calculatedRowCount: number
+  ): number => {
+    const calculatedRowHeight =
+      calculatedRowCount !== 0 ? height / calculatedRowCount : 0
+    return Math.max(calculatedRowHeight, ROW_HEIGHT)
   }
 
   private renderTopLeftGrid(props) {

--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -33,7 +33,7 @@
   -moz-user-select: text !important;
   -webkit-user-select: text !important;
   line-height: 28px; // Cell height - 2x border width
-  padding: 0 6px 6px;
+  padding: 0 6px;
   font-size: 12px;
   font-weight: 500;
   color: $g12-forge;

--- a/ui/src/style/components/table-graph.scss
+++ b/ui/src/style/components/table-graph.scss
@@ -33,7 +33,7 @@
   -moz-user-select: text !important;
   -webkit-user-select: text !important;
   line-height: 28px; // Cell height - 2x border width
-  padding: 0 6px;
+  padding: 0 6px 6px;
   font-size: 12px;
   font-weight: 500;
   color: $g12-forge;


### PR DESCRIPTION
Closes https://github.com/influxdata/EAR/issues/1399
Closes https://github.com/influxdata/chronograf/issues/5441

### Problem

In trying to expand the cell size of the table, the sum total of table rows ended up being larger than the table height, causing #5441 

### Solution

Reverted a few of the styling changes that were made to ensure that rows were bigger. Instead, used the autosize-generated height of the rows and the number of rows to make the row size more deterministic. Also removed the inline styling for the grid so that it wouldn't interfere with the default height properties

![chronograf-added-height](https://user-images.githubusercontent.com/19984220/78839161-b5d21000-79ac-11ea-85d7-faeff8185844.gif)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
 