### PR TITLE
feat(server): allow to configure basic access authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ### Features
 
+1. [#5577](https://github.com/influxdata/chronograf/pull/5577): Allow to configure HTTP basic access authentication.
+
 ### Other
+
+1. [#5574](https://github.com/influxdata/chronograf/pull/5574): Migrate also users.
 
 ## v1.8.6 [2020-08-26]
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,7 @@ module github.com/influxdata/chronograf
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1
+	github.com/abbot/go-http-auth v0.4.0
 	github.com/boltdb/bolt v1.3.1
 	github.com/bouk/httprouter v0.0.0-20160817010721-ee8b3818a7f5
 	github.com/coreos/bbolt v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cq
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/abbot/go-http-auth v0.4.0 h1:QjmvZ5gSC7jm3Zg54DqWE/T5m1t2AfDu6QlXJT0EVT0=
+github.com/abbot/go-http-auth v0.4.0/go.mod h1:Cz6ARTIzApMJDzh5bRMSUou6UMSp0IEXg9km/ci7TJM=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=

--- a/server/mux.go
+++ b/server/mux.go
@@ -10,9 +10,10 @@ import (
 	"strings"
 	"time"
 
-	_ "net/http/pprof"
+	_ "net/http/pprof" // required for /debug/pprof endpoint
 
 	"github.com/NYTimes/gziphandler"
+	basicAuth "github.com/abbot/go-http-auth"
 	"github.com/bouk/httprouter" // When julienschmidt/httprouter v2 w/ context is out, switch
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/oauth2"
@@ -38,6 +39,7 @@ type MuxOpts struct {
 	PprofEnabled  bool         // Mount pprof routes for profiling
 	DisableGZip   bool         // Optionally disable gzip.
 	nonceExpire   time.Duration
+	BasicAuth     *basicAuth.BasicAuth // HTTP basic authentication provider
 }
 
 // NewMux attaches all the route handlers; handler returned servers chronograf.
@@ -375,10 +377,13 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 
 		// Create middleware that redirects to the appropriate provider logout
 		router.GET("/oauth/logout", logout("/", opts.Basepath, allRoutes.AuthRoutes))
-		out = Logger(opts.Logger, FlushingHandler(auth))
+		out = auth
+	} else if opts.BasicAuth != nil {
+		out = BasicAuthWrapper(router, opts.BasicAuth)
 	} else {
-		out = Logger(opts.Logger, FlushingHandler(router))
+		out = router
 	}
+	out = Logger(opts.Logger, FlushingHandler(out))
 
 	return out
 }
@@ -425,6 +430,14 @@ func AuthAPI(opts MuxOpts, router chronograf.Router) (http.Handler, AuthRoutes) 
 		}
 		router.ServeHTTP(w, r)
 	}), routes
+}
+
+// BasicAuthWrapper returns http handlers that wraps the supplied handler with HTTP Basic authentication
+func BasicAuthWrapper(router chronograf.Router, auth *basicAuth.BasicAuth) http.Handler {
+	return auth.Wrap(func(response http.ResponseWriter, authRequest *basicAuth.AuthenticatedRequest) {
+		router.ServeHTTP(response, &authRequest.Request)
+	})
+
 }
 
 func encodeJSON(w http.ResponseWriter, status int, v interface{}, logger chronograf.Logger) {


### PR DESCRIPTION
Closes #4562

This PR allows to turn on HTTP basic access authentication so that all HTTP requests to chronograf are restricted to selected users. This is possible on CLI with `--htpasswd <path to .htpasswd file>` or with `HTPASSWD` environment variable.

The `.htpasswd` file contains users and their passwords, it is usually managed by the `htpasswd` utility, see https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basic-authentication/ to know more.
This type of authentication should be used in cases, in which OAuth integration is not possible.

**Warning**: When using basic authentication, the authorization rules of Chronograf are not enforced. Basic access authentication only controls who can access Chronograf, users are then super users.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
