### PR TITLE
fix(server): ignore databases that cannot be read

### DIFF
--- a/ui/src/admin/containers/QueriesPage.js
+++ b/ui/src/admin/containers/QueriesPage.js
@@ -56,7 +56,7 @@ class QueriesPage extends Component {
         results.forEach((settledResponse, i) => {
           if (!settledResponse.value) {
             console.error(
-              `Unable to show queries for '${databases[i]}': `,
+              `Unable to show queries on '${databases[i]}': `,
               settledResponse.reason
             )
             return

--- a/ui/src/shared/apis/databases.ts
+++ b/ui/src/shared/apis/databases.ts
@@ -10,9 +10,8 @@ const getRetentionPolices = async (proxy, databases) => {
   let results = []
 
   for (let i = 0; i < databases.length; i++) {
+    const database = databases[i]
     try {
-      const database = databases[i]
-
       const {
         data: {results: rps},
       } = await showRetentionPolicies(proxy, database)
@@ -29,7 +28,7 @@ const getRetentionPolices = async (proxy, databases) => {
         results = [...results, ...dbrp]
       }
     } catch (e) {
-      console.error(e)
+      console.error(`Unable to show retention policies on ${database}`, e)
     }
   }
 


### PR DESCRIPTION
Closes #5531

Some UI pages show no data for all databases when chronograf uses InfluxDB Enterprise connection with a user that does not have ReadData permission to one database. This PR repairs these pages to show data for the databases that can be read.

1. Admin/Databases: The databases that are shown by `SHOW DATABASES` and cannot be further inspected with `SHOW RETENTION POLICIES ON database` are logged in the server log and ignored in the returned database list.
2. Admin/Queries: Only the databases for which the user cannot execute `SHOW QUERIES` are now shown.
3. Explorer/Schema Explorer: Only databases with retention policies that can be read are already shown in 1.8.9, only the console log was improved herein.

  - [x] CHANGELOG.md updated in #5647 5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
