### PR TITLE
fix: validate oauth settings prior to starting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#5456](https://github.com/influxdata/chronograf/pull/5456): Fixed missing `token` subcommand
+1. [#5458](https://github.com/influxdata/chronograf/pull/5458): Don't start with partial oauth configuration
 
 ### Features
 

--- a/server/server.go
+++ b/server/server.go
@@ -251,9 +251,8 @@ func (s *Server) UseGenericOAuth2() error {
 		s.GenericClientSecret != "" && s.GenericAuthURL != "" &&
 		s.GenericTokenURL != "":
 		return nil
-	case s.GenericClientID == "" &&
-		s.GenericClientSecret == "" && s.GenericAuthURL == "" &&
-		s.GenericTokenURL == "":
+	case s.GenericClientID == "" && s.GenericClientSecret == "" &&
+		s.GenericAuthURL == "" && s.GenericTokenURL == "":
 		return errNoAuth
 	}
 
@@ -416,6 +415,10 @@ func (s *Server) validateAuth() error {
 		if err := useAuths[i](); err != nil && err != errNoAuth {
 			errs = append(errs, err.Error())
 		}
+	}
+
+	if !s.useAuth() && s.TokenSecret != "" {
+		errs = append(errs, "token secret without oauth config is invalid")
 	}
 
 	if len(errs) == 0 {

--- a/server/server.go
+++ b/server/server.go
@@ -138,10 +138,9 @@ func provide(p oauth2.Provider, m oauth2.Mux, ok func() error) func(func(oauth2.
 func (s *Server) UseGithub() error {
 	errMsg := []string{}
 
-	switch {
-	case s.TokenSecret != "" && s.GithubClientID != "" && s.GithubClientSecret != "":
+	if s.TokenSecret != "" && s.GithubClientID != "" && s.GithubClientSecret != "" {
 		return nil
-	case s.GithubClientID == "" && s.GithubClientSecret == "":
+	} else if s.GithubClientID == "" && s.GithubClientSecret == "" {
 		return errNoAuth
 	}
 
@@ -165,10 +164,9 @@ func (s *Server) UseGithub() error {
 func (s *Server) UseGoogle() error {
 	errMsg := []string{}
 
-	switch {
-	case s.TokenSecret != "" && s.GoogleClientID != "" && s.GoogleClientSecret != "" && s.PublicURL != "":
+	if s.TokenSecret != "" && s.GoogleClientID != "" && s.GoogleClientSecret != "" && s.PublicURL != "" {
 		return nil
-	case s.GoogleClientID == "" && s.GoogleClientSecret == "" && s.PublicURL == "":
+	} else if s.GoogleClientID == "" && s.GoogleClientSecret == "" && s.PublicURL == "" {
 		return errNoAuth
 	}
 
@@ -195,10 +193,9 @@ func (s *Server) UseGoogle() error {
 func (s *Server) UseHeroku() error {
 	errMsg := []string{}
 
-	switch {
-	case s.TokenSecret != "" && s.HerokuClientID != "" && s.HerokuSecret != "":
+	if s.TokenSecret != "" && s.HerokuClientID != "" && s.HerokuSecret != "" {
 		return nil
-	case s.HerokuClientID == "" && s.HerokuSecret == "":
+	} else if s.HerokuClientID == "" && s.HerokuSecret == "" {
 		return errNoAuth
 	}
 
@@ -222,10 +219,9 @@ func (s *Server) UseHeroku() error {
 func (s *Server) UseAuth0() error {
 	errMsg := []string{}
 
-	switch {
-	case s.Auth0ClientID != "" && s.Auth0ClientSecret != "":
+	if s.Auth0ClientID != "" && s.Auth0ClientSecret != "" {
 		return nil
-	case s.Auth0ClientID == "" && s.Auth0ClientSecret == "":
+	} else if s.Auth0ClientID == "" && s.Auth0ClientSecret == "" {
 		return errNoAuth
 	}
 
@@ -246,13 +242,12 @@ func (s *Server) UseAuth0() error {
 func (s *Server) UseGenericOAuth2() error {
 	errMsg := []string{}
 
-	switch {
-	case s.TokenSecret != "" && s.GenericClientID != "" &&
+	if s.TokenSecret != "" && s.GenericClientID != "" &&
 		s.GenericClientSecret != "" && s.GenericAuthURL != "" &&
-		s.GenericTokenURL != "":
+		s.GenericTokenURL != "" {
 		return nil
-	case s.GenericClientID == "" && s.GenericClientSecret == "" &&
-		s.GenericAuthURL == "" && s.GenericTokenURL == "":
+	} else if s.GenericClientID == "" && s.GenericClientSecret == "" &&
+		s.GenericAuthURL == "" && s.GenericTokenURL == "" {
 		return errNoAuth
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"runtime"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/influxdata/chronograf"
@@ -35,6 +36,7 @@ import (
 
 var (
 	startTime time.Time
+	errNoAuth = errors.New("no auth configured")
 )
 
 func init() {
@@ -124,42 +126,160 @@ type Server struct {
 	BuildInfo         chronograf.BuildInfo
 }
 
-func provide(p oauth2.Provider, m oauth2.Mux, ok func() bool) func(func(oauth2.Provider, oauth2.Mux)) {
+func provide(p oauth2.Provider, m oauth2.Mux, ok func() error) func(func(oauth2.Provider, oauth2.Mux)) {
 	return func(configure func(oauth2.Provider, oauth2.Mux)) {
-		if ok() {
+		if err := ok(); err == nil {
 			configure(p, m)
 		}
 	}
 }
 
 // UseGithub validates the CLI parameters to enable github oauth support
-func (s *Server) UseGithub() bool {
-	return s.TokenSecret != "" && s.GithubClientID != "" && s.GithubClientSecret != ""
+func (s *Server) UseGithub() error {
+	errMsg := []string{}
+
+	switch {
+	case s.TokenSecret != "" && s.GithubClientID != "" && s.GithubClientSecret != "":
+		return nil
+	case s.GithubClientID == "" && s.GithubClientSecret == "":
+		return errNoAuth
+	}
+
+	if s.TokenSecret == "" {
+		errMsg = append(errMsg, "token secret")
+	}
+	if s.GithubClientID == "" {
+		errMsg = append(errMsg, "client id")
+	}
+	if s.GithubClientSecret == "" {
+		errMsg = append(errMsg, "client secret")
+	}
+	if errMsg != nil {
+		return fmt.Errorf("missing Github oauth setting[s]: %s", strings.Join(errMsg, ", "))
+	}
+
+	return nil
 }
 
 // UseGoogle validates the CLI parameters to enable google oauth support
-func (s *Server) UseGoogle() bool {
-	return s.TokenSecret != "" && s.GoogleClientID != "" && s.GoogleClientSecret != "" && s.PublicURL != ""
+func (s *Server) UseGoogle() error {
+	errMsg := []string{}
+
+	switch {
+	case s.TokenSecret != "" && s.GoogleClientID != "" && s.GoogleClientSecret != "" && s.PublicURL != "":
+		return nil
+	case s.GoogleClientID == "" && s.GoogleClientSecret == "" && s.PublicURL == "":
+		return errNoAuth
+	}
+
+	if s.TokenSecret == "" {
+		errMsg = append(errMsg, "token secret")
+	}
+	if s.GoogleClientID == "" {
+		errMsg = append(errMsg, "client id")
+	}
+	if s.GoogleClientSecret == "" {
+		errMsg = append(errMsg, "client secret")
+	}
+	if s.PublicURL == "" {
+		errMsg = append(errMsg, "public url")
+	}
+	if errMsg != nil {
+		return fmt.Errorf("missing Google oauth setting[s]: %s", strings.Join(errMsg, ", "))
+	}
+
+	return nil
 }
 
 // UseHeroku validates the CLI parameters to enable heroku oauth support
-func (s *Server) UseHeroku() bool {
-	return s.TokenSecret != "" && s.HerokuClientID != "" && s.HerokuSecret != ""
+func (s *Server) UseHeroku() error {
+	errMsg := []string{}
+
+	switch {
+	case s.TokenSecret != "" && s.HerokuClientID != "" && s.HerokuSecret != "":
+		return nil
+	case s.HerokuClientID == "" && s.HerokuSecret == "":
+		return errNoAuth
+	}
+
+	if s.TokenSecret == "" {
+		errMsg = append(errMsg, "token secret")
+	}
+	if s.HerokuClientID == "" {
+		errMsg = append(errMsg, "client id")
+	}
+	if s.HerokuSecret == "" {
+		errMsg = append(errMsg, "client secret")
+	}
+	if errMsg != nil {
+		return fmt.Errorf("missing Heroku oauth setting[s]: %s", strings.Join(errMsg, ", "))
+	}
+
+	return nil
 }
 
 // UseAuth0 validates the CLI parameters to enable Auth0 oauth support
-func (s *Server) UseAuth0() bool {
-	return s.Auth0ClientID != "" && s.Auth0ClientSecret != ""
+func (s *Server) UseAuth0() error {
+	errMsg := []string{}
+
+	switch {
+	case s.Auth0ClientID != "" && s.Auth0ClientSecret != "":
+		return nil
+	case s.Auth0ClientID == "" && s.Auth0ClientSecret == "":
+		return errNoAuth
+	}
+
+	if s.Auth0ClientID == "" {
+		errMsg = append(errMsg, "client id")
+	}
+	if s.Auth0ClientSecret == "" {
+		errMsg = append(errMsg, "client secret")
+	}
+	if errMsg != nil {
+		return fmt.Errorf("missing Auth0 oauth setting[s]: %s", strings.Join(errMsg, ", "))
+	}
+
+	return nil
 }
 
 // UseGenericOAuth2 validates the CLI parameters to enable generic oauth support
-func (s *Server) UseGenericOAuth2() bool {
-	return s.TokenSecret != "" && s.GenericClientID != "" &&
+func (s *Server) UseGenericOAuth2() error {
+	errMsg := []string{}
+
+	switch {
+	case s.TokenSecret != "" && s.GenericClientID != "" &&
 		s.GenericClientSecret != "" && s.GenericAuthURL != "" &&
-		s.GenericTokenURL != ""
+		s.GenericTokenURL != "":
+		return nil
+	case s.GenericClientID == "" &&
+		s.GenericClientSecret == "" && s.GenericAuthURL == "" &&
+		s.GenericTokenURL == "":
+		return errNoAuth
+	}
+
+	if s.TokenSecret == "" {
+		errMsg = append(errMsg, "token secret")
+	}
+	if s.GenericClientID == "" {
+		errMsg = append(errMsg, "client id")
+	}
+	if s.GenericClientSecret == "" {
+		errMsg = append(errMsg, "client secret")
+	}
+	if s.GenericAuthURL == "" {
+		errMsg = append(errMsg, "auth url")
+	}
+	if s.GenericTokenURL == "" {
+		errMsg = append(errMsg, "token url")
+	}
+	if errMsg != nil {
+		return fmt.Errorf("missing Generic oauth setting[s]: %s", strings.Join(errMsg, ", "))
+	}
+
+	return nil
 }
 
-func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() bool) {
+func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() error) {
 	gh := oauth2.Github{
 		ClientID:     s.GithubClientID,
 		ClientSecret: s.GithubClientSecret,
@@ -171,7 +291,7 @@ func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 	return &gh, ghMux, s.UseGithub
 }
 
-func (s *Server) googleOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() bool) {
+func (s *Server) googleOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() error) {
 	redirectURL := s.PublicURL + s.Basepath + "/oauth/google/callback"
 	google := oauth2.Google{
 		ClientID:     s.GoogleClientID,
@@ -185,7 +305,7 @@ func (s *Server) googleOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 	return &google, goMux, s.UseGoogle
 }
 
-func (s *Server) herokuOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() bool) {
+func (s *Server) herokuOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() error) {
 	heroku := oauth2.Heroku{
 		ClientID:      s.HerokuClientID,
 		ClientSecret:  s.HerokuSecret,
@@ -197,7 +317,7 @@ func (s *Server) herokuOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 	return &heroku, hMux, s.UseHeroku
 }
 
-func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() bool) {
+func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() error) {
 	gen := oauth2.Generic{
 		PageName:       s.GenericName,
 		ClientID:       s.GenericClientID,
@@ -216,12 +336,12 @@ func (s *Server) genericOAuth(logger chronograf.Logger, auth oauth2.Authenticato
 	return &gen, genMux, s.UseGenericOAuth2
 }
 
-func (s *Server) auth0OAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() bool) {
+func (s *Server) auth0OAuth(logger chronograf.Logger, auth oauth2.Authenticator) (oauth2.Provider, oauth2.Mux, func() error) {
 	redirectPath := path.Join(s.Basepath, "oauth", "auth0", "callback")
 	redirectURL, err := url.Parse(s.PublicURL)
 	if err != nil {
 		logger.Error("Error parsing public URL: err:", err)
-		return &oauth2.Auth0{}, &oauth2.AuthMux{}, func() bool { return false }
+		return &oauth2.Auth0{}, &oauth2.AuthMux{}, func() error { return fmt.Errorf("failed to parse public URL: %s", err.Error()) }
 	}
 	redirectURL.Path = redirectPath
 
@@ -232,7 +352,7 @@ func (s *Server) auth0OAuth(logger chronograf.Logger, auth oauth2.Authenticator)
 
 	if err != nil {
 		logger.Error("Error parsing Auth0 domain: err:", err)
-		return &auth0, genMux, func() bool { return false }
+		return &auth0, genMux, func() error { return fmt.Errorf("failed to parse Auth0 domain: %s", err.Error()) }
 	}
 	return &auth0, genMux, s.UseAuth0
 }
@@ -257,7 +377,52 @@ func (s *Server) genericRedirectURL() string {
 }
 
 func (s *Server) useAuth() bool {
-	return s.UseGithub() || s.UseGoogle() || s.UseHeroku() || s.UseGenericOAuth2() || s.UseAuth0()
+	useAuths := []func() error{
+		s.UseGithub,
+		s.UseGoogle,
+		s.UseHeroku,
+		s.UseGenericOAuth2,
+		s.UseAuth0,
+	}
+
+	var err error
+	for i := range useAuths {
+		switch err = useAuths[i](); err {
+		case nil:
+			return true
+		case errNoAuth:
+			continue
+		default:
+			// If there was an attempt to configure authentication,
+			// chronograf should not disable authentication.
+			return true
+		}
+	}
+
+	return false
+}
+
+func (s *Server) validateAuth() error {
+	useAuths := []func() error{
+		s.UseGithub,
+		s.UseGoogle,
+		s.UseHeroku,
+		s.UseGenericOAuth2,
+		s.UseAuth0,
+	}
+
+	var errs []string
+	for i := range useAuths {
+		if err := useAuths[i](); err != nil && err != errNoAuth {
+			errs = append(errs, err.Error())
+		}
+	}
+
+	if len(errs) == 0 {
+		return nil
+	}
+
+	return errors.New(strings.Join(errs, "; "))
 }
 
 func (s *Server) useTLS() bool {
@@ -435,6 +600,14 @@ func (s *Server) Serve(ctx context.Context) {
 			WithField("component", "server").
 			WithField("basepath", "invalid").
 			Error(err)
+		return
+	}
+
+	if err = s.validateAuth(); err != nil {
+		logger.
+			WithField("component", "server").
+			WithField("basepath", "invalid").
+			Error(fmt.Errorf("Failed to validate Oauth settings: %s", err))
 		return
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -138,6 +138,13 @@ func TestValidAuth(t *testing.T) {
 			},
 			err: "missing Google oauth setting[s]: token secret, client secret, public url",
 		},
+		{
+			desc: "test invalid config (only token)",
+			s: &Server{
+				TokenSecret: "abc123",
+			},
+			err: "token secret without oauth config is invalid",
+		},
 	}
 
 	for _, test := range tests {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,10 +2,12 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 
 	"github.com/bouk/httprouter"
+	"github.com/stretchr/testify/assert"
 )
 
 // WithContext is a helper function to cut down on boilerplate in server test files
@@ -71,5 +73,75 @@ func Test_validBasepath(t *testing.T) {
 				t.Errorf("validBasepath() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestValidAuth(t *testing.T) {
+	tests := []struct {
+		desc string
+		s    *Server
+		err  string
+	}{
+		{
+			desc: "test valid github config",
+			s: &Server{
+				GithubClientID:     "abc123",
+				GithubClientSecret: "abc123",
+				TokenSecret:        "abc123",
+			},
+			err: "<nil>",
+		},
+		{
+			desc: "test invalid github config (no clientID)",
+			s: &Server{
+				GithubClientSecret: "abc123",
+				TokenSecret:        "abc123",
+			},
+			err: "missing Github oauth setting[s]: client id",
+		},
+		{
+			desc: "test invalid github config (no token or clientID)",
+			s: &Server{
+				GithubClientSecret: "abc123",
+			},
+			err: "missing Github oauth setting[s]: token secret, client id",
+		},
+		{
+			desc: "test invalid generic config (no clientSecret)",
+			s: &Server{
+				GenericClientID: "abc123",
+				GenericAuthURL:  "abc123",
+				GenericTokenURL: "abc123",
+				TokenSecret:     "abc123",
+			},
+			err: "missing Generic oauth setting[s]: client secret",
+		},
+		{
+			desc: "test invalid heroku config (no clientSecret)",
+			s: &Server{
+				HerokuClientID: "abc123",
+				TokenSecret:    "abc123",
+			},
+			err: "missing Heroku oauth setting[s]: client secret",
+		},
+		{
+			desc: "test invalid auth0 config (no clientSecret)",
+			s: &Server{
+				Auth0ClientID: "abc123",
+			},
+			err: "missing Auth0 oauth setting[s]: client secret",
+		},
+		{
+			desc: "test invalid google config (no token or clientSecret or publicUrl)",
+			s: &Server{
+				GoogleClientID: "abc123",
+			},
+			err: "missing Google oauth setting[s]: token secret, client secret, public url",
+		},
+	}
+
+	for _, test := range tests {
+		err := test.s.validateAuth()
+		assert.Equal(t, test.err, fmt.Sprintf("%v", err), test.desc)
 	}
 }


### PR DESCRIPTION
Closes #5450

_What was the problem?_
If there were any missing oauth settings, chronograf would start without authentication.
_What was the solution?_
If oauth settings are only partially added, an error is logged and chronograf fails to start.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
