### PR TITLE
feat(kapacitor/opsgenie2): add recovery action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Features
 
+1. [#5595](https://github.com/influxdata/chronograf/pull/5595): Allow to select recovery action in OpsGenie2 configuration.
+
 ### Other
 
 ## v1.8.7 [2020-10-06]

--- a/ui/src/kapacitor/components/AlertTabs.tsx
+++ b/ui/src/kapacitor/components/AlertTabs.tsx
@@ -282,6 +282,7 @@ class AlertTabs extends PureComponent<Props, State> {
               configSections,
               AlertTypes.opsgenie2
             )}
+            v2={true}
           />
         )
       case AlertTypes.pagerduty:

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -350,6 +350,7 @@ export interface OpsGenieProperties {
   teams: string[]
   recipients: string[]
   enabled: boolean
+  recovery_action?: 'notes' | 'close' // available in OpsGenie2
 }
 
 export interface PagerDutyProperties {


### PR DESCRIPTION
Closes #5594 

_Briefly describe your proposed changes:_
UI enahnced to specify Opsgenie2 recovery actions
![image](https://user-images.githubusercontent.com/16321466/96491583-b9d7c800-1242-11eb-90fe-5cc3a81f63da.png)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
