### PR TITLE
fix(ui/dashboard): repair import to remap also sources in variables

### DIFF
--- a/ui/src/dashboards/utils/importDashboardMappings.ts
+++ b/ui/src/dashboards/utils/importDashboardMappings.ts
@@ -8,7 +8,7 @@ import {getDeep} from 'src/utils/wrappers'
 import {DYNAMIC_SOURCE, DYNAMIC_SOURCE_INFO} from 'src/dashboards/constants'
 
 // Types
-import {CellQuery, Cell, Source} from 'src/types'
+import {CellQuery, Cell, Source, Template} from 'src/types'
 import {
   CellInfo,
   SourceInfo,
@@ -22,7 +22,8 @@ const REGEX_SOURCE_ID = /sources\/(\d+)/g
 export const createSourceMappings = (
   source,
   cells,
-  importedSources
+  importedSources,
+  variables: Template[] = []
 ): {sourcesCells: SourcesCells; sourceMappings: SourceMappings} => {
   let sourcesCells: SourcesCells = {}
   const sourceMappings: SourceMappings = {}
@@ -66,6 +67,13 @@ export const createSourceMappings = (
     },
     sourcesCells
   )
+  // add sources also for variables
+  variables.forEach(v => {
+    if (v.sourceID && !sourceMappings[v.sourceID]) {
+      sourceMappings[v.sourceID] = sourceInfo
+      sourcesCells[v.sourceID] = []
+    }
+  })
 
   if (cellsWithNoSource.length) {
     sourcesCells[DYNAMIC_SOURCE] = cellsWithNoSource

--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -113,8 +113,9 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
       sourceID = props.template.sourceID
       selectedSource = props.sources.find(source => source.id === sourceID)
       if (!selectedSource) {
+        const v = props.template.tempVar
         console.error(
-          `Template for tempVar '${props.template.tempVar}' uses source '${sourceID}' that does not exist. Using dynamic source.`
+          `Variable '${v}' uses source '${sourceID}' that does not exist.`
         )
         sourceID = DYNAMIC_SOURCE_DATABASE_ID
       }
@@ -482,11 +483,11 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
   }
 }
 
