### PR TITLE
fix(kapacitor): AND not equal conditions in where filter

### DIFF
--- a/kapacitor/ast.go
+++ b/kapacitor/ast.go
@@ -106,7 +106,7 @@ func varWhereFilter(vars map[string]tick.Var) (WhereFilter, bool) {
 	}
 
 	lambda := value.ExpressionString()
-	// Chronograf TICKScripts use lambda: TRUE as a pass-throug where clause
+	// Chronograf TICKScripts use lambda: TRUE as a pass-through where clause
 	// if the script does not have a where clause set.
 	// isPresent(fieldName) is also used since chronograf 1.8.7 in place of TRUE
 	// https://github.com/influxdata/chronograf/issues/5566

--- a/kapacitor/vars.go
+++ b/kapacitor/vars.go
@@ -235,8 +235,10 @@ func field(q *chronograf.QueryConfig) (string, error) {
 func whereFilter(q *chronograf.QueryConfig) string {
 	if q != nil {
 		operator := "=="
+		combineOperators := " OR "
 		if !q.AreTagsAccepted {
 			operator = "!="
+			combineOperators = " AND " // negative comparisons are ANDed
 		}
 
 		outer := []string{}
@@ -245,7 +247,7 @@ func whereFilter(q *chronograf.QueryConfig) string {
 			for _, value := range values {
 				inner = append(inner, fmt.Sprintf(`"%s" %s '%s'`, tag, operator, value))
 			}
-			outer = append(outer, "("+strings.Join(inner, " OR ")+")")
+			outer = append(outer, "("+strings.Join(inner, combineOperators)+")")
 		}
 
 		// add isPresent filters, see https://github.com/influxdata/chronograf/issues/5566


### PR DESCRIPTION
Closes #5518 

_Briefly describe your proposed changes:_
When creating `whereFilter` variable in alert rule builder, join not-equal tag conditions with AND operator.
_What was the problem?_
They were OR-ed, which is desired for `==` conditions, but it is not `!=`
_What was the solution?_
Use AND when `!=` tag comparison operator is used.

  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
