### PR TITLE
fix(ui): report worker errors, better parse flux CSV results

### DIFF
--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -23,7 +23,8 @@ const parseChunks = (response: string): string[] => {
     return []
   }
 
-  const chunks = trimmedResponse.split(/\n\s*\n/)
+  // some influxDB versions (docker v1.8.0) return \r\n as a new line separator
+  const chunks = trimmedResponse.split(/\r?\n\s*\n/)
 
   return chunks
 }

--- a/ui/src/worker/worker.ts
+++ b/ui/src/worker/worker.ts
@@ -44,6 +44,8 @@ onmessage = async (workerMessage: WorkerMessage) => {
     const result = await job(data)
     success(data, result)
   } catch (e) {
+    const {type, id} = data
+    console.error(`Worker job (type=${type} id=${id}) failed`, e)
     error(data, e)
   }
 }


### PR DESCRIPTION
_Briefly describe your proposed changes:_
_What was the problem?_
When I was trying to reproduce #4825, no Line Graph visualization was shown even for a simple query, the browser console did not help to trace down the issue.  It was really difficult to find out the root cause. There were two problems:
1. it was difficult to trace of what exactly failed because the trace to the failing code is hidden (in the worker)
1. no visualization was shown because I was using the latest influxDB1.8 docker, that returns CSV query results separated by \r\n, the parser then created lines with null data that then failed in the background worker job.

_What was the solution?_
1. chore: log worker errors
1. repair the flux result parser to support also \r\n line separators sent from the latest 1.8 [influxdb docker](https://hub.docker.com/_/influxdb)

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
