### PR TITLE
fix(dashboard): keep table sorting on refresh

### DIFF
--- a/ui/src/shared/components/TableGraphFormat.tsx
+++ b/ui/src/shared/components/TableGraphFormat.tsx
@@ -167,7 +167,8 @@ class TableGraphFormat extends PureComponent<Props, State> {
 
     if (sortField === sort.field) {
       sort.direction = sort.direction === ASCENDING ? DESCENDING : ASCENDING
-    } else {
+    } else if (sortField !== undefined) {
+      // setup sort unless the data are refreshed
       sort.field = sortField || this.sortField
       sort.direction = DEFAULT_SORT_DIRECTION
     }


### PR DESCRIPTION
Closes #5457 

_What was the problem?_
The sorting function is also called with an undefined sort column upon every refresh. When undefined is received, the table graph's default sorting is applied.

_What was the solution?_
Change the state of the table sorting only upon a change of sorting key, ignore actions that want to sort by undefined columns (refresh).

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
