### PR TITLE
chore: upgrade docker alpine to 3.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Other
 
+1. [#5560](https://github.com/influxdata/chronograf/pull/5560): Upgrade Dockerfile to use Alpine 3.12
+
 ## v1.8.5 [2020-07-08]
 
 ### Bug Fixes

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.12
 MAINTAINER Chris Goller <chris@influxdb.com>
 
 ENV PROTOBOARDS_PATH /usr/share/chronograf/protoboards


### PR DESCRIPTION
_Briefly describe your proposed changes:_
upgrade docker to use Alpine Linux to 3.12
_What was the problem?_
Dockerfile is based on Alpine Linux 3.8, which is out of support. 
_What was the solution?_
Upgrade to 3.12 + tested manually with 
```
make docker
- docker run --name cl --network host chronograf:latest 
- check that UI is running fine, do a simple adhoc query
```

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
