### PR TITLE
fix: remove common public-url config from oauth validation check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5475](https://github.com/influxdata/chronograf/pull/5475): Fix public-url generic oauth configuration issue
+
 ### Features
 
 ### Other

--- a/server/server.go
+++ b/server/server.go
@@ -171,7 +171,7 @@ func (s *Server) UseGoogle() error {
 
 	if s.TokenSecret != "" && s.GoogleClientID != "" && s.GoogleClientSecret != "" && s.PublicURL != "" {
 		return nil
-	} else if s.GoogleClientID == "" && s.GoogleClientSecret == "" && s.PublicURL == "" {
+	} else if s.GoogleClientID == "" && s.GoogleClientSecret == "" {
 		return errNoAuth
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -150,11 +150,36 @@ func TestValidAuth(t *testing.T) {
 			},
 			err: "token secret without oauth config is invalid",
 		},
+		{
+			desc: "test valid generic config",
+			s: &Server{
+				TokenSecret:         "abc123",
+				GenericClientID:     "abc123",
+				GenericClientSecret: "abc123",
+				GenericAuthURL:      "abc123",
+				GenericTokenURL:     "abc123",
+			},
+			err: "<nil>",
+		},
+		{
+			desc: "test valid generic config with public url",
+			s: &Server{
+				TokenSecret:         "abc123",
+				GenericClientID:     "abc123",
+				GenericClientSecret: "abc123",
+				GenericAuthURL:      "abc123",
+				GenericTokenURL:     "abc123",
+				PublicURL:           "abc123",
+			},
+			err: "<nil>",
+		},
 	}
 
 	for _, test := range tests {
-		err := test.s.validateAuth()
-		assert.Equal(t, test.err, fmt.Sprintf("%v", err), test.desc)
+		t.Run(test.desc, func(t *testing.T) {
+			err := test.s.validateAuth()
+			assert.Equal(t, test.err, fmt.Sprintf("%v", err), test.desc)
+		})
 	}
 }
 


### PR DESCRIPTION
Closes #5473

Repro/verify with:
```sh
./chronograf \
  --generic-auth-url abc123 \
  --generic-token-url abc123 \
  --generic-client-id abc123 \
  --generic-client-secret abc123 \
  --public-url abc123 \
  -t abc123
```