### PR TITLE
fix(ui): avoid blinking during dashboard refresh

### DIFF
--- a/ui/src/shared/components/RefreshingGraph.tsx
+++ b/ui/src/shared/components/RefreshingGraph.tsx
@@ -190,10 +190,7 @@ class RefreshingGraph extends Component<Props> {
                       )
                     }
 
-                    if (
-                      !this.hasValues(timeSeriesFlux, timeSeriesInfluxQL) &&
-                      loading !== RemoteDataState.Loading
-                    ) {
+                    if (!this.hasValues(timeSeriesFlux, timeSeriesInfluxQL)) {
                       if (errorMessage && _.get(queries, '0.text', '').trim()) {
                         return <InvalidData message={errorMessage} />
                       }

--- a/ui/src/shared/parsing/index.ts
+++ b/ui/src/shared/parsing/index.ts
@@ -51,7 +51,8 @@ export const extractQueryErrorMessage = (errorMessage: string): string => {
     return 'Could not retrieve data'
   }
 
-  const parseErrorMatch = errorMessage.match('error parsing query')
+  const parseErrorMatch =
+    errorMessage.match && errorMessage.match('error parsing query')
 
   if (parseErrorMatch) {
     return errorMessage.slice(parseErrorMatch.index)

--- a/ui/src/utils/ajax.ts
+++ b/ui/src/utils/ajax.ts
@@ -93,7 +93,7 @@ async function AJAX<T = any>(
     headers = {},
   }: RequestParams,
   excludeBasepath = false
-): Promise<(T | T & {links: object}) | AxiosResponse<T>> {
+): Promise<(T | (T & {links: object})) | AxiosResponse<T>> {
   try {
     url = addBasepath(url, excludeBasepath)
 
@@ -117,7 +117,11 @@ async function AJAX<T = any>(
     return links ? generateResponseWithLinks(response, links) : response
   } catch (error) {
     const {response} = error
-    throw links ? generateResponseWithLinks(response, links) : response // eslint-disable-line no-throw-literal
+    if (response) {
+      throw links ? generateResponseWithLinks(response, links) : response // eslint-disable-line no-throw-literal
+    } else {
+      throw error
+    }
   }
 }
 


### PR DESCRIPTION
Closes #5599

_Briefly describe your proposed changes:_
Default visualizations are not shown when no data is present + repair handling of network errors.
_What was the problem?_
Default visualizations were shown when loading + no previous results.
_What was the solution?_
Default visualizations are not shown when no data is present.

  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
