### PR TITLE
feat: add ability to ignore or verify self signed oauth certs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#5459](https://github.com/influxdata/chronograf/pull/5459): Extend oauth JWT timeout to match cookie lifespan
 
 ### Features
+1. [#5461](https://github.com/influxdata/chronograf/pull/5461): add ability to ignore or verify custom oauth certs
 
 ### Other
 

--- a/oauth2/mux.go
+++ b/oauth2/mux.go
@@ -1,6 +1,7 @@
 package oauth2
 
 import (
+	"context"
 	"net/http"
 	"path"
 	"time"
@@ -16,8 +17,8 @@ var _ Mux = &AuthMux{}
 const TenMinutes = 10 * time.Minute
 
 // NewAuthMux constructs a Mux handler that checks a cookie against the authenticator
-func NewAuthMux(p Provider, a Authenticator, t Tokenizer, basepath string, l chronograf.Logger, UseIDToken bool, LoginHint string) *AuthMux {
-	return &AuthMux{
+func NewAuthMux(p Provider, a Authenticator, t Tokenizer, basepath string, l chronograf.Logger, UseIDToken bool, LoginHint string, client *http.Client) *AuthMux {
+	mux := &AuthMux{
 		Provider:   p,
 		Auth:       a,
 		Tokens:     t,
@@ -28,6 +29,12 @@ func NewAuthMux(p Provider, a Authenticator, t Tokenizer, basepath string, l chr
 		UseIDToken: UseIDToken,
 		LoginHint:  LoginHint,
 	}
+
+	if client != nil {
+		mux.client = client
+	}
+
+	return mux
 }
 
 // AuthMux services an Oauth2 interaction with a provider and browser and
@@ -45,6 +52,7 @@ type AuthMux struct {
 	Now        func() time.Time  // Now returns the current time (for testing)
 	UseIDToken bool              // UseIDToken enables OpenID id_token support
 	LoginHint  string            // LoginHint will be included as a parameter during authentication if non-nil
+	client     *http.Client      // client is the http client used in oauth exchange.
 }
 
 // Login uses a Cookie with a random string as the state validation method.  JWTs are
@@ -119,7 +127,14 @@ func (j *AuthMux) Callback() http.Handler {
 		// Exchange the code back with the provider to the the token
 		conf := j.Provider.Config()
 		code := r.FormValue("code")
-		token, err := conf.Exchange(r.Context(), code)
+
+		// Use http client with transport options.
+		ctx := r.Context()
+		if j.client != nil {
+			ctx = context.WithValue(r.Context(), oauth2.HTTPClient, j.client)
+		}
+
+		token, err := conf.Exchange(ctx, code)
 		if err != nil {
 			log.Error("Unable to exchange code for token ", err.Error())
 			http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)
@@ -188,8 +203,7 @@ func (j *AuthMux) Callback() http.Handler {
 			Issuer:  j.Provider.Name(),
 			Group:   group,
 		}
-		ctx := r.Context()
-		err = j.Auth.Authorize(ctx, w, p)
+		err = j.Auth.Authorize(r.Context(), w, p)
 		if err != nil {
 			log.Error("Unable to get add session to response ", err.Error())
 			http.Redirect(w, r, j.FailureURL, http.StatusTemporaryRedirect)

--- a/oauth2/mux_test.go
+++ b/oauth2/mux_test.go
@@ -53,7 +53,7 @@ func setupMuxTest(response interface{}, selector func(*AuthMux) http.Handler) (*
 
 	useidtoken := false
 
-	jm := NewAuthMux(mp, auth, mt, "", clog.New(clog.ParseLevel("debug")), useidtoken, "")
+	jm := NewAuthMux(mp, auth, mt, "", clog.New(clog.ParseLevel("debug")), useidtoken, "", nil)
 	ts := httptest.NewServer(selector(jm))
 	jar, _ := cookiejar.New(nil)
 	hc := http.Client{


### PR DESCRIPTION
Closes #5402

_What was the problem?_
When using generic oauth provider with tls, you will get insecure cert errors.
_What was the solution?_
Add a way to skip verifying those certs as well as pointing to a root ca that can be used to verify the "insecure" cert.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests