### PR TITLE
feat: let user specify InfluxDB v2 authentication type and then fully use v2 flux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@
 
 ### Other
 
+## v1.8.9.1 
+
+### Features
+
+1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Support flux schema explorer in InfluxDB v2 sources.
+1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Let user specify InfluxDB v2 authentication.
+
 ## v1.8.9 [2020-12-04]
 
 ### Bug Fixes
@@ -22,6 +29,8 @@
 
 1. [#5612](https://github.com/influxdata/chronograf/pull/5612): Allow to configure etcd with client certificate.
 1. [#5619](https://github.com/influxdata/chronograf/pull/5619): Support flux in InfluxDB v2 sources.
+1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Support flux schema explorer in InfluxDB v2 sources.
+1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Let user specify InfluxDB v2 authentication.
 
 ### Other
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -95,6 +95,8 @@ const (
 	InfluxEnterprise = "influx-enterprise"
 	// InfluxRelay is the basic HA layer over InfluxDB
 	InfluxRelay = "influx-relay"
+	// InfluxDBv2 is influx DB 2.x with Token authentication
+	InfluxDBv2 = "influx-v2"
 )
 
 // TSDBStatus represents the current status of a time series database

--- a/chronograf.go
+++ b/chronograf.go
@@ -95,7 +95,7 @@ const (
 	InfluxEnterprise = "influx-enterprise"
 	// InfluxRelay is the basic HA layer over InfluxDB
 	InfluxRelay = "influx-relay"
-	// InfluxDBv2 is influx DB 2.x with Token authentication
+	// InfluxDBv2 is Influx DB 2.x with Token authentication
 	InfluxDBv2 = "influx-v2"
 )
 

--- a/influx/authorization.go
+++ b/influx/authorization.go
@@ -67,7 +67,6 @@ type TokenAuth struct {
 
 // Set adds the token authentication to the request
 func (a *TokenAuth) Set(r *http.Request) error {
-	fmt.Println("setting up token " + a.Token)
 	r.Header.Set("Authorization", "Token "+a.Token)
 	return nil
 }

--- a/influx/authorization.go
+++ b/influx/authorization.go
@@ -23,7 +23,7 @@ func (n *NoAuthorization) Set(req *http.Request) error { return nil }
 
 // DefaultAuthorization creates either a shared JWT builder, basic auth or Noop or Token authentication
 func DefaultAuthorization(src *chronograf.Source) Authorizer {
-	// Token authentication for InfluxDB-v2
+	// Use Token authentication for InfluxDB v2
 	if src.Type == chronograf.InfluxDBv2 {
 		return &TokenAuth{
 			Token: src.Password,

--- a/influx/authorization.go
+++ b/influx/authorization.go
@@ -3,7 +3,6 @@ package influx
 import (
 	"fmt"
 	"net/http"
-	"strings"
 	"time"
 
 	jwt "github.com/dgrijalva/jwt-go"
@@ -24,8 +23,8 @@ func (n *NoAuthorization) Set(req *http.Request) error { return nil }
 
 // DefaultAuthorization creates either a shared JWT builder, basic auth or Noop or Token authentication
 func DefaultAuthorization(src *chronograf.Source) Authorizer {
-	// Token authentication for InfluxDB v2
-	if (src.Version == "" || strings.HasPrefix(src.Version, "2.")) && src.Password != "" {
+	// Token authentication for InfluxDB-v2
+	if src.Type == chronograf.InfluxDBv2 {
 		return &TokenAuth{
 			Token: src.Password,
 		}

--- a/server/flux.go
+++ b/server/flux.go
@@ -178,7 +178,7 @@ func (s *Service) ProxyFlux(w http.ResponseWriter, r *http.Request) {
 		req.Host = u.Host
 		// Add v2-required org parameter
 		query := u.Query()
-		query.Add("org", src.Username) // v2 organization name is stored as v1 username
+		query.Add("org", src.Username) // v2 organization name is stored in username
 		u.RawQuery = query.Encode()
 		// Set URL
 		req.URL = u

--- a/server/sources.go
+++ b/server/sources.go
@@ -82,7 +82,7 @@ var (
 func hasFlux(ctx context.Context, src chronograf.Source) (bool, error) {
 	// flux is always available in v2 version, but it requires v2 Token authentication (distinguished by Type)
 	// and a non-empty Organization (stored in Username)
-	if src.Version == "" || strings.HasPrefix(src.Version, "2.") {
+	if src.Version == "" /* v2 OSS reports no version */ || strings.HasPrefix(src.Version, "2.") {
 		return src.Type == chronograf.InfluxDBv2 && src.Username != "", nil
 	}
 

--- a/server/sources.go
+++ b/server/sources.go
@@ -467,9 +467,12 @@ func ValidSourceRequest(s *chronograf.Source, defaultOrgID string) error {
 	if s.URL == "" {
 		return fmt.Errorf("url required")
 	}
-	// Type must be influx or influx-enterprise
+	// Validate Type
 	if s.Type != "" {
-		if s.Type != chronograf.InfluxDB && s.Type != chronograf.InfluxDBv2 && s.Type != chronograf.InfluxEnterprise && s.Type != chronograf.InfluxRelay {
+		if s.Type != chronograf.InfluxDB &&
+			s.Type != chronograf.InfluxDBv2 &&
+			s.Type != chronograf.InfluxEnterprise &&
+			s.Type != chronograf.InfluxRelay {
 			return fmt.Errorf("invalid source type %s", s.Type)
 		}
 	}

--- a/server/sources_test.go
+++ b/server/sources_test.go
@@ -118,6 +118,39 @@ func Test_ValidSourceRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "support InfluxDBv2 type",
+			args: args{
+				source: &chronograf.Source{
+					ID:                 1,
+					Name:               "I'm a really great source",
+					Type:               chronograf.InfluxDBv2,
+					Username:           "organization",
+					Password:           "pwd",
+					SharedSecret:       "supersecret",
+					URL:                "http://www.any.url.com",
+					MetaURL:            "http://www.so.meta.com",
+					InsecureSkipVerify: true,
+					Default:            true,
+					Telegraf:           "telegraf",
+				},
+			},
+			wants: wants{
+				source: &chronograf.Source{
+					ID:                 1,
+					Name:               "I'm a really great source",
+					Type:               chronograf.InfluxDBv2,
+					Username:           "organization",
+					Password:           "pwd",
+					SharedSecret:       "supersecret",
+					URL:                "http://www.any.url.com",
+					MetaURL:            "http://www.so.meta.com",
+					InsecureSkipVerify: true,
+					Default:            true,
+					Telegraf:           "telegraf",
+				},
+			},
+		},
+		{
 			name: "bad url",
 			args: args{
 				source: &chronograf.Source{

--- a/ui/src/admin/containers/AdminInfluxDBPage.tsx
+++ b/ui/src/admin/containers/AdminInfluxDBPage.tsx
@@ -114,6 +114,7 @@ export class AdminInfluxDBPage extends PureComponent<Props, State> {
   public async componentDidMount() {
     const {source, loadUsers, loadRoles, loadPermissions} = this.props
     if (!source.version || source.version.startsWith('2')) {
+      // administration is not possible for v2 type
       return
     }
 

--- a/ui/src/admin/containers/AdminInfluxDBPage.tsx
+++ b/ui/src/admin/containers/AdminInfluxDBPage.tsx
@@ -113,6 +113,9 @@ export class AdminInfluxDBPage extends PureComponent<Props, State> {
   }
   public async componentDidMount() {
     const {source, loadUsers, loadRoles, loadPermissions} = this.props
+    if (!source.version || source.version.startsWith('2')) {
+      return
+    }
 
     this.setState({loading: RemoteDataState.Loading})
 

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -23,6 +23,14 @@ interface Props {
   onChangeSource: (source: SourcesModels.Source, type: QueryType) => void
 }
 
+function fluxDisabledTooltip(source: SourcesModels.Source): string {
+  // if source is version 2, recommend InfluxDB v2 authentication
+  if (!source.version || source.version.startsWith('2.')) {
+    return 'To enable Flux modify the connection to use InfluxDB v2 Auth with an organization and a token.'
+  }
+  return 'The current source does not support Flux.'
+}
+
 const SourceSelector: FunctionComponent<Props> = ({
   source,
   sources = [],
@@ -77,7 +85,7 @@ const SourceSelector: FunctionComponent<Props> = ({
       {!sourceSupportsFlux && (
         <QuestionMarkTooltip
           tipID="token"
-          tipContent={`<p>The current source does not support Flux.</p>`}
+          tipContent={`<p>${fluxDisabledTooltip(source)}</p>`}
         />
       )}
     </div>

--- a/ui/src/flux/components/DatabaseList.tsx
+++ b/ui/src/flux/components/DatabaseList.tsx
@@ -7,10 +7,29 @@ import showDatabasesParser from 'src/shared/parsing/showDatabases'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Source, NotificationAction} from 'src/types'
+import {executeQuery} from 'src/shared/apis/flux/query'
+import {parseResponse} from 'src/shared/parsing/flux/response'
 
 interface Props {
   source: Source
   notify: NotificationAction
+  v2?: boolean
+}
+
+export async function getBuckets(source: Source): Promise<string[]> {
+  const {csv} = await executeQuery(source, 'buckets()')
+  const tables = parseResponse(csv)
+  if (tables && tables.length > 0) {
+    const data = tables[0].data
+    if (data.length > 1) {
+      const nameIndex = data[0].indexOf('name')
+      if (nameIndex > 0) {
+        const buckets = data.slice(1).map(arr => arr[nameIndex] as string)
+        return buckets.sort()
+      }
+    }
+  }
+  return []
 }
 
 interface State {
@@ -32,13 +51,16 @@ class DatabaseList extends PureComponent<Props, State> {
   }
 
   public async getDatabases() {
-    const {source} = this.props
+    const {source, v2} = this.props
     try {
-      const {data} = await showDatabases(source.links.proxy)
-      const {databases} = showDatabasesParser(data)
-      const sorted = databases.sort()
-
-      this.setState({databases: sorted})
+      if (v2) {
+        const buckets = await getBuckets(source)
+        this.setState({databases: buckets})
+      } else {
+        const {data} = await showDatabases(source.links.proxy)
+        const {databases} = showDatabasesParser(data)
+        this.setState({databases: databases.sort()})
+      }
     } catch (err) {
       console.error(err)
     }

--- a/ui/src/flux/components/FetchMeasurements.tsx
+++ b/ui/src/flux/components/FetchMeasurements.tsx
@@ -19,6 +19,14 @@ interface State {
   loading: RemoteDataState
 }
 
+export async function fetchFluxMeasurements(
+  source: Source,
+  bucket: string
+): Promise<string[]> {
+  const measurementResults = await fetchMeasurementsAsync(source, bucket)
+  return parseValuesColumn(measurementResults)
+}
+
 class FetchMeasurements extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
@@ -39,8 +47,7 @@ class FetchMeasurements extends PureComponent<Props, State> {
     const {source, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const measurementResults = await fetchMeasurementsAsync(source, bucket)
-      const measurements = parseValuesColumn(measurementResults)
+      const measurements = await fetchFluxMeasurements(source, bucket)
       this.setState({measurements, loading: RemoteDataState.Done})
     } catch (error) {
       this.setState({loading: RemoteDataState.Error})

--- a/ui/src/flux/components/SchemaExplorer.tsx
+++ b/ui/src/flux/components/SchemaExplorer.tsx
@@ -7,15 +7,16 @@ import {Source, NotificationAction} from 'src/types'
 interface Props {
   source: Source
   notify: NotificationAction
+  v2?: boolean
 }
 
 class SchemaExplorer extends PureComponent<Props> {
   public render() {
-    const {source, notify} = this.props
+    const {source, notify, v2} = this.props
     return (
       <div className="flux-schema-explorer">
         <FancyScrollbar>
-          <DatabaseList source={source} notify={notify} />
+          <DatabaseList source={source} notify={notify} v2={v2} />
         </FancyScrollbar>
       </div>
     )

--- a/ui/src/flux/helpers/scriptBuilder.ts
+++ b/ui/src/flux/helpers/scriptBuilder.ts
@@ -5,10 +5,21 @@ interface Status {
 
 export const parseError = (error): Status => {
   if (error.data) {
-    const s = error.data.slice(0, -5) // There is a 'null\n' at the end of these responses
-    const data = JSON.parse(s)
-    return {type: 'error', text: data.message}
+    if (typeof error.data === 'string') {
+      const s = error.data.slice(0, -5) // There is a 'null\n' at the end of these responses
+      const data = JSON.parse(s)
+      return {type: 'error', text: data.message}
+    } else if (typeof error.data === 'object') {
+      if (error.data.error) {
+        return {type: 'error', text: error.data.error}
+      }
+    }
   }
-
-  return {type: 'error', text: error.message}
+  if (error.message) {
+    return {type: 'error', text: error.message}
+  }
+  if (error.statusText) {
+    return {type: 'error', text: error.statusText}
+  }
+  return {type: 'error', text: error.toString()}
 }

--- a/ui/src/shared/apis/flux/query.ts
+++ b/ui/src/shared/apis/flux/query.ts
@@ -78,7 +78,11 @@ export const executeQuery = async (
     let bodyError = null
 
     try {
-      bodyError = JSON.parse(xhr.responseText).error
+      const json = JSON.parse(xhr.responseText)
+      bodyError = json.error
+      if (!bodyError && json.code && json.message) {
+        bodyError = json.code + ':\n' + json.message
+      }
     } catch {
       if (xhr.responseText && xhr.responseText.trim() !== '') {
         bodyError = xhr.responseText

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -12,7 +12,7 @@ import {Button, ComponentSize, ComponentColor} from 'src/reusable_ui'
 import FluxFunctionsToolbar from 'src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar'
 
 // Constants
-import {HANDLE_VERTICAL} from 'src/shared/constants'
+import {HANDLE_VERTICAL, SOURCE_TYPE_INFLUX_V2} from 'src/shared/constants'
 
 // Utils
 import {getAST} from 'src/shared/apis/flux/ast'
@@ -90,6 +90,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
     const {suggestions, isWizardActive, draftScriptStatus} = this.state
 
     const [leftSize, middleSize, rightSize] = fluxProportions
+    const v2 = source.type === SOURCE_TYPE_INFLUX_V2
 
     const divisions = [
       {
@@ -97,7 +98,9 @@ class FluxQueryMaker extends PureComponent<Props, State> {
         size: leftSize,
         headerButtons: [],
         menuOptions: [],
-        render: () => <SchemaExplorer source={source} notify={notify} />,
+        render: () => (
+          <SchemaExplorer source={source} notify={notify} v2={v2} />
+        ),
         headerOrientation: HANDLE_VERTICAL,
       },
       {
@@ -152,6 +155,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
       <FluxScriptWizard
         source={source}
         isWizardActive={isWizardActive}
+        v2={v2}
         onSetIsWizardActive={this.handleSetIsWizardActive}
         onAddToScript={this.handleAddToScript}
       >

--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
@@ -365,6 +365,10 @@ class FluxScriptWizard extends PureComponent<Props, State> {
       fieldsStatus: RemoteDataState.NotStarted,
       selectedFields: [],
     })
+    if (!selectedDB) {
+      // no database selected
+      return
+    }
 
     let measurements
 

--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
@@ -85,10 +85,6 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   private fetchMeasurements = restartable(fetchMeasurements)
   private fetchFields = restartable(fetchFields)
 
-  public componentDidMount() {
-    this.fetchAndSetDBsToRPs()
-  }
-
   public render() {
     const {children, isWizardActive} = this.props
 
@@ -100,12 +96,17 @@ class FluxScriptWizard extends PureComponent<Props, State> {
       )
     }
     const {
+      dbsToRPsStatus,
       measurements,
       fields,
       selectedMeasurement,
       selectedFields,
       selectedAggFunction,
     } = this.state
+
+    if (dbsToRPsStatus === RemoteDataState.NotStarted) {
+      this.fetchAndSetDBsToRPs()
+    }
 
     return (
       <div className="flux-script-wizard">

--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
@@ -33,6 +33,10 @@ import {
 
 // Types
 import {RemoteDataState, Source} from 'src/types'
+import {getBuckets} from 'src/flux/components/DatabaseList'
+import {fetchFluxMeasurements} from 'src/flux/components/FetchMeasurements'
+import {fieldsByMeasurement} from 'src/shared/apis/flux/metaQueries'
+import {parseFieldsByMeasurements} from 'src/shared/parsing/flux/values'
 
 // These constants are selected so that the dropdown menus will not overflow
 // out of the `.flux-script-wizard--wizard` window
@@ -45,6 +49,7 @@ interface Props {
   isWizardActive: boolean
   onSetIsWizardActive: (isWizardActive: boolean) => void
   onAddToScript: (script: string) => void
+  v2?: boolean
 }
 
 interface State {
@@ -86,13 +91,6 @@ class FluxScriptWizard extends PureComponent<Props, State> {
 
   public render() {
     const {children, isWizardActive} = this.props
-    const {
-      measurements,
-      fields,
-      selectedMeasurement,
-      selectedFields,
-      selectedAggFunction,
-    } = this.state
 
     if (!isWizardActive) {
       return (
@@ -101,6 +99,13 @@ class FluxScriptWizard extends PureComponent<Props, State> {
         </div>
       )
     }
+    const {
+      measurements,
+      fields,
+      selectedMeasurement,
+      selectedFields,
+      selectedAggFunction,
+    } = this.state
 
     return (
       <div className="flux-script-wizard">
@@ -249,11 +254,9 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private get buttonStatus(): ComponentStatus {
-    const {selectedDB, selectedRP, selectedMeasurement} = this.state
+    const {selectedDB, selectedMeasurement} = this.state
 
-    const needsSelection = [selectedDB, selectedRP, selectedMeasurement].some(
-      isEmpty
-    )
+    const needsSelection = [selectedDB, selectedMeasurement].some(isEmpty)
 
     const buttonStatus = needsSelection
       ? ComponentStatus.Disabled
@@ -304,7 +307,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetDBsToRPs = async () => {
-    const {source} = this.props
+    const {source, v2} = this.props
 
     this.setState({
       dbsToRPs: {},
@@ -322,7 +325,15 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let dbsToRPs
 
     try {
-      dbsToRPs = await this.fetchDBsToRPs(source.links.proxy)
+      if (v2) {
+        const buckets = await getBuckets(source)
+        dbsToRPs = buckets.reduce((acc, db) => {
+          acc[db] = ['']
+          return acc
+        }, {})
+      } else {
+        dbsToRPs = await this.fetchDBsToRPs(source.links.proxy)
+      }
     } catch {
       this.setState({dbsToRPsStatus: RemoteDataState.Error})
 
@@ -343,7 +354,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetMeasurements = async () => {
-    const {source} = this.props
+    const {source, v2} = this.props
     const {selectedDB} = this.state
 
     this.setState({
@@ -358,10 +369,14 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let measurements
 
     try {
-      measurements = await this.fetchMeasurements(
-        source.links.proxy,
-        selectedDB
-      )
+      if (v2) {
+        measurements = await fetchFluxMeasurements(source, selectedDB)
+      } else {
+        measurements = await this.fetchMeasurements(
+          source.links.proxy,
+          selectedDB
+        )
+      }
     } catch {
       this.setState({
         measurements: [],
@@ -383,7 +398,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetFields = async () => {
-    const {source} = this.props
+    const {source, v2} = this.props
     const {selectedDB, selectedMeasurement} = this.state
 
     this.setState({
@@ -395,11 +410,17 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let fields
 
     try {
-      fields = await this.fetchFields(
-        source.links.proxy,
-        selectedDB,
-        selectedMeasurement
-      )
+      if (v2) {
+        const fieldsResults = await fieldsByMeasurement(source, selectedDB)
+        const {fieldsByMeasurements} = parseFieldsByMeasurements(fieldsResults)
+        fields = fieldsByMeasurements[selectedMeasurement] || []
+      } else {
+        fields = await this.fetchFields(
+          source.links.proxy,
+          selectedDB,
+          selectedMeasurement
+        )
+      }
     } catch {
       this.setState({
         fields: [],

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -34,6 +34,7 @@ import {
 } from 'src/types'
 import {TimeSeriesServerResponse} from 'src/types/series'
 import {GrabDataForDownloadHandler} from 'src/types/layout'
+import {parseError} from 'src/flux/helpers/scriptBuilder'
 
 export const DEFAULT_TIME_SERIES = [{response: {results: []}}]
 const EXECUTE_QUERIES_DEBOUNCE_MS = 400
@@ -243,7 +244,8 @@ class TimeSeries extends PureComponent<Props, State> {
       loading = RemoteDataState.Done
     } catch (err) {
       loading = RemoteDataState.Error
-      errorMessage = err.toString()
+      errorMessage = parseError(err).text
+      console.trace(err, errorMessage)
     }
 
     this.setState({

--- a/ui/src/shared/constants/index.ts
+++ b/ui/src/shared/constants/index.ts
@@ -511,6 +511,9 @@ export const MIN_SIZE = 0
 
 export const QUERY_BUILDER_LIST_ITEM_HEIGHT = 28
 
+export const SOURCE_TYPE_INFLUX_V1 = 'influx'
+export const SOURCE_TYPE_INFLUX_V2 = 'influx-v2'
+
 export enum DataType {
   flux = 'flux',
   influxQL = 'influxQL',

--- a/ui/src/shared/utils/fluxScriptWizard.ts
+++ b/ui/src/shared/utils/fluxScriptWizard.ts
@@ -62,7 +62,7 @@ export async function fetchFields(
 }
 
 export function formatDBwithRP(db: string, rp: string): string {
-  return `${db}/${rp}`
+  return rp ? `${db}/${rp}` : `${db}`
 }
 
 export function toComponentStatus(

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -162,7 +162,7 @@ class SourceStep extends PureComponent<Props, State> {
           halfWidth={!onBoarding}
           isChecked={sourceIsV2}
           text={'InfluxDB v2 Auth'}
-          onChange={this.changeVersion}
+          onChange={this.changeAuth}
         />
 
         {this.isHTTPS && (
@@ -227,11 +227,13 @@ class SourceStep extends PureComponent<Props, State> {
     this.setState({source: {...source, [key]: value}})
     setError(false)
   }
-  private changeVersion = (v2: boolean) => {
+  private changeAuth = (v2: boolean) => {
     const {source} = this.state
     this.setState({
       source: {
         ...source,
+        username: '',
+        password: '',
         type: v2 ? SOURCE_TYPE_INFLUX_V2 : SOURCE_TYPE_INFLUX_V1,
         version: v2 ? '2.x' : '1.x',
       },

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -40,7 +40,7 @@ import {Source, Me} from 'src/types'
 import {NextReturn} from 'src/types/wizard'
 
 const isNewSource = (source: Partial<Source>) => !source.id
-const isSourceV2 = (source: Partial<Source>) =>
+const isV2Auth = (source: Partial<Source>) =>
   source.type && source.type === SOURCE_TYPE_INFLUX_V2
 
 interface Props {
@@ -104,7 +104,7 @@ class SourceStep extends PureComponent<Props, State> {
   public render() {
     const {source} = this.state
     const {isUsingAuth, onBoarding} = this.props
-    const sourceIsV2 = isSourceV2(source)
+    const sourceIsV2 = isV2Auth(source)
 
     return (
       <>

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -233,7 +233,7 @@ class SourceStep extends PureComponent<Props, State> {
       source: {
         ...source,
         type: v2 ? SOURCE_TYPE_INFLUX_V2 : SOURCE_TYPE_INFLUX_V1,
-        version: v2 ? '2.x' : '1.x'
+        version: v2 ? '2.x' : '1.x',
       },
     })
   }

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -28,7 +28,11 @@ import {
   notifySourceConnectionSucceeded,
 } from 'src/shared/copy/notifications'
 import {insecureSkipVerifyText} from 'src/shared/copy/tooltipText'
-import {DEFAULT_SOURCE} from 'src/shared/constants'
+import {
+  DEFAULT_SOURCE,
+  SOURCE_TYPE_INFLUX_V2,
+  SOURCE_TYPE_INFLUX_V1,
+} from 'src/shared/constants'
 import {SUPERADMIN_ROLE} from 'src/auth/Authorized'
 
 // Types
@@ -37,7 +41,7 @@ import {NextReturn} from 'src/types/wizard'
 
 const isNewSource = (source: Partial<Source>) => !source.id
 const isSourceV2 = (source: Partial<Source>) =>
-  !source.version || source.version.startsWith('2.')
+  source.type && source.type === SOURCE_TYPE_INFLUX_V2
 
 interface Props {
   notify: typeof notifyAction
@@ -157,7 +161,7 @@ class SourceStep extends PureComponent<Props, State> {
         <WizardCheckbox
           halfWidth={!onBoarding}
           isChecked={sourceIsV2}
-          text={'InfluxDB v2'}
+          text={'InfluxDB v2 Auth'}
           onChange={this.changeVersion}
         />
 
@@ -226,7 +230,11 @@ class SourceStep extends PureComponent<Props, State> {
   private changeVersion = (v2: boolean) => {
     const {source} = this.state
     this.setState({
-      source: {...source, version: v2 ? '2.x' : '1.x'},
+      source: {
+        ...source,
+        type: v2 ? SOURCE_TYPE_INFLUX_V2 : SOURCE_TYPE_INFLUX_V1,
+        version: v2 ? '2.x' : '1.x'
+      },
     })
   }
 


### PR DESCRIPTION
This PR lets the user choose whether to communicate with InfluxDB with v1 (basic) or v2 (token) authentication. It further improves #5617 in the following way:

1. v1 authentication is used by default, no changes are thus required when InfluxDB source upgrades from v1 to v2. The upgrade process creates v1 authentication credentials in v2.
1. The user can choose whether to use v1 (default) or v2 authentication when establishing a new connection or updating an existing one using the `InfluxDB v2 Auth` checkbox. The type of user-selected authentication is then persisted in the chronograf database and used in the communication with InfluxDB.
   * v1 (unchecked) changes the UI to let the user enter `Username` and `Password` fields: 
     ![image](https://user-images.githubusercontent.com/16321466/101330198-9e686100-3872-11eb-82f9-a6d7e0c88d16.png)
   * v2 (checked) let the user specify `Organization` and `Token`:
     ![image](https://user-images.githubusercontent.com/16321466/101330526-fef79e00-3872-11eb-9d1a-2ee56366d115.png)
1. The Flux part of the Explorer UI is enabled only if it can work, i.e.
   * v1 server connection is used and flux support is enabled in the server. If it is disabled, a tooltip is shown: 
![image](https://user-images.githubusercontent.com/16321466/101329531-c7d4bd00-3871-11eb-9cf8-f54287b4c542.png)
   * v2 server connection is used, `InfluxDB v2 Auth` is turned on with `Organization` and `Token` specified. If a v2 connection is detected and Flux cannot be enabled, a tooltip is shown:
![image](https://user-images.githubusercontent.com/16321466/101327984-b8547480-386f-11eb-881e-31e52b14acfb.png)
1. When v2 is used, the Explorer's Schema part and its Flux Wizard uses Flux (does not use any v1 API) to inspect metadata about buckets, measurements, tags, and fields.
1. Error reporting was enhanced to provide better messages out of flux errors sent by InfluxDB v2.

Tested with InfluxDB 1.8, v2.0.2 OSS, and https://eu-central-1-1.aws.cloud2.influxdata.com/

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
