### PR TITLE
fix(ui/logs): show timestamp with full nanosecond precision

### DIFF
--- a/ui/src/logs/components/LogsTable.tsx
+++ b/ui/src/logs/components/LogsTable.tsx
@@ -508,7 +508,13 @@ class LogsTable extends Component<Props, State> {
       return (
         <div
           className="logs-viewer--cell"
-          title={`Jump to '${value}'`}
+          title={
+            typeof value === 'string' && value.length > 9
+              ? `Jump to '${formattedValue}.${value.substring(
+                  value.length - 9
+                )}' (${value})`
+              : `Jump to '${value}'`
+          }
           key={key}
           style={style}
           data-index={rowIndex}

--- a/ui/src/logs/constants/index.ts
+++ b/ui/src/logs/constants/index.ts
@@ -1,6 +1,23 @@
+import {Field} from 'src/types'
 import {TableData} from 'src/types/logs'
 
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+
+/** name of a column to carry nanosecond fraction of timestamp */
+export const TIMESTAMP_NSINMS = '_timestamp_nsinms'
+/**
+ * "_timestamp_nsinms" field is added to query to know nanosecond fraction
+ * after millis, which is lost during JSON deserialization to number
+ */
+export const FIELD_TIMESTAMP_NSINMS: Field = {
+  type: 'infixfunc',
+  value: '%',
+  alias: TIMESTAMP_NSINMS,
+  args: [
+    {type: 'field', value: 'timestamp'},
+    {type: 'integer', value: '1000000'},
+  ],
+}
 
 export enum SeverityColorOptions {
   ruby = 'ruby',

--- a/ui/src/logs/reducers/index.ts
+++ b/ui/src/logs/reducers/index.ts
@@ -160,7 +160,7 @@ const prependMoreLogs = (
   action: PrependMoreLogsAction
 ): LogsState => {
   const {
-    series: {values},
+    series: {columns, values},
   } = action.payload
   const {tableInfiniteData} = state
   const {forward} = tableInfiniteData
@@ -174,7 +174,7 @@ const prependMoreLogs = (
     tableInfiniteData: {
       ...tableInfiniteData,
       forward: {
-        columns: forward.columns,
+        columns,
         values: vals,
       },
     },

--- a/ui/src/logs/utils/index.ts
+++ b/ui/src/logs/utils/index.ts
@@ -15,7 +15,7 @@ import {
 
 import {HistogramData} from 'src/types/histogram'
 import {executeQueryAsync} from 'src/logs/api'
-import {DEFAULT_TIME_FORMAT} from 'src/logs/constants'
+import {DEFAULT_TIME_FORMAT, FIELD_TIMESTAMP_NSINMS} from 'src/logs/constants'
 
 const BIN_COUNT = 30
 
@@ -159,7 +159,7 @@ export function buildInfiniteScrollWhereClause({
   return ` WHERE ${subClauses.join(' AND ')}`
 }
 
-export function buildGeneralLogQuery(
+function buildGeneralLogQuery(
   condition: string,
   config: QueryConfig,
   filters: Filter[],
@@ -229,6 +229,9 @@ export function buildInfiniteScrollLogQuery(
     tags,
     areTagsAccepted,
   })
+  // add extra "_timestamp_ns" field to be able to know precise nanosecond time
+  // with full precision that is lost during JSON deserialization to number
+  config = {...config, fields: [...config.fields, FIELD_TIMESTAMP_NSINMS]}
 
   return buildGeneralLogQuery(condition, config, filters, searchTerm)
 }

--- a/ui/src/logs/utils/table.ts
+++ b/ui/src/logs/utils/table.ts
@@ -2,7 +2,11 @@ import _ from 'lodash'
 import moment from 'moment'
 import {getDeep} from 'src/utils/wrappers'
 import {TableData, LogsTableColumn, SeverityFormat} from 'src/types/logs'
-import {SeverityFormatOptions, DEFAULT_TIME_FORMAT} from 'src/logs/constants'
+import {
+  SeverityFormatOptions,
+  DEFAULT_TIME_FORMAT,
+  TIMESTAMP_NSINMS,
+} from 'src/logs/constants'
 import {
   orderTableColumns,
   filterTableColumns,
@@ -179,11 +183,16 @@ export const applyChangesToTableData = (
   // #5472 fallback to timestamp when time is not defined
   const timeColumnIndex = _.indexOf(columns, 'time')
   const timestampColumnIndex = _.indexOf(columns, 'timestamp')
+  const timestampNsInMsColumnIndex = _.indexOf(columns, TIMESTAMP_NSINMS)
   if (timeColumnIndex >= 0 && timestampColumnIndex >= 0) {
     // modify existing data to save memory
     values.forEach(row => {
       if (row[timestampColumnIndex] === null) {
         row[timestampColumnIndex] = (row[timeColumnIndex] as number) * 1000000
+      } else if (timestampNsInMsColumnIndex >= 0) {
+        const ms = Math.floor((row[timestampColumnIndex] as number) / 1000000)
+        const ns = String(row[timestampNsInMsColumnIndex]).padStart(6, '0')
+        row[timestampColumnIndex] = `${ms}${ns}`
       }
     })
   }

--- a/ui/src/utils/influxql.ts
+++ b/ui/src/utils/influxql.ts
@@ -51,7 +51,7 @@ export function buildSelect(
   }
 
   const rpSegment = retentionPolicy ? `"${retentionPolicy}"` : ''
-  const fieldsClause = buildFields(fields, shift)
+  const fieldsClause = buildFields(fields, shift).join(', ')
   const fullyQualifiedMeasurement = `"${database}".${rpSegment}."${measurement}"`
   const statement = `SELECT ${fieldsClause} FROM ${fullyQualifiedMeasurement}`
   return statement
@@ -89,9 +89,9 @@ export function buildSelectStatement(config: QueryConfig): string {
   return buildSelect(config)
 }
 
-function buildFields(fieldFuncs: Field[], shift = '', useAlias = true): string {
+function buildFields(fieldFuncs: Field[], shift = '', useAlias = true): string[] {
   if (!fieldFuncs) {
-    return ''
+    return []
   }
 
   return fieldFuncs
@@ -119,11 +119,15 @@ function buildFields(fieldFuncs: Field[], shift = '', useAlias = true): string {
         case 'func': {
           const args = buildFields(f.args, '', false)
           const alias = f.alias ? ` AS "${f.alias}${shift}"` : ''
-          return `${f.value}(${args})${alias}`
+          return `${f.value}(${args.join(', ')})${alias}`
+        }
+        case 'infixfunc': {
+          const args = buildFields(f.args, '', false)
+          const alias = f.alias ? ` AS "${f.alias}"` : ''
+          return `${args[0]}${f.value}${args[1]}${alias}`
         }
       }
     })
-    .join(', ')
 }
 
 export function buildWhereClause({

--- a/ui/src/utils/influxql.ts
+++ b/ui/src/utils/influxql.ts
@@ -89,45 +89,48 @@ export function buildSelectStatement(config: QueryConfig): string {
   return buildSelect(config)
 }
 
-function buildFields(fieldFuncs: Field[], shift = '', useAlias = true): string[] {
+function buildFields(
+  fieldFuncs: Field[],
+  shift = '',
+  useAlias = true
+): string[] {
   if (!fieldFuncs) {
     return []
   }
 
-  return fieldFuncs
-    .map(f => {
-      switch (f.type) {
-        case 'field': {
-          const quoted = f.value === '*' ? '*' : `"${f.value}"`
-          const aliased =
-            useAlias && f.alias ? `${quoted} AS "${f.alias}"` : quoted
+  return fieldFuncs.map(f => {
+    switch (f.type) {
+      case 'field': {
+        const quoted = f.value === '*' ? '*' : `"${f.value}"`
+        const aliased =
+          useAlias && f.alias ? `${quoted} AS "${f.alias}"` : quoted
 
-          return aliased
-        }
-        case 'wildcard': {
-          return '*'
-        }
-        case 'regex': {
-          return `/${f.value}/`
-        }
-        case 'number': {
-          return `${f.value}`
-        }
-        case 'integer': {
-          return `${f.value}`
-        }
-        case 'func': {
-          const args = buildFields(f.args, '', false)
-          const alias = f.alias ? ` AS "${f.alias}${shift}"` : ''
-          return `${f.value}(${args.join(', ')})${alias}`
-        }
-        case 'infixfunc': {
-          const args = buildFields(f.args, '', false)
-          const alias = f.alias ? ` AS "${f.alias}"` : ''
-          return `${args[0]}${f.value}${args[1]}${alias}`
-        }
+        return aliased
       }
-    })
+      case 'wildcard': {
+        return '*'
+      }
+      case 'regex': {
+        return `/${f.value}/`
+      }
+      case 'number': {
+        return `${f.value}`
+      }
+      case 'integer': {
+        return `${f.value}`
+      }
+      case 'func': {
+        const args = buildFields(f.args, '', false)
+        const alias = f.alias ? ` AS "${f.alias}${shift}"` : ''
+        return `${f.value}(${args.join(', ')})${alias}`
+      }
+      case 'infixfunc': {
+        const args = buildFields(f.args, '', false)
+        const alias = f.alias ? ` AS "${f.alias}"` : ''
+        return `${args[0]}${f.value}${args[1]}${alias}`
+      }
+    }
+  })
 }
 
 export function buildWhereClause({


### PR DESCRIPTION
Closes #3839

_Briefly describe your proposed changes:_
Log Viewer shows a tooltip with a precise nanosecond timestamp of a Syslog message.
![image](https://user-images.githubusercontent.com/16321466/103776471-c85aa200-502f-11eb-8e41-eebfcdc7f318.png)


_What was the problem?_
The visible timestamps were not the same as reported to Syslog. They lose precision during JSON parsing of query results in the browser transport layer. Today's nanosecond timestamps are always bigger to fit into javascript number. 

_What was the solution?_
Log Viewer queries were changed to include also `timestamp % 1000000`, which gets nanoseconds in a particular millisecond. A precise timestamp (nanos) is then computed in the UI code as String(Math.floor(timestamp/1000000)) + String(timestamp % 1000000).padStart(6,0) and better shown to the user in a tooltip.

  - [x] CHANGELOG.md updated in #5647
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
