### PR TITLE
feat: support flux against InfluxDB v2 sources

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -293,6 +293,10 @@ func (c *Client) ping(u *url.URL) (string, string, error) {
 	} else if strings.Contains(version, "relay") {
 		return version, chronograf.InfluxRelay, nil
 	}
+	// older InfluxDB instances might have version 'v1.x.x'
+	if strings.HasPrefix(version, "v") {
+		version = version[1:]
+	}
 
 	return version, chronograf.InfluxDB, nil
 }

--- a/server/flux.go
+++ b/server/flux.go
@@ -176,6 +176,11 @@ func (s *Service) ProxyFlux(w http.ResponseWriter, r *http.Request) {
 	director := func(req *http.Request) {
 		// Set the Host header of the original Flux URL
 		req.Host = u.Host
+		// Add v2-required org parameter
+		query := u.Query()
+		query.Add("org", src.Username) // v2 organization name is stored as v1 username
+		u.RawQuery = query.Encode()
+		// Set URL
 		req.URL = u
 
 		// Use authorization method based on whether it is OSS or Enterprise

--- a/server/sources.go
+++ b/server/sources.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/influxdata/chronograf/enterprise"
@@ -166,12 +167,7 @@ func (s *Service) NewSource(w http.ResponseWriter, r *http.Request) {
 		src.Telegraf = "telegraf"
 	}
 
-	dbVersion, err := s.tsdbVersion(ctx, &src)
-	if err != nil {
-		dbVersion = "Unknown"
-		s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
-	}
-	src.Version = dbVersion
+	src.Version = s.sourceVersion(ctx, &src)
 
 	dbType, err := s.tsdbType(ctx, &src)
 	if err != nil {
@@ -189,6 +185,19 @@ func (s *Service) NewSource(w http.ResponseWriter, r *http.Request) {
 	res := newSourceResponse(ctx, src)
 	location(w, res.Links.Self)
 	encodeJSON(w, http.StatusCreated, res, s.Logger)
+}
+
+func (s *Service) sourceVersion(ctx context.Context, src *chronograf.Source) string {
+	retVal, err := s.tsdbVersion(ctx, src)
+	if err == nil {
+		return retVal
+	}
+	s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
+	if strings.HasPrefix(src.Version, "1.") || strings.HasPrefix(src.Version, "2.") {
+		// keep the client version unchanged
+		return src.Version
+	}
+	return "Unknown"
 }
 
 func (s *Service) tsdbVersion(ctx context.Context, src *chronograf.Source) (string, error) {
@@ -242,12 +251,7 @@ func (s *Service) Sources(w http.ResponseWriter, r *http.Request) {
 	sourceCh := make(chan sourceResponse, len(srcs))
 	for _, src := range srcs {
 		go func(src chronograf.Source) {
-			dbVersion, err := s.tsdbVersion(ctx, &src)
-			if err != nil {
-				dbVersion = "Unknown"
-				s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
-			}
-			src.Version = dbVersion
+			src.Version = s.sourceVersion(ctx, &src)
 			sourceCh <- newSourceResponse(ctx, src)
 		}(src)
 	}
@@ -273,12 +277,7 @@ func (s *Service) SourcesID(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbVersion, err := s.tsdbVersion(ctx, &src)
-	if err != nil {
-		dbVersion = "Unknown"
-		s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
-	}
-	src.Version = dbVersion
+	src.Version = s.sourceVersion(ctx, &src)
 
 	res := newSourceResponse(ctx, src)
 	encodeJSON(w, http.StatusOK, res, s.Logger)
@@ -433,12 +432,7 @@ func (s *Service) UpdateSource(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	dbVersion, err := s.tsdbVersion(ctx, &src)
-	if err != nil {
-		dbVersion = "Unknown"
-		s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
-	}
-	src.Version = dbVersion
+	src.Version = s.sourceVersion(ctx, &src)
 
 	dbType, err := s.tsdbType(ctx, &src)
 	if err != nil {

--- a/ui/src/reusable_ui/components/wizard/WizardCheckbox.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardCheckbox.tsx
@@ -8,15 +8,16 @@ interface Props {
   text: string
   subtext?: string
   onChange: (isChecked: boolean) => void
+  halfWidth?: boolean
 }
 
 @ErrorHandling
 class WizardCheckbox extends PureComponent<Props> {
   public render() {
-    const {text, isChecked, subtext} = this.props
+    const {text, isChecked, subtext, halfWidth} = this.props
 
     return (
-      <div className="form-group col-xs-12">
+      <div className={'form-group ' + (halfWidth ? 'col-xs-6' : 'col-xs-12')}>
         <div className="form-control-static wizard-checkbox--group">
           <SlideToggle
             color={ComponentColor.Success}

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -446,6 +446,7 @@ export const DEFAULT_SOURCE = {
   telegraf: 'telegraf',
   insecureSkipVerify: false,
   metaUrl: 'http://localhost:8091',
+  version: '1.x',
 }
 
 export const DEFAULT_KAPACITOR = {

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -36,6 +36,8 @@ import {Source, Me} from 'src/types'
 import {NextReturn} from 'src/types/wizard'
 
 const isNewSource = (source: Partial<Source>) => !source.id
+const isSourceV2 = (source: Partial<Source>) =>
+  !source.version || source.version.startsWith('2.')
 
 interface Props {
   notify: typeof notifyAction
@@ -98,6 +100,8 @@ class SourceStep extends PureComponent<Props, State> {
   public render() {
     const {source} = this.state
     const {isUsingAuth, onBoarding} = this.props
+    const sourceIsV2 = isSourceV2(source)
+
     return (
       <>
         {isUsingAuth && onBoarding && this.authIndicator}
@@ -115,12 +119,12 @@ class SourceStep extends PureComponent<Props, State> {
         />
         <WizardTextInput
           value={source.username}
-          label="Username"
+          label={sourceIsV2 ? 'Organization' : 'Username'}
           onChange={this.onChangeInput('username')}
         />
         <WizardTextInput
           value={source.password}
-          label="Password"
+          label={sourceIsV2 ? 'Token' : 'Password'}
           placeholder={this.passwordPlaceholder}
           type="password"
           onChange={this.onChangeInput('password')}

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -148,7 +148,7 @@ class SourceStep extends PureComponent<Props, State> {
         )}
         {!onBoarding && (
           <WizardCheckbox
-            halfWidth
+            halfWidth={true}
             isChecked={source.default}
             text={'Default connection'}
             onChange={this.onChangeInput('default')}
@@ -158,11 +158,7 @@ class SourceStep extends PureComponent<Props, State> {
           halfWidth={!onBoarding}
           isChecked={sourceIsV2}
           text={'InfluxDB v2'}
-          onChange={() =>
-            this.setState({
-              source: {...source, version: sourceIsV2 ? '1.x' : '2.x'},
-            })
-          }
+          onChange={this.changeVersion}
         />
 
         {this.isHTTPS && (
@@ -226,6 +222,12 @@ class SourceStep extends PureComponent<Props, State> {
     const {setError} = this.props
     this.setState({source: {...source, [key]: value}})
     setError(false)
+  }
+  private changeVersion = (v2: boolean) => {
+    const {source} = this.state
+    this.setState({
+      source: {...source, version: v2 ? '2.x' : '1.x'},
+    })
   }
 
   private handleSubmitUrl = async (sourceURLstring: string) => {

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -148,11 +148,23 @@ class SourceStep extends PureComponent<Props, State> {
         )}
         {!onBoarding && (
           <WizardCheckbox
+            halfWidth
             isChecked={source.default}
-            text={'Make this the default connection'}
+            text={'Default connection'}
             onChange={this.onChangeInput('default')}
           />
         )}
+        <WizardCheckbox
+          halfWidth={!onBoarding}
+          isChecked={sourceIsV2}
+          text={'InfluxDB v2'}
+          onChange={() =>
+            this.setState({
+              source: {...source, version: sourceIsV2 ? '1.x' : '2.x'},
+            })
+          }
+        />
+
         {this.isHTTPS && (
           <WizardCheckbox
             isChecked={source.insecureSkipVerify}


### PR DESCRIPTION
Closes #5617

_Briefly describe your proposed changes:_

  * flux support is automatically detected also for v2 InfluxDB instances (OSS and cloud)
     * org parameter is added from username in `/api/v2/query` requests
     * token authentication is used, it is required for v2 `/api/v2/query`
  * InfluxDB source wizard shows Organization + Token when v2 is detected.
     * a new checkbox `InfluxDB v2` wad added to switch labels between v1 and v2 connections
     * connection type (v1 vs v2) is automatically detected, a user can switch between v1 and v2 to adjust form labels (v1:username+password , v2: organization+token)
![image](https://user-images.githubusercontent.com/16321466/100267597-fbe7de00-2f53-11eb-9c06-bac7b5a43d86.png)


The schema part of flux explorer still uses the v1 API. It does not show all buckets of InfluxDB v2, but only v1-mapped. See https://docs.influxdata.com/influxdb/v2.0/reference/api/influxdb-1x/dbrp/ for details.
 
  - [x] CHANGELOG.md updated in #5621
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
