### PR TITLE
fix(ui): generate correct flux property expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5677](https://github.com/influxdata/chronograf/pull/5677): Open event handler configuration specified in URL hash.
 1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.
 1. [#5679](https://github.com/influxdata/chronograf/pull/5679): Dispose log stream when Tickscript editor page is closed.
+1. [#5680](https://github.com/influxdata/chronograf/pull/5680): Generate correct flux property expressions.
 
 ### Features
 

--- a/ui/src/flux/helpers/recordProperty.ts
+++ b/ui/src/flux/helpers/recordProperty.ts
@@ -1,0 +1,6 @@
+export default function recordProperty(key: string) {
+  if (key && /[^A-Za-z0-9_]/.test(key)) {
+    return `r.["${key}"]`
+  }
+  return `r.${key}`
+}

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -143,11 +143,12 @@ export const proxy = async (source: Source, script: string) => {
   const garbage = script.replace(/\s/g, '') // server cannot handle whitespace
   const dialect = {annotations: ['group', 'datatype', 'default']}
   const data = {query: garbage, dialect}
+  const base = source.links.flux
 
   try {
     const response = await AJAX({
       method: 'POST',
-      url: `${source.links.flux}?path=/api/v2/query${mark}organization=defaultorgname`,
+      url: `${base}?path=/api/v2/query${mark}organization=defaultorgname`,
       data,
       headers: {'Content-Type': 'application/json'},
     })

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -2,6 +2,7 @@ import _ from 'lodash'
 
 import AJAX from 'src/utils/ajax'
 import {Source, SchemaFilter} from 'src/types'
+import recordProperty from 'src/flux/helpers/recordProperty'
 
 export const measurements = async (
   source: Source,
@@ -94,7 +95,9 @@ export const tagValues = async ({
 }: TagValuesParams): Promise<any> => {
   let regexFilter = ''
   if (searchTerm) {
-    regexFilter = `|> filter(fn: (r) => r.${tagKey} =~ /${searchTerm}/)`
+    regexFilter = `|> filter(fn: (r) => ${recordProperty(
+      tagKey
+    )} =~ /${searchTerm}/)`
   }
 
   const limitFunc = count ? '' : `|> limit(n:${limit})`
@@ -144,9 +147,7 @@ export const proxy = async (source: Source, script: string) => {
   try {
     const response = await AJAX({
       method: 'POST',
-      url: `${
-        source.links.flux
-      }?path=/api/v2/query${mark}organization=defaultorgname`,
+      url: `${source.links.flux}?path=/api/v2/query${mark}organization=defaultorgname`,
       data,
       headers: {'Content-Type': 'application/json'},
     })

--- a/ui/src/shared/utils/TimeMachineContainer.ts
+++ b/ui/src/shared/utils/TimeMachineContainer.ts
@@ -68,6 +68,7 @@ import {
   Axes,
 } from 'src/types/dashboards'
 import {ColorString, ColorNumber} from 'src/types/colors'
+import recordProperty from 'src/flux/helpers/recordProperty'
 
 const LOCAL_STORAGE_DELAY_MS = 1000
 
@@ -189,7 +190,7 @@ export class TimeMachineContainer extends Container<TimeMachineState> {
 
     const body = Object.entries(filter)
       .map(([key, value]) => {
-        return `r.${key} == "${value}"`
+        return `${recordProperty(key)} == "${value}"`
       })
       .join(' and ')
 

--- a/ui/test/flux/helpers/recordProperty.test.ts
+++ b/ui/test/flux/helpers/recordProperty.test.ts
@@ -6,7 +6,9 @@ describe('Flux.helpers.recordProperty', () => {
     expect(recordProperty('server')).toEqual('r.server')
   })
   it('creates string member expression', () => {
-    expect(recordProperty('value-with-hyphen')).toEqual('r.["value-with-hyphen"]')
+    expect(recordProperty('value-with-hyphen')).toEqual(
+      'r.["value-with-hyphen"]'
+    )
     expect(recordProperty('value%')).toEqual('r.["value%"]')
     expect(recordProperty('value a')).toEqual('r.["value a"]')
   })

--- a/ui/test/flux/helpers/recordProperty.test.ts
+++ b/ui/test/flux/helpers/recordProperty.test.ts
@@ -1,0 +1,13 @@
+import recordProperty from 'src/flux/helpers/recordProperty'
+
+describe('Flux.helpers.recordProperty', () => {
+  it('creates identifier member expression', () => {
+    expect(recordProperty('_time')).toEqual('r._time')
+    expect(recordProperty('server')).toEqual('r.server')
+  })
+  it('creates string member expression', () => {
+    expect(recordProperty('value-with-hyphen')).toEqual('r.["value-with-hyphen"]')
+    expect(recordProperty('value%')).toEqual('r.["value%"]')
+    expect(recordProperty('value a')).toEqual('r.["value a"]')
+  })
+})


### PR DESCRIPTION
Closes #5262

_Briefly describe your proposed changes:_
Generates property expression is `r.key` only if key contains only `A-Za-z0-9_` characters, otherwise it is `r.["key"]`

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
