### PR TITLE
feat: add BigPanda UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@
 1. [#5672](https://github.com/influxdata/chronograf/pull/5672): Allow to migrate data to ETCD over HTTPS.
 1. [#5672](https://github.com/influxdata/chronograf/pull/5672): Allow to specify trusted CA certificate for ETCD connections.
 1. [#5673](https://github.com/influxdata/chronograf/pull/5673): Add documentation link when 1.8 flux is not installed.
-1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Event Handler configuration UI.
-1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Alert Handler configuration UI.
+1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow configuration and alert UI.
+1. [#5682](https://github.com/influxdata/chronograf/pull/5682): Add BigPanda configuration and alert UI.
 1. [#5681](https://github.com/influxdata/chronograf/pull/5681): Allow to hide/show histogram in Log Viewer.
 1. [#5687](https://github.com/influxdata/chronograf/pull/5687): Add more meta query templates to Explore UI.
 1. [#5688](https://github.com/influxdata/chronograf/pull/5688): Add UI variables to flux query execution.

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 // indirect
-	github.com/google/go-cmp v0.4.0
+	github.com/google/go-cmp v0.5.4
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/uuid v1.1.1
@@ -19,7 +19,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway v1.12.1 // indirect
 	github.com/influxdata/flux v0.65.0
 	github.com/influxdata/influxdb v1.1.5
-	github.com/influxdata/kapacitor v1.5.8
+	github.com/influxdata/kapacitor v1.5.9
 	github.com/influxdata/usage-client v0.0.0-20160829180054-6d3895376368
 	github.com/jessevdk/go-flags v1.4.0
 	github.com/kevinburke/go-bindata v3.22.0+incompatible // indirect
@@ -35,7 +35,7 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	go.uber.org/zap v1.13.0 // indirect
 	golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f // indirect
-	golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0
+	golang.org/x/net v0.0.0-20201021035429-f5854403a974
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/tools v0.0.0-20200107050322-53017a39ae36 // indirect
 	google.golang.org/api v0.15.0

--- a/go.sum
+++ b/go.sum
@@ -176,6 +176,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
@@ -245,6 +247,8 @@ github.com/influxdata/kapacitor v1.5.7 h1:USCSHbvaEdaWsHooShIRtSIEpGfJv1vKo/H/kX
 github.com/influxdata/kapacitor v1.5.7/go.mod h1:vv15yTwFBi1kUhCUrM/PGdfsbh5Y5F8BaCrdOg2S+d8=
 github.com/influxdata/kapacitor v1.5.8 h1:SyN9WnHlFkzNgB9gwpqWK6/bCumZsq84OnYF6/3Zyyg=
 github.com/influxdata/kapacitor v1.5.8/go.mod h1:d3TpoOgTXaUnKpBfcxyOOjtIITaqD/1C9vkHvqpMcZ4=
+github.com/influxdata/kapacitor v1.5.9 h1:uot4VuaY4G9J73ijuNsotP7EOxJPuQUuybIgbbC7ths=
+github.com/influxdata/kapacitor v1.5.9/go.mod h1:OXB+57nnTxlqOoumijh+dXn2/5JySCZrJ2NtR1+IiFs=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e h1:/o3vQtpWJhvnIbXley4/jwzzqNeigJK9z+LZcJZ9zfM=
 github.com/influxdata/line-protocol v0.0.0-20180522152040-32c6aa80de5e/go.mod h1:4kt73NQhadE3daL3WhR5EJ/J2ocX0PZzwxQ0gXJ7oFE=
 github.com/influxdata/promql/v2 v2.12.0/go.mod h1:fxOPu+DY0bqCTCECchSRtWfc+0X19ybifQhZoQNF5D8=
@@ -294,6 +298,7 @@ github.com/lestrrat-go/jwx v0.9.0/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/Y
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mailru/easyjson v0.0.0-20201007175905-fca00f44f19d/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRUIY4=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
@@ -510,6 +515,8 @@ golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0 h1:wBouT66WTYFXdxfVdz9sVWARVd/2vfGcmI45D2gj45M=
 golang.org/x/net v0.0.0-20201006153459-a7d1128ccaa0/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
+golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20170412232759-a6bd8cefa181/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -550,6 +557,8 @@ golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210305215415-5cdee2b1b5a0 h1:MOJR6AyRlIYMexU2acorBot1aPks0cBDOyUA4hFlBhE=
+golang.org/x/sys v0.0.0-20210305215415-5cdee2b1b5a0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
@@ -587,6 +596,8 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca h1:PupagGYwj8+I4ubCxcmcBRk3VlUWtTg5huQpZR9flmE=
 gonum.org/v1/gonum v0.0.0-20181121035319-3f7ecaa7e8ca/go.mod h1:Y+Yx5eoAFn32cQvJDxZx5Dpnq+c3wtXuadVZAcxbbBo=
 gonum.org/v1/netlib v0.0.0-20181029234149-ec6d1f5cefe6 h1:4WsZyVtkthqrHTbDCJfiTs8IWNYE4uvsSDgaV6xpp+o=

--- a/kapacitor.go
+++ b/kapacitor.go
@@ -24,6 +24,7 @@ type AlertNodes struct {
 	Talk               []*Talk       `json:"talk"`             // Talk will send alert to all Talk
 	Kafka              []*Kafka      `json:"kafka"`            // Kafka will send alert to all Kafka
 	ServiceNow         []*ServiceNow `json:"serviceNow"`       // ServiceNow alert options
+	BigPanda           []*BigPanda   `json:"bigPanda"`         // BigPanda alert options
 }
 
 // Post will POST alerts to a destination URL
@@ -146,6 +147,13 @@ type ServiceNow struct {
 	Resource   string `json:"resource"`
 	MetricName string `json:"metric_name"`
 	MessageKey string `json:"message_key"`
+}
+
+// BigPanda properties
+type BigPanda struct {
+	AppKey            string `json:"app-key"`
+	PrimaryProperty   string `json:"primary-property"`
+	SecondaryProperty string `json:"secondary-property"`
 }
 
 // MarshalJSON converts AlertNodes to JSON

--- a/kapacitor/alerts_test.go
+++ b/kapacitor/alerts_test.go
@@ -9,7 +9,6 @@ import (
 func TestAlertServices(t *testing.T) {
 	tests := []struct {
 		name    string
-		skip    string
 		rule    chronograf.AlertRule
 		want    chronograf.TICKScript
 		wantErr bool
@@ -168,7 +167,6 @@ func TestAlertServices(t *testing.T) {
 		},
 		{
 			name: "Test BigPanda",
-			skip: "Does not work fine with kapacitor 1.5.8 (https://github.com/influxdata/kapacitor/pull/#2491)",
 			rule: chronograf.AlertRule{
 				AlertNodes: chronograf.AlertNodes{
 					BigPanda: []*chronograf.BigPanda{{
@@ -188,9 +186,6 @@ func TestAlertServices(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip != "" {
-				t.Skip(tt.skip)
-			}
 			got, err := AlertServices(tt.rule)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q. AlertServices() error = %v, wantErr %v", tt.name, err, tt.wantErr)

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -4517,7 +4517,8 @@
               "talk",
               "telegram",
               "tcp",
-              "serviceNow"
+              "serviceNow",
+              "bigPanda"
             ]
           }
         },

--- a/ui/src/kapacitor/components/AlertTabs.tsx
+++ b/ui/src/kapacitor/components/AlertTabs.tsx
@@ -33,6 +33,7 @@ import {
   SlackConfigs,
   KafkaConfigs,
   ServiceNowConfig,
+  BigPandaConfig,
 } from './config'
 
 import {
@@ -393,6 +394,15 @@ class AlertTabs extends PureComponent<Props, State> {
               configSections,
               AlertTypes.servicenow
             )}
+          />
+        )
+      case AlertTypes.bigpanda:
+        return (
+          <BigPandaConfig
+            onSave={this.handleSaveConfig(AlertTypes.bigpanda)}
+            config={this.getSectionElement(configSections, AlertTypes.bigpanda)}
+            onTest={this.handleTestConfig(AlertTypes.bigpanda)}
+            enabled={this.getConfigEnabled(configSections, AlertTypes.bigpanda)}
           />
         )
     }

--- a/ui/src/kapacitor/components/HandlerOptions.js
+++ b/ui/src/kapacitor/components/HandlerOptions.js
@@ -18,6 +18,7 @@ import {
   TelegramHandler,
   VictoropsHandler,
   ServiceNowHandler,
+  BigPandaHandler,
 } from 'src/kapacitor/components/handlers'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -189,6 +190,15 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('servicenow')}
+            validationError={validationError}
+          />
+        )
+      case 'bigPanda':
+        return (
+          <BigPandaHandler
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            onGoToConfig={onGoToConfig('bigpanda')}
             validationError={validationError}
           />
         )

--- a/ui/src/kapacitor/components/config/BigPandaConfig.tsx
+++ b/ui/src/kapacitor/components/config/BigPandaConfig.tsx
@@ -1,0 +1,164 @@
+import _ from 'lodash'
+import React, {PureComponent, ChangeEvent} from 'react'
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {BigPandaProperties} from 'src/types/kapacitor'
+import RedactedInput from './RedactedInput'
+
+interface Config {
+  options: {
+    url: string
+    token: boolean
+    'app-key': string
+    'insecure-skip-verify': boolean
+  }
+}
+
+interface Props {
+  config: Config
+  onSave: (properties: BigPandaProperties) => Promise<boolean>
+  onTest: (event: React.MouseEvent<HTMLButtonElement>) => void
+  enabled: boolean
+}
+
+interface State {
+  testEnabled: boolean
+  enabled: boolean
+}
+
+@ErrorHandling
+class BigPandaConfig extends PureComponent<Props, State> {
+  private url: HTMLInputElement
+  private token: HTMLInputElement
+  private appKey: HTMLInputElement
+  private insecureSkipVerify: HTMLInputElement
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      testEnabled: this.props.enabled,
+      enabled: _.get(this.props, 'config.options.enabled', false),
+    }
+  }
+
+  public render() {
+    const {
+      url,
+      token,
+      'app-key': appKey,
+      'insecure-skip-verify': insecureSkipVerify,
+    } = this.props.config.options
+    const {testEnabled, enabled} = this.state
+
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <div className="form-group col-xs-12">
+          <label htmlFor="source">URL</label>
+          <input
+            className="form-control"
+            id="url"
+            type="text"
+            ref={r => (this.url = r)}
+            defaultValue={url || 'https://api.bigpanda.io/data/v2/alerts'}
+            onChange={this.disableTest}
+          />
+        </div>
+        <div className="form-group col-xs-12">
+          <label htmlFor="address">Token</label>
+          <RedactedInput
+            defaultValue={token}
+            id="token"
+            refFunc={this.handleTokenRef}
+            disableTest={this.disableTest}
+            isFormEditing={!testEnabled}
+          />
+        </div>
+        <div className="form-group col-xs-12">
+          <label htmlFor="source">Application Key</label>
+          <input
+            className="form-control"
+            id="app-key"
+            type="text"
+            ref={r => (this.appKey = r)}
+            placeholder="ex: My_Application_Key"
+            defaultValue={appKey || ''}
+            onChange={this.disableTest}
+          />
+        </div>
+
+        <div className="form-group col-xs-12">
+          <div className="form-control-static">
+            <input
+              id="insecureSkipVerify"
+              type="checkbox"
+              defaultChecked={insecureSkipVerify}
+              ref={r => (this.insecureSkipVerify = r)}
+              onChange={this.disableTest}
+            />
+            <label htmlFor="insecureSkipVerify">Insecure Skip Verify</label>
+          </div>
+        </div>
+
+        <div className="form-group col-xs-12">
+          <div className="form-control-static">
+            <input
+              type="checkbox"
+              id="disabled"
+              checked={enabled}
+              onChange={this.handleEnabledChange}
+            />
+            <label htmlFor="disabled">Configuration Enabled</label>
+          </div>
+        </div>
+
+        <div className="form-group form-group-submit col-xs-12 text-center">
+          <button
+            className="btn btn-primary"
+            type="submit"
+            disabled={this.state.testEnabled}
+          >
+            <span className="icon checkmark" />
+            Save Changes
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={!this.state.testEnabled || !enabled}
+            onClick={this.props.onTest}
+          >
+            <span className="icon pulse-c" />
+            Send Test Event
+          </button>
+        </div>
+      </form>
+    )
+  }
+
+  private handleTokenRef = (r: HTMLInputElement) => (this.token = r)
+
+  private handleEnabledChange = (e: ChangeEvent<HTMLInputElement>) => {
+    this.setState({enabled: e.target.checked})
+    this.disableTest()
+  }
+
+  private handleSubmit = async e => {
+    e.preventDefault()
+
+    const properties: BigPandaProperties = {
+      url: this.url.value,
+      token: this.token.value,
+      'app-key': this.appKey.value,
+      'insecure-skip-verify': this.insecureSkipVerify.checked,
+      enabled: this.state.enabled,
+    }
+
+    const success = await this.props.onSave(properties)
+    if (success) {
+      this.setState({testEnabled: true})
+    }
+  }
+
+  private disableTest = () => {
+    this.setState({testEnabled: false})
+  }
+}
+
+export default BigPandaConfig

--- a/ui/src/kapacitor/components/config/ServiceNowConfig.tsx
+++ b/ui/src/kapacitor/components/config/ServiceNowConfig.tsx
@@ -27,7 +27,7 @@ interface State {
 }
 
 @ErrorHandling
-class SensuConfig extends PureComponent<Props, State> {
+class ServiceNowConfig extends PureComponent<Props, State> {
   private url: HTMLInputElement
   private source: HTMLInputElement
   private username: HTMLInputElement
@@ -155,4 +155,4 @@ class SensuConfig extends PureComponent<Props, State> {
   }
 }
 
-export default SensuConfig
+export default ServiceNowConfig

--- a/ui/src/kapacitor/components/config/index.js
+++ b/ui/src/kapacitor/components/config/index.js
@@ -13,6 +13,7 @@ import VictorOpsConfig from './VictorOpsConfig'
 import SlackConfigs from './SlackConfigs'
 import KafkaConfigs from './KafkaConfigs'
 import ServiceNowConfig from './ServiceNowConfig'
+import BigPandaConfig from './BigPandaConfig'
 
 export {
   AlertaConfig,
@@ -30,4 +31,5 @@ export {
   SlackConfigs,
   KafkaConfigs,
   ServiceNowConfig,
+  BigPandaConfig,
 }

--- a/ui/src/kapacitor/components/handlers/BigPandaHandler.js
+++ b/ui/src/kapacitor/components/handlers/BigPandaHandler.js
@@ -1,0 +1,72 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import HandlerInput from 'src/kapacitor/components/HandlerInput'
+import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+const BigPandaHandler = ({
+  selectedHandler,
+  handleModifyHandler,
+  onGoToConfig,
+  validationError,
+}) =>
+  selectedHandler.enabled ? (
+    <div className="endpoint-tab-contents">
+      <div className="endpoint-tab--parameters">
+        <h4 className="u-flex u-jc-space-between">
+          Parameters from Kapacitor Configuration
+          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
+            <span className="icon cog-thick" />
+            {validationError
+              ? 'Exit this Rule and Edit Configuration'
+              : 'Save this Rule and Edit Configuration'}
+          </div>
+        </h4>
+        <div className="faux-form">
+          <HandlerInput
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            fieldName="app-key"
+            fieldDisplay="Application Key:"
+            placeholder="ex: my_app"
+            fieldColumns="col-md-12"
+          />
+        </div>
+      </div>
+      <div className="endpoint-tab--parameters">
+        <h4>Parameters for this Alert Handler</h4>
+        <div className="faux-form">
+          <HandlerInput
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            fieldName="primary-property"
+            fieldDisplay="Primary Property"
+            placeholder=""
+            fieldColumns="col-md-12"
+          />
+          <HandlerInput
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            fieldName="secondary-property"
+            fieldDisplay="Secondary Property"
+            placeholder=""
+            fieldColumns="col-md-12"
+          />
+        </div>
+      </div>
+    </div>
+  ) : (
+    <HandlerEmpty
+      onGoToConfig={onGoToConfig}
+      validationError={validationError}
+    />
+  )
+
+const {func, shape, string} = PropTypes
+
+BigPandaHandler.propTypes = {
+  selectedHandler: shape({}).isRequired,
+  handleModifyHandler: func.isRequired,
+  onGoToConfig: func.isRequired,
+  validationError: string.isRequired,
+}
+
+export default BigPandaHandler

--- a/ui/src/kapacitor/components/handlers/index.js
+++ b/ui/src/kapacitor/components/handlers/index.js
@@ -15,6 +15,7 @@ import TalkHandler from './TalkHandler'
 import TelegramHandler from './TelegramHandler'
 import VictoropsHandler from './VictoropsHandler'
 import ServiceNowHandler from './ServiceNowHandler'
+import BigPandaHandler from './BigPandaHandler'
 
 export {
   PostHandler,
@@ -34,4 +35,5 @@ export {
   TelegramHandler,
   VictoropsHandler,
   ServiceNowHandler,
+  BigPandaHandler,
 }

--- a/ui/src/kapacitor/constants/index.ts
+++ b/ui/src/kapacitor/constants/index.ts
@@ -32,6 +32,7 @@ export enum AlertTypes {
   exec = 'exec',
   log = 'log',
   servicenow = 'servicenow',
+  bigpanda = 'bigpanda',
 }
 
 export enum AlertDisplayText {
@@ -49,10 +50,12 @@ export enum AlertDisplayText {
   telegram = 'Telegram',
   victorops = 'VictorOps',
   servicenow = 'ServiceNow',
+  bigpanda = 'BigPanda',
 }
 
 export const SupportedServices: string[] = [
   'alerta',
+  'bigpanda',
   'kafka',
   'opsgenie',
   'opsgenie2',
@@ -238,6 +241,7 @@ export const ALERTS_FROM_CONFIG: FieldsFromConfigAlerts = {
   // influxdb:[],
   // mqtt:[]
   serviceNow: ['url', 'source', 'username', 'password'],
+  bigPanda: ['app-key'],
 }
 
 export const MAP_FIELD_KEYS_FROM_CONFIG: ConfigKeyMaps = {
@@ -262,6 +266,7 @@ export const MAP_FIELD_KEYS_FROM_CONFIG: ConfigKeyMaps = {
   // influxd: {},
   // mqtt: {}
   serviceNow: {},
+  bigPanda: {},
 }
 
 // HANDLERS_TO_RULE returns array of fields that may be updated for each alert on rule.
@@ -299,11 +304,11 @@ export const HANDLERS_TO_RULE_THEM_ALL: FieldsFromAllAlerts = {
   // snmpTrap: ['trapOid', 'data'], // [oid/type/value]
   serviceNow: [
     'node',
-    'snType',
     'resource',
     'metric_name',
     'message_key',
     'source',
     '_type', // serviceNow type, remapped from type on the wire
   ],
+  bigPanda: ['app-key', 'primary-property', 'secondary-property'],
 }

--- a/ui/src/kapacitor/constants/index.ts
+++ b/ui/src/kapacitor/constants/index.ts
@@ -214,6 +214,7 @@ export const MAP_KEYS_FROM_CONFIG: KeyMappings = {
   smtp: 'email',
   victorops: 'victorOps',
   servicenow: 'serviceNow',
+  bigpanda: 'bigPanda',
 }
 
 // ALERTS_FROM_CONFIG the array of fields to accept from Kapacitor Config

--- a/ui/src/shared/parsing/parseHandlersFromConfig.js
+++ b/ui/src/shared/parsing/parseHandlersFromConfig.js
@@ -60,6 +60,7 @@ const parseHandlersFromConfig = config => {
       return _.get(MAP_FIELD_KEYS_FROM_CONFIG[h.type], k, k)
     })
   })
+  console.log(config, allHandlers, mappedHandlers, allowedHandlers, pickedHandlers, fieldKeyMappedHandlers)
 
   return fieldKeyMappedHandlers
 }

--- a/ui/src/shared/parsing/parseHandlersFromConfig.js
+++ b/ui/src/shared/parsing/parseHandlersFromConfig.js
@@ -60,7 +60,6 @@ const parseHandlersFromConfig = config => {
       return _.get(MAP_FIELD_KEYS_FROM_CONFIG[h.type], k, k)
     })
   })
-  console.log(config, allHandlers, mappedHandlers, allowedHandlers, pickedHandlers, fieldKeyMappedHandlers)
 
   return fieldKeyMappedHandlers
 }

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -276,6 +276,7 @@ export interface KeyMappings {
   smtp: string
   victorops: string
   servicenow: string
+  bigpanda: string
 }
 
 export interface FieldsFromConfigAlerts {

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -89,6 +89,7 @@ interface AlertNodes {
   opsGenie2?: OpsGenie[]
   talk: Talk[]
   serviceNow?: ServiceNow[]
+  bigPanda?: BigPanda[]
 }
 
 interface Headers {
@@ -146,6 +147,13 @@ interface ServiceNow {
   metricName: string
   messageKey: string
   source: string
+}
+
+// BigPanda alert options
+interface BigPanda {
+  'app-key': string
+  'primary-property': string
+  'secondary-property': string
 }
 
 // PagerDuty sends alerts to the pagerduty.com service
@@ -285,6 +293,7 @@ export interface FieldsFromConfigAlerts {
   telegram: string[]
   victorOps: string[]
   serviceNow: string[]
+  bigPanda: string[]
 }
 
 export interface FieldsFromAllAlerts extends FieldsFromConfigAlerts {
@@ -424,6 +433,14 @@ export interface ServiceNowProperties {
   enabled: boolean
 }
 
+export interface BigPandaProperties {
+  url: string
+  token: string
+  'app-key': string
+  'insecure-skip-verify': boolean
+  enabled: boolean
+}
+
 export type ServiceProperties =
   | AlertaProperties
   | KafkaProperties
@@ -438,6 +455,7 @@ export type ServiceProperties =
   | TelegramProperties
   | VictorOpsProperties
   | ServiceNowProperties
+  | BigPandaProperties
 
 export type SpecificConfigOptions = Partial<SlackProperties & KafkaProperties>
 


### PR DESCRIPTION
Closes #5674

This PR adds 
__BigPanda Configuration UI__
![image](https://user-images.githubusercontent.com/16321466/109820836-aba8a800-7c35-11eb-9955-bff4918686c6.png)

__BigPanda Alert configuration UI__
![image](https://user-images.githubusercontent.com/16321466/109965470-4dd89680-7cef-11eb-9ad5-fdbf99ef67d8.png)


It also:
   * provides serialization/parsing of BigPanda alert properties from/to TICKScript (server side)
   * updates swagger

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
