### PR TITLE
feat(ui): add documentation link when 1.8 flux is not installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Other
 
+1. [#5673](https://github.com/influxdata/chronograf/pull/5673): Add documentation link when 1.8 flux is not installed.
+
 ## v1.8.10 [2021-02-08]
 
 ### Bug Fixes

--- a/ui/src/dashboards/components/SourceSelector.tsx
+++ b/ui/src/dashboards/components/SourceSelector.tsx
@@ -28,7 +28,9 @@ function fluxDisabledTooltip(source: SourcesModels.Source): string {
   if (!source.version || source.version.startsWith('2.')) {
     return 'To enable Flux modify the connection to use InfluxDB v2 Auth with an organization and a token.'
   }
-  return 'The current source does not support Flux.'
+  return `The current source does not support Flux.<br>
+  See <a href="https://docs.influxdata.com/influxdb/v1.8/flux/installation/" 
+  target="_blank">https://docs.influxdata.com/influxdb/v1.8/flux/installation/</a>`
 }
 
 const SourceSelector: FunctionComponent<Props> = ({
@@ -68,6 +70,7 @@ const SourceSelector: FunctionComponent<Props> = ({
           onClick={toggleFlux}
           active={!isFluxSelected}
           disabled={!sourceSupportsFlux}
+          disabledTitleText=""
         >
           InfluxQL
         </Radio.Button>

--- a/ui/src/shared/components/QuestionMarkTooltip.tsx
+++ b/ui/src/shared/components/QuestionMarkTooltip.tsx
@@ -12,6 +12,8 @@ const QuestionMarkTooltip: FunctionComponent<Props> = ({tipID, tipContent}) => (
       className="question-mark-tooltip--icon"
       data-for={`${tipID}-tooltip`}
       data-tip={tipContent}
+      data-delay-hide='100'
+      data-delay-show='50'
     >
       ?
     </div>

--- a/ui/src/shared/components/QuestionMarkTooltip.tsx
+++ b/ui/src/shared/components/QuestionMarkTooltip.tsx
@@ -12,8 +12,8 @@ const QuestionMarkTooltip: FunctionComponent<Props> = ({tipID, tipContent}) => (
       className="question-mark-tooltip--icon"
       data-for={`${tipID}-tooltip`}
       data-tip={tipContent}
-      data-delay-hide='100'
-      data-delay-show='50'
+      data-delay-hide="100"
+      data-delay-show="50"
     >
       ?
     </div>

--- a/ui/src/style/components/react-tooltips.scss
+++ b/ui/src/style/components/react-tooltips.scss
@@ -28,6 +28,7 @@ $tooltip-code-color: $c-potassium;
   text-transform: none;
   text-align: left;
   cursor: default;
+  pointer-events: auto;
 
   &.type-dark {
     background-color: $tooltip-bg;


### PR DESCRIPTION
Closes #5670

_Briefly describe your proposed changes:_
1. Allow to mouse over question tooltips.
2. Make tooltip content clickable.
3. Add a link to docs when 1.8 flux is not enabled

![image](https://user-images.githubusercontent.com/16321466/109141183-bc50ae00-775d-11eb-8401-f36b59e325c7.png)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
