### PR TITLE
Updated dockerfile to alpine 3.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.11
 MAINTAINER Chris Goller <chris@influxdb.com>
 
 ENV PROTOBOARDS_PATH /usr/share/chronograf/protoboards


### PR DESCRIPTION
Signed-off-by: Daniel Sutton <daniel@ducksecops.uk>

Updates Alpine using in dockerfile to 3.11. 3.8 alpine in current dockerfile is end of life as of 1st Mat 2020
