### PR TITLE
feat: allow to set active database for InfluxQL commands

### DIFF
--- a/server/influx_test.go
+++ b/server/influx_test.go
@@ -3,13 +3,16 @@ package server
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/bouk/httprouter"
 
+	"github.com/influxdata/chronograf/log"
 	"github.com/influxdata/chronograf/mocks"
 
 	"github.com/influxdata/chronograf"
@@ -114,5 +117,102 @@ func TestService_Influx(t *testing.T) {
 			t.Errorf("%q. Influx() =\ngot  ***%v***\nwant ***%v***\n", tt.name, string(body), tt.want.Body)
 		}
 
+	}
+}
+
+// TestService_Influx_UseCommand test preprocessing of use command
+func TestService_Influx_UseCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		db   string
+		rp   string
+	}{
+		{
+			name: "/* no command */",
+		},
+		{
+			name: "USE mydb",
+			db:   "mydb",
+		},
+		{
+			name: "USE mydb.myrp",
+			db:   "mydb",
+			rp:   "myrp",
+		},
+		{
+			name: `use "mydb"`,
+			db:   "mydb",
+		},
+		{
+			name: `use "mydb.myrp"`,
+			db:   "mydb.myrp",
+		},
+		{
+			name: `USE "mydb"."myrp"`,
+			db:   "mydb",
+			rp:   "myrp",
+		},
+	}
+
+	h := &Service{
+		Store: &mocks.Store{
+			SourcesStore: &mocks.SourcesStore{
+				GetF: func(ctx context.Context, ID int) (chronograf.Source, error) {
+					return chronograf.Source{
+						ID:  1337,
+						URL: "http://any.url",
+					}, nil
+				},
+			},
+		},
+		TimeSeriesClient: &mocks.TimeSeries{
+			ConnectF: func(ctx context.Context, src *chronograf.Source) error {
+				return nil
+			},
+			QueryF: func(ctx context.Context, query chronograf.Query) (chronograf.Response, error) {
+				return mocks.NewResponse(
+						fmt.Sprintf(`{"db":"%s","rp":"%s"}`, query.DB, query.RP),
+						nil,
+					),
+					nil
+			},
+		},
+		Logger: log.New(log.ErrorLevel),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prefixCommand := strings.ReplaceAll(tt.name, "\"", "\\\"")
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(
+				"POST",
+				"http://any.url",
+				ioutil.NopCloser(
+					bytes.NewReader([]byte(
+						`{"uuid": "tst", "query":"`+prefixCommand+` ; DROP MEASUREMENT test"}`,
+					)),
+				),
+			)
+			r = r.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{
+						Key:   "id",
+						Value: "1",
+					},
+				},
+			))
+
+			h.Influx(w, r)
+
+			resp := w.Result()
+			body, _ := ioutil.ReadAll(resp.Body)
+
+			want := fmt.Sprintf(`{"results":{"db":"%s","rp":"%s"},"uuid":"tst"}`, tt.db, tt.rp)
+			got := strings.TrimSpace(string(body))
+			if got != want {
+				t.Errorf("%q. Influx() =\ngot  ***%v***\nwant ***%v***\n", tt.name, got, want)
+			}
+
+		})
 	}
 }

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -48,6 +48,7 @@ interface Props {
   onUpdate: (text: string) => Promise<void>
   config: QueryConfig
   templates: Template[]
+  onMetaQuerySelected?: () => void
 }
 
 const FIRST_TEMP_VAR = '0.tempVar'
@@ -357,6 +358,9 @@ class InfluxQLEditor extends Component<Props, State> {
   }
 
   private handleChooseMetaQuery = (mqto: MetaQueryTemplateOption): void => {
+    if (this.props.onMetaQuerySelected) {
+      this.props.onMetaQuerySelected()
+    }
     this.handleChange(mqto.query)
   }
 

