### PR TITLE
fix(servers): apply default timeouts in server connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5596](https://github.com/influxdata/chronograf/pull/5596): Show rule name from tickscript.
 1. [#5597](https://github.com/influxdata/chronograf/pull/5597): Do not truncate dashboard name with lots of room.
 1. [#5598](https://github.com/influxdata/chronograf/pull/5598): Repair TICKscript editor scrolling.
+1. [#5600](https://github.com/influxdata/chronograf/pull/5600): Apply default timeouts in server connections.
 
 ### Features
 


### PR DESCRIPTION
Closes #5583 

_Briefly describe your proposed changes:_
This PR ensures that a shared HTTP Transport is used in client connections from chronograf to connected InfluxDB databases and kapacitors. The shared transport is built on top of golang's [DefaultTransport](https://golang.org/pkg/net/http/#RoundTripper) that applies reasonable timeouts and system proxies.

_What was the problem?_
No transport timeouts caused failing idle connections in AWS; no proxy can be configured; leaking transport in a kapacitor proxy that does not reuse existing transport (when InsecureSkipVerify)

_What was the solution?_
Use shared transport(s), apply golang's defaults.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
