### PR TITLE
feat(ui): Allow to show/hide histogram in Log Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5672](https://github.com/influxdata/chronograf/pull/5672): Allow to specify trusted CA certificate for ETCD connections.
 1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Event Handler configuration UI.
 1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Alert Handler configuration UI.
+1. [#5640](https://github.com/influxdata/chronograf/pull/5640): Allow to hide/show histogram in Log Viewer.
 
 ### Other
 

--- a/ui/src/logs/components/LogsFilterBar.tsx
+++ b/ui/src/logs/components/LogsFilterBar.tsx
@@ -10,6 +10,8 @@ interface Props {
   onFilterChange: (id: string, operator: string, value: string) => void
   onUpdateTruncation: (isTruncated: boolean) => Promise<void>
   isTruncated: boolean
+  isHistogramHidden: boolean
+  onShowHistogram: () => void
 }
 
 class LogsFilters extends PureComponent<Props> {
@@ -40,29 +42,47 @@ class LogsFilters extends PureComponent<Props> {
   }
 
   private get truncationToggle(): JSX.Element {
-    const {isTruncated, onUpdateTruncation} = this.props
+    const {
+      isTruncated,
+      onUpdateTruncation,
+      isHistogramHidden,
+      onShowHistogram,
+    } = this.props
 
     return (
-      <Radio>
-        <Radio.Button
-          id="logs-truncation--truncate"
-          active={isTruncated === true}
-          value={true}
-          titleText="Truncate log messages when they exceed 1 line"
-          onClick={onUpdateTruncation}
-        >
-          Truncate
-        </Radio.Button>
-        <Radio.Button
-          id="logs-truncation--multi"
-          active={isTruncated === false}
-          value={false}
-          titleText="Allow log messages to wrap text"
-          onClick={onUpdateTruncation}
-        >
-          Wrap
-        </Radio.Button>
-      </Radio>
+      <div className="page-header--right">
+        {isHistogramHidden ? (
+          <button
+            className="btn btn-sm btn-square btn-default"
+            onClick={onShowHistogram}
+            title="Show Histogram"
+          >
+            <span className="icon bar-chart" />
+          </button>
+        ) : (
+          undefined
+        )}
+        <Radio>
+          <Radio.Button
+            id="logs-truncation--truncate"
+            active={isTruncated === true}
+            value={true}
+            titleText="Truncate log messages when they exceed 1 line"
+            onClick={onUpdateTruncation}
+          >
+            Truncate
+          </Radio.Button>
+          <Radio.Button
+            id="logs-truncation--multi"
+            active={isTruncated === false}
+            value={false}
+            titleText="Allow log messages to wrap text"
+            onClick={onUpdateTruncation}
+          >
+            Wrap
+          </Radio.Button>
+        </Radio>
+      </div>
     )
   }
 

--- a/ui/src/logs/components/OptionsOverlay.tsx
+++ b/ui/src/logs/components/OptionsOverlay.tsx
@@ -25,8 +25,6 @@ interface Props {
   onDismissOverlay: () => void
   columns: LogsTableColumn[]
   severityFormat: SeverityFormat
-  histogramHidden: boolean
-  onShowHistogram: () => void
 }
 
 interface State {
@@ -99,17 +97,10 @@ class OptionsOverlay extends Component<Props, State> {
   }
 
   private get overlayActionButtons(): JSX.Element {
-    const {onDismissOverlay, onShowHistogram, histogramHidden} = this.props
+    const {onDismissOverlay} = this.props
 
     return (
       <div className="btn-group--right">
-        {histogramHidden ? (
-          <button className="btn btn-sm btn-info" onClick={onShowHistogram}>
-            Show Histogram
-          </button>
-        ) : (
-          undefined
-        )}
         <button className="btn btn-sm btn-default" onClick={onDismissOverlay}>
           Cancel
         </button>

--- a/ui/src/logs/components/OptionsOverlay.tsx
+++ b/ui/src/logs/components/OptionsOverlay.tsx
@@ -17,14 +17,16 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   severityLevelColors: SeverityLevelColor[]
-  onUpdateSeverityLevels: (
-    severityLevelColors: SeverityLevelColor[]
+  onUpdate: (
+    severityLevelColors: SeverityLevelColor[],
+    severityFormat: SeverityFormat,
+    tableColumns: LogsTableColumn[]
   ) => Promise<void>
   onDismissOverlay: () => void
   columns: LogsTableColumn[]
-  onUpdateColumns: (columns: LogsTableColumn[]) => Promise<void>
   severityFormat: SeverityFormat
-  onUpdateSeverityFormat: (format: SeverityFormat) => Promise<void>
+  histogramHidden: boolean
+  onShowHistogram: () => void
 }
 
 interface State {
@@ -67,7 +69,6 @@ class OptionsOverlay extends Component<Props, State> {
 
   public render() {
     const {workingLevelColumns, workingColumns, workingFormat} = this.state
-
     return (
       <Container maxWidth={800}>
         <Heading title="Configure Log Viewer">
@@ -98,10 +99,17 @@ class OptionsOverlay extends Component<Props, State> {
   }
 
   private get overlayActionButtons(): JSX.Element {
-    const {onDismissOverlay} = this.props
+    const {onDismissOverlay, onShowHistogram, histogramHidden} = this.props
 
     return (
       <div className="btn-group--right">
+        {histogramHidden ? (
+          <button className="btn btn-sm btn-info" onClick={onShowHistogram}>
+            Show Histogram
+          </button>
+        ) : (
+          undefined
+        )}
         <button className="btn btn-sm btn-default" onClick={onDismissOverlay}>
           Cancel
         </button>
@@ -132,17 +140,10 @@ class OptionsOverlay extends Component<Props, State> {
   }
 
   private handleSave = async () => {
-    const {
-      onUpdateSeverityLevels,
-      onDismissOverlay,
-      onUpdateSeverityFormat,
-      onUpdateColumns,
-    } = this.props
+    const {onUpdate, onDismissOverlay} = this.props
     const {workingLevelColumns, workingFormat, workingColumns} = this.state
 
-    await onUpdateSeverityFormat(workingFormat)
-    await onUpdateSeverityLevels(workingLevelColumns)
-    await onUpdateColumns(workingColumns)
+    await onUpdate(workingLevelColumns, workingFormat, workingColumns)
     onDismissOverlay()
   }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -4,7 +4,7 @@ import uuid from 'uuid'
 import _ from 'lodash'
 import {connect} from 'react-redux'
 import {AutoSizer} from 'react-virtualized'
-import {withRouter, InjectedRouter} from 'react-router'
+import {withRouter, InjectedRouter, WithRouterProps} from 'react-router'
 
 // Components
 import LogsHeader from 'src/logs/components/LogsHeader'
@@ -98,7 +98,7 @@ import {
 } from 'src/types/logs'
 import {RemoteDataState} from 'src/types'
 
-interface Props {
+interface Props extends WithRouterProps {
   sources: Source[]
   currentSource: Source | null
   currentNamespaces: Namespace[]
@@ -256,21 +256,34 @@ class LogsPage extends Component<Props, State> {
       currentTailUpperBound,
       searchStatus,
       tableTime,
+      location: {
+        query: {table},
+      },
     } = this.props
 
     if (this.isLoadingSourcesStatus) {
       return <PageSpinner />
     }
 
+    const hideGraph = table !== undefined
+
     return (
       <>
         <div className="page">
           {this.header}
-          <div className="page-contents logs-viewer">
-            <LogsGraphContainer>
-              {this.chartControlBar}
-              {this.chart}
-            </LogsGraphContainer>
+          <div
+            className={`page-contents logs-viewer ${
+              hideGraph ? 'logs-viewer--table-only' : ''
+            }`}
+          >
+            {hideGraph ? (
+              undefined
+            ) : (
+              <LogsGraphContainer>
+                {this.chartControlBar}
+                {this.chart}
+              </LogsGraphContainer>
+            )}
             <SearchBar
               onSearch={this.handleSubmitSearch}
               customTime={tableTime.custom}

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -301,6 +301,8 @@ class LogsPage extends Component<Props, State> {
               onClearFilters={this.handleClearFilters}
               onUpdateTruncation={this.handleUpdateTruncation}
               isTruncated={this.isTruncated}
+              isHistogramHidden={isHistogramHidden}
+              onShowHistogram={this.handleShowHistogram}
             />
             <LogsTable
               queryCount={this.state.queryCount}
@@ -865,10 +867,19 @@ class LogsPage extends Component<Props, State> {
           searchStatus={searchStatus}
           selectedTimeWindow={timeRange}
         />
-        <TimeWindowDropdown
-          selectedTimeWindow={timeRange}
-          onSetTimeWindow={this.handleSetTimeWindow}
-        />
+        <div className="page-header--right">
+          <button
+            className="btn btn-sm btn-square btn-default"
+            onClick={this.handleHideHistogram}
+            title="Hide Histogram"
+          >
+            <span className="icon eye-closed" />
+          </button>
+          <TimeWindowDropdown
+            selectedTimeWindow={timeRange}
+            onSetTimeWindow={this.handleSetTimeWindow}
+          />
+        </div>
       </div>
     )
   }
@@ -1001,9 +1012,12 @@ class LogsPage extends Component<Props, State> {
   private handleShowHistogram = (): void => {
     this.setState({isHistogramHidden: false, isOverlayVisible: false})
   }
+  private handleHideHistogram = (): void => {
+    this.setState({isHistogramHidden: true})
+  }
 
   private renderImportOverlay = (): JSX.Element => {
-    const {isOverlayVisible, isHistogramHidden} = this.state
+    const {isOverlayVisible} = this.state
 
     return (
       <OverlayTechnology visible={isOverlayVisible}>
@@ -1013,8 +1027,6 @@ class LogsPage extends Component<Props, State> {
           onDismissOverlay={this.handleToggleOverlay}
           columns={this.tableColumns}
           severityFormat={this.severityFormat}
-          histogramHidden={isHistogramHidden}
-          onShowHistogram={this.handleShowHistogram}
         />
       </OverlayTechnology>
     )

--- a/ui/src/style/pages/logs-viewer.scss
+++ b/ui/src/style/pages/logs-viewer.scss
@@ -4,7 +4,7 @@
 */
 
 $logs-viewer-graph-height: 170px;
-$logs-viewer-search-height: 46px; 
+$logs-viewer-search-height: 46px;
 $logs-viewer-filter-height: 40px;
 $logs-viewer-results-text-indent: 33px;
 $logs-viewer-gutter: 60px;
@@ -53,6 +53,13 @@ $logs-viewer-gutter: 60px;
       $logs-viewer-filter-height}
   );
   background-color: $g3-castle;
+}
+.logs-viewer--table-only {
+  .logs-viewer--table-container {
+    height: calc(
+      100% - #{$logs-viewer-search-height + $logs-viewer-filter-height}
+    );
+  }
 }
 
 // Search Bar
@@ -111,7 +118,6 @@ $logs-viewer-gutter: 60px;
     font-weight: 900;
   }
 }
-
 
 @keyframes resultsSpinner {
   0% {
@@ -271,7 +277,7 @@ $logs-viewer-gutter: 60px;
   font-family: $code-font;
 
   &.message-wrap {
-    word-break: break-all
+    word-break: break-all;
   }
 }
 .logs-viewer--cell-header {
@@ -342,16 +348,16 @@ $logs-viewer-gutter: 60px;
 
 @keyframes magnifier {
   0% {
-    transform: translate(-50%,-50%);
+    transform: translate(-50%, -50%);
   }
   25% {
-    transform: translate(0%,-50%);
+    transform: translate(0%, -50%);
   }
   75% {
-    transform: translate(-100%,-50%);
+    transform: translate(-100%, -50%);
   }
   100% {
-    transform: translate(-50%,-50%);
+    transform: translate(-50%, -50%);
   }
 }
 
@@ -366,10 +372,10 @@ $logs-viewer-gutter: 60px;
 
 @keyframes magRotateB {
   0% {
-    transform: translate(-50%,-50%) rotate(0deg);
+    transform: translate(-50%, -50%) rotate(0deg);
   }
   100% {
-    transform: translate(-50%,-50%) rotate(-360deg);
+    transform: translate(-50%, -50%) rotate(-360deg);
   }
 }
 
@@ -401,7 +407,7 @@ $logs-viewer-gutter: 60px;
   background-image: url('../../assets/images/log.svg');
   width: 50px;
   height: 50px;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
 }
 .logs-viewer--graphic-magnifier-b {
   background-image: url('../../assets/images/magnifier.svg');
@@ -415,5 +421,5 @@ $logs-viewer-gutter: 60px;
   background-image: url('../../assets/images/no-logs.svg');
   width: 60px;
   height: 60px;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
Closes #5355

_Briefly describe your proposed changes:_
   * URL query parameter `table` hides histogram in the Logs page, for example:`http://localhost:8080/logs?table`
   * Allow to hide histogram in its top-right area (eye-closed button): 
![image](https://user-images.githubusercontent.com/16321466/109650169-281b8800-7b5d-11eb-967e-4ed08a2ab8e8.png)
   * Allow to show histogram from the top-right area of logs table (bar-chart button): 
![image](https://user-images.githubusercontent.com/16321466/109650220-34074a00-7b5d-11eb-87b6-33a9436da284.png)



  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
