### PR TITLE
fix(ui): do not log failure during line visualization of meta query results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 1. [#5677](https://github.com/influxdata/chronograf/pull/5677): Open event handler configuration specified in URL hash.
-1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.\
+1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [#5677](https://github.com/influxdata/chronograf/pull/5677): Open event handler configuration specified in URL hash.
+1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.\
 
 ### Features
 

--- a/ui/src/worker/jobs/timeSeriesToDygraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToDygraph.ts
@@ -24,7 +24,7 @@ export const timeSeriesToDygraphWork = (
     raw,
     isTable
   )
-  // InfluxQL metaquery has no sortedTimeSeries and therefore cannot 
+  // InfluxQL metaquery has no sortedTimeSeries and therefore cannot
   // be ever processed
   if (!sortedTimeSeries) {
     return null

--- a/ui/src/worker/jobs/timeSeriesToDygraph.ts
+++ b/ui/src/worker/jobs/timeSeriesToDygraph.ts
@@ -24,6 +24,11 @@ export const timeSeriesToDygraphWork = (
     raw,
     isTable
   )
+  // InfluxQL metaquery has no sortedTimeSeries and therefore cannot 
+  // be ever processed
+  if (!sortedTimeSeries) {
+    return null
+  }
 
   const labels = [
     'time',

--- a/ui/src/worker/worker.ts
+++ b/ui/src/worker/worker.ts
@@ -45,7 +45,7 @@ onmessage = async (workerMessage: WorkerMessage) => {
     success(data, result)
   } catch (e) {
     const {type, id} = data
-    console.error(`Worker job (type=${type} id=${id}) failed`, e)
+    console.error(`Worker job (type=${type} id=${id}) failed`, e, JSON.stringify(workerMessage))
     error(data, e)
   }
 }

--- a/ui/src/worker/worker.ts
+++ b/ui/src/worker/worker.ts
@@ -45,7 +45,11 @@ onmessage = async (workerMessage: WorkerMessage) => {
     success(data, result)
   } catch (e) {
     const {type, id} = data
-    console.error(`Worker job (type=${type} id=${id}) failed`, e, JSON.stringify(workerMessage))
+    console.error(
+      `Worker job (type=${type} id=${id}) failed`,
+      e,
+      JSON.stringify(workerMessage)
+    )
     error(data, e)
   }
 }


### PR DESCRIPTION
Closes #5666

_Briefly describe your proposed changes:_
1. worker error messages are logged in a way so that reported errors could be better reproduced next time
1. influxQL meta query results cannot be parsed to a line-chart data (as a fact), do not log this as an error and let the UI signalize it in a standard way, which is: 
![image](https://user-images.githubusercontent.com/16321466/109428768-d8bc4700-79f8-11eb-930f-5e794fe7e259.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