--- a/ui/src/dashboards/components/InfluxQLEditor.tsx
+++ b/ui/src/dashboards/components/InfluxQLEditor.tsx
@@ -48,7 +48,7 @@ interface Props {
   onUpdate: (text: string) => Promise<void>
   config: QueryConfig
   templates: Template[]
-  onMetaQuerySelected?: () => void
+  onMetaQuerySelected: () => void
 }
 
 const FIRST_TEMP_VAR = '0.tempVar'

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -208,6 +208,28 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     type: DropdownChildTypes.Divider,
   },
   {
+    id: 'Drop Measurement',
+    text: 'Drop Measurement',
+    query: 'USE "db_name"; DROP MEASUREMENT "measurement_name"',
+    type: DropdownChildTypes.Item,
+  },
+  {
+    id: 'Drop Series',
+    text: 'Drop Series',
+    query: 'USE "db_name"; DROP SERIES FROM "measurement_name" WHERE "tag" = \'value\'',
+    type: DropdownChildTypes.Item,
+  },
+  {
+    id: 'Delete',
+    text: 'Delete',
+    query: 'USE "db_name"; DELETE FROM "measurement_name" WHERE "tag" = \'value\' AND time < \'2020-01-01\'',
+    type: DropdownChildTypes.Item,
+  },
+  {
+    id: `mqtd-divider-7`,
+    type: DropdownChildTypes.Divider,
+  },
+  {
     id: 'Show Stats',
     text: 'Show Stats',
     query: 'SHOW STATS',

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -216,13 +216,15 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
   {
     id: 'Drop Series',
     text: 'Drop Series',
-    query: 'USE "db_name"; DROP SERIES FROM "measurement_name" WHERE "tag" = \'value\'',
+    query:
+      'USE "db_name"; DROP SERIES FROM "measurement_name" WHERE "tag" = \'value\'',
     type: DropdownChildTypes.Item,
   },
   {
     id: 'Delete',
     text: 'Delete',
-    query: 'USE "db_name"; DELETE FROM "measurement_name" WHERE "tag" = \'value\' AND time < \'2020-01-01\'',
+    query:
+      'USE "db_name"; DELETE FROM "measurement_name" WHERE "tag" = \'value\' AND time < \'2020-01-01\'',
     type: DropdownChildTypes.Item,
   },
   {

--- a/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/InfluxQLQueryMaker.tsx
@@ -49,6 +49,7 @@ interface PassedProps {
   onAddQuery: () => void
   onDeleteQuery: (index: number) => void
   onEditRawText: (text: string) => Promise<void>
+  onMetaQuerySelected: () => void
 }
 
 type Props = ConnectedProps & PassedProps
@@ -76,6 +77,7 @@ const QueryMaker: FunctionComponent<Props> = ({
   onChooseMeasurement,
   onApplyFuncsToField,
   onToggleTagAcceptance,
+  onMetaQuerySelected,
 }) => {
   if (!activeQuery || !activeQuery.id) {
     return (
@@ -102,6 +104,7 @@ const QueryMaker: FunctionComponent<Props> = ({
             config={activeQuery}
             onUpdate={onEditRawText}
             templates={templates}
+            onMetaQuerySelected={onMetaQuerySelected}
           />
           <SchemaExplorer
             source={source}

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -29,7 +29,10 @@ import {updateSourceLink as updateSourceLinkAction} from 'src/data_explorer/acti
 // Constants
 import {HANDLE_HORIZONTAL} from 'src/shared/constants'
 import {CEOTabs} from 'src/dashboards/constants'
-import {AutoRefreshOption} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
+import {
+  AutoRefreshOption,
+  autoRefreshOptionPaused,
+} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
 
 // Types
 import {
@@ -365,6 +368,7 @@ class TimeMachine extends PureComponent<Props, State> {
         activeQuery={this.activeQuery}
         setActiveQueryIndex={this.handleSetActiveQueryIndex}
         onEditRawText={this.handleEditRawText}
+        onMetaQuerySelected={this.handleChangeAutoRefreshDuration}
       />
     )
   }
@@ -526,7 +530,7 @@ class TimeMachine extends PureComponent<Props, State> {
   }
 
   private handleChangeAutoRefreshDuration = (
-    autoRefreshOption: AutoRefreshOption
+    autoRefreshOption: AutoRefreshOption = autoRefreshOptionPaused
   ): void => {
     const {milliseconds} = autoRefreshOption
     this.setState({autoRefreshDuration: milliseconds})

--- a/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
+++ b/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
@@ -10,6 +10,13 @@ export interface AutoRefreshOption {
   type: AutoRefreshOptionType
 }
 
+export const autoRefreshOptionPaused: AutoRefreshOption = {
+  id: 'auto-refresh-paused',
+  milliseconds: 0,
+  label: 'Paused',
+  type: AutoRefreshOptionType.Option,
+}
+
 const autoRefreshOptions: AutoRefreshOption[] = [
   {
     id: 'auto-refresh-header',
@@ -17,12 +24,7 @@ const autoRefreshOptions: AutoRefreshOption[] = [
     label: 'Refresh',
     type: AutoRefreshOptionType.Header,
   },
-  {
-    id: 'auto-refresh-paused',
-    milliseconds: 0,
-    label: 'Paused',
-    type: AutoRefreshOptionType.Option,
-  },
+  autoRefreshOptionPaused,
   {
     id: 'auto-refresh-5s',
     milliseconds: 5000,

--- a/ui/src/shared/parsing/index.ts
+++ b/ui/src/shared/parsing/index.ts
@@ -40,7 +40,7 @@ export const extractQueryWarningMessage = (
   }
 
   if (!series) {
-    return 'Your query is syntactically correct but returned no results'
+    return 'Your query or command is syntactically correct but returned no results'
   }
 
   return null


### PR DESCRIPTION
Closes #5650 #5651

_Briefly describe your proposed changes:_
The InfluxQL command that is sent to chronograf (from the Explorer UI) can specify a database and retention policy to use for the next command with the USE command (already used in  `influx` tool ). Example:

```
USE telegraf ; DELETE FROM mem WHERE time < '2020-12-19T15:00:00Z'
```

_Metaquery Templates_ are enhanced with the following items

![image](https://user-images.githubusercontent.com/16321466/105387102-83c92c00-5c15-11eb-8eeb-248ee4cb3c49.png)

   * `USE "db_name"; DROP MEASUREMENT "measurement_name"`
   * `USE "db_name"; DROP SERIES FROM "measurement_name" WHERE "tag" = 'value'`
   * `USE "db_name"; DELETE FROM "measurement_name" WHERE "tag" = 'value' AND time < '2020-01-01'`

Additionally, auto-refresh is always paused when a particular `Metaquery Template` is selected.

_What was the problem?_
Certain InfluxQL commands, such as DELETE or DROP MEASUREMENT always fail in Chronograf explorer UI, since there is no way to specify the required database and retention policy (in UI or in InfluxQL command itself).

_What was the solution?_
An extra `USE` (or `use`) command can be placed at the beginning of the InfluxQL command to specify database (and retention policy) to use for the next command. The command is pre-processed in chronograf. The USE command syntax is one of the following:

```
USE database ;
USE database.retentionPolicy ;
USE "database" ;
USE "database"."retentionPolicy" ;
```
The next command(s) must appear after the semicolon

  - [x] CHANGELOG.md updated in #5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
