### PR TITLE
chore(ui): remove deprecated react SFC type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 1. [#5610](https://github.com/influxdata/chronograf/pull/5610): Upgrade golang to 1.15.5, node to 14 LTS.
 1. [#5624](https://github.com/influxdata/chronograf/pull/5624): Repair possible millisecond differences in duration computation.
+1. [#5626](https://github.com/influxdata/chronograf/pull/5626): Remove deprecated React SFC type.
 
 ## v1.8.8 [2020-11-04]
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ReactChildren} from 'react'
+import React, {FunctionComponent, ReactChildren} from 'react'
 
 import SideNav from 'src/side_nav'
 import Notifications from 'src/shared/components/Notifications'
@@ -7,7 +7,7 @@ interface Props {
   children: ReactChildren
 }
 
-const App: SFC<Props> = ({children}) => (
+const App: FunctionComponent<Props> = ({children}) => (
   <div className="chronograf-root">
     <Notifications />
     <SideNav />

--- a/ui/src/admin/components/DeprecationWarning.tsx
+++ b/ui/src/admin/components/DeprecationWarning.tsx
@@ -1,10 +1,10 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   message: JSX.Element
 }
 
-const DeprecationWarning: SFC<Props> = ({message}) => (
+const DeprecationWarning: FunctionComponent<Props> = ({message}) => (
   <div className="alert alert-primary">
     <span className="icon octagon" />
     <div className="alert-message">{message}</div>

--- a/ui/src/admin/components/EmptyRow.tsx
+++ b/ui/src/admin/components/EmptyRow.tsx
@@ -1,9 +1,9 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   tableName: string
 }
-const EmptyRow: SFC<Props> = ({tableName}) => (
+const EmptyRow: FunctionComponent<Props> = ({tableName}) => (
   <tr className="table-empty-state">
     <th colSpan={5}>
       <p>

--- a/ui/src/admin/components/UserRowEdit.tsx
+++ b/ui/src/admin/components/UserRowEdit.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import UserEditName from 'src/admin/components/UserEditName'
 import UserNewPassword from 'src/admin/components/UserNewPassword'
 import ConfirmOrCancel from 'src/shared/components/ConfirmOrCancel'
@@ -15,7 +15,7 @@ interface UserRowEditProps {
   hasRoles: boolean
 }
 
-const UserRowEdit: SFC<UserRowEditProps> = ({
+const UserRowEdit: FunctionComponent<UserRowEditProps> = ({
   user,
   onEdit,
   onSave,

--- a/ui/src/dashboards/components/DisplayOptionsInput.tsx
+++ b/ui/src/dashboards/components/DisplayOptionsInput.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ChangeEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent} from 'react'
 
 interface Props {
   name: string
@@ -10,7 +10,7 @@ interface Props {
   placeholder?: string
 }
 
-const DisplayOptionsInput: SFC<Props> = ({
+const DisplayOptionsInput: FunctionComponent<Props> = ({
   id,
   name,
   value,

--- a/ui/src/dashboards/components/GraphOptionsFixFirstColumn.tsx
+++ b/ui/src/dashboards/components/GraphOptionsFixFirstColumn.tsx
@@ -1,11 +1,11 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   fixed: boolean
   onToggleFixFirstColumn: () => void
 }
 
-const GraphOptionsFixFirstColumn: SFC<Props> = ({
+const GraphOptionsFixFirstColumn: FunctionComponent<Props> = ({
   fixed,
   onToggleFixFirstColumn,
 }) => (

--- a/ui/src/dashboards/components/GraphOptionsTimeAxis.tsx
+++ b/ui/src/dashboards/components/GraphOptionsTimeAxis.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 // Components
 import {Radio, ButtonShape} from 'src/reusable_ui'
@@ -9,7 +9,7 @@ interface GraphOptionsTimeAxisProps {
   onToggleVerticalTimeAxis: (vertical: boolean) => void
 }
 
-const GraphOptionsTimeAxis: SFC<GraphOptionsTimeAxisProps> = ({
+const GraphOptionsTimeAxis: FunctionComponent<GraphOptionsTimeAxisProps> = ({
   verticalTimeAxis,
   onToggleVerticalTimeAxis,
 }) => (

--- a/ui/src/dashboards/components/NoteOptions.tsx
+++ b/ui/src/dashboards/components/NoteOptions.tsx
@@ -1,6 +1,6 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
-const NoteOptions: SFC = () => (
+const NoteOptions: FunctionComponent = () => (
   <div className="note-options---panel">
     <div className="note-options--text">
       <p>

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 // Components
 import SourceDropdown from 'src/flux/components/SourceDropdown'
@@ -23,7 +23,7 @@ interface Props {
   onChangeSource: (source: SourcesModels.Source, type: QueryType) => void
 }
 
-const SourceSelector: SFC<Props> = ({
+const SourceSelector: FunctionComponent<Props> = ({
   source,
   sources = [],
   queries,

--- a/ui/src/flux/components/LoaderSkeleton.tsx
+++ b/ui/src/flux/components/LoaderSkeleton.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, MouseEvent, CSSProperties} from 'react'
+import React, {FunctionComponent, MouseEvent, CSSProperties} from 'react'
 import _ from 'lodash'
 
 const handleClick = (e: MouseEvent<HTMLDivElement>): void => {
@@ -11,7 +11,7 @@ const randomSize = (): CSSProperties => {
   return {width: `${width}px`}
 }
 
-const LoaderSkeleton: SFC = () => {
+const LoaderSkeleton: FunctionComponent = () => {
   return (
     <>
       <div

--- a/ui/src/flux/components/LoadingSpinner.tsx
+++ b/ui/src/flux/components/LoadingSpinner.tsx
@@ -1,10 +1,10 @@
-import React, {SFC, CSSProperties} from 'react'
+import React, {FunctionComponent, CSSProperties} from 'react'
 
 interface Props {
   style?: CSSProperties
 }
 
-const LoadingSpinner: SFC<Props> = ({style}) => {
+const LoadingSpinner: FunctionComponent<Props> = ({style}) => {
   return (
     <div className="loading-spinner" style={style}>
       <div className="spinner">

--- a/ui/src/flux/components/NoResults.tsx
+++ b/ui/src/flux/components/NoResults.tsx
@@ -1,6 +1,6 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
-const NoResult: SFC = () => (
+const NoResult: FunctionComponent = () => (
   <div className="graph-empty">
     <p>No Results</p>
   </div>

--- a/ui/src/hosts/components/HostRow.tsx
+++ b/ui/src/hosts/components/HostRow.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Link} from 'react-router'
 import classnames from 'classnames'
 
@@ -10,7 +10,7 @@ interface Props {
   host: Host
 }
 
-const HostRow: SFC<Props> = ({host, sourceID}) => {
+const HostRow: FunctionComponent<Props> = ({host, sourceID}) => {
   const {name, cpu, load, apps = []} = host
   const {NameWidth, StatusWidth, CPUWidth, LoadWidth} = HOSTS_TABLE_SIZING
 

--- a/ui/src/kapacitor/components/AlertOutputs.tsx
+++ b/ui/src/kapacitor/components/AlertOutputs.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import AlertTabs from 'src/kapacitor/components/AlertTabs'
 
@@ -12,7 +12,7 @@ interface AlertOutputProps {
   notify: (message: Notification | NotificationFunc) => void
 }
 
-const AlertOutputs: SFC<AlertOutputProps> = ({
+const AlertOutputs: FunctionComponent<AlertOutputProps> = ({
   hash,
   exists,
   source,

--- a/ui/src/kapacitor/components/CodeData.tsx
+++ b/ui/src/kapacitor/components/CodeData.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {RuleMessage} from 'src/types/kapacitor'
 
@@ -7,7 +7,7 @@ interface Props {
   template: RuleMessage
 }
 
-const CodeData: SFC<Props> = ({onClickTemplate, template}) => (
+const CodeData: FunctionComponent<Props> = ({onClickTemplate, template}) => (
   <code
     className="rule-builder--message-template"
     data-tip={template.text}

--- a/ui/src/kapacitor/components/Deadman.tsx
+++ b/ui/src/kapacitor/components/Deadman.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {PERIODS} from 'src/kapacitor/constants'
 import Dropdown from 'src/shared/components/Dropdown'
@@ -18,7 +18,7 @@ interface Props {
   onChange: (item: Item) => void
 }
 
-const Deadman: SFC<Props> = ({rule, onChange}) => (
+const Deadman: FunctionComponent<Props> = ({rule, onChange}) => (
   <div className="rule-section--row rule-section--row-first rule-section--row-last">
     <p>Send Alert if Data is missing for</p>
     <Dropdown

--- a/ui/src/kapacitor/components/HandlerTabs.tsx
+++ b/ui/src/kapacitor/components/HandlerTabs.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, MouseEvent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import classnames from 'classnames'
 import uuid from 'uuid'
 
@@ -19,7 +19,7 @@ interface Props {
   ) => (event: MouseEvent<HTMLButtonElement>) => void
 }
 
-const HandlerTabs: SFC<Props> = ({
+const HandlerTabs: FunctionComponent<Props> = ({
   handlersOnThisAlert,
   selectedHandler,
   handleChooseHandler,

--- a/ui/src/kapacitor/components/KapacitorFormInput.tsx
+++ b/ui/src/kapacitor/components/KapacitorFormInput.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, SFC} from 'react'
+import React, {ChangeEvent, FunctionComponent} from 'react'
 
 interface Props {
   name: string
@@ -11,7 +11,7 @@ interface Props {
   onChange: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
-const KapacitorFormInput: SFC<Props> = ({
+const KapacitorFormInput: FunctionComponent<Props> = ({
   name,
   label,
   value,

--- a/ui/src/kapacitor/components/KapacitorFormSkipVerify.tsx
+++ b/ui/src/kapacitor/components/KapacitorFormSkipVerify.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ChangeEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent} from 'react'
 import {Kapacitor} from 'src/types'
 import {insecureSkipVerifyText} from 'src/shared/copy/tooltipText'
 
@@ -7,7 +7,7 @@ interface Props {
   onCheckboxChange: (e: ChangeEvent<HTMLInputElement>) => void
 }
 
-const KapacitorFormSkipVerify: SFC<Props> = ({
+const KapacitorFormSkipVerify: FunctionComponent<Props> = ({
   kapacitor: {insecureSkipVerify},
   onCheckboxChange,
 }) => {

--- a/ui/src/kapacitor/components/KapacitorRules.tsx
+++ b/ui/src/kapacitor/components/KapacitorRules.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Link} from 'react-router'
 
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
@@ -14,7 +14,7 @@ interface KapacitorRulesProps {
   onChangeRuleStatus: (rule: AlertRule) => void
 }
 
-const KapacitorRules: SFC<KapacitorRulesProps> = ({
+const KapacitorRules: FunctionComponent<KapacitorRulesProps> = ({
   source,
   kapacitor,
   rules,

--- a/ui/src/kapacitor/components/KapacitorRulesTable.tsx
+++ b/ui/src/kapacitor/components/KapacitorRulesTable.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, SFC} from 'react'
+import React, {PureComponent, FunctionComponent} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
 import {ErrorHandling} from 'src/shared/decorators/errors'
@@ -31,7 +31,7 @@ interface RuleRowProps {
   onDelete: (rule: AlertRule) => void
 }
 
-const KapacitorRulesTable: SFC<KapacitorRulesTableProps> = ({
+const KapacitorRulesTable: FunctionComponent<KapacitorRulesTableProps> = ({
   rules,
   kapacitorLink,
   onChangeRuleStatus,

--- a/ui/src/kapacitor/components/LogItemHTTP.tsx
+++ b/ui/src/kapacitor/components/LogItemHTTP.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemHTTP: SFC<Props> = ({logItem}) => (
+const LogItemHTTP: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row">
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogItemHTTPError.tsx
+++ b/ui/src/kapacitor/components/LogItemHTTPError.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemHTTPError: SFC<Props> = ({logItem}) => (
+const LogItemHTTPError: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row" key={logItem.key}>
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogItemInfluxDBDebug.tsx
+++ b/ui/src/kapacitor/components/LogItemInfluxDBDebug.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemInfluxDBDebug: SFC<Props> = ({logItem}) => (
+const LogItemInfluxDBDebug: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row">
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogItemKapacitorDebug.tsx
+++ b/ui/src/kapacitor/components/LogItemKapacitorDebug.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemKapacitorDebug: SFC<Props> = ({logItem}) => (
+const LogItemKapacitorDebug: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row">
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogItemKapacitorError.tsx
+++ b/ui/src/kapacitor/components/LogItemKapacitorError.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemKapacitorError: SFC<Props> = ({logItem}) => (
+const LogItemKapacitorError: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row">
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogItemSession.tsx
+++ b/ui/src/kapacitor/components/LogItemSession.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,7 +6,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemSession: SFC<Props> = ({logItem}) => (
+const LogItemSession: FunctionComponent<Props> = ({logItem}) => (
   <div className="logs-table--row">
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />

--- a/ui/src/kapacitor/components/LogsTable.tsx
+++ b/ui/src/kapacitor/components/LogsTable.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import LogsTableRow from 'src/kapacitor/components/LogsTableRow'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
@@ -11,7 +11,7 @@ interface Props {
   logs: LogItem[]
 }
 
-const LogsTable: SFC<Props> = ({logs}) => (
+const LogsTable: FunctionComponent<Props> = ({logs}) => (
   <div className="logs-table">
     <div className="logs-table--header">
       {`${numLogsToRender} Most Recent Logs`}

--- a/ui/src/kapacitor/components/LogsTableRow.tsx
+++ b/ui/src/kapacitor/components/LogsTableRow.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import LogItemSession from 'src/kapacitor/components/LogItemSession'
 import LogItemHTTP from 'src/kapacitor/components/LogItemHTTP'
@@ -14,7 +14,7 @@ interface Props {
   logItem: LogItem
 }
 
-const LogsTableRow: SFC<Props> = ({logItem}) => {
+const LogsTableRow: FunctionComponent<Props> = ({logItem}) => {
   if (logItem.service === 'sessions') {
     return <LogItemSession logItem={logItem} />
   }

--- a/ui/src/kapacitor/components/Relative.tsx
+++ b/ui/src/kapacitor/components/Relative.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ChangeEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent} from 'react'
 
 import {CHANGES, RELATIVE_OPERATORS, SHIFTS} from 'src/kapacitor/constants'
 import Dropdown from 'src/shared/components/Dropdown'
@@ -21,7 +21,7 @@ interface Props {
   rule: AlertRule
 }
 
-const Relative: SFC<Props> = ({
+const Relative: FunctionComponent<Props> = ({
   onRuleTypeInputChange,
   onDropdownChange,
   rule: {

--- a/ui/src/kapacitor/components/TasksTable.tsx
+++ b/ui/src/kapacitor/components/TasksTable.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, SFC} from 'react'
+import React, {PureComponent, FunctionComponent} from 'react'
 import {Link} from 'react-router'
 import _ from 'lodash'
 
@@ -22,7 +22,7 @@ interface TaskRowProps {
   onDelete: (rule: AlertRule) => void
 }
 
-const TasksTable: SFC<TasksTableProps> = ({
+const TasksTable: FunctionComponent<TasksTableProps> = ({
   tasks,
   kapacitorLink,
   onDelete,

--- a/ui/src/kapacitor/components/TickscriptEditorConsole.tsx
+++ b/ui/src/kapacitor/components/TickscriptEditorConsole.tsx
@@ -1,11 +1,11 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   consoleMessage: string
   unsavedChanges: boolean
 }
 
-const TickscriptEditorConsole: SFC<Props> = ({
+const TickscriptEditorConsole: FunctionComponent<Props> = ({
   consoleMessage,
   unsavedChanges,
 }) => {

--- a/ui/src/kapacitor/components/TickscriptID.tsx
+++ b/ui/src/kapacitor/components/TickscriptID.tsx
@@ -1,4 +1,4 @@
-import React, {Component, SFC, ChangeEvent} from 'react'
+import React, {Component, FunctionComponent, ChangeEvent} from 'react'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface TickscriptIDProps {
@@ -32,8 +32,8 @@ class TickscriptID extends Component<TickscriptIDProps> {
 interface TickscriptStaticIDProps {
   id: string
 }
-export const TickscriptStaticID: SFC<TickscriptStaticIDProps> = ({id}) => (
-  <h1 className="tickscript-controls--name">{id}</h1>
-)
+export const TickscriptStaticID: FunctionComponent<TickscriptStaticIDProps> = ({
+  id,
+}) => <h1 className="tickscript-controls--name">{id}</h1>
 
 export default TickscriptID

--- a/ui/src/kapacitor/components/alert_rules/RuleHeaderSave.tsx
+++ b/ui/src/kapacitor/components/alert_rules/RuleHeaderSave.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import ReactTooltip from 'react-tooltip'
 
 interface Props {
@@ -6,7 +6,10 @@ interface Props {
   validationError: string
 }
 
-const RuleHeaderSave: SFC<Props> = ({onSave, validationError}) => (
+const RuleHeaderSave: FunctionComponent<Props> = ({
+  onSave,
+  validationError,
+}) => (
   <>
     {validationError ? (
       <button

--- a/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
+++ b/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
@@ -29,7 +29,7 @@ interface Props {
   validationError: string
 }
 
-const KafkaHandler: SFC<Props> = ({
+const KafkaHandler: FunctionComponent<Props> = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,

--- a/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
+++ b/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
 
@@ -11,7 +11,7 @@ interface Props {
   validationError: string
 }
 
-const Pagerduty2Handler: SFC<Props> = ({
+const Pagerduty2Handler: FunctionComponent<Props> = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,

--- a/ui/src/logs/components/SeverityOptions.tsx
+++ b/ui/src/logs/components/SeverityOptions.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import uuid from 'uuid'
 import ColorDropdown from 'src/logs/components/ColorDropdown'
 import SeverityColumnFormat from 'src/logs/components/SeverityColumnFormat'
@@ -15,7 +15,7 @@ interface Props {
   onChangeSeverityFormat: (format: SeverityFormat) => void
 }
 
-const SeverityConfig: SFC<Props> = ({
+const SeverityConfig: FunctionComponent<Props> = ({
   severityLevelColors,
   onReset,
   onChangeSeverityLevel,

--- a/ui/src/reusable_ui/components/overlays/OverlayBody.tsx
+++ b/ui/src/reusable_ui/components/overlays/OverlayBody.tsx
@@ -1,10 +1,10 @@
-import React, {SFC, ReactNode} from 'react'
+import React, {FunctionComponent, ReactNode} from 'react'
 
 interface Props {
   children: ReactNode
 }
 
-const OverlayBody: SFC<Props> = ({children}) => (
+const OverlayBody: FunctionComponent<Props> = ({children}) => (
   <div className="overlay--body">{children}</div>
 )
 

--- a/ui/src/reusable_ui/components/page_layout/PageHeaderTitle.tsx
+++ b/ui/src/reusable_ui/components/page_layout/PageHeaderTitle.tsx
@@ -1,10 +1,10 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   title: string
 }
 
-const PageTitle: SFC<Props> = ({title}) => (
+const PageTitle: FunctionComponent<Props> = ({title}) => (
   <h1 className="page-header--title">{title}</h1>
 )
 

--- a/ui/src/shared/components/AddAnnotationToggle.tsx
+++ b/ui/src/shared/components/AddAnnotationToggle.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 
 import {Button, ComponentColor, IconFont} from 'src/reusable_ui'
@@ -16,7 +16,7 @@ interface Props {
   onDismissAddingAnnotation: typeof dismissAddingAnnotation
 }
 
-const AddAnnotationToggle: SFC<Props> = props => {
+const AddAnnotationToggle: FunctionComponent<Props> = props => {
   const {
     isAddingAnnotation,
     onAddingAnnotation,

--- a/ui/src/shared/components/Annotation.tsx
+++ b/ui/src/shared/components/Annotation.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import AnnotationPoint from 'src/shared/components/AnnotationPoint'
 import AnnotationSpan from 'src/shared/components/AnnotationSpan'
@@ -14,7 +14,7 @@ interface Props {
   staticLegendHeight: number
 }
 
-const Annotation: SFC<Props> = ({
+const Annotation: FunctionComponent<Props> = ({
   mode,
   dygraph,
   dWidth,

--- a/ui/src/shared/components/AnnotationTooltip.tsx
+++ b/ui/src/shared/components/AnnotationTooltip.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, MouseEvent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {connect} from 'react-redux'
 import moment from 'moment'
 import classnames from 'classnames'
@@ -12,7 +12,7 @@ interface TimeStampProps {
   time: number
 }
 
-const TimeStamp: SFC<TimeStampProps> = ({time}) => (
+const TimeStamp: FunctionComponent<TimeStampProps> = ({time}) => (
   <div className="annotation-tooltip--timestamp">
     {`${moment(time).format('YYYY/MM/DD HH:mm:ss.SS')}`}
   </div>
@@ -31,7 +31,7 @@ interface Props {
   onSetEditingAnnotation: typeof setEditingAnnotation
 }
 
-const AnnotationTooltip: SFC<Props> = props => {
+const AnnotationTooltip: FunctionComponent<Props> = props => {
   const {
     annotation,
     onMouseLeave,

--- a/ui/src/shared/components/AnnotationsDisplaySettingDropdown.tsx
+++ b/ui/src/shared/components/AnnotationsDisplaySettingDropdown.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
 
 import {Dropdown} from 'src/reusable_ui'
@@ -15,7 +15,7 @@ interface Props {
 
 const DROPDOWN_WIDTH = 210
 
-const AnnotationsDisplaySettingDropdown: SFC<Props> = ({
+const AnnotationsDisplaySettingDropdown: FunctionComponent<Props> = ({
   displaySetting,
   onSetDisplaySetting,
 }) => {

--- a/ui/src/shared/components/ConfirmOrCancel.tsx
+++ b/ui/src/shared/components/ConfirmOrCancel.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, SFC} from 'react'
+import React, {PureComponent, FunctionComponent} from 'react'
 
 import classnames from 'classnames'
 
@@ -34,7 +34,7 @@ interface ConfirmOrCancelProps {
   cancelTitle?: string
 }
 
-export const Confirm: SFC<ConfirmProps> = ({
+export const Confirm: FunctionComponent<ConfirmProps> = ({
   buttonSize,
   isDisabled,
   onConfirm,
@@ -57,7 +57,7 @@ export const Confirm: SFC<ConfirmProps> = ({
   </button>
 )
 
-export const Cancel: SFC<CancelProps> = ({
+export const Cancel: FunctionComponent<CancelProps> = ({
   buttonSize,
   onCancel,
   icon,

--- a/ui/src/shared/components/CustomTimeIndicator.tsx
+++ b/ui/src/shared/components/CustomTimeIndicator.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import _ from 'lodash'
 
 import {TEMP_VAR_DASHBOARD_TIME} from 'src/shared/constants'
@@ -13,7 +13,7 @@ interface Props {
   queries: Query[]
 }
 
-const CustomTimeIndicator: SFC<Props> = ({queries}) => {
+const CustomTimeIndicator: FunctionComponent<Props> = ({queries}) => {
   const q = queries.find(
     query =>
       _.get(query, 'text', '').includes(TEMP_VAR_DASHBOARD_TIME) === false

--- a/ui/src/shared/components/DatabaseListItem.tsx
+++ b/ui/src/shared/components/DatabaseListItem.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import classnames from 'classnames'
 
@@ -10,7 +10,7 @@ export interface DatabaseListItemProps {
   onChooseNamespace: (namespace: Namespace) => () => void
 }
 
-const DatabaseListItem: SFC<DatabaseListItemProps> = ({
+const DatabaseListItem: FunctionComponent<DatabaseListItemProps> = ({
   isActive,
   namespace,
   namespace: {database, retentionPolicy},

--- a/ui/src/shared/components/DropdownHead.tsx
+++ b/ui/src/shared/components/DropdownHead.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import classnames from 'classnames'
 
 const disabledClass = (disabled: boolean) => (disabled ? ' disabled' : '')
@@ -12,7 +12,7 @@ interface Props {
   disabled: boolean
 }
 
-const DropdownHead: SFC<Props> = ({
+const DropdownHead: FunctionComponent<Props> = ({
   iconName,
   selected,
   buttonSize,

--- a/ui/src/shared/components/DropdownInput.tsx
+++ b/ui/src/shared/components/DropdownInput.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ChangeEvent, KeyboardEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent, KeyboardEvent} from 'react'
 
 const disabledClass = (disabled: boolean) => (disabled ? ' disabled' : '')
 
@@ -15,7 +15,7 @@ interface Props {
   onFilterKeyPress: OnFilterKeyPress
 }
 
-const DropdownInput: SFC<Props> = ({
+const DropdownInput: FunctionComponent<Props> = ({
   searchTerm,
   buttonSize,
   buttonColor,

--- a/ui/src/shared/components/DropdownLoadingPlaceholder.tsx
+++ b/ui/src/shared/components/DropdownLoadingPlaceholder.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {RemoteDataState} from 'src/types'
 import LoadingSpinner from 'src/flux/components/LoadingSpinner'
@@ -8,7 +8,10 @@ interface Props {
   children: JSX.Element
 }
 
-const DropdownLoadingPlaceholder: SFC<Props> = ({children, rds}) => {
+const DropdownLoadingPlaceholder: FunctionComponent<Props> = ({
+  children,
+  rds,
+}) => {
   if (rds === RemoteDataState.Loading) {
     return (
       <div className="dropdown-placeholder">

--- a/ui/src/shared/components/DropdownMenu.tsx
+++ b/ui/src/shared/components/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Link} from 'react-router'
 
 import classnames from 'classnames'
@@ -26,7 +26,7 @@ interface AddNew {
   handler?: () => void
 }
 
-const AddNewButton: SFC<AddNew> = ({url, text, handler}) => {
+const AddNewButton: FunctionComponent<AddNew> = ({url, text, handler}) => {
   if (handler) {
     return (
       <li className="multi-select--apply">
@@ -69,7 +69,7 @@ interface Props {
   highlightedItemIndex?: number
 }
 
-const DropdownMenu: SFC<Props> = ({
+const DropdownMenu: FunctionComponent<Props> = ({
   items,
   addNew,
   actions,
@@ -128,7 +128,7 @@ interface DropdownMenuEmptyProps {
   menuClass: string
 }
 
-export const DropdownMenuEmpty: SFC<DropdownMenuEmptyProps> = ({
+export const DropdownMenuEmpty: FunctionComponent<DropdownMenuEmptyProps> = ({
   useAutoComplete,
   menuClass,
 }) => (

--- a/ui/src/shared/components/DropdownMenuItem.tsx
+++ b/ui/src/shared/components/DropdownMenuItem.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, MouseEvent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 
 import _ from 'lodash'
 import classnames from 'classnames'
@@ -28,7 +28,7 @@ interface ItemProps {
   onAction?: OnActionHandler
 }
 
-const DropdownMenuItem: SFC<ItemProps> = ({
+const DropdownMenuItem: FunctionComponent<ItemProps> = ({
   item,
   highlightedItemIndex,
   onSelection,

--- a/ui/src/shared/components/EmptyQuery.tsx
+++ b/ui/src/shared/components/EmptyQuery.tsx
@@ -1,10 +1,10 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   onAddQuery: () => void
 }
 
-const EmptyQueryState: SFC<Props> = ({onAddQuery}) => (
+const EmptyQueryState: FunctionComponent<Props> = ({onAddQuery}) => (
   <div className="query-maker--empty">
     <h5>This Graph has no Queries</h5>
     <br />

--- a/ui/src/shared/components/FeatureFlag.tsx
+++ b/ui/src/shared/components/FeatureFlag.tsx
@@ -1,11 +1,11 @@
-import {SFC} from 'react'
+import {FunctionComponent} from 'react'
 
 interface Props {
   name?: string
   children?: any
 }
 
-const FeatureFlag: SFC<Props> = props => {
+const FeatureFlag: FunctionComponent<Props> = props => {
   if (process.env.NODE_ENV === 'development') {
     return props.children
   }

--- a/ui/src/shared/components/FuncSelectorInput.tsx
+++ b/ui/src/shared/components/FuncSelectorInput.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, ChangeEvent, KeyboardEvent} from 'react'
+import React, {FunctionComponent, ChangeEvent, KeyboardEvent} from 'react'
 
 type OnFilterChangeHandler = (e: ChangeEvent<HTMLInputElement>) => void
 type OnFilterKeyPress = (e: KeyboardEvent<HTMLInputElement>) => void
@@ -9,7 +9,7 @@ interface Props {
   onFilterKeyPress: OnFilterKeyPress
 }
 
-const FuncSelectorInput: SFC<Props> = ({
+const FuncSelectorInput: FunctionComponent<Props> = ({
   searchTerm,
   onFilterChange,
   onFilterKeyPress,

--- a/ui/src/shared/components/GraphTips.tsx
+++ b/ui/src/shared/components/GraphTips.tsx
@@ -1,10 +1,10 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import ReactTooltip from 'react-tooltip'
 
 const graphTipsText =
   '<h1>Graph Tips:</h1><p><code>Click + Drag</code> Zoom in (X or Y)<br/><code>Shift + Click</code> Pan Graph Window<br/><code>Double Click</code> Reset Graph Window</p><h1>Static Legend Tips:</h1><p><code>Click</code>Focus on single Series<br/><code>Shift + Click</code> Show/Hide single Series</p>'
 
-const GraphTips: SFC = () => (
+const GraphTips: FunctionComponent = () => (
   <div
     className="graph-tips"
     data-for="graph-tips-tooltip"

--- a/ui/src/shared/components/HistogramChartSkeleton.tsx
+++ b/ui/src/shared/components/HistogramChartSkeleton.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import _ from 'lodash'
 
 import {Margins} from 'src/types/histogram'
@@ -11,7 +11,7 @@ interface Props {
   margins: Margins
 }
 
-const HistogramChartSkeleton: SFC<Props> = props => {
+const HistogramChartSkeleton: FunctionComponent<Props> = props => {
   const {margins, width, height} = props
 
   const spacing = (height - margins.top - margins.bottom) / NUM_TICKS

--- a/ui/src/shared/components/HistogramChartTooltip.tsx
+++ b/ui/src/shared/components/HistogramChartTooltip.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, CSSProperties} from 'react'
+import React, {FunctionComponent, CSSProperties} from 'react'
 import _ from 'lodash'
 
 import {HoverData, ColorScale, HistogramColor} from 'src/types/histogram'
@@ -9,7 +9,7 @@ interface Props {
   colors: HistogramColor[]
 }
 
-const HistogramChartTooltip: SFC<Props> = props => {
+const HistogramChartTooltip: FunctionComponent<Props> = props => {
   const {colorScale, colors} = props
   const {data, x, y, anchor = 'left'} = props.data
 

--- a/ui/src/shared/components/MeasurementListFilter.tsx
+++ b/ui/src/shared/components/MeasurementListFilter.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 interface Props {
   filterText: string
@@ -6,7 +6,7 @@ interface Props {
   onFilterText: (e: React.InputHTMLAttributes<HTMLInputElement>) => void
 }
 
-const MeasurementListFilter: SFC<Props> = ({
+const MeasurementListFilter: FunctionComponent<Props> = ({
   onEscape,
   onFilterText,
   filterText,

--- a/ui/src/shared/components/NoKapacitorError.tsx
+++ b/ui/src/shared/components/NoKapacitorError.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Link} from 'react-router'
 
 import Authorized, {EDITOR_ROLE} from 'src/auth/Authorized'
@@ -9,7 +9,7 @@ interface Props {
   }
 }
 
-const NoKapacitorError: SFC<Props> = ({source}) => {
+const NoKapacitorError: FunctionComponent<Props> = ({source}) => {
   const path = `/sources/${source.id}/kapacitors/new`
   return (
     <div className="graph-empty">

--- a/ui/src/shared/components/NotFound.tsx
+++ b/ui/src/shared/components/NotFound.tsx
@@ -1,6 +1,6 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
-const NotFound: SFC = () => (
+const NotFound: FunctionComponent = () => (
   <div className="container-fluid">
     <div className="panel">
       <div className="panel-heading text-center">

--- a/ui/src/shared/components/PageSpinner.tsx
+++ b/ui/src/shared/components/PageSpinner.tsx
@@ -1,6 +1,6 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
-const PageSpinner: SFC<{}> = () => {
+const PageSpinner: FunctionComponent<{}> = () => {
   return (
     <div className="page-spinner-container">
       <div className="page-spinner" />

--- a/ui/src/shared/components/QueryOptions.tsx
+++ b/ui/src/shared/components/QueryOptions.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {GroupBy, TimeShift} from 'src/types'
 
@@ -17,7 +17,7 @@ interface Props {
   isDisabled: boolean
 }
 
-const QueryOptions: SFC<Props> = ({
+const QueryOptions: FunctionComponent<Props> = ({
   fill,
   shift,
   onFill,

--- a/ui/src/shared/components/QuestionMarkTooltip.tsx
+++ b/ui/src/shared/components/QuestionMarkTooltip.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import ReactTooltip from 'react-tooltip'
 
 interface Props {
@@ -6,7 +6,7 @@ interface Props {
   tipContent: string
 }
 
-const QuestionMarkTooltip: SFC<Props> = ({tipID, tipContent}) => (
+const QuestionMarkTooltip: FunctionComponent<Props> = ({tipID, tipContent}) => (
   <div className="question-mark-tooltip">
     <div
       className="question-mark-tooltip--icon"

--- a/ui/src/shared/components/ResizeHandle.tsx
+++ b/ui/src/shared/components/ResizeHandle.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import classnames from 'classnames'
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
   top?: string
 }
 
-const ResizeHandle: SFC<Props> = ({
+const ResizeHandle: FunctionComponent<Props> = ({
   onHandleStartDrag,
   isDragging,
   theme,

--- a/ui/src/shared/components/SchemaExplorer.tsx
+++ b/ui/src/shared/components/SchemaExplorer.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 // Components
 import DatabaseList from 'src/shared/components/DatabaseList'
@@ -35,7 +35,7 @@ interface Props {
   onToggleTagAcceptance: TimeMachineContainer['handleToggleTagAcceptance']
 }
 
-const SchemaExplorer: SFC<Props> = ({
+const SchemaExplorer: FunctionComponent<Props> = ({
   query,
   source,
   initialGroupByTime,

--- a/ui/src/shared/components/SourceIndicator.tsx
+++ b/ui/src/shared/components/SourceIndicator.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import _ from 'lodash'
 import uuid from 'uuid'
 
@@ -18,7 +18,7 @@ const getTooltipText = (source: Source, sourceOverride: Source): string => {
   return `<h1>Connected to Source:</h1><p><code>${sourceName} @ ${sourceUrl}</code></p>`
 }
 
-const SourceIndicator: SFC<Props> = ({sourceOverride}) => {
+const SourceIndicator: FunctionComponent<Props> = ({sourceOverride}) => {
   const uuidTooltip: string = uuid.v4()
 
   return (

--- a/ui/src/shared/components/Spinner.tsx
+++ b/ui/src/shared/components/Spinner.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import {RemoteDataState} from 'src/types'
 
@@ -6,7 +6,7 @@ interface Props {
   status: RemoteDataState
 }
 
-const Spinner: SFC<Props> = ({status}) => {
+const Spinner: FunctionComponent<Props> = ({status}) => {
   if (status !== RemoteDataState.Loading) {
     return null
   }

--- a/ui/src/shared/components/SplashPage.tsx
+++ b/ui/src/shared/components/SplashPage.tsx
@@ -1,10 +1,10 @@
-import React, {SFC, ReactElement} from 'react'
+import React, {FunctionComponent, ReactElement} from 'react'
 
 interface Props {
   children: ReactElement<any>
 }
 
-const SplashPage: SFC<Props> = ({children}) => (
+const SplashPage: FunctionComponent<Props> = ({children}) => (
   <div className="auth-page">
     <div className="auth-box">
       <div className="auth-logo" />

--- a/ui/src/shared/components/SubSectionsTab.tsx
+++ b/ui/src/shared/components/SubSectionsTab.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {PageSection} from 'src/types/shared'
 
 interface TabProps {
@@ -7,7 +7,7 @@ interface TabProps {
   activeSection: string
 }
 
-const SubSectionsTab: SFC<TabProps> = ({
+const SubSectionsTab: FunctionComponent<TabProps> = ({
   handleClick,
   section,
   activeSection,

--- a/ui/src/shared/components/Tabs.tsx
+++ b/ui/src/shared/components/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, ReactElement, SFC} from 'react'
+import React, {PureComponent, ReactElement, FunctionComponent} from 'react'
 
 import classnames from 'classnames'
 
@@ -10,7 +10,7 @@ interface TabProps {
   isConfigured?: boolean
 }
 
-export const Tab: SFC<TabProps> = ({
+export const Tab: FunctionComponent<TabProps> = ({
   children,
   onClick,
   isDisabled,
@@ -35,7 +35,7 @@ interface TabListProps {
   customClass?: string
 }
 
-export const TabList: SFC<TabListProps> = ({
+export const TabList: FunctionComponent<TabListProps> = ({
   children,
   activeIndex,
   onActivate,
@@ -68,7 +68,7 @@ interface TabPanelsProps {
   customClass?: string
 }
 
-export const TabPanels: SFC<TabPanelsProps> = ({
+export const TabPanels: FunctionComponent<TabPanelsProps> = ({
   children,
   activeIndex,
   customClass,
@@ -81,7 +81,7 @@ interface TabPanelProps {
   children: JSX.Element[] | JSX.Element
 }
 
-export const TabPanel: SFC<TabPanelProps> = ({children}) => (
+export const TabPanel: FunctionComponent<TabPanelProps> = ({children}) => (
   <div>{children}</div>
 )
 

--- a/ui/src/shared/components/Tags.tsx
+++ b/ui/src/shared/components/Tags.tsx
@@ -1,4 +1,4 @@
-import React, {PureComponent, SFC} from 'react'
+import React, {PureComponent, FunctionComponent} from 'react'
 import TagsAddButton from 'src/shared/components/TagsAddButton'
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import uuid from 'uuid'
@@ -17,7 +17,7 @@ interface TagsProps {
   addMenuChoose?: (item: Item) => void
 }
 
-const Tags: SFC<TagsProps> = ({
+const Tags: FunctionComponent<TagsProps> = ({
   tags,
   onDeleteTag,
   addMenuItems,

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -1,4 +1,4 @@
-import React, {SFC, MouseEvent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import OnClickOutside from 'react-onclickoutside'
 import classnames from 'classnames'
 
@@ -14,7 +14,7 @@ interface Props {
     template: Template
   ) => (e: MouseEvent<HTMLDivElement>) => void
 }
-const TemplateDrawer: SFC<Props> = ({
+const TemplateDrawer: FunctionComponent<Props> = ({
   templates,
   selected,
   onMouseOverTempVar,

--- a/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import _ from 'lodash'
 import {Subscribe} from 'unstated'
 
@@ -53,7 +53,7 @@ interface PassedProps {
 
 type Props = ConnectedProps & PassedProps
 
-const QueryMaker: SFC<Props> = ({
+const QueryMaker: FunctionComponent<Props> = ({
   source,
   queries,
   timeRange,

--- a/ui/src/shared/components/TimeMachine/TimeMachineBottom.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineBottom.tsx
@@ -1,10 +1,10 @@
-import React, {ReactNode, SFC} from 'react'
+import React, {ReactNode, FunctionComponent} from 'react'
 
 interface Props {
   children: ReactNode
 }
 
-const TimeMachineBottom: SFC<Props> = ({children}) => (
+const TimeMachineBottom: FunctionComponent<Props> = ({children}) => (
   <div className="deceo--bottom">{children}</div>
 )
 

--- a/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineControls.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 // Components
 import SourceSelector from 'src/dashboards/components/SourceSelector'
@@ -40,7 +40,7 @@ interface Props {
   onManualRefresh: () => void
 }
 
-const TimeMachineControls: SFC<Props> = ({
+const TimeMachineControls: FunctionComponent<Props> = ({
   script,
   source,
   sources,

--- a/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachineVisualization.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {Subscribe} from 'unstated'
 
 import RefreshingGraph from 'src/shared/components/RefreshingGraph'
@@ -60,7 +60,7 @@ interface PassedProps {
 
 type Props = PassedProps & ConnectedProps
 
-const TimeMachineVisualization: SFC<Props> = props => {
+const TimeMachineVisualization: FunctionComponent<Props> = props => {
   const colors: ColorString[] = getCellTypeColors({
     cellType: props.type,
     gaugeColors: props.gaugeColors,

--- a/ui/src/shared/components/TimeShiftDropdown.tsx
+++ b/ui/src/shared/components/TimeShiftDropdown.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import Dropdown from 'src/shared/components/Dropdown'
 import {TIME_SHIFTS} from 'src/shared/constants/timeShift'
@@ -10,7 +10,7 @@ interface Props {
   isDisabled: boolean
 }
 
-const TimeShiftDropdown: SFC<Props> = ({
+const TimeShiftDropdown: FunctionComponent<Props> = ({
   selected,
   onChooseTimeShift,
   isDisabled,

--- a/ui/src/shared/components/Tooltip.tsx
+++ b/ui/src/shared/components/Tooltip.tsx
@@ -1,11 +1,11 @@
-import React, {SFC, ReactElement} from 'react'
+import React, {FunctionComponent, ReactElement} from 'react'
 import ReactTooltip from 'react-tooltip'
 
 interface Props {
   tip: string
   children: ReactElement<any>
 }
-const Tooltip: SFC<Props> = ({tip, children}) => (
+const Tooltip: FunctionComponent<Props> = ({tip, children}) => (
   <div>
     <div data-tip={tip}>{children}</div>
     <ReactTooltip

--- a/ui/src/shared/components/WidgetCell.tsx
+++ b/ui/src/shared/components/WidgetCell.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import AlertsApp from 'src/alerts/containers/AlertsApp'
 import NewsFeed from 'src/status/components/NewsFeed'
@@ -15,7 +15,7 @@ interface Props {
   source: Source
 }
 
-const WidgetCell: SFC<Props> = ({cell, source, timeRange}) => {
+const WidgetCell: FunctionComponent<Props> = ({cell, source, timeRange}) => {
   switch (cell.type) {
     case 'alerts': {
       return (

--- a/ui/src/shared/decorators/errors.tsx
+++ b/ui/src/shared/decorators/errors.tsx
@@ -42,7 +42,7 @@ ${mdMarker}
 }
 
 export function ErrorHandlingWith(
-  Error: ErrorComponentClass, // Must be a class based component and not an SFC
+  Error: ErrorComponentClass, // Must be a class based component and not an FunctionComponent
   alwaysDisplay = false
 ) {
   return <P, S, T extends {new (...args: any[]): Component<P, S>}>(

--- a/ui/src/side_nav/components/NavItems.tsx
+++ b/ui/src/side_nav/components/NavItems.tsx
@@ -1,4 +1,9 @@
-import React, {PureComponent, SFC, ReactNode, ReactElement} from 'react'
+import React, {
+  PureComponent,
+  FunctionComponent,
+  ReactNode,
+  ReactElement,
+} from 'react'
 import {Link} from 'react-router'
 import classnames from 'classnames'
 import _ from 'lodash'
@@ -11,7 +16,7 @@ interface NavListItemProps {
   children?: ReactNode
 }
 
-const NavListItem: SFC<NavListItemProps> = ({
+const NavListItem: FunctionComponent<NavListItemProps> = ({
   link,
   children,
   location,
@@ -43,7 +48,11 @@ interface NavHeaderProps {
   useAnchor?: string
 }
 
-const NavHeader: SFC<NavHeaderProps> = ({link, title, useAnchor}) => {
+const NavHeader: FunctionComponent<NavHeaderProps> = ({
+  link,
+  title,
+  useAnchor,
+}) => {
   // Some nav items, such as Logout, need to hit an external link rather
   // than simply route to an internal page. Anchor tags serve that purpose.
   return useAnchor ? (

--- a/ui/src/sources/components/InfluxTableHead.tsx
+++ b/ui/src/sources/components/InfluxTableHead.tsx
@@ -1,10 +1,10 @@
-import React, {SFC, ReactElement} from 'react'
+import React, {FunctionComponent, ReactElement} from 'react'
 
 import QuestionMarkTooltip from 'src/shared/components/QuestionMarkTooltip'
 
 import {KAPACITOR_TOOLTIP_COPY} from 'src/sources/constants'
 
-const InfluxTableHead: SFC<{}> = (): ReactElement<
+const InfluxTableHead: FunctionComponent<{}> = (): ReactElement<
   HTMLTableHeaderCellElement
 > => {
   return (

--- a/ui/src/status/components/JSONFeedReader.tsx
+++ b/ui/src/status/components/JSONFeedReader.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 import {JSONFeedData} from 'src/types'
 
 import moment from 'moment'
@@ -7,7 +7,7 @@ interface Props {
   data: JSONFeedData
 }
 
-const JSONFeedReader: SFC<Props> = ({data}) =>
+const JSONFeedReader: FunctionComponent<Props> = ({data}) =>
   data && data.items ? (
     <div className="newsfeed">
       {data.items

--- a/ui/src/tempVars/components/TemplateDropdown.tsx
+++ b/ui/src/tempVars/components/TemplateDropdown.tsx
@@ -1,4 +1,4 @@
-import React, {SFC} from 'react'
+import React, {FunctionComponent} from 'react'
 
 import Dropdown from 'src/shared/components/Dropdown'
 
@@ -9,7 +9,7 @@ interface Props {
   onPickValue: (v: TemplateValue) => void
 }
 
-const TemplateDropdown: SFC<Props> = props => {
+const TemplateDropdown: FunctionComponent<Props> = props => {
   const {template, onPickValue} = props
 
   const dropdownItems = template.values.map(value => {


### PR DESCRIPTION
This PR replaces the deprecated React `SFC` type with `FunctionComponent` type.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
