### PR TITLE
fix: make MySQL protoboard more useful by using derivatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Other
 
+1. [#5552] (https://github.com/influxdata/chronograf/pull/5552): Make MySQL protoboard more useful by using derivatives for counter values
+
 ## v1.8.5 [2020-07-08]
 
 ### Bug Fixes

--- a/protoboards/mysql.json
+++ b/protoboards/mysql.json
@@ -93,7 +93,7 @@
         "name": "InnoDB data",
         "queries": [
           {
-            "query": "SELECT mean(\"innodb_data_writes\") AS \"writes\", mean(\"innodb_data_reads\") AS \"reads\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host =:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
+            "query": "SELECT non_negative_derivative(mean(\"innodb_data_writes\")) AS \"writes\", non_negative_derivative(mean(\"innodb_data_reads\")) AS \"reads\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host =:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
             "queryConfig": {
               "database": "",
               "measurement": "",
@@ -102,7 +102,7 @@
               "tags": {},
               "groupBy": {"time": "", "tags": []},
               "areTagsAccepted": false,
-              "rawText": "SELECT mean(\"innodb_data_writes\") AS \"writes\", mean(\"innodb_data_reads\") AS \"reads\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host =:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
+              "rawText": "SELECT non_negative_derivative(mean(\"innodb_data_writes\")) AS \"writes\", non_negative_derivative(mean(\"innodb_data_reads\")) AS \"reads\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host =:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
               "range": null,
               "shifts": null
             },
@@ -838,7 +838,7 @@
         "name": "MySQL slow queries",
         "queries": [
           {
-            "query": "SELECT mean(\"slow_queries\") AS \"mean_slow_queries\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host=:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
+            "query": "SELECT non_negative_derivative(mean(\"slow_queries\")) AS \"slow_queries\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host=:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
             "queryConfig": {
               "database": "",
               "measurement": "",
@@ -847,7 +847,7 @@
               "tags": {},
               "groupBy": {"time": "", "tags": []},
               "areTagsAccepted": false,
-              "rawText": "SELECT mean(\"slow_queries\") AS \"mean_slow_queries\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host=:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
+              "rawText": "SELECT non_negative_derivative(mean(\"slow_queries\")) AS \"slow_queries\" FROM \":db:\".\":rp:\".\"mysql\" WHERE host=:host: AND time > :dashboardTime: GROUP BY time(:interval:) FILL(null)",
               "range": null,
               "shifts": null
             },


### PR DESCRIPTION
Closes #5552 

The display of counters isn't very useful, it can be far better to show the absolute change. For graphs like that I've used the non_negative_derivative to show this.

  - [X] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] Rebased/mergeable
  - [N/A] Tests pass
  - [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
