### PR TITLE
fix(dashboard): don't truncate dashboard name with lots of room

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#5596](https://github.com/influxdata/chronograf/pull/5596): Show rule name from tickscript.
+1. [#5597](https://github.com/influxdata/chronograf/pull/5597): Do not truncate dashboard name with lots of room.
 
 ### Features
 

--- a/ui/src/dashboards/components/rename_dashboard/RenameDashboard.scss
+++ b/ui/src/dashboards/components/rename_dashboard/RenameDashboard.scss
@@ -11,7 +11,7 @@ $rename-dash-title-padding: 7px;
   max-width: 40vw;
 }
 .dashboard-switcher + .rename-dashboard {
-  width: calc(100% - 38px);
+  width: calc(100% - 37px);
 }
 
 .rename-dashboard--title {


### PR DESCRIPTION
Closes #5593 #5296 

Caused by decimal width conversions, fixed by extending the dashboard name width by 1px

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
