### PR TITLE
fix(TableGraph): merge query results with unique column names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5521](https://github.com/influxdata/chronograf/pull/5521): Avoid undefined error when dashboard is not ready yet
 1. [#5516](https://github.com/influxdata/chronograf/pull/5516): Fall back to point timestamp in log viewer
 1. [#5517](https://github.com/influxdata/chronograf/pull/5517): Add global functions and string trimmming to alert message validation
+1. [#5519](https://github.com/influxdata/chronograf/pull/5519): Merge query results with unique column names
 
 ### Features
 

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -85,8 +85,8 @@ interface State {
   shouldResize: boolean
 }
 
-// When error occurs in TableGraph, it has to be wrapped into 'table-graph-container'
-// to become visible to the user, because of <AutoSizer> element used in renderring
+// A TableGraph error message has to be wrapped into 'table-graph-container'
+// to be visible to the user, the same way as the table data is.
 export class TableGraphError extends PureComponent<{error: Error}> {
   public render() {
     return (

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -11,7 +11,7 @@ import {MultiGrid, PropsMultiGrid} from 'src/shared/components/MultiGrid'
 
 // Utils
 import {fastReduce} from 'src/utils/fast'
-import {ErrorHandling} from 'src/shared/decorators/errors'
+import {ErrorHandlingWith, DefaultError} from 'src/shared/decorators/errors'
 import {
   getDefaultTimeField,
   isNumerical,
@@ -85,7 +85,19 @@ interface State {
   shouldResize: boolean
 }
 
-@ErrorHandling
+// When error occurs in TableGraph, it has to be wrapped into 'table-graph-container'
+// to become visible to the user, because of <AutoSizer> element used in renderring
+export class TableGraphError extends PureComponent<{error: Error}> {
+  public render() {
+    return (
+      <div className="table-graph-container">
+        <DefaultError error={this.props.error} />
+      </div>
+    )
+  }
+}
+
+@ErrorHandlingWith(TableGraphError)
 class TableGraph extends PureComponent<Props, State> {
   private multiGrid?: MultiGrid
 

--- a/ui/src/shared/decorators/errors.tsx
+++ b/ui/src/shared/decorators/errors.tsx
@@ -9,7 +9,7 @@ const VERSION = process.env.npm_package_version
 
 type ErrorComponentClass = ComponentClass<{error: Error} & any>
 
-class DefaultError extends Component<{error: Error}> {
+export class DefaultError extends Component<{error: Error}> {
   public render() {
     const {error} = this.props
     const {stack, message} = error

--- a/ui/src/worker/jobs/timeSeriesToTableGraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToTableGraph.ts
@@ -51,8 +51,7 @@ export const timeSeriesToTableGraphWork = (
   }
 
   // #5347 rename columns of the same name
-  const uniqueLabels: Record<string, boolean> = {}
-  sortedLabels.forEach(l => {
+  sortedLabels.reduce((uniqueLabels, l) => {
     if (uniqueLabels[l.label]) {
       const origLabel = l.label
       let i = 2
@@ -62,7 +61,8 @@ export const timeSeriesToTableGraphWork = (
       l.label = origLabel + '_' + i
     }
     uniqueLabels[l.label] = true
-  })
+    return uniqueLabels
+  }, {})
 
   let labels = fastMap<Label, string>(sortedLabels, ({label}) => label)
 

--- a/ui/src/worker/jobs/timeSeriesToTableGraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToTableGraph.ts
@@ -50,6 +50,20 @@ export const timeSeriesToTableGraphWork = (
     return {data: metaQuerySeries, sortedLabels, influxQLQueryType: queryType}
   }
 
+  // #5347 rename columns of the same name
+  const uniqueLabels: Record<string, boolean> = {}
+  sortedLabels.forEach(l => {
+    if (uniqueLabels[l.label]) {
+      const origLabel = l.label
+      let i = 2
+      while (uniqueLabels[origLabel + '_' + i]) {
+        i++
+      }
+      l.label = origLabel + '_' + i
+    }
+    uniqueLabels[l.label] = true
+  })
+
   let labels = fastMap<Label, string>(sortedLabels, ({label}) => label)
 
   if (queryType === InfluxQLQueryType.DataQuery) {

--- a/ui/test/worker/jobs/timeSeriesToTableGraph.test.tsx
+++ b/ui/test/worker/jobs/timeSeriesToTableGraph.test.tsx
@@ -1,0 +1,46 @@
+import {timeSeriesToTableGraphWork} from 'src/worker/jobs/timeSeriesToTableGraph'
+
+describe('worker/jobs/timeSeriesToTableGraph', () => {
+  it('generates unique column names', () => {
+    const testData = [
+      {
+        response: {
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {name: 'cpu', columns: ['time', 'count'], values: [[0, 495]]},
+              ],
+            },
+          ],
+          uuid: '76c20d6b-6803-44b9-a292-213d8b298aa5',
+        },
+      },
+      {
+        response: {
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {name: 'cpu', columns: ['time', 'count'], values: [[0, 495]]},
+              ],
+            },
+          ],
+          uuid: '76c20d6b-6803-44b9-a292-213d8b298aa5',
+        },
+      },
+    ]
+    const result = timeSeriesToTableGraphWork(testData)
+    expect(result).toEqual({
+      data: [
+        ['time', 'cpu.count', 'cpu.count_2'], // the second column is renamed
+        [0, 495, 495],
+      ],
+      sortedLabels: [
+        {label: 'cpu.count', responseIndex: 0, seriesIndex: 0},
+        {label: 'cpu.count_2', responseIndex: 1, seriesIndex: 0},
+      ],
+      influxQLQueryType: 'DataQuery',
+    })
+  })
+})


### PR DESCRIPTION
Closes #5347

_What was the problem?_
- when an error occurs, no error message is displayed to the user, since the Error component is inside an <AutoSizer> element of 0x0px size.
- if multiple queries return the same column name(s), invalid data are created for the table graph to display

_What was the solution?_
- Added custom rendering of an error when it appears in TableGraph. It is now rendered inside an element with an absolute position, the table data are rendered this way to be visible.
- Columns in the merged data have unique names so that there is no name-clash anymore.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
