### PR TITLE
fix(ui): show also bool tag/field values in tickscript editor logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5554](https://github.com/influxdata/chronograf/pull/5554): Escape tag values in query builder.
 1. [#5551](https://github.com/influxdata/chronograf/pull/5551): Sort namespaces by database and retention policy.
+1. [#5555](https://github.com/influxdata/chronograf/pull/5555): Show also boolean field/tag values in tickscript editor logs.
 
 ### Features
 

--- a/ui/src/kapacitor/components/LogItemKapacitorPoint.tsx
+++ b/ui/src/kapacitor/components/LogItemKapacitorPoint.tsx
@@ -43,7 +43,7 @@ class LogItemKapacitorPoint extends PureComponent<Props> {
         <div className="logs-table--scrollbox">
           {sortedObjKeys.map(objKey => (
             <div key={objKey} className="logs-table--key-value">
-              {objKey}: <span>{object[objKey]}</span>
+              {objKey}: <span>{String(object[objKey])}</span>
             </div>
           ))}
         </div>


### PR DESCRIPTION
Closes #5481

![image](https://user-images.githubusercontent.com/16321466/89331968-edb73e80-d692-11ea-9c69-b2016f80d92b.png)


_Briefly describe your proposed changes:_
Field/Tag values are now printed in tickscript logs.
_What was the problem?_
The tag/field value was rendered as `{val}`, https://reactjs.org/docs/jsx-in-depth.html#booleans-null-and-undefined-are-ignored ... so that no value is shown to the user
_What was the solution?_
`{String(val)}`

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] Rebased/mergeable
  - [x] Tests pass
