### PR TITLE
fix(ui):  export CSV with a time column formatted according to selected time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [#5598](https://github.com/influxdata/chronograf/pull/5598): Repair TICKscript editor scrolling.
 1. [#5600](https://github.com/influxdata/chronograf/pull/5600): Apply default timeouts in server connections.
 1. [#5603](https://github.com/influxdata/chronograf/pull/5603): Respect selected time zone in range picker.
+1. [#5604](https://github.com/influxdata/chronograf/pull/5604): Export CSV with a time column formatted according to selected time zone.
 
 ### Features
 

--- a/ui/src/shared/components/TimeMachine/CSVExporter.tsx
+++ b/ui/src/shared/components/TimeMachine/CSVExporter.tsx
@@ -12,7 +12,7 @@ import {
   fluxResponseTruncatedError,
 } from 'src/shared/copy/notifications'
 
-import {Query, Template, Source, TimeRange} from 'src/types'
+import {Query, Template, Source, TimeRange, TimeZones} from 'src/types'
 
 interface Props {
   // Used for downloading an InfluxQL query
@@ -27,6 +27,7 @@ interface Props {
 
   isFluxSelected: boolean
   onNotify: typeof notify
+  timeZone?: TimeZones
 }
 
 interface State {
@@ -73,9 +74,9 @@ class CSVExporter extends PureComponent<Props, State> {
   }
 
   private downloadInfluxQLCSV = (): Promise<void> => {
-    const {queries, templates} = this.props
+    const {queries, templates, timeZone} = this.props
 
-    return downloadInfluxQLCSV(queries, templates)
+    return downloadInfluxQLCSV(queries, templates, timeZone)
   }
 
   private downloadFluxCSV = async (): Promise<void> => {
@@ -98,6 +99,7 @@ class CSVExporter extends PureComponent<Props, State> {
 
 const mstp = state => ({
   fluxASTLink: state.links.flux.ast,
+  timeZone: state.app.persisted.timeZone,
 })
 
 const mdtp = {

--- a/ui/src/shared/utils/downloadTimeseriesCSV.ts
+++ b/ui/src/shared/utils/downloadTimeseriesCSV.ts
@@ -9,12 +9,13 @@ import {executeQuery as executeFluxQuery} from 'src/shared/apis/flux/query'
 import {renderTemplatesInScript} from 'src/flux/helpers/templates'
 
 // Types
-import {Query, Template, Source, TimeRange} from 'src/types'
+import {Query, Template, Source, TimeRange, TimeZones} from 'src/types'
 import {TimeSeriesResponse} from 'src/types/series'
 
 export const downloadInfluxQLCSV = async (
   queries: Query[],
-  templates: Template[]
+  templates: Template[],
+  timeZone: TimeZones = TimeZones.UTC
 ): Promise<void> => {
   const responses = await Promise.all(
     queries.map(query =>
@@ -22,7 +23,7 @@ export const downloadInfluxQLCSV = async (
     )
   )
 
-  const csv = await timeseriesToCSV(responses)
+  const csv = await timeseriesToCSV(responses, timeZone)
 
   downloadCSV(csv, csvName())
 }
@@ -50,7 +51,8 @@ export const downloadFluxCSV = async (
 }
 
 const timeseriesToCSV = async (
-  responses: TimeSeriesResponse[]
+  responses: TimeSeriesResponse[],
+  timeZone: TimeZones
 ): Promise<string> => {
   const wrapped = responses.map(response => ({response}))
   const tableResponse = await timeSeriesToTableGraph(wrapped)
@@ -64,11 +66,14 @@ const timeseriesToCSV = async (
   const tableData = table.slice(1)
 
   const timeIndex = tableHeader.indexOf('time')
+  const isLocal = timeZone === TimeZones.Local
 
   if (timeIndex > -1) {
     for (let i = 0; i < tableData.length; i++) {
       // Convert times to a (somewhat) human readable ISO8601 string
-      tableData[i][timeIndex] = new Date(tableData[i][timeIndex]).toISOString()
+      tableData[i][timeIndex] = moment(
+        new Date(tableData[i][timeIndex])
+      ).toISOString(isLocal)
     }
   }
 


### PR DESCRIPTION
Closes #5329

_Briefly describe your proposed changes:_
When the user executes an InfluxQL query and clicks the `CSV` button to download results as CSV, the CSV results contains a time column that is always formatted according ISO8601 with a time zone that is selected in UI (UTC or Local).

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
