### PR TITLE
fix(ui): disable InfluxDB admin page if administration is not possible

### DIFF
--- a/ui/src/admin/containers/AdminInfluxDBPage.tsx
+++ b/ui/src/admin/containers/AdminInfluxDBPage.tsx
@@ -160,6 +160,14 @@ export class AdminInfluxDBPage extends PureComponent<Props, State> {
       return <PageSpinner />
     }
 
+    if (!source.version || source.version.startsWith('2')) {
+      return (
+        <div className="container-fluid">
+          These functions are not available for the currently selected InfluxDB
+          Connection.
+        </div>
+      )
+    }
     return (
       <div className="container-fluid">
         <SubSections


### PR DESCRIPTION
Closes #5614

_Briefly describe your proposed changes:_
InfluxDB Admin Page shows

```
These functions are not available for the currently selected InfluxDB Connection.
```
if non-v1 InfluxDB source is detected.

  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
