### PR TITLE
fix(kapacitor/alert): support .Time.Unix message validation #5492

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 1. [#5475](https://github.com/influxdata/chronograf/pull/5475): Fix public-url generic oauth configuration issue
 1. [#5512](https://github.com/influxdata/chronograf/pull/5512): Fix crash when starting Chronograf built by Go 1.14 on Windows
+1. [#5513](https://github.com/influxdata/chronograf/pull/5513): Keep dashboard's table sorting stable on data refresh
+1. [#5503](https://github.com/influxdata/chronograf/pull/5503): Repair tick script editor scrolling on Firefox
+1. [#5506](https://github.com/influxdata/chronograf/pull/5506): Parse flux CSV results in a way to support existing dockerized 1.8.0 InfluxDB
+1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
 
 ### Features
 

--- a/ui/src/kapacitor/utils/alertMessageValidation.ts
+++ b/ui/src/kapacitor/utils/alertMessageValidation.ts
@@ -1,8 +1,18 @@
 import _ from 'lodash'
 import {RULE_MESSAGE_TEMPLATE_TEXTS} from 'src/kapacitor/constants'
 
+// the following template variables must also pass validation, see #5492
+// they are not that much common to be part of RULE_MESSAGE_TEMPLATE_TEXTS
+const EXTRA_MESSAGE_VARIABLES = ['.Time.Unix', '.Time.UnixNano']
+
 export const isValidTemplate = (template: string): boolean => {
-  const exactMatch = !!_.find(RULE_MESSAGE_TEMPLATE_TEXTS, t => t === template)
+  if (
+    !!_.find(RULE_MESSAGE_TEMPLATE_TEXTS, t => t === template) ||
+    !!_.find(EXTRA_MESSAGE_VARIABLES, t => t === template)
+  ) {
+    return true
+  }
+
   const fieldsRegex = /(index .Fields ".+")/
   const tagsRegex = /(index .Tags ".+")/
   const ifRegex = /(if .+)/
@@ -10,15 +20,14 @@ export const isValidTemplate = (template: string): boolean => {
   const blockRegex = /(block .+)/
   const withRegex = /(with .+)/
 
-  const fuzzyMatch =
+  return (
     fieldsRegex.test(template) ||
     tagsRegex.test(template) ||
     ifRegex.test(template) ||
     rangeRegex.test(template) ||
     blockRegex.test(template) ||
     withRegex.test(template)
-
-  return exactMatch || fuzzyMatch
+  )
 }
 
 export const isValidMessage = (message: string): boolean => {

--- a/ui/test/kapacitor/utils/alertMessageValidation.test.ts
+++ b/ui/test/kapacitor/utils/alertMessageValidation.test.ts
@@ -67,6 +67,11 @@ describe('kapacitor.utils.alertMessageValidation', () => {
 
       expect(isValid).toEqual(true)
     })
+    it('is True for for .Time.Unix (#5492)', () => {
+      const isValid = isValidTemplate('.Time.Unix')
+
+      expect(isValid).toEqual(true)
+    })
 
     it('is False for a jibberish input', () => {
       const isValid = isValidTemplate('laslkj;owaiu0294u,mxn')


### PR DESCRIPTION
Closes #5492 

_Briefly describe your proposed changes:_
_What was the problem?_
 {{.Time.Unix}} was reported as invalid in alert message template, although it is valid 
_What was the solution?_
The UI message validator was enhanced to support {{.Time.Unix}} and {{.Time.UnixNano}}

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
