### PR TITLE
fix: token option issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v1.8.3
 
 ### Bug Fixes
+1. [#5456](https://github.com/influxdata/chronograf/pull/5456): Fixed missing `token` subcommand
 
 ### Features
 

--- a/cmd/chronoctl/main_test.go
+++ b/cmd/chronoctl/main_test.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"testing"
+
+	flags "github.com/jessevdk/go-flags"
+)
+
+func TestChronoctlCommands(t *testing.T) {
+	tests := []struct {
+		args []string
+		err  bool
+	}{
+		{
+			args: []string{"not", "a", "command"},
+			err:  true,
+		},
+		{
+			args: []string{"add-superadmin", "-h"},
+			err:  false,
+		},
+		{
+			args: []string{"gen-keypair", "-h"},
+			err:  false,
+		},
+		{
+			args: []string{"list-users", "-h"},
+			err:  false,
+		},
+		{
+			args: []string{"token", "-h"},
+			err:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Log("Testing", test.args)
+		if _, err := parser.ParseArgs(test.args); err != nil {
+			if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+				if test.err {
+					t.Errorf("%v - should have failed", test.args)
+				}
+			} else {
+				if !test.err {
+					t.Errorf("%v - shouldn't have failed", test.args)
+				}
+			}
+		}
+	}
+}

--- a/cmd/chronoctl/token.go
+++ b/cmd/chronoctl/token.go
@@ -25,7 +25,7 @@ func init() {
 
 type tokenCommand struct {
 	ChronoURL   string         `long:"chronograf-url" default:"http://localhost:8888" description:"Chronograf's URL." env:"CHRONOGRAF_URL"`
-	SkipVerify  bool           `long:"skip-verify" short:"k" default:"false" description:"Don't verify TLS cert at endpoint (allows self-signed certs)."`
+	SkipVerify  bool           `long:"skip-verify" short:"k" description:"Don't verify TLS cert at endpoint (allows self-signed certs)."`
 	PrivKeyFile flags.Filename `long:"priv-key-file" description:"File location of private key (corresponding to the public key chronograf was started with) for superadmin token authentication." env:"PRIV_KEY_FILE"`
 }
 


### PR DESCRIPTION
Closes #5454

_What was the problem?_
The `token` command had an option added with a bad default value causing the adding of the command to fail, which we silently ignored.
_What was the solution?_
Remove the bad option default and add tests to ensure all subcommands stay available.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass