### PR TITLE
fix: example statusFeed URL in swagger

### DIFF
--- a/server/swagger.json
+++ b/server/swagger.json
@@ -6153,7 +6153,7 @@
         "me": "/chronograf/v1/me",
         "dashboards": "/chronograf/v1/dashboards",
         "external": {
-          "statusFeed": "http://news.influxdata.com/feed.json",
+          "statusFeed": "https://www.influxdata.com/feed/json",
           "custom": [
             {
               "name": "InfluxData",


### PR DESCRIPTION
The external `statusFeed` parameter has been corrected.

_Briefly describe your proposed changes:_ Updating JSON feed URL
_What was the problem?_ Incorrect news feed URL
_What was the solution?_ Update news feed URL

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
