### PR TITLE
fix(ui/kapacitor): dispose log stream when Tickscript editor page is closed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5677](https://github.com/influxdata/chronograf/pull/5677): Open event handler configuration specified in URL hash.
 1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.
+1. [#5679](https://github.com/influxdata/chronograf/pull/5679): Dispose log stream when Tickscript editor page is closed.
 
 ### Features
 

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -142,20 +142,7 @@ const kapacitorLogHeaders = {
   Accept: 'application/json',
 }
 
-export const getLogStream = kapacitor => {
-  // axios doesn't support the chunked transfer encoding response kapacitor uses for logs
-  // AJAX adds basepath, but we need to supply it directly to fetch
-  const url = `${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs`
-  const basepath = window.basepath || ''
-
-  return fetch(`${basepath}${url}`, {
-    method: 'GET',
-    headers: kapacitorLogHeaders,
-    credentials: 'include',
-  })
-}
-
-export const getLogStreamByRuleID = (kapacitor, ruleID) => {
+export const getLogStreamByRuleID = (kapacitor, ruleID, signal) => {
   // axios doesn't support the chunked transfer encoding response kapacitor uses for logs
   // AJAX adds basepath, but we need to supply it directly to fetch
   const url = `${kapacitor.links.proxy}?path=/kapacitor/v1preview/logs?task=${ruleID}`
@@ -165,6 +152,7 @@ export const getLogStreamByRuleID = (kapacitor, ruleID) => {
     method: 'GET',
     headers: kapacitorLogHeaders,
     credentials: 'include',
+    signal,
   })
 }
 

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -86,6 +86,8 @@ interface State {
 
 @ErrorHandling
 export class TickscriptPage extends PureComponent<Props, State> {
+  private abortController: AbortController
+
   constructor(props) {
     super(props)
     this.state = {
@@ -153,6 +155,9 @@ export class TickscriptPage extends PureComponent<Props, State> {
     this.setState({
       areLogsEnabled: false,
     })
+    if (this.abortController) {
+      this.abortController.abort()
+    }
   }
 
   public render() {
@@ -319,7 +324,18 @@ export class TickscriptPage extends PureComponent<Props, State> {
         })
       }
 
-      const response = await getLogStreamByRuleID(kapacitor, ruleID)
+      const abortController = new AbortController()
+      this.abortController = abortController
+      const response = await getLogStreamByRuleID(
+        kapacitor,
+        ruleID,
+        abortController.signal
+      )
+      if (!this.state.areLogsEnabled) {
+        // applies when component destroyment happens sooner than response
+        abortController.abort()
+        return
+      }
 
       const reader = await response.body.getReader()
       const decoder = new TextDecoder()
@@ -365,9 +381,12 @@ export class TickscriptPage extends PureComponent<Props, State> {
         }
       }
     } catch (error) {
-      console.error(error)
-      notify(notifyTickscriptLoggingError())
-      throw error
+      // do not log error if it was programatically aborted
+      if (!error.name || error.name !== 'AbortError') {
+        console.error(error)
+        notify(notifyTickscriptLoggingError())
+        throw error
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #5657

_Briefly describe your proposed changes:_
   * log stream is programmatically aborted when the Tickscript page is being destroyed
   * abort errors are not logged in the Tickscript page, they are expected to happen as a part of normal workflow


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
