### PR TITLE
fix: Avoiding passing invalid number to Grid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#5503](https://github.com/influxdata/chronograf/pull/5503): Repair tick script editor scrolling on Firefox
 1. [#5506](https://github.com/influxdata/chronograf/pull/5506): Parse flux CSV results in a way to support existing dockerized 1.8.0 InfluxDB
 1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
+1. [#5514](https://github.com/influxdata/chronograf/pull/5514): Error when viewing flux raw data after edit
 
 ### Features
 

--- a/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
+++ b/ui/src/shared/components/TimeMachine/RawFluxDataTable.tsx
@@ -69,7 +69,10 @@ class RawFluxDataTable extends PureComponent<Props, State> {
     scrollTop: number
   ): JSX.Element {
     const rowCount = data.length
-    const columnWidth = Math.max(MIN_COLUMN_WIDTH, width / maxColumnCount)
+    const columnWidth =
+      maxColumnCount > 0
+        ? Math.max(MIN_COLUMN_WIDTH, width / maxColumnCount)
+        : MIN_COLUMN_WIDTH
     const style = this.gridStyle(columnWidth, maxColumnCount, rowCount)
 
     return (

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -126,7 +126,10 @@ interface ParseResponseRawResult {
 export const parseResponseRaw = (response: string): ParseResponseRawResult => {
   const chunks = parseChunks(response)
   const parsedChunks = chunks.map(c => Papa.parse(c).data)
-  const maxColumnCount = Math.max(...parsedChunks.map(c => c[0].length))
+  const maxColumnCount =
+    parsedChunks.length > 0
+      ? Math.max(...parsedChunks.map(c => c[0].length))
+      : 0
   const data = []
 
   for (let i = 0; i < parsedChunks.length; i++) {


### PR DESCRIPTION
Closes #5476

_Briefly describe your proposed changes:_
_What was the problem?_
Error when changing view from the empty graph to raw table data with data. It was caused by passing `-Infinity` to `Grid`
_What was the solution?_
Make sure param for `Grid` is valid.

  - [X] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] Rebased/mergeable
  - [x] Tests pass
