### PR TITLE
fix(ui): show all query results in table view #5502

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5554](https://github.com/influxdata/chronograf/pull/5554): Escape tag values in query builder.
 1. [#5551](https://github.com/influxdata/chronograf/pull/5551): Sort namespaces by database and retention policy.
+1. [#5553](https://github.com/influxdata/chronograf/pull/5553): Show all query results in table view.
 
 ### Features
 

--- a/ui/src/utils/groupByTimeSeriesTransform.ts
+++ b/ui/src/utils/groupByTimeSeriesTransform.ts
@@ -343,10 +343,9 @@ const constructTimeSeries = (
   serieses: Series[],
   cells: Cells,
   sortedLabels: Label[],
-  seriesLabels: Label[][]
+  seriesLabels: Label[][],
+  allowDuplicateTime = false
 ): TimeSeries[] => {
-  const nullArray: TimeSeriesValue[] = Array(sortedLabels.length).fill(null)
-
   const labelsToValueIndex = fastReduce<Label, {[x: string]: number}>(
     sortedLabels,
     (acc, {label, responseIndex, seriesIndex}, i) => {
@@ -382,22 +381,37 @@ const constructTimeSeries = (
     }
 
     existingRowIndex = tsMemo[time]
+    const valueIndex = labelsToValueIndex[label + responseIndex + seriesIndex]
 
     // avoid memoizing null time columns for meta queries
-    if (existingRowIndex === undefined || time === null) {
+    // + optionally create a duplicate entry if it would overwrite existing
+    if (
+      existingRowIndex === undefined ||
+      time === null ||
+      (allowDuplicateTime &&
+        existingRowIndex !== undefined &&
+        timeSeries[existingRowIndex].values[valueIndex] !== undefined)
+    ) {
       timeSeries.push({
         time,
-        values: fastCloneArray(nullArray),
+        values: new Array(sortedLabels.length),
       })
 
       existingRowIndex = timeSeries.length - 1
       tsMemo[time] = existingRowIndex
     }
 
-    timeSeries[existingRowIndex].values[
-      labelsToValueIndex[label + responseIndex + seriesIndex]
-    ] = value
+    timeSeries[existingRowIndex].values[valueIndex] = value
   }
+
+  // change all undefined values to null
+  timeSeries.forEach(x => {
+    for (let i = 0; i < x.values.length; i++) {
+      if (x.values[i] === undefined) {
+        x.values[i] = null
+      }
+    }
+  })
 
   return _.sortBy(timeSeries, 'time')
 }
@@ -434,7 +448,8 @@ export const groupByTimeSeriesTransform = (
     serieses,
     cells,
     sortedLabels,
-    seriesLabels
+    seriesLabels,
+    isTable
   )
   return {
     sortedLabels,

--- a/ui/src/utils/groupByTimeSeriesTransform.ts
+++ b/ui/src/utils/groupByTimeSeriesTransform.ts
@@ -404,7 +404,7 @@ const constructTimeSeries = (
     timeSeries[existingRowIndex].values[valueIndex] = value
   }
 
-  // change all undefined values to null
+  // change all undefined values to null, these values were not set
   timeSeries.forEach(x => {
     for (let i = 0; i < x.values.length; i++) {
       if (x.values[i] === undefined) {

--- a/ui/test/utils/timeSeriesTransformers.test.ts
+++ b/ui/test/utils/timeSeriesTransformers.test.ts
@@ -971,6 +971,44 @@ describe('timeSeriesToTableGraph', () => {
     expect(actual.data).toEqual(expected)
     expect(actual.influxQLQueryType).toEqual(InfluxQLQueryType.MetaQuery)
   })
+  it('returns all table results even with duplicate time rows #5502', () => {
+    const influxResponse = [
+      {
+        response: {
+          results: [
+            {
+              statement_id: 0,
+              series: [
+                {
+                  name: 'mem',
+                  columns: ['time', 'host', 'val'],
+                  values: [
+                    [1000, 'a', 1],
+                    [1000, 'b', 2],
+                    [2000, 'b', 3],
+                    [2000, 'c', 4],
+                  ],
+                },
+              ],
+            },
+          ],
+          uuid: '8cb3862f-aacf-4c3a-990f-4479de00ff99',
+        },
+      },
+    ]
+
+    const actual = timeSeriesToTableGraph(influxResponse)
+    const expected = [
+      ['time', 'mem.host', 'mem.val'],
+      [1000, 'a', 1],
+      [1000, 'b', 2],
+      [2000, 'b', 3],
+      [2000, 'c', 4],
+    ]
+
+    expect(actual.data).toEqual(expected)
+    expect(actual.influxQLQueryType).toEqual(InfluxQLQueryType.DataQuery)
+  })
 })
 
 describe('filterTableColumns', () => {


### PR DESCRIPTION
Closes #5502

_Briefly describe your proposed changes:_
The transformation that creates table data from InfluxDB response returns time series values that do not require a unique time. If there are more values for a specific time, there will be more rows of the same time with all the data for that time.

_What was the problem?_
The transformation 'from influx responses to table data' groups table data by time and always updates an existing time item when found. This approach overrides existing data if there are more results for a specific time.

_What was the solution?_
If the transformation is allowed to create time series with duplicate time (which is the case of table data), the existing item is updated only if it does not override data that were already set. If an override is detected, a new item for the same time is created. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
