### PR TITLE
fix(tickscript): repair editor scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5596](https://github.com/influxdata/chronograf/pull/5596): Show rule name from tickscript.
 1. [#5597](https://github.com/influxdata/chronograf/pull/5597): Do not truncate dashboard name with lots of room.
+1. [#5598](https://github.com/influxdata/chronograf/pull/5598): Repair TICKscript editor scrolling.
 
 ### Features
 

--- a/ui/src/style/external/codemirror.scss
+++ b/ui/src/style/external/codemirror.scss
@@ -16,9 +16,9 @@
   padding: 0 4px; /* Horizontal padding of content */
 }
 
-.CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
-  background-color: white; /* The little square between H and V scrollbars */
-}
+// .CodeMirror-scrollbar-filler, .CodeMirror-gutter-filler {
+//   background-color: white; /* The little square between H and V scrollbars */
+// }
 
 /* GUTTER */
 

--- a/ui/src/style/pages/tickscript-editor.scss
+++ b/ui/src/style/pages/tickscript-editor.scss
@@ -13,7 +13,9 @@ $tickscript-controls-height: 60px;
 .tickscript-controls,
 .tickscript-console,
 .tickscript-editor {
-  width: 100%;
+  // cannot use 100%, since it does not work in FireFox
+  // see https://github.com/influxdata/chronograf/issues/5037
+  width: calc(100vw - 60px);
 }
 .tickscript-console,
 .tickscript-controls {


### PR DESCRIPTION
Closes #5037

Fixes layout so that the TICKscript editor is scrollable in Firefox. Firefox seems to compute the width of an editor element from the nested elements of the flex layout, even though the width of the parent element shall be used. Specifying width in _vw_ units fixes the issue and ensures that it does not affect other supported browsers.

Additionally, the following disturbing white box becomes transparent (black) in this PR (for all browsers):
![image](https://user-images.githubusercontent.com/16321466/96687704-8e5af780-1380-11eb-949a-9b262fff8f3f.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
