### PR TITLE
fix: zooming out stops presentation mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,11 @@
 1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
 1. [#5514](https://github.com/influxdata/chronograf/pull/5514): Error when viewing flux raw data after edit
 1. [#5505](https://github.com/influxdata/chronograf/pull/5505): Repair management of kapacitor rules and tick scripts
-1. [#5522](https://github.com/influxdata/chronograf/pull/5522): Prevent exit presentation mode when zooming out
-
 1. [#5521](https://github.com/influxdata/chronograf/pull/5521): Avoid undefined error when dashboard is not ready yet
 1. [#5516](https://github.com/influxdata/chronograf/pull/5516): Fall back to point timestamp in log viewer
 1. [#5517](https://github.com/influxdata/chronograf/pull/5517): Add global functions and string trimmming to alert message validation
 1. [#5519](https://github.com/influxdata/chronograf/pull/5519): Merge query results with unique column names
+1. [#5524](https://github.com/influxdata/chronograf/pull/5524): Prevent exiting presentation mode when zooming out
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 1. [#5492](https://github.com/influxdata/chronograf/pull/5492): Support `.Time.Unix` in alert message validation
 1. [#5514](https://github.com/influxdata/chronograf/pull/5514): Error when viewing flux raw data after edit
 1. [#5505](https://github.com/influxdata/chronograf/pull/5505): Repair management of kapacitor rules and tick scripts
+1. [#5522](https://github.com/influxdata/chronograf/pull/5522): Prevent exit presentation mode when zooming out
+
 
 ### Features
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -5,7 +5,7 @@ import {render} from 'react-dom'
 import {Provider as ReduxProvider} from 'react-redux'
 import {Provider as UnstatedProvider} from 'unstated'
 import {Router, Route, useRouterHistory} from 'react-router'
-import {createHistory} from 'history'
+import {createHistory, Pathname} from 'history'
 import {syncHistoryWithStore} from 'react-router-redux'
 import {bindActionCreators} from 'redux'
 
@@ -78,8 +78,15 @@ const browserHistory = useRouterHistory(createHistory)({
 const store = configureStore(loadLocalStorage(errorsQueue), browserHistory)
 const {dispatch} = store
 
-browserHistory.listen(() => {
-  dispatch(disablePresentationMode())
+// pathname of last location change
+let lastPathname: Pathname
+
+browserHistory.listen(location => {
+  // disable presentation mode only if pathname changes, #5382
+  if (lastPathname !== location.pathname) {
+    dispatch(disablePresentationMode())
+  }
+  lastPathname = location.pathname
 })
 
 window.addEventListener('keyup', event => {

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -85,8 +85,8 @@ browserHistory.listen(location => {
   // disable presentation mode only if pathname changes, #5382
   if (lastPathname !== location.pathname) {
     dispatch(disablePresentationMode())
+    lastPathname = location.pathname
   }
-  lastPathname = location.pathname
 })
 
 window.addEventListener('keyup', event => {


### PR DESCRIPTION
Closes #5382 

_Briefly describe your proposed changes:_
_What was the problem?_ Zooming out in presentation mode exits presentation mode
_What was the solution?_ disablePresenstationMode() event was dispatch every time location has been changed. Added filter to dispatch even only if path part changes

  - [X] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] Rebased/mergeable
  - [x] Tests pass
