### PR TITLE
fix(dashboard): avoid undefined error when dashboard is not ready yet

### DIFF
--- a/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
+++ b/ui/src/dashboards/utils/dashboardSwitcherLinks.ts
@@ -27,6 +27,10 @@ export const updateDashboardLinks = (
 ) => {
   const {active} = dashboardLinks
 
+  if (!activeDashboard) {
+    return {...dashboardLinks, active: null}
+  }
+
   if (!active || active.key !== String(activeDashboard.id)) {
     return updateActiveDashboardLink(dashboardLinks, activeDashboard)
   }
@@ -38,10 +42,6 @@ const updateActiveDashboardLink = (
   dashboardLinks: DashboardSwitcherLinks,
   dashboard: Dashboard
 ) => {
-  if (!dashboard) {
-    return {...dashboardLinks, active: null}
-  }
-
   const active = dashboardLinks.links.find(
     link => link.key === String(dashboard.id)
   )


### PR DESCRIPTION
Closes #5474

_What was the problem?_
When dashboard page is loading, the associated dashboard is undefined until it is fetched. Having an undefined dashboard (not yet known), https://github.com/influxdata/chronograf/blob/15bf39703f3ed0b3ef439fe39eb943836d557573/ui/src/dashboards/utils/dashboardSwitcherLinks.ts#L30 
fails on `activeDashboard.id`

_What was the solution?_
The code already reacts upon undefined dashboard to return a new valid state, so I moved this section before checking `activeDashboard.id`

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
