### PR TITLE
fix(alert rule): warn about unsupported data

### DIFF
--- a/ui/src/kapacitor/components/RuleGraphDygraph.tsx
+++ b/ui/src/kapacitor/components/RuleGraphDygraph.tsx
@@ -64,6 +64,17 @@ class RuleGraphDygraph extends Component<Props, State> {
     if (!timeSeriesToDygraphResult) {
       return null
     }
+    if (timeSeriesToDygraphResult.unsupportedValue) {
+      console.error(
+        'Unsupported y-axis value, cannot display data',
+        timeSeriesToDygraphResult
+      )
+      return (
+        <p className="unexpected-error">
+          Unsupported y-axis value, only numbers are supported.
+        </p>
+      )
+    }
 
     return (
       <Dygraph

--- a/ui/src/shared/components/FieldList.tsx
+++ b/ui/src/shared/components/FieldList.tsx
@@ -253,10 +253,10 @@ class FieldList extends PureComponent<Props, State> {
       const newFields = _.get(fieldSets, measurement, []).map(f => ({
         value: f,
         type: 'field',
-      }))
+      })) as Field[]
 
       this.setState({
-        fields: newFields,
+        fields: _.uniqBy(newFields, 'value'), // do not duplicate items
       })
     })
   }

--- a/ui/src/utils/timeSeriesTransformers.ts
+++ b/ui/src/utils/timeSeriesTransformers.ts
@@ -11,6 +11,7 @@ export interface TimeSeriesToDyGraphReturnType {
   labels: string[]
   timeSeries: DygraphValue[][]
   dygraphSeries: DygraphSeries
+  unsupportedValue?: any
 }
 
 export const timeSeriesToDygraph = async (
@@ -19,12 +20,18 @@ export const timeSeriesToDygraph = async (
 ): Promise<TimeSeriesToDyGraphReturnType> => {
   const result = await manager.timeSeriesToDygraph(raw, pathname)
   const {timeSeries} = result
+  let unsupportedValue: any
   const newTimeSeries = fastMap<DygraphValue[], DygraphValue[]>(
     timeSeries,
-    ([time, ...values]) => [new Date(time), ...values]
+    ([time, ...values]) => {
+      if (unsupportedValue === undefined) {
+        unsupportedValue = values.find(x => x !== null && typeof x !== 'number')
+      }
+      return [new Date(time), ...values]
+    }
   )
 
-  return {...result, timeSeries: newTimeSeries}
+  return {...result, timeSeries: newTimeSeries, unsupportedValue}
 }
 
 export const timeSeriesToTableGraph = async (


### PR DESCRIPTION
Closes #5561 

_Briefly describe your proposed changes:_
No dygraph is visualized when non-numerical data are detected.
![image](https://user-images.githubusercontent.com/16321466/99552957-e3108300-29bd-11eb-8ee6-c8c29216b431.png)

_What was the problem?_
String values cannot be visualized in dygraph, such data will not work in a tick script created by `Rule Alert Builder`
_What was the solution?_
Detect non-numerical values and display a warning.

  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
