### PR TITLE
feat(etcd): allow to configure  ETCD with client certificate

### DIFF
--- a/kv/etcd/client.go
+++ b/kv/etcd/client.go
@@ -3,6 +3,7 @@ package etcd
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"errors"
 	"math/rand"
 	"time"
@@ -125,6 +126,16 @@ func WithLogin(u, p string) Option {
 	return func(c *client) error {
 		c.config.Username = u
 		c.config.Password = p
+		return nil
+	}
+}
+
+// WithTLS allows set TLS config.
+func WithTLS(tlsConfig *tls.Config) Option {
+	return func(c *client) error {
+		if tlsConfig != nil {
+			c.config.TLS = tlsConfig
+		}
 		return nil
 	}
 }

--- a/server/tls_options.go
+++ b/server/tls_options.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 )
 
-type tlsServerOptions struct {
+type tlsOptions struct {
 	// Cert contains path to PEM encoded public key certificate
 	Cert string
 	// Key contains Path to private key associated with given certificate.
@@ -58,7 +58,7 @@ var versionsMap = map[string]uint16{
 	"1.3": tls.VersionTLS13,
 }
 
-func createTLSConfig(o tlsServerOptions) (out *tls.Config, err error) {
+func createTLSConfig(o tlsOptions) (out *tls.Config, err error) {
 	// load key pair
 	if o.Cert == "" {
 		return nil, errors.New("no TLS certificate specified")

--- a/server/tls_options_test.go
+++ b/server/tls_options_test.go
@@ -11,25 +11,25 @@ import (
 func Test_createTLSConfig(t *testing.T) {
 	var tests = []struct {
 		name string
-		in   tlsServerOptions
+		in   tlsOptions
 		out  *tls.Config
 		err  string
 	}{
 		{
 			name: "empty options",
-			in:   tlsServerOptions{},
+			in:   tlsOptions{},
 			err:  "no TLS certificate specified",
 		},
 		{
 			name: "missing key",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert: "tls_options_test.cert",
 			},
 			err: "private key",
 		},
 		{
 			name: "cert and key",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert: "tls_options_test.cert",
 				Key:  "tls_options_test.key",
 			},
@@ -37,7 +37,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "minVersion",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert:       "tls_options_test.cert",
 				Key:        "tls_options_test.key",
 				MinVersion: "1.1",
@@ -46,7 +46,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "maxVersion",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert:       "tls_options_test.cert",
 				Key:        "tls_options_test.key",
 				MaxVersion: "1.2",
@@ -55,7 +55,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "ciphers",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert: "tls_options_test.cert",
 				Key:  "tls_options_test.key",
 				Ciphers: []string{
@@ -74,7 +74,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "help on ciphers",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert: "tls_options_test.cert",
 				Key:  "tls_options_test.key",
 				Ciphers: []string{
@@ -85,7 +85,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "unknown cipher",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert: "tls_options_test.cert",
 				Key:  "tls_options_test.key",
 				Ciphers: []string{
@@ -96,7 +96,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "unknown minVersion",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert:       "tls_options_test.cert",
 				Key:        "tls_options_test.key",
 				MinVersion: "0.9",
@@ -105,7 +105,7 @@ func Test_createTLSConfig(t *testing.T) {
 		},
 		{
 			name: "unknown maxVersion",
-			in: tlsServerOptions{
+			in: tlsOptions{
 				Cert:       "tls_options_test.cert",
 				Key:        "tls_options_test.key",
 				MaxVersion: "f1",


### PR DESCRIPTION
Closes #5576

This PR adds `--etcd-cert` and `--etcd-key` options to `chronograf` so that SSL/TLS client authentication can be used in communication with ETCD. Environment variables `ETCD_CERTIFICATE` and `ETCD_PRIVATE_KEY` can be used as well.

  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
