### PR TITLE
fix: table graph panels should be aligned when scrolling

### DIFF
--- a/ui/src/shared/components/MultiGrid/MultiGrid.tsx
+++ b/ui/src/shared/components/MultiGrid/MultiGrid.tsx
@@ -396,7 +396,10 @@ class MultiGrid extends React.PureComponent<PropsMultiGrid, State> {
               scrollToRow={scrollToRow - fixedRowCount}
               style={{
                 overflowY: 'hidden',
-                height: Math.max(calculatedRowCount * ROW_HEIGHT, height),
+                height: Math.max(
+                  calculatedRowCount * ROW_HEIGHT + SCROLLBAR_SIZE_BUFFER,
+                  height
+                ),
               }}
               width={width - leftWidth}
             />


### PR DESCRIPTION
Closes #5465 

### Issue:
When scrolling through a table graph type, the left and right panels became misaligned
![Screen Shot 2020-04-28 at 5 09 00 PM](https://user-images.githubusercontent.com/146112/80549993-78d9b780-8973-11ea-9257-fbce921191fa.png)

### Fix: 
The [original fix](https://github.com/influxdata/chronograf/commit/c8ba74b441c4a648a371f3c2ae8f37686bb43eb1#diff-a5aa3b99aa7b563a84bca863d3b71a9dR399) missed adding back `SCROLLBAR_SIZE_BUFFER`

Chrome and Firefox respectively:
![Screen Shot 2020-04-28 at 5 15 17 PM](https://user-images.githubusercontent.com/146112/80550119-e71e7a00-8973-11ea-89c2-89f38bc2f457.png)
![Screen Shot 2020-04-28 at 5 15 27 PM](https://user-images.githubusercontent.com/146112/80550120-e7b71080-8973-11ea-8cba-ba09b9561328.png)


[The original EAR fix](https://github.com/influxdata/chronograf/pull/5429) remains intact:
![Screen Shot 2020-04-28 at 5 14 03 PM](https://user-images.githubusercontent.com/146112/80550057-ad4d7380-8973-11ea-95bc-3e9734346709.png)


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass