### PR TITLE
fix(ui): upgrade papaparse to 5.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#5580](https://github.com/influxdata/chronograf/pull/5580): Add 'isPresent' filter to rule tickscript.
 1. [#5579](https://github.com/influxdata/chronograf/pull/5579): Disable default dashboard auto refresh.
 1. [#5574](https://github.com/influxdata/chronograf/pull/5574): Migrate also users.
+1. [#5592](https://github.com/influxdata/chronograf/pull/5592): Upgrade papaparse to 5.3.0.
 
 ### Features
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -114,7 +114,7 @@
     "memoize-one": "^4.0.2",
     "moment": "^2.13.0",
     "nano-date": "^2.0.1",
-    "papaparse": "^4.4.0",
+    "papaparse": "^5.3.0",
     "prop-types": "^15.6.1",
     "qs": "^6.5.2",
     "react": "^16.8.6",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -8024,10 +8024,10 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.6.tgz#0101211baa70c4bca4a0f63f2206e97b7dfaf258"
   integrity sha512-lQe48YPsMJAig+yngZ87Lus+NF+3mtu7DVOBu6b/gHO1YpKwIj5AWjZ/TOS7i46HD/UixzWb1zeWDZfGZ3iYcg==
 
-papaparse@^4.4.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.0.tgz#4e3b8d6bf9f7900da437912794ec292207526867"
-  integrity sha512-ylm8pmgyz9rkS3Ng/ru5tHUF3JxWwKYP0aZZWZ8eCGdSxoqgYiDUXLNQei73mUJOjHw8QNu5ZNCsLoDpkMA6sg==
+papaparse@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.0.tgz#ab1702feb96e79ab4309652f36db9536563ad05a"
+  integrity sha512-Lb7jN/4bTpiuGPrYy4tkKoUS8sTki8zacB5ke1p5zolhcSE4TlWgrlsxjrDTbG/dFVh07ck7X36hUf/b5V68pg==
 
 parcel@^1.12.4:
   version "1.12.4"


### PR DESCRIPTION
This PR upgrades `papaparse` in order to fix high-severity security issue https://github.com/advisories/GHSA-qvjc-g5vr-mfgr .

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
