### PR TITLE
fix(duration): repair relative computation of multiple ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Other
 
 1. [#5610](https://github.com/influxdata/chronograf/pull/5610): Upgrade golang to 1.15.5, node to 14 LTS.
+1. [#5624](https://github.com/influxdata/chronograf/pull/5624): Repair possible millisecond differences in duration computation.
 
 ## v1.8.8 [2020-11-04]
 

--- a/ui/src/shared/parsing/flux/durations.ts
+++ b/ui/src/shared/parsing/flux/durations.ts
@@ -109,21 +109,21 @@ interface DurationBinaryExpression {
 }
 
 export function allRangeTimes(ast: any): Array<[number, number]> {
-  return findNodes(isRangeNode, ast).map(node => rangeTimes(ast, node))
+  const now = Date.now()
+  return findNodes(isRangeNode, ast).map(node => rangeTimes(ast, node, now))
 }
 
 /*
   Given a `range` call in an AST, reports the `start` and `stop` arguments the
   the call as absolute instants in time. If the `start` or `stop` argument is a
-  relative duration literal, it is interpreted as relative to the current
-  instant (`Date.now()`).
+  relative duration literal, it is interpreted as relative to now (`Date.now()`).
 */
 function rangeTimes(
   ast: any,
-  rangeNode: RangeCallExpression
+  rangeNode: RangeCallExpression,
+  now: number
 ): [number, number] {
   const properties = rangeNode.arguments[0].properties
-  const now = Date.now()
 
   // The `start` argument is required
   const startProperty = properties.find(p => p.key.name === 'start')


### PR DESCRIPTION
Closes #5623

_What was the problem?_
A new current time was used across in partial functions
_What was the solution?_
All partial functions share the same current time, it is now passed from outside.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
