### PR TITLE
fix(build): replace dependencies on unstable gonum.org website

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,10 @@ require (
 
 replace github.com/coreos/go-systemd => github.com/coreos/go-systemd/v22 v22.0.0
 
+// avoid dependency error: https://gonum.org/v1/gonum?go-get=1 (status code 404)
+replace gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca => github.com/gonum/gonum v0.0.0-20181121035319-3f7ecaa7e8ca
+
+// avoid dependency error: https://gonum.org/v1/netlib?go-get=1 (status code 404)
+replace gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6 => github.com/gonum/netlib v0.0.0-20181029234149-ec6d1f5cefe6
+
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,10 @@ github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pO
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/gonum/gonum v0.0.0-20181121035319-3f7ecaa7e8ca h1:njtQLQ3VJQwk78HsF3MO/i/MHoek2Tih3+I5njfBH3I=
+github.com/gonum/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
+github.com/gonum/netlib v0.0.0-20181029234149-ec6d1f5cefe6 h1:2iUB+bJRgLekJD+9CwnxUZpTc14IF9I6mENlhYZ7lWk=
+github.com/gonum/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:hFiNNtqInBiFqirPqtwhb/rTh2DoajGxXznxncUoHoU=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -369,10 +373,6 @@ golang.org/x/tools v0.0.0-20200107050322-53017a39ae36 h1:+eY+U4SdIdum+uGmzG+Y7oP
 golang.org/x/tools v0.0.0-20200107050322-53017a39ae36/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca h1:PupagGYwj8+I4ubCxcmcBRk3VlUWtTg5huQpZR9flmE=
-gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
-gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6 h1:4WsZyVtkthqrHTbDCJfiTs8IWNYE4uvsSDgaV6xpp+o=
-gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6/go.mod h1:wa6Ws7BG/ESfp6dHfk7C6KdzKA7wR7u/rKwOGE66zvw=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0 h1:9sdfJOzWlkqPltHAuzT2Cp+yrBeY1KRVYgms8soxMwM=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=


### PR DESCRIPTION
The CI builds fails to because of these errors:
```
go: gonum.org/v1/gonum@v0.0.0-20181121035319-3f7ecaa7e8ca: unrecognized import path "gonum.org/v1/gonum" (parse https://gonum.org/v1/gonum?go-get=1: no go-import meta tags ())
```

_What was the problem?_
The gonum.org web site does not serve go modules well, at least today.

```
Parsing meta tags from https://gonum.org/v1/netlib?go-get=1 (status code 404)
```

_What was the solution?_
Replace the dependency to use original sources at github.com

  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
