### PR TITLE
fix(kapacitor): parse task name from TICKScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5596](https://github.com/influxdata/chronograf/pull/5596): Show rule name from tickscript.
+
 ### Features
 
 ### Other

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/id"
@@ -68,6 +69,8 @@ type Task struct {
 	TICKScript chronograf.TICKScript // TICKScript is the running script
 }
 
+var reTaskName = regexp.MustCompile(`[\r\n]*var[ \t]+name[ \t]+=[ \t]+'([^']+)'`)
+
 // NewTask creates a task from a kapacitor client task
 func NewTask(task *client.Task) *Task {
 	dbrps := make([]chronograf.DBRP, len(task.DBRPs))
@@ -79,8 +82,13 @@ func NewTask(task *client.Task) *Task {
 	script := chronograf.TICKScript(task.TICKscript)
 	rule, err := Reverse(script)
 	if err != nil {
+		// try to parse Name from a line such as: `var name = 'Rule Name'
+		name := task.ID
+		if matches := reTaskName.FindStringSubmatch(task.TICKscript); matches != nil {
+			name = matches[1]
+		}
 		rule = chronograf.AlertRule{
-			Name:  task.ID,
+			Name:  name,
 			Query: nil,
 		}
 	}

--- a/kapacitor/client_test.go
+++ b/kapacitor/client_test.go
@@ -140,6 +140,45 @@ func TestClient_All(t *testing.T) {
 			},
 		},
 		{
+			name: "return a non-reversible named task",
+			fields: fields{
+				kapaClient: func(url, username, password string, insecureSkipVerify bool) (KapaClient, error) {
+					return kapa, nil
+				},
+			},
+			listTasksOptions: &client.ListTasksOptions{},
+			resTasks: []client.Task{
+				{
+					ID:     "howdy",
+					Status: client.Enabled,
+					TICKscript: `var whereFilter = lambda: TRUE
+
+var name = 'rule 1'
+
+var idVar = name + '-{{.Group}}'`,
+				},
+			},
+			want: map[string]*Task{
+				"howdy": {
+					ID: "howdy",
+
+					HrefOutput: "/kapacitor/v1/tasks/howdy/output",
+					Rule: chronograf.AlertRule{
+						ID:   "howdy",
+						Name: "rule 1",
+						TICKScript: `var whereFilter = lambda: TRUE
+
+var name = 'rule 1'
+
+var idVar = name + '-{{.Group}}'`,
+						Type:   "invalid",
+						Status: "enabled",
+						DBRPs:  []chronograf.DBRP{},
+					},
+				},
+			},
+		},
+		{
 			name: "return a reversible task",
 			fields: fields{
 				kapaClient: func(url, username, password string, insecureSkipVerify bool) (KapaClient, error) {


### PR DESCRIPTION
Closes #4304 

Chronograf tries to parse TICK script to determine if it can display it as an alert tule or a generic TICK script. If the parsing (to alert rule) fails, chronograf (since this PR) also tries to find a line with `var name = 'Rule Name')  to find a task name. If that also fails, the kapacitor task id is used, as it was before this PR.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
