### PR TITLE
feat(kapacitor): repair management of kapacitor rules and tickscripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#5503](https://github.com/influxdata/chronograf/pull/5503): Repair tick script editor scrolling on Firefox
 1. [#5506](https://github.com/influxdata/chronograf/pull/5506): Parse flux CSV results in a way to support existing dockerized 1.8.0 InfluxDB
 1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
+1. [#5505](https://github.com/influxdata/chronograf/pull/5505): Repair management of kapacitor rules and tick scripts
 
 ### Features
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -179,12 +179,17 @@ class Root extends PureComponent<{}, State> {
                 <Route path="alerts" component={AlertsApp} />
                 <Route path="alert-rules" component={KapacitorRulesPage} />
                 <Route
+                  path="kapacitors/:kid/alert-rules/:ruleID" // ruleID can be "new"
+                  component={KapacitorRulePage}
+                />
+                <Route
                   path="alert-rules/:ruleID"
                   component={KapacitorRulePage}
                 />
-                <Route path="alert-rules/new" component={KapacitorRulePage} />
-                <Route path="tickscript/new" component={TickscriptPage} />
-                <Route path="tickscript/:ruleID" component={TickscriptPage} />
+                <Route
+                  path="kapacitors/:kid/tickscripts/:ruleID" // ruleID can be "new"
+                  component={TickscriptPage}
+                />
                 <Route path="kapacitors/new" component={KapacitorPage} />
                 <Route path="kapacitors/:id/edit" component={KapacitorPage} />
                 <Route

--- a/ui/src/kapacitor/components/KapacitorRules.tsx
+++ b/ui/src/kapacitor/components/KapacitorRules.tsx
@@ -4,10 +4,11 @@ import {Link} from 'react-router'
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import TasksTable from 'src/kapacitor/components/TasksTable'
 
-import {Source, AlertRule} from 'src/types'
+import {Source, AlertRule, Kapacitor} from 'src/types'
 
 interface KapacitorRulesProps {
   source: Source
+  kapacitor: Kapacitor
   rules: AlertRule[]
   onDelete: (rule: AlertRule) => void
   onChangeRuleStatus: (rule: AlertRule) => void
@@ -15,6 +16,7 @@ interface KapacitorRulesProps {
 
 const KapacitorRules: SFC<KapacitorRulesProps> = ({
   source,
+  kapacitor,
   rules,
   onDelete,
   onChangeRuleStatus,
@@ -26,6 +28,7 @@ const KapacitorRules: SFC<KapacitorRulesProps> = ({
   const scriptsHeader = `${rules.length} TICKscript${
     rules.length === 1 ? '' : 's'
   }`
+  const kapacitorLink = `/sources/${source.id}/kapacitors/${kapacitor.id}`
 
   return (
     <div>
@@ -33,7 +36,7 @@ const KapacitorRules: SFC<KapacitorRulesProps> = ({
         <div className="panel-heading">
           <h2 className="panel-title">{builderHeader}</h2>
           <Link
-            to={`/sources/${source.id}/alert-rules/new`}
+            to={`${kapacitorLink}/alert-rules/new`}
             className="btn btn-sm btn-primary"
             style={{marginRight: '4px'}}
           >
@@ -42,7 +45,7 @@ const KapacitorRules: SFC<KapacitorRulesProps> = ({
         </div>
         <div className="panel-body">
           <KapacitorRulesTable
-            source={source}
+            kapacitorLink={kapacitorLink}
             rules={builderRules}
             onDelete={onDelete}
             onChangeRuleStatus={onChangeRuleStatus}
@@ -53,7 +56,7 @@ const KapacitorRules: SFC<KapacitorRulesProps> = ({
         <div className="panel-heading">
           <h2 className="panel-title">{scriptsHeader}</h2>
           <Link
-            to={`/sources/${source.id}/tickscript/new`}
+            to={`${kapacitorLink}/tickscripts/new`}
             className="btn btn-sm btn-success"
             style={{marginRight: '4px'}}
           >
@@ -62,7 +65,7 @@ const KapacitorRules: SFC<KapacitorRulesProps> = ({
         </div>
         <div className="panel-body">
           <TasksTable
-            source={source}
+            kapacitorLink={kapacitorLink}
             tasks={rules}
             onDelete={onDelete}
             onChangeRuleStatus={onChangeRuleStatus}

--- a/ui/src/kapacitor/components/KapacitorRulesTable.tsx
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.tsx
@@ -3,7 +3,7 @@ import {Link} from 'react-router'
 import _ from 'lodash'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
-import {AlertRule, Source} from 'src/types'
+import {AlertRule} from 'src/types'
 
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {parseAlertNodeList} from 'src/shared/parsing/parseHandlersFromRule'
@@ -19,21 +19,21 @@ const {
 
 interface KapacitorRulesTableProps {
   rules: AlertRule[]
-  source: Source
+  kapacitorLink: string
   onChangeRuleStatus: (rule: AlertRule) => void
   onDelete: (rule: AlertRule) => void
 }
 
 interface RuleRowProps {
   rule: AlertRule
-  source: Source
+  editLink: string
   onChangeRuleStatus: (rule: AlertRule) => void
   onDelete: (rule: AlertRule) => void
 }
 
 const KapacitorRulesTable: SFC<KapacitorRulesTableProps> = ({
   rules,
-  source,
+  kapacitorLink,
   onChangeRuleStatus,
   onDelete,
 }) => (
@@ -56,7 +56,7 @@ const KapacitorRulesTable: SFC<KapacitorRulesTableProps> = ({
           <RuleRow
             key={rule.id}
             rule={rule}
-            source={source}
+            editLink={`${kapacitorLink}/alert-rules/${rule.id}`}
             onDelete={onDelete}
             onChangeRuleStatus={onChangeRuleStatus}
           />
@@ -90,14 +90,12 @@ export class RuleRow extends PureComponent<RuleRowProps> {
   }
 
   public render() {
-    const {rule, source} = this.props
+    const {rule, editLink} = this.props
 
     return (
       <tr key={rule.id}>
         <td style={{minWidth: colName}}>
-          <Link to={`/sources/${source.id}/alert-rules/${rule.id}`}>
-            {rule.name}
-          </Link>
+          <Link to={editLink}>{rule.name}</Link>
         </td>
         <td style={{width: colTrigger, textTransform: 'capitalize'}}>
           {rule.trigger}

--- a/ui/src/kapacitor/components/TasksTable.tsx
+++ b/ui/src/kapacitor/components/TasksTable.tsx
@@ -2,7 +2,7 @@ import React, {PureComponent, SFC} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
 
-import {AlertRule, Source} from 'src/types'
+import {AlertRule} from 'src/types'
 
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
@@ -10,21 +10,21 @@ const {colName, colType, colEnabled, colActions} = TASKS_TABLE
 
 interface TasksTableProps {
   tasks: AlertRule[]
-  source: Source
+  kapacitorLink: string
   onChangeRuleStatus: (rule: AlertRule) => void
   onDelete: (rule: AlertRule) => void
 }
 
 interface TaskRowProps {
   task: AlertRule
-  source: Source
+  editLink: string
   onChangeRuleStatus: (rule: AlertRule) => void
   onDelete: (rule: AlertRule) => void
 }
 
 const TasksTable: SFC<TasksTableProps> = ({
   tasks,
-  source,
+  kapacitorLink,
   onDelete,
   onChangeRuleStatus,
 }) => (
@@ -45,7 +45,7 @@ const TasksTable: SFC<TasksTableProps> = ({
           <TaskRow
             key={task.id}
             task={task}
-            source={source}
+            editLink={`${kapacitorLink}/tickscripts/${task.id}`}
             onDelete={onDelete}
             onChangeRuleStatus={onChangeRuleStatus}
           />
@@ -57,15 +57,12 @@ const TasksTable: SFC<TasksTableProps> = ({
 
 export class TaskRow extends PureComponent<TaskRowProps> {
   public render() {
-    const {task, source} = this.props
+    const {task, editLink} = this.props
 
     return (
       <tr key={task.id}>
         <td style={{minWidth: colName}}>
-          <Link
-            className="link-success"
-            to={`/sources/${source.id}/tickscript/${task.id}`}
-          >
+          <Link className="link-success" to={editLink}>
             {task.name}
           </Link>
         </td>

--- a/ui/src/kapacitor/containers/KapacitorRulePage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulePage.tsx
@@ -9,7 +9,11 @@ import * as kapacitorRuleActionCreators from 'src/kapacitor/actions/view'
 import * as kapacitorQueryConfigActionCreators from 'src/kapacitor/actions/queryConfigs'
 
 import {bindActionCreators} from 'redux'
-import {getActiveKapacitor, getKapacitorConfig} from 'src/shared/apis/index'
+import {
+  getActiveKapacitor,
+  getKapacitorConfig,
+  getKapacitor,
+} from 'src/shared/apis/index'
 import {DEFAULT_RULE_ID} from 'src/kapacitor/constants'
 import KapacitorRule from 'src/kapacitor/components/KapacitorRule'
 import parseHandlersFromConfig from 'src/shared/parsing/parseHandlersFromConfig'
@@ -35,6 +39,7 @@ import {
 
 interface Params {
   ruleID: string
+  kid?: string
 }
 
 interface Props {
@@ -72,8 +77,12 @@ class KapacitorRulePage extends Component<Props, State> {
     } else {
       ruleActions.fetchRule(source, params.ruleID)
     }
-
-    const kapacitor = await getActiveKapacitor(this.props.source)
+    let kapacitor: Kapacitor
+    if (params.kid) {
+      kapacitor = await getKapacitor(this.props.source, params.kid)
+    } else {
+      kapacitor = await getActiveKapacitor(source)
+    }
     if (!kapacitor) {
       return notify(notifyCouldNotFindKapacitor())
     }

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -109,6 +109,7 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
       <KapacitorRules
         rules={rules}
         source={source}
+        kapacitor={kapacitor}
         onDelete={this.handleDeleteRule}
         onChangeRuleStatus={this.handleRuleStatus}
       />

--- a/ui/test/kapacitor/components/KapacitorRulesTable.test.tsx
+++ b/ui/test/kapacitor/components/KapacitorRulesTable.test.tsx
@@ -4,12 +4,12 @@ import {shallow} from 'enzyme'
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import {RuleRow} from 'src/kapacitor/components/KapacitorRulesTable'
 
-import {source, kapacitorRules} from 'test/resources'
+import {kapacitorRules} from 'test/resources'
 
 describe('Kapacitor.Components.KapacitorRulesTable', () => {
   describe('rendering', () => {
     const props = {
-      source,
+      kapacitorLink: '/sources/1/kapacitors/1',
       rules: kapacitorRules,
       onDelete: () => {},
       onChangeRuleStatus: () => {},
@@ -25,7 +25,7 @@ describe('Kapacitor.Components.KapacitorRulesTable', () => {
 
 describe('Kapacitor.Containers.KapacitorRulesTable.RuleRow', () => {
   const props = {
-    source,
+    editLink: '/sources/1/kapacitors/1/alert-rules/1',
     rule: kapacitorRules[0],
     onDelete: () => {},
     onChangeRuleStatus: jest.fn(),

--- a/ui/test/kapacitor/components/TasksTable.test.tsx
+++ b/ui/test/kapacitor/components/TasksTable.test.tsx
@@ -5,11 +5,11 @@ import _ from 'lodash'
 import TasksTable from 'src/kapacitor/components/TasksTable'
 import {TaskRow} from 'src/kapacitor/components/TasksTable'
 
-import {source, kapacitorRules} from 'test/resources'
+import {kapacitorRules} from 'test/resources'
 
 const setup = (override = {}) => {
   const props = {
-    source,
+    kapacitorLink: '/sources/1/kapacitors/1',
     tasks: kapacitorRules,
     onDelete: () => {},
     onChangeRuleStatus: () => {},


### PR DESCRIPTION
Closes #5493

_Briefly describe your proposed changes:_
Ensure that there is at most one active kapacitor per source DB.

_What was the problem?_
The `active kapacitor` from the dropdown is not reliably set in the chronograf server store (go part). The server-side active kapacitor is now always used when creating/updating kapacitor's rules or tickscripts.

_What was the solution?_
1. Change API that activate kapacitor to deactivate existing active kapacitor(s).
2. Change UI routing paths of pages that create/update rules/tickscripts to include kapacitor ID and propagate it to nested react components

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
