### PR TITLE
feat(oauth): support bitbucket primary email retrieval

### DIFF
--- a/oauth2/generic.go
+++ b/oauth2/generic.go
@@ -217,7 +217,7 @@ func (g *Generic) primaryEmail(emails []*UserEmail) (string, error) {
 	for _, m := range emails {
 		if m != nil && m.Email != nil &&
 			((m.Primary != nil && *m.Primary) || (m.IsPrimary != nil && *m.IsPrimary)) &&
-			((m.Verified != nil && *m.Verified) || (m.IsConfirmed != nil && *m.IsConfirmed)) {
+			((m.Verified != nil) || (m.IsConfirmed != nil)) {
 			return *m.Email, nil
 		}
 	}

--- a/oauth2/generic.go
+++ b/oauth2/generic.go
@@ -214,14 +214,21 @@ func (g *Generic) getPrimaryEmail(client *http.Client) (string, error) {
 }
 
 func (g *Generic) primaryEmail(emails []*UserEmail) (string, error) {
+	var email string
 	for _, m := range emails {
-		if m != nil && m.Email != nil &&
-			((m.Primary != nil && *m.Primary) || (m.IsPrimary != nil && *m.IsPrimary)) &&
-			((m.Verified != nil) || (m.IsConfirmed != nil)) {
-			return *m.Email, nil
+		if m != nil && m.Email != nil && ((m.Verified != nil) || (m.IsConfirmed != nil)) {
+			if email != "" {
+				email = *m.Email
+			}
+			if (m.Primary != nil && *m.Primary) || (m.IsPrimary != nil && *m.IsPrimary) {
+				return *m.Email, nil
+			}
 		}
 	}
-	return "", errors.New("No primary email address")
+	if email == "" {
+		return "", errors.New("No primary email address")
+	}
+	return email, nil
 }
 
 // ofDomain makes sure that the email is in one of the required domains

--- a/oauth2/generic_test.go
+++ b/oauth2/generic_test.go
@@ -198,3 +198,66 @@ func TestGenericPrincipalIDDomain(t *testing.T) {
 		t.Fatal("Retrieved email was not as expected. Want:", want, "Got:", got)
 	}
 }
+
+func TestGenericPrincipalIDDomain_BitBucket(t *testing.T) {
+	// Test of https://github.com/influxdata/chronograf/issues/5399
+	t.Parallel()
+	emailsResponse := `{
+		"pagelen": 10,
+		"values": [
+			{
+				"is_primary": true,
+				"is_confirmed": true,
+				"type": "email",
+				"email": "pavel.zavora@xyz.io",
+				"links": {
+					"self": {
+						"href": "https://api.bitbucket.org/2.0/user/emails/pavel.zavora@xyz.io"
+					}
+				}
+			}
+		],
+		"page": 1,
+		"size": 1
+	}`
+
+	mockAPI := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/" {
+			enc := json.NewEncoder(rw)
+			rw.WriteHeader(http.StatusOK)
+			_ = enc.Encode(struct{}{})
+			return
+		}
+		if r.URL.Path == "/emails" {
+			rw.WriteHeader(http.StatusOK)
+			rw.Write([]byte(emailsResponse))
+			return
+		}
+
+		rw.WriteHeader(http.StatusNotFound)
+	}))
+	defer mockAPI.Close()
+
+	logger := clog.New(clog.ParseLevel("debug"))
+	prov := oauth2.Generic{
+		Logger:  logger,
+		Domains: []string{"xyz.io"},
+	}
+	tt, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
+	if err != nil {
+		t.Fatal("Error initializing TestTripper: err:", err)
+	}
+
+	tc := &http.Client{
+		Transport: tt,
+	}
+
+	got, err := prov.PrincipalID(tc)
+	if err != nil {
+		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+	}
+	want := "pavel.zavora@xyz.io"
+	if got != want {
+		t.Fatal("Retrieved email was not as expected. Want:", want, "Got:", got)
+	}
+}

--- a/oauth2/generic_test.go
+++ b/oauth2/generic_test.go
@@ -202,6 +202,8 @@ func TestGenericPrincipalIDDomain(t *testing.T) {
 func TestGenericPrincipalIDDomain_BitBucket(t *testing.T) {
 	// Test of https://github.com/influxdata/chronograf/issues/5399
 	t.Parallel()
+	expectedGroup := "xyz.io"
+	expectedPrincipalID := "pavel.zavora@xyz.io"
 	emailsResponse := `{
 		"pagelen": 10,
 		"values": [
@@ -241,7 +243,7 @@ func TestGenericPrincipalIDDomain_BitBucket(t *testing.T) {
 	logger := clog.New(clog.ParseLevel("debug"))
 	prov := oauth2.Generic{
 		Logger:  logger,
-		Domains: []string{"xyz.io"},
+		Domains: []string{expectedGroup},
 	}
 	tt, err := oauth2.NewTestTripper(logger, mockAPI, http.DefaultTransport)
 	if err != nil {
@@ -256,8 +258,16 @@ func TestGenericPrincipalIDDomain_BitBucket(t *testing.T) {
 	if err != nil {
 		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
 	}
-	want := "pavel.zavora@xyz.io"
-	if got != want {
-		t.Fatal("Retrieved email was not as expected. Want:", want, "Got:", got)
+	if got != expectedPrincipalID {
+		t.Fatal("Retrieved email was not as expected. Want:", expectedPrincipalID, "Got:", got)
 	}
+
+	group, err := prov.Group(tc)
+	if err != nil {
+		t.Fatal("Unexpected error while retrieiving PrincipalID: err:", err)
+	}
+	if group != expectedGroup {
+		t.Fatal("Retrieved group was not as expected. Want:", expectedGroup, "Got:", group)
+	}
+
 }


### PR DESCRIPTION
Closes #5399

_Briefly describe your proposed changes:_
Enhance processing of "user emails" response to support bitbucket's https://developer.atlassian.com/bitbucket/api/2/reference/resource/user/emails 

_What was the problem?_
Bitbucket's `/emails` response was not recognized.

_What was the solution?_
Support for bitbucket `/emails` response added and an example bitbucket response is unit-tested.

  - [x] CHANGELOG.md updated in #5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
