### PR TITLE
feat(ui): validate connection credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Support flux schema explorer in InfluxDB v2 sources.
 1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Let user specify InfluxDB v2 authentication.
+1. [#5634](https://github.com/influxdata/chronograf/pull/5634): Validate credentials before creating/updating InfluxDB sources.
 
 ## v1.8.9 [2020-12-04]
 

--- a/server/sources_test.go
+++ b/server/sources_test.go
@@ -409,8 +409,13 @@ func TestService_UpdateSource(t *testing.T) {
 			Logger: tt.fields.Logger,
 		}
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusNoContent)
-			w.Header().Set("X-Influxdb-Build", "ENT")
+			if r.URL.Path == "/query" {
+				w.WriteHeader(http.StatusOK) // credentials
+			} else {
+				w.WriteHeader(http.StatusNoContent)
+				w.Header().Set("X-Influxdb-Build", "ENT")
+			}
+			w.Write(([]byte)("{}"))
 		}))
 		defer ts.Close()
 

--- a/ui/src/sources/components/DashboardStep.tsx
+++ b/ui/src/sources/components/DashboardStep.tsx
@@ -251,6 +251,11 @@ class DashboardStep extends Component<Props, State> {
         )
 
         if (suggestedProtoboardsList.length === 0) {
+          if (this.isComponentMounted) {
+            this.setState({
+              fetchingSuggested: RemoteDataState.Done,
+            })
+          }
           return
         }
 


### PR DESCRIPTION
Closes #5633

* Credentials are validated when creating or updating InfluxDB connection
   * v1 auth: executes `SHOW DATABASES` InfluxQL query
   * v2 auth: executes `buckets()` Flux query
   * a possible server error message is shown in UI's notification center:
![image](https://user-images.githubusercontent.com/16321466/101659959-e7710e80-3a46-11eb-97c2-133f368b6723.png)
![image](https://user-images.githubusercontent.com/16321466/101660028-01125600-3a47-11eb-932d-ab7643789474.png)

* `Dashboards` step in the connection wizard is not randomly stuck in a Loading state anymore

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
