### PR TITLE
fix(kapacitor/alert): accept valid templates 

### DIFF
--- a/ui/src/kapacitor/utils/alertMessageValidation.ts
+++ b/ui/src/kapacitor/utils/alertMessageValidation.ts
@@ -1,9 +1,24 @@
 import _ from 'lodash'
 import {RULE_MESSAGE_TEMPLATE_TEXTS} from 'src/kapacitor/constants'
 
-// the following template variables must also pass validation, see #5492
+// the following template variables must also pass validation
 // they are not that much common to be part of RULE_MESSAGE_TEMPLATE_TEXTS
-const EXTRA_MESSAGE_VARIABLES = ['.Time.Unix', '.Time.UnixNano']
+const EXTRA_MESSAGE_VARIABLES = ['.Time.Unix', '.Time.UnixNano', '.']
+// templates with global functions are valid as well - https://golang.org/pkg/text/template/#hdr-Functions
+const GLOBAL_FUNCTIONS = [
+  'and',
+  'call',
+  'html',
+  'index',
+  'slice',
+  'js',
+  'len',
+  'not',
+  'print',
+  'printf',
+  'println',
+  'urlquery',
+]
 
 export const isValidTemplate = (template: string): boolean => {
   if (
@@ -20,14 +35,29 @@ export const isValidTemplate = (template: string): boolean => {
   const blockRegex = /(block .+)/
   const withRegex = /(with .+)/
 
-  return (
+  const regexpTests =
     fieldsRegex.test(template) ||
     tagsRegex.test(template) ||
     ifRegex.test(template) ||
     rangeRegex.test(template) ||
     blockRegex.test(template) ||
     withRegex.test(template)
+  if (regexpTests) {
+    return true
+  }
+
+  // check if we have a prefix that we can remove
+  const validPrefix = _.find(
+    GLOBAL_FUNCTIONS,
+    t =>
+      template.startsWith(t) &&
+      template.length > t.length &&
+      /\s/.test(template[t.length])
   )
+  if (!!validPrefix) {
+    return isValidTemplate(template.substring(validPrefix.length + 1).trim())
+  }
+  return false
 }
 
 export const isValidMessage = (message: string): boolean => {
@@ -35,7 +65,15 @@ export const isValidMessage = (message: string): boolean => {
   const matches = []
   let match = templateRegexp.exec(message)
   while (match) {
-    matches[matches.length] = match[2].trim()
+    let insideBraces = match[2]
+    // ignore template's text trimming when '{{- ' prefix or ' -}}' suffix
+    if (insideBraces.startsWith('- ')) {
+      insideBraces = insideBraces.substring(2)
+    }
+    if (insideBraces.endsWith(' -')) {
+      insideBraces = insideBraces.substring(0, insideBraces.length - 2)
+    }
+    matches[matches.length] = insideBraces.trim()
     match = templateRegexp.exec(message)
   }
 

--- a/ui/test/kapacitor/utils/alertMessageValidation.test.ts
+++ b/ui/test/kapacitor/utils/alertMessageValidation.test.ts
@@ -59,6 +59,16 @@ describe('kapacitor.utils.alertMessageValidation', () => {
 
       expect(isValid).toEqual(true)
     })
+    ;[
+      'CI ID = {{ with (index .Tags "ci_id") }}{{ . }}{{ else }}Unknown{{ end }}',
+      'CI ID = {{ if (index .Tags "ci_id") }}{{ index .Tags "ci_id" }}{{ else -}} Unknown {{- end }}',
+      '# of Tags = {{ len .Tags }}',
+    ].forEach(m => {
+      it(`#5343 accepts message '${m}'`, () => {
+        const isValid = isValidMessage(m)
+        expect(isValid).toEqual(true)
+      })
+    })
   })
 
   describe('isValidTemplate', () => {
@@ -69,6 +79,11 @@ describe('kapacitor.utils.alertMessageValidation', () => {
     })
     it('is True for for .Time.Unix (#5492)', () => {
       const isValid = isValidTemplate('.Time.Unix')
+
+      expect(isValid).toEqual(true)
+    })
+    it('is True for for len .Tags (#5343)', () => {
+      const isValid = isValidTemplate('len .Tags')
 
       expect(isValid).toEqual(true)
     })


### PR DESCRIPTION
Closes #5343

_What was the problem?_
- {{.}} was not supported
- [global functions](https://golang.org/pkg/text/template/#hdr-Functions) were not supported
- [text trimming](https://golang.org/pkg/text/template/#hdr-Text_and_spaces) was not supported

_What was the solution?_
- validation was enhanced to pass in such cases

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
