### PR TITLE
fix(ui): respect selected timezone in range picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#5597](https://github.com/influxdata/chronograf/pull/5597): Do not truncate dashboard name with lots of room.
 1. [#5598](https://github.com/influxdata/chronograf/pull/5598): Repair TICKscript editor scrolling.
 1. [#5600](https://github.com/influxdata/chronograf/pull/5600): Apply default timeouts in server connections.
+1. [#5603](https://github.com/influxdata/chronograf/pull/5603): Respect selected time zone in range picker.
 
 ### Features
 

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -2,6 +2,8 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import moment from 'moment'
+import {connect} from 'react-redux'
+import _ from 'lodash'
 
 import OnClickOutside from 'shared/components/OnClickOutside'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
@@ -10,10 +12,17 @@ import CustomTimeRangeOverlay from 'shared/components/CustomTimeRangeOverlay'
 import {timeRanges} from 'shared/data/timeRanges'
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'shared/constants/index'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import {TimeZones} from 'src/types'
 
 const dateFormat = 'YYYY-MM-DD HH:mm'
 const emptyTime = {lower: '', upper: ''}
-const format = t => moment(t.replace(/\'/g, '')).format(dateFormat)
+const format = (t, timeZone) => {
+  const m = moment(t.replace(/\'/g, ''))
+  if (timeZone === TimeZones.UTC) {
+    m.utc()
+  }
+  return m.format(dateFormat)
+}
 
 class TimeRangeDropdown extends Component {
   constructor(props) {
@@ -34,10 +43,10 @@ class TimeRangeDropdown extends Component {
   findTimeRangeInputValue = ({upper, lower}) => {
     if (upper && lower) {
       if (upper === 'now()') {
-        return `${format(lower)} - Now`
+        return `${format(lower, this.props.timeZone)} - Now`
       }
 
-      return `${format(lower)} - ${format(upper)}`
+      return `${format(lower, this.props.timeZone)} - ${format(upper, this.props.timeZone)}`
     }
 
     const selected = timeRanges.find(range => range.lower === lower)
@@ -169,6 +178,10 @@ TimeRangeDropdown.propTypes = {
   onChooseTimeRange: func.isRequired,
   preventCustomTimeRange: bool,
   page: string,
+  timeZone: string,
 }
 
-export default OnClickOutside(ErrorHandling(TimeRangeDropdown))
+const mstp = state => ({
+  timeZone: _.get(state, ['app', 'persisted', 'timeZone']),
+})
+export default OnClickOutside(ErrorHandling(connect(mstp)(TimeRangeDropdown)))


### PR DESCRIPTION
Closes #5602

_Briefly describe your proposed changes:_
![image](https://user-images.githubusercontent.com/16321466/97267823-221e3f00-182b-11eb-8105-614a557402ef.png)

- time is printed in the selected time zone (Local , UTC)
- time is picked in the selected time zone
- time rendering reacts upon change of the time zone

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
