### PR TITLE
fix(ui/explore): repair Send to Dashboard functionality

### DIFF
--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -41,7 +41,6 @@ import {
   QueryType,
   Notification,
 } from 'src/types'
-import {getDeep} from 'src/utils/wrappers'
 import {VisualizationOptions} from 'src/types/dataExplorer'
 import {ColorString} from 'src/types/colors'
 
@@ -205,11 +204,11 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
   }
 
   private get hasQuery(): boolean {
-    const {queryConfig, script, queryType} = this.props
+    const {rawText, script, queryType} = this.props
     if (queryType === QueryType.Flux) {
       return !!script.length
     }
-    return getDeep<number>(queryConfig, 'fields.length', 0) !== 0
+    return !!rawText.length
   }
 
   private get selectedDashboards(): Dashboard[] {

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -111,43 +111,60 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
       <OverlayContainer>
         <OverlayHeading title="Send to Dashboard" onDismiss={onCancel} />
         <OverlayBody>
-          <Form>
-            <Form.Element label="Target Dashboard(s)">
-              <MultiSelectDropdown
-                onChange={this.handleSelect}
-                selectedIDs={this.state.selectedIDs}
-                emptyText="Choose at least 1 dashboard"
-              >
-                {this.dropdownItems}
-              </MultiSelectDropdown>
-            </Form.Element>
-            {this.isNewDashboardSelected && (
-              <Form.Element label="Name new dashboard">
+          {this.hasQuery() ? (
+            <Form>
+              <Form.Element label="Target Dashboard(s)">
+                <MultiSelectDropdown
+                  onChange={this.handleSelect}
+                  selectedIDs={this.state.selectedIDs}
+                  emptyText="Choose at least 1 dashboard"
+                >
+                  {this.dropdownItems}
+                </MultiSelectDropdown>
+              </Form.Element>
+              {this.isNewDashboardSelected && (
+                <Form.Element label="Name new dashboard">
+                  <Input
+                    value={newDashboardName}
+                    onChange={this.handleChangeNewDashboardName}
+                    placeholder={'Name new dashboard'}
+                  />
+                </Form.Element>
+              )}
+              <Form.Element label="Cell Name">
                 <Input
-                  value={newDashboardName}
-                  onChange={this.handleChangeNewDashboardName}
-                  placeholder={'Name new dashboard'}
+                  value={name}
+                  onChange={this.handleChangeName}
+                  placeholder={'Name this new cell'}
                 />
               </Form.Element>
-            )}
-            <Form.Element label="Cell Name">
-              <Input
-                value={name}
-                onChange={this.handleChangeName}
-                placeholder={'Name this new cell'}
-              />
-            </Form.Element>
-            <Form.Footer>
-              <Button
-                color={ComponentColor.Success}
-                text={`Send to ${numberDashboards} Dashboard${pluralizer}`}
-                titleText="Must choose at least 1 dashboard and set a name"
-                status={this.submitButtonStatus}
-                onClick={this.sendToDashboard}
-              />
-              <Button text="Cancel" onClick={onCancel} />
-            </Form.Footer>
-          </Form>
+              <Form.Footer>
+                <Button
+                  color={ComponentColor.Success}
+                  text={`Send to ${numberDashboards} Dashboard${pluralizer}`}
+                  titleText="Must choose at least 1 dashboard and set a name"
+                  status={this.submitButtonStatus}
+                  onClick={this.sendToDashboard}
+                />
+                <Button text="Cancel" onClick={onCancel} />
+              </Form.Footer>
+            </Form>
+          ) : (
+            <Form>
+              <Form.Element>
+                <div className="text-center">
+                  No
+                  {this.props.queryType === QueryType.Flux
+                    ? ' script '
+                    : ' query '}
+                  specified!
+                </div>
+              </Form.Element>
+              <Form.Footer>
+                <Button text="Back" onClick={onCancel} />
+              </Form.Footer>
+            </Form>
+          )}
         </OverlayBody>
       </OverlayContainer>
     )
@@ -203,12 +220,12 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
     return this.state.selectedIDs.includes(NEW_DASHBOARD_ID)
   }
 
-  private get hasQuery(): boolean {
+  private hasQuery(): boolean {
     const {rawText, script, queryType} = this.props
     if (queryType === QueryType.Flux) {
-      return !!script.length
+      return script && !!script.trim()
     }
-    return !!rawText.length
+    return rawText && !!rawText.trim()
   }
 
   private get selectedDashboards(): Dashboard[] {
@@ -223,11 +240,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
   private get submitButtonStatus(): ComponentStatus {
     const {name, selectedIDs} = this.state
 
-    if (
-      !this.hasQuery ||
-      selectedIDs.length === 0 ||
-      name.trim().length === 0
-    ) {
+    if (selectedIDs.length === 0 || name.trim().length === 0) {
       return ComponentStatus.Disabled
     }
 


### PR DESCRIPTION
Closes #5351

_Briefly describe your proposed changes:_
`Send to Dashboard` button now requires the `InfluxQL` query to be non-empty. It does not require any fields to be explicitly specified in the query anymore. If `Send to Dashboard` cannot succeed, a message with a `Back` button is displayed.
![image](https://user-images.githubusercontent.com/16321466/102488932-0e45cb00-406d-11eb-9c28-0674568fde4e.png)


_What was the problem?_
`Send to Dashboard` button in a modal popup was always disabled when no query fields were detected, it won't let the user succeed without any visible reason. For example, queries such as `SHOW DATABASES` or `SELECT * FROM ...` do not describe any specific field, but they are still valid and properly visualized. The original restriction to require specific fields comes from the early days, where such a restriction might make sense. Today's implementation simply requires a non-empty FLUX or InfluxQL script.


  - [x] CHANGELOG.md updated in #5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
