### PR TITLE
fix: making each csv.from unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 1. [#5516](https://github.com/influxdata/chronograf/pull/5516): Fall back to point timestamp in log viewer
 1. [#5517](https://github.com/influxdata/chronograf/pull/5517): Add global functions and string trimmming to alert message validation
 1. [#5519](https://github.com/influxdata/chronograf/pull/5519): Merge query results with unique column names
+1. [#5529](https://github.com/influxdata/chronograf/pull/5529): Multiplication of `csv.from` in functions list
+
 
 ### Features
 

--- a/ui/src/flux/constants/functions.ts
+++ b/ui/src/flux/constants/functions.ts
@@ -463,13 +463,23 @@ export const FUNCTIONS: FluxToolbarFunction[] = [
       'https://docs.influxdata.com/flux/latest/stdlib/built-in/transformations/aggregates/covariance/',
   },
   {
-    name: 'csv.from',
+    name: 'csv.from (file)',
     args: [
       {
         name: 'file',
         desc: 'The file path of the CSV file to query.',
         type: 'String',
       },
+    ],
+    package: 'csv',
+    desc: 'Retrieves data from a comma-separated value (CSV) data source.',
+    example: 'csv.from(file: path)',
+    category: 'Inputs',
+    link: 'https://docs.influxdata.com/flux/latest/stdlib/csv/from/',
+  },
+  {
+    name: 'csv.from (csvData)',
+    args: [
       {
         name: 'csv',
         desc:
@@ -484,7 +494,7 @@ export const FUNCTIONS: FluxToolbarFunction[] = [
     link: 'https://docs.influxdata.com/flux/latest/stdlib/csv/from/',
   },
   {
-    name: 'csv.from',
+    name: 'csv.from (url)',
     args: [
       {
         name: 'url',


### PR DESCRIPTION
Along with the fix, this also proposal about improving the view on `csv.from` functions.
When someone filters `csv.from` she sees  2 (actually 4 because of a bug) `csv.from`, without any distinguisher.  She must place the cursor over each entry to see the difference.

Also, the first cvs.from from the `csv` package has two possible params, but there can be the only one argument used at a time, which is against other functions, where all params can/must be used. 

![image](https://user-images.githubusercontent.com/29980246/86380121-05fafe80-bc8c-11ea-9df5-49c64001a3fc.png)



Closes #5523

_Briefly describe your proposed changes:_
_What was the problem?_ 
`cvs.from` was shown multiple times because of the duplicate key in the list
_What was the solution?_ 
Make each `cvs.from` unique.



  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass

