### PR TITLE
fix(ui): escape tag values in query builder

### DIFF
--- a/ui/src/utils/influxql.ts
+++ b/ui/src/utils/influxql.ts
@@ -154,11 +154,13 @@ export function buildWhereClause({
     const cond = areTagsAccepted ? ' OR ' : ' AND '
 
     if (tags[k].length > 1) {
-      const joinedOnOr = tags[k].map(v => `"${k}"${operator}'${v}'`).join(cond)
+      const joinedOnOr = tags[k]
+        .map(v => `"${k}"${operator}'${v.replace(/'/g, "\\'")}'`)
+        .join(cond)
       return `(${joinedOnOr})`
     }
 
-    return `"${k}"${operator}'${tags[k]}'`
+    return `"${k}"${operator}'${tags[k].map(v => v.replace(/'/g, "\\'"))}'`
   })
 
   const subClauses = timeClauses.concat(tagClauses)


### PR DESCRIPTION
Closes #5489

_Briefly describe your proposed changes:_
Tag values are escaped when building influxql query strings
_What was the problem?_
missing escaping of `'`
_What was the solution?_
'`' is escaped according to https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#strings

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
