### PR TITLE
feat(ui): use fully qualified names of v1 buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Support flux schema explorer in InfluxDB v2 sources.
 1. [#5631](https://github.com/influxdata/chronograf/pull/5631): Let user specify InfluxDB v2 authentication.
 1. [#5634](https://github.com/influxdata/chronograf/pull/5634): Validate credentials before creating/updating InfluxDB sources.
+1. [#5635](https://github.com/influxdata/chronograf/pull/5635): Use fully-qualified bucket names in the Flux part of Explore UI.
 
 ## v1.8.9 [2020-12-04]
 

--- a/ui/src/flux/components/DatabaseList.tsx
+++ b/ui/src/flux/components/DatabaseList.tsx
@@ -2,9 +2,6 @@ import React, {PureComponent} from 'react'
 
 import DatabaseListItem from 'src/flux/components/DatabaseListItem'
 
-import {showDatabases} from 'src/shared/apis/metaQuery'
-import showDatabasesParser from 'src/shared/parsing/showDatabases'
-
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {Source, NotificationAction} from 'src/types'
 import {executeQuery} from 'src/shared/apis/flux/query'
@@ -13,7 +10,6 @@ import {parseResponse} from 'src/shared/parsing/flux/response'
 interface Props {
   source: Source
   notify: NotificationAction
-  v2?: boolean
 }
 
 export async function getBuckets(source: Source): Promise<string[]> {
@@ -51,16 +47,10 @@ class DatabaseList extends PureComponent<Props, State> {
   }
 
   public async getDatabases() {
-    const {source, v2} = this.props
+    const {source} = this.props
     try {
-      if (v2) {
-        const buckets = await getBuckets(source)
-        this.setState({databases: buckets})
-      } else {
-        const {data} = await showDatabases(source.links.proxy)
-        const {databases} = showDatabasesParser(data)
-        this.setState({databases: databases.sort()})
-      }
+      const buckets = await getBuckets(source)
+      this.setState({databases: buckets})
     } catch (err) {
       console.error(err)
     }

--- a/ui/src/flux/components/SchemaExplorer.tsx
+++ b/ui/src/flux/components/SchemaExplorer.tsx
@@ -7,12 +7,11 @@ import {Source, NotificationAction} from 'src/types'
 interface Props {
   source: Source
   notify: NotificationAction
-  v2?: boolean
 }
 
 class SchemaExplorer extends PureComponent<Props> {
   public render() {
-    const {source, notify, v2} = this.props
+    const {source, notify} = this.props
     return (
       <div className="flux-schema-explorer">
         <FancyScrollbar>

--- a/ui/src/flux/components/SchemaExplorer.tsx
+++ b/ui/src/flux/components/SchemaExplorer.tsx
@@ -16,7 +16,7 @@ class SchemaExplorer extends PureComponent<Props> {
     return (
       <div className="flux-schema-explorer">
         <FancyScrollbar>
-          <DatabaseList source={source} notify={notify} v2={v2} />
+          <DatabaseList source={source} notify={notify} />
         </FancyScrollbar>
       </div>
     )

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -12,7 +12,7 @@ import {Button, ComponentSize, ComponentColor} from 'src/reusable_ui'
 import FluxFunctionsToolbar from 'src/flux/components/flux_functions_toolbar/FluxFunctionsToolbar'
 
 // Constants
-import {HANDLE_VERTICAL, SOURCE_TYPE_INFLUX_V2} from 'src/shared/constants'
+import {HANDLE_VERTICAL} from 'src/shared/constants'
 
 // Utils
 import {getAST} from 'src/shared/apis/flux/ast'
@@ -90,7 +90,6 @@ class FluxQueryMaker extends PureComponent<Props, State> {
     const {suggestions, isWizardActive, draftScriptStatus} = this.state
 
     const [leftSize, middleSize, rightSize] = fluxProportions
-    const v2 = source.type === SOURCE_TYPE_INFLUX_V2
 
     const divisions = [
       {
@@ -98,9 +97,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
         size: leftSize,
         headerButtons: [],
         menuOptions: [],
-        render: () => (
-          <SchemaExplorer source={source} notify={notify} v2={v2} />
-        ),
+        render: () => <SchemaExplorer source={source} notify={notify} />,
         headerOrientation: HANDLE_VERTICAL,
       },
       {
@@ -155,7 +152,6 @@ class FluxQueryMaker extends PureComponent<Props, State> {
       <FluxScriptWizard
         source={source}
         isWizardActive={isWizardActive}
-        v2={v2}
         onSetIsWizardActive={this.handleSetIsWizardActive}
         onAddToScript={this.handleAddToScript}
       >

--- a/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxScriptWizard.tsx
@@ -13,11 +13,7 @@ import {
 } from 'src/reusable_ui'
 
 // Utils
-import {restartable} from 'src/shared/utils/restartable'
 import {
-  fetchDBsToRPs,
-  fetchMeasurements,
-  fetchFields,
   formatDBwithRP,
   toComponentStatus,
   renderScript,
@@ -49,7 +45,6 @@ interface Props {
   isWizardActive: boolean
   onSetIsWizardActive: (isWizardActive: boolean) => void
   onAddToScript: (script: string) => void
-  v2?: boolean
 }
 
 interface State {
@@ -80,10 +75,6 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     selectedFields: null,
     selectedAggFunction: DEFAULT_AGG_FUNCTION.value,
   }
-
-  private fetchDBsToRPs = restartable(fetchDBsToRPs)
-  private fetchMeasurements = restartable(fetchMeasurements)
-  private fetchFields = restartable(fetchFields)
 
   public render() {
     const {children, isWizardActive} = this.props
@@ -308,7 +299,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetDBsToRPs = async () => {
-    const {source, v2} = this.props
+    const {source} = this.props
 
     this.setState({
       dbsToRPs: {},
@@ -326,15 +317,11 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let dbsToRPs
 
     try {
-      if (v2) {
-        const buckets = await getBuckets(source)
-        dbsToRPs = buckets.reduce((acc, db) => {
-          acc[db] = ['']
-          return acc
-        }, {})
-      } else {
-        dbsToRPs = await this.fetchDBsToRPs(source.links.proxy)
-      }
+      const buckets = await getBuckets(source)
+      dbsToRPs = buckets.reduce((acc, db) => {
+        acc[db] = ['']
+        return acc
+      }, {})
     } catch {
       this.setState({dbsToRPsStatus: RemoteDataState.Error})
 
@@ -355,7 +342,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetMeasurements = async () => {
-    const {source, v2} = this.props
+    const {source} = this.props
     const {selectedDB} = this.state
 
     this.setState({
@@ -374,14 +361,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let measurements
 
     try {
-      if (v2) {
-        measurements = await fetchFluxMeasurements(source, selectedDB)
-      } else {
-        measurements = await this.fetchMeasurements(
-          source.links.proxy,
-          selectedDB
-        )
-      }
+      measurements = await fetchFluxMeasurements(source, selectedDB)
     } catch {
       this.setState({
         measurements: [],
@@ -403,7 +383,7 @@ class FluxScriptWizard extends PureComponent<Props, State> {
   }
 
   private fetchAndSetFields = async () => {
-    const {source, v2} = this.props
+    const {source} = this.props
     const {selectedDB, selectedMeasurement} = this.state
 
     this.setState({
@@ -415,17 +395,9 @@ class FluxScriptWizard extends PureComponent<Props, State> {
     let fields
 
     try {
-      if (v2) {
-        const fieldsResults = await fieldsByMeasurement(source, selectedDB)
-        const {fieldsByMeasurements} = parseFieldsByMeasurements(fieldsResults)
-        fields = fieldsByMeasurements[selectedMeasurement] || []
-      } else {
-        fields = await this.fetchFields(
-          source.links.proxy,
-          selectedDB,
-          selectedMeasurement
-        )
-      }
+      const fieldsResults = await fieldsByMeasurement(source, selectedDB)
+      const {fieldsByMeasurements} = parseFieldsByMeasurements(fieldsResults)
+      fields = fieldsByMeasurements[selectedMeasurement] || []
     } catch {
       this.setState({
         fields: [],


### PR DESCRIPTION
This PR repairs the way of how Flux buckets are retrieved in the Explorer UI for v1 InfluxDB sources. The v1 buckets are shown using a fully-qualified name ( `database/retentionPolicy`) that will also work after migration to InfluxDB v2.

Additionally, it does the same changes in the Flux Script Wizard when v1 Flux is used.

_Briefly describe your proposed changes:_
Use `buckets()` flux query under the hood so that a bucket name is the same after data migration to v2, it is "database/retentionPolicy".

_What was the problem?_
Short names are offered, these short names AFAIK cannot be used after migration of v1 to v2.
![image](https://user-images.githubusercontent.com/16321466/101785501-1e096080-3afd-11eb-8abe-71566b6698b9.png)


_What was the solution?_
v2 API is used to obtain bucket names, these are then fully qualified.
![image](https://user-images.githubusercontent.com/16321466/101785112-ac311700-3afc-11eb-91d7-ea6ae86050c3.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
