### PR TITLE
fix(logs): fall back to point timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
 1. [#5514](https://github.com/influxdata/chronograf/pull/5514): Error when viewing flux raw data after edit
 1. [#5505](https://github.com/influxdata/chronograf/pull/5505): Repair management of kapacitor rules and tick scripts
+1. [#5521](https://github.com/influxdata/chronograf/pull/5521): Avoid undefined error when dashboard is not ready yet
+1. [#5516](https://github.com/influxdata/chronograf/pull/5516): Fall back to point timestamp in log viewer
+1. [#5517](https://github.com/influxdata/chronograf/pull/5517): Add global functions and string trimmming to alert message validation
 
 ### Features
 

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -7,6 +7,7 @@ import {
   orderTableColumns,
   filterTableColumns,
 } from 'src/dashboards/utils/tableGraph'
+import {TimeSeriesValue} from 'src/types/series'
 
 export const ROW_HEIGHT = 18
 const CHAR_WIDTH = 9
@@ -174,8 +175,20 @@ export const applyChangesToTableData = (
 ): TableData => {
   const columns = _.get(tableData, 'columns', [])
   const values = _.get(tableData, 'values', [])
-  const data = [columns, ...values]
 
+  // #5472 fallback to timestamp when time is not defined
+  const timeColumnIndex = _.indexOf(columns, 'time')
+  const timestampColumnIndex = _.indexOf(columns, 'timestamp')
+  if (timeColumnIndex >= 0 && timestampColumnIndex >= 0) {
+    // modify existing data to save memory  
+    (values as TimeSeriesValue[][]).forEach(row => {
+      if (row[timestampColumnIndex] === null) {
+        row[timestampColumnIndex] = (row[timeColumnIndex] as number) * 1000000
+      }
+    })
+  }
+
+  const data = [columns, ...values]
   const filteredData = filterTableColumns(data, tableColumns)
   const orderedData = orderTableColumns(filteredData, tableColumns)
   const updatedColumns: string[] = _.get(orderedData, '0', [])

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -180,8 +180,8 @@ export const applyChangesToTableData = (
   const timeColumnIndex = _.indexOf(columns, 'time')
   const timestampColumnIndex = _.indexOf(columns, 'timestamp')
   if (timeColumnIndex >= 0 && timestampColumnIndex >= 0) {
-    // modify existing data to save memory  
-    (values as TimeSeriesValue[][]).forEach(row => {
+    // modify existing data to save memory
+    ;(values as TimeSeriesValue[][]).forEach(row => {
       if (row[timestampColumnIndex] === null) {
         row[timestampColumnIndex] = (row[timeColumnIndex] as number) * 1000000
       }

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -174,14 +174,14 @@ export const applyChangesToTableData = (
   tableColumns: LogsTableColumn[]
 ): TableData => {
   const columns = _.get(tableData, 'columns', [])
-  const values = _.get(tableData, 'values', [])
+  const values: TimeSeriesValue[][] = _.get(tableData, 'values', [])
 
   // #5472 fallback to timestamp when time is not defined
   const timeColumnIndex = _.indexOf(columns, 'time')
   const timestampColumnIndex = _.indexOf(columns, 'timestamp')
   if (timeColumnIndex >= 0 && timestampColumnIndex >= 0) {
     // modify existing data to save memory
-    ;(values as TimeSeriesValue[][]).forEach(row => {
+    values.forEach(row => {
       if (row[timestampColumnIndex] === null) {
         row[timestampColumnIndex] = (row[timeColumnIndex] as number) * 1000000
       }


### PR DESCRIPTION
Closes #5472

_Briefly describe your proposed changes:_
If no timestamp field is defined in the syslog measurement, point's time is used.  

_What was the problem?_
Null values were shown as 1970-01-01...  

_What was the solution?_
Null timestamp value is replaced by point's time value multiplied by 1_000_000 ( nanos are used by [telegram syslog input plugin](https://github.com/influxdata/telegraf/blob/master/plugins/inputs/syslog/syslog.go#L382), but millis are used to represent time in the web UI ) 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
