### PR TITLE
fix: extend jwt expiration time to match cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 1. [#5456](https://github.com/influxdata/chronograf/pull/5456): Fixed missing `token` subcommand
 1. [#5458](https://github.com/influxdata/chronograf/pull/5458): Don't start with partial oauth configuration
+1. [#5459](https://github.com/influxdata/chronograf/pull/5459): Extend oauth JWT timeout to match cookie lifespan
 
 ### Features
 

--- a/oauth2/cookies.go
+++ b/oauth2/cookies.go
@@ -56,11 +56,11 @@ func (c *cookie) Validate(ctx context.Context, r *http.Request) (Principal, erro
 	return c.Tokens.ValidPrincipal(ctx, Token(cookie.Value), c.Lifespan)
 }
 
-// Extend will extend the lifetime of the Token by the Inactivity time.  Assumes
+// Extend will extend the lifetime of the Token by the Lifespan time.  Assumes
 // Principal is already valid.
 func (c *cookie) Extend(ctx context.Context, w http.ResponseWriter, p Principal) (Principal, error) {
-	// Refresh the token by extending its life another Inactivity duration
-	p, err := c.Tokens.ExtendedPrincipal(ctx, p, c.Inactivity)
+	// Refresh the token by extending its life another Lifespan duration
+	p, err := c.Tokens.ExtendedPrincipal(ctx, p, c.Lifespan)
 	if err != nil {
 		return Principal{}, ErrAuthentication
 	}
@@ -85,10 +85,10 @@ func (c *cookie) Extend(ctx context.Context, w http.ResponseWriter, p Principal)
 // a token with cookie.Duration of life to be stored as the cookie's value.
 func (c *cookie) Authorize(ctx context.Context, w http.ResponseWriter, p Principal) error {
 	// Principal will be issued at Now() and will expire
-	// c.Inactivity into the future
+	// c.Lifespan into the future
 	now := c.Now()
 	p.IssuedAt = now
-	p.ExpiresAt = now.Add(c.Inactivity)
+	p.ExpiresAt = now.Add(c.Lifespan)
 
 	token, err := c.Tokens.Create(ctx, p)
 	if err != nil {

--- a/oauth2/google.go
+++ b/oauth2/google.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -8,6 +9,7 @@ import (
 
 	"golang.org/x/oauth2"
 	goauth2 "google.golang.org/api/oauth2/v2"
+	"google.golang.org/api/option"
 )
 
 // GoogleEndpoint is Google's OAuth 2.0 endpoint.
@@ -64,7 +66,7 @@ func (g *Google) Config() *oauth2.Config {
 
 // PrincipalID returns the google email address of the user.
 func (g *Google) PrincipalID(provider *http.Client) (string, error) {
-	srv, err := goauth2.New(provider)
+	srv, err := goauth2.NewService(context.TODO(), option.WithHTTPClient(provider))
 	if err != nil {
 		g.Logger.Error("Unable to communicate with Google ", err.Error())
 		return "", err
@@ -91,7 +93,7 @@ func (g *Google) PrincipalID(provider *http.Client) (string, error) {
 
 // Group returns the string of domain a user belongs to in Google
 func (g *Google) Group(provider *http.Client) (string, error) {
-	srv, err := goauth2.New(provider)
+	srv, err := goauth2.NewService(context.TODO(), option.WithHTTPClient(provider))
 	if err != nil {
 		g.Logger.Error("Unable to communicate with Google ", err.Error())
 		return "", err


### PR DESCRIPTION
also updates google oauth to use non-deprecated calls

Closes #5395 

_What was the problem?_
jwts were expiring faster (5 mins) than a user cookie was which was logging users out if they closed chronograf browser sessions for longer than the 5 minutes.
_What was the solution?_
Increase the refreshed timeout (refreshed each call to `/me`) to match the configured cookie lifespan.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
