### PR TITLE
fix(ui/logs): stop log fetches after 10 empty cycles

### DIFF
--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -220,14 +220,17 @@ export const NOW = 0
 const NEWER_CHUNK_SIZE_LIMIT = 100
 const OLDER_CHUNK_SIZE_LIMIT = 100
 const MAX_FETCH_COUNT = Infinity // never stop fetching
+const MAX_NO_CHANGE_FETCH_COUNT = 10 // but stop after no data are received after a few attempts
 
 export const NEWER_CHUNK_OPTIONS = {
   maxFetchCount: MAX_FETCH_COUNT,
+  maxNoChangeFetchCount: MAX_NO_CHANGE_FETCH_COUNT,
   chunkSize: NEWER_CHUNK_SIZE_LIMIT,
 }
 
 export const OLDER_CHUNK_OPTIONS = {
   maxFetchCount: MAX_FETCH_COUNT,
+  maxNoChangeFetchCount: MAX_NO_CHANGE_FETCH_COUNT,
   chunkSize: OLDER_CHUNK_SIZE_LIMIT,
 }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -309,8 +309,8 @@ class LogsPage extends Component<Props, State> {
               searchStatus={searchStatus}
               filters={filters}
               upper={
-                nextNewerLowerBound ||
                 currentTailUpperBound ||
+                nextNewerLowerBound ||
                 nextTailLowerBound
               }
               lower={nextOlderUpperBound}

--- a/ui/src/logs/utils/fetchChunk.ts
+++ b/ui/src/logs/utils/fetchChunk.ts
@@ -5,19 +5,29 @@ interface ChunkParams {
   getCurrentSize: () => number
   chunkSize: number
   maxFetchCount: number
+  maxNoChangeFetchCount: number
 }
 
 export const fetchChunk = <T>(
   request: () => Promise<T>,
   chunkParams: ChunkParams
 ): FetchLoop => {
-  const {getCurrentSize, maxFetchCount, chunkSize} = chunkParams
+  const {getCurrentSize, maxFetchCount, maxNoChangeFetchCount, chunkSize} = chunkParams
   const initialSize = getCurrentSize()
   const fetchCount = fetchCounter()
+  let lastSize = initialSize
 
   const isDone = () => {
-    const isChunkLoaded = getCurrentSize() - initialSize >= chunkSize
-    const isCountMaxed = fetchCount.next().value > maxFetchCount
+    const size = getCurrentSize()
+    const cycle = fetchCount.next().value as number
+    const isChunkLoaded = size - initialSize >= chunkSize
+    const isCountMaxed = cycle > maxFetchCount
+    if ((cycle + 1) % maxNoChangeFetchCount === 0) {
+       if (lastSize - size > 0) {
+         lastSize = size
+       }
+       return true
+    }
 
     return isChunkLoaded || isCountMaxed
   }

--- a/ui/src/logs/utils/fetchChunk.ts
+++ b/ui/src/logs/utils/fetchChunk.ts
@@ -12,7 +12,12 @@ export const fetchChunk = <T>(
   request: () => Promise<T>,
   chunkParams: ChunkParams
 ): FetchLoop => {
-  const {getCurrentSize, maxFetchCount, maxNoChangeFetchCount, chunkSize} = chunkParams
+  const {
+    getCurrentSize,
+    maxFetchCount,
+    maxNoChangeFetchCount,
+    chunkSize,
+  } = chunkParams
   const initialSize = getCurrentSize()
   const fetchCount = fetchCounter()
   let lastSize = initialSize
@@ -23,10 +28,10 @@ export const fetchChunk = <T>(
     const isChunkLoaded = size - initialSize >= chunkSize
     const isCountMaxed = cycle > maxFetchCount
     if ((cycle + 1) % maxNoChangeFetchCount === 0) {
-       if (lastSize - size > 0) {
-         lastSize = size
-       }
-       return true
+      if (lastSize - size > 0) {
+        lastSize = size
+      }
+      return true
     }
 
     return isChunkLoaded || isCountMaxed


### PR DESCRIPTION
Closes #5434

_Briefly describe your proposed changes:_
   * Limit the count of empty fetches to at most 10 when extending the time interval for the Logs table.
   * Show actual time interval when loading Logs table, it was not properly updated every 5 seconds when switching from the `date picker value` and `now`.

_What was the problem?_
https://github.com/influxdata/chronograf/issues/5434#issuecomment-748915638

_What was the solution?_
Limit the count of empty fetches to at most 10 when extending the time interval for the Logs table.

  - [x] CHANGELOG.md updated in #5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