-const mapDispatchToProps = {
+const mdtp = {
   notify: notifyActionCreator,
 }
 
-const mapStateToProps = state => {
+const mstp = state => {
   const {sources} = state
 
   return {
@@ -494,7 +495,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(withRouter(TemplateVariableEditor))
+export default connect(mstp, mdtp)(withRouter(TemplateVariableEditor))

--- a/ui/src/tempVars/components/TemplateVariableEditor.tsx
+++ b/ui/src/tempVars/components/TemplateVariableEditor.tsx
@@ -105,19 +105,30 @@ class TemplateVariableEditor extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
 
-    let sourceID = DYNAMIC_SOURCE_DATABASE_ID
+    let sourceID: string
+    let selectedSource: Source
 
     // If props.template exists, we're loading a source. If it doesn't, we're creating one
     if (props.template && props.template.sourceID) {
       sourceID = props.template.sourceID
+      selectedSource = props.sources.find(source => source.id === sourceID)
+      if (!selectedSource) {
+        console.error(
+          `Template for tempVar '${props.template.tempVar}' uses source '${sourceID}' that does not exist. Using dynamic source.`
+        )
+        sourceID = DYNAMIC_SOURCE_DATABASE_ID
+      }
+    } else {
+      sourceID = DYNAMIC_SOURCE_DATABASE_ID
     }
 
     const isDynamicSourceSelected = sourceID === DYNAMIC_SOURCE_DATABASE_ID
-
-    const selectedSource = isDynamicSourceSelected
-      ? // The source id of the current dynamic source is available as a url param
-        props.sources.find(source => source.id === props.params.sourceID)
-      : props.sources.find(source => source.id === sourceID)
+    if (!selectedSource) {
+      // The source id of the current dynamic source is available as a url param
+      selectedSource = props.sources.find(
+        source => source.id === props.params.sourceID
+      )
+    }
 
     const defaultState = {
       savingStatus: RemoteDataState.NotStarted,
@@ -483,6 +494,7 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(
-  withRouter(TemplateVariableEditor)
-)
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(withRouter(TemplateVariableEditor))

--- a/ui/test/dashboards/components/ImportDashboardMappings.test.tsx
+++ b/ui/test/dashboards/components/ImportDashboardMappings.test.tsx
@@ -11,6 +11,7 @@ const setup = (override = {}) => {
     sources: [source],
     importedSources: {},
     onSubmit: () => {},
+    variables: [],
     ...override,
   }
 

--- a/ui/test/dashboards/utils/importDashboardMappings.test.ts
+++ b/ui/test/dashboards/utils/importDashboardMappings.test.ts
@@ -7,10 +7,11 @@ import {
 } from 'src/dashboards/utils/importDashboardMappings'
 
 // fixtures
-import {source, cell, query} from 'test/fixtures'
+import {source, cell, query, template} from 'test/fixtures'
 
 // constants
 import {DYNAMIC_SOURCE, DYNAMIC_SOURCE_INFO} from 'src/dashboards/constants'
+import {Template} from 'src/types'
 
 describe('Dashboards.Utils.importDashboardMappings', () => {
   describe('createSourceMappings', () => {
@@ -149,6 +150,53 @@ describe('Dashboards.Utils.importDashboardMappings', () => {
         importedSources
       )
       expect(sourceMappings).toEqual(expected)
+    })
+    it('maps also imported variables', () => {
+      const currentSource = {...source, id: 11, name: 'MY SOURCE'}
+      const sourceLink1 = '/chronograf/v1/sources/1'
+      const cellName1 = 'Cell 1'
+      const cellID1 = '1'
+      const queryWithSource1 = {...query, source: sourceLink1}
+      const cellWithSource1 = {
+        ...cell,
+        name: cellName1,
+        queries: [queryWithSource1],
+        i: cellID1,
+      }
+      const cells = [cellWithSource1]
+      const importedSources = {
+        1: {name: 'Source 1', link: sourceLink1},
+      }
+      const sourceInfo = {
+        name: currentSource.name,
+        id: currentSource.id,
+        link: currentSource.links.self,
+      }
+      const variables: Template[] = [
+        {
+          ...template,
+          sourceID: undefined,
+        },
+        {
+          ...template,
+          id: 'var2',
+          sourceID: '2',
+        },
+      ]
+
+      const expectedMapping = {
+        1: sourceInfo,
+        2: sourceInfo,
+      }
+
+      const {sourcesCells, sourceMappings} = createSourceMappings(
+        currentSource,
+        cells,
+        importedSources,
+        variables
+      )
+      expect(sourceMappings).toEqual(expectedMapping)
+      expect(sourcesCells[2]).toEqual([])
     })
   })
 

--- a/ui/test/fixtures/index.ts
+++ b/ui/test/fixtures/index.ts
@@ -54,6 +54,14 @@ export const source: Source = {
   authentication: SourceAuthenticationMethod.Basic,
 }
 
+export const template: Template = {
+  id: '1',
+  label: 'var',
+  tempVar: ':var:',
+  type: TemplateType.Constant,
+  values: [],
+}
+
 export const service: Service = {
   id: '1',
   sourceID: '1',


### PR DESCRIPTION
Closes #5645

_Briefly describe your proposed changes:_
* sources in variables are identified and remapped during dashboard import
   * a missing variable is also identified and created
* variables are also shown in the mapping table
![image](https://user-images.githubusercontent.com/16321466/102242188-16312e00-3efa-11eb-94a0-3b581a46fdce.png)
* when a variable source does not exist now a dynamic source is used (with an error message logged)
 
_What was the problem?_
* source reference in variables were ignored during import and can then lead to an inconsistent state in the UI
* a variable that uses a source that was later deleted cannot be then changed in UI

_What was the solution?_
* sources in variables are remapped during dashboard import
* when a variable source does not exist now a dynamic source is used (with an error message logged)

  - [x] CHANGELOG.md updated in #5647 
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
