### PR TITLE
fix(ui): repair stale database list in Log Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 1. [#5678](https://github.com/influxdata/chronograf/pull/5678): Do not log error during line visualization of meta query results.
 1. [#5679](https://github.com/influxdata/chronograf/pull/5679): Dispose log stream when tickscript editor page is closed.
 1. [#5680](https://github.com/influxdata/chronograf/pull/5680): Generate correct flux property expressions.
+1. [#5683](https://github.com/influxdata/chronograf/pull/5683): Repair stale database list in Log Viewer.
 
 ### Features
 

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -18,7 +18,11 @@ export const loadLocalStorage = (errorsQueue: any[]): LocalStorage | {} => {
     const gitSHAChanged = state.GIT_SHA && state.GIT_SHA !== GIT_SHA
     const npmVersionChanged = state.VERSION && state.VERSION !== VERSION
 
-    if (npmVersionChanged || gitSHAChanged) {
+    if (
+      npmVersionChanged ||
+      gitSHAChanged ||
+      window.location.search === '?clearLocalStorage'
+    ) {
       window.localStorage.removeItem('state')
 
       if (npmVersionChanged) {

--- a/ui/src/logs/actions/index.ts
+++ b/ui/src/logs/actions/index.ts
@@ -951,9 +951,10 @@ export const setTimeRangeAsync = () => async (dispatch): Promise<void> => {
 }
 
 export const populateNamespacesAsync = (
-  proxyLink: string,
-  source: Source = null
+  source: Source,
+  currentNamespace: Namespace = undefined
 ) => async (dispatch): Promise<void> => {
+  const proxyLink = getDeep<string | null>(source, 'links.proxy', null)
   const namespaces = await getDatabasesWithRetentionPolicies(proxyLink)
 
   if (namespaces && namespaces.length > 0) {
@@ -961,13 +962,22 @@ export const populateNamespacesAsync = (
 
     let defaultNamespace: Namespace
 
-    if (source && source.telegraf) {
-      defaultNamespace = _.find(
-        namespaces,
-        ns => ns.database === source.telegraf
-      )
+    if (source) {
+      if (currentNamespace) {
+        defaultNamespace = _.find(
+          namespaces,
+          ns =>
+            ns.database === currentNamespace.database &&
+            ns.retentionPolicy === currentNamespace.retentionPolicy
+        )
+      }
+      if (!defaultNamespace && source.telegraf) {
+        defaultNamespace = _.find(
+          namespaces,
+          ns => ns.database === source.telegraf
+        )
+      }
     }
-
     const namespace = defaultNamespace || namespaces[0]
 
     await Promise.all([
@@ -986,7 +996,7 @@ export const getSourceAndPopulateNamespacesAsync = (sourceID: string) => async (
 
   if (proxyLink) {
     dispatch(setSource(source))
-    await dispatch(populateNamespacesAsync(proxyLink, source))
+    await dispatch(populateNamespacesAsync(source))
   }
 }
 

--- a/ui/src/logs/containers/LogsPage.tsx
+++ b/ui/src/logs/containers/LogsPage.tsx
@@ -61,6 +61,7 @@ import {
   clearSearchData,
   setSearchStatus,
   executeHistogramQueryAsync,
+  populateNamespacesAsync,
 } from 'src/logs/actions'
 import {getSourcesAsync} from 'src/shared/actions/sources'
 
@@ -140,6 +141,7 @@ interface Props {
   fetchNewerChunkAsync: typeof fetchNewerChunkAsync
   fetchTailAsync: typeof fetchTailAsync
   fetchNamespaceSyslogStatusAsync: typeof fetchNamespaceSyslogStatusAsync
+  populateNamespacesAsync: typeof populateNamespacesAsync
   flushTailBuffer: typeof flushTailBuffer
   clearAllTimeBounds: typeof clearAllTimeBounds
   setNextTailLowerBound: typeof setNextTailLowerBound
@@ -340,9 +342,10 @@ class LogsPage extends Component<Props, State> {
           return src.default
         }) || this.props.sources[0]
 
-      return await this.props.getSourceAndPopulateNamespaces(source.id)
+      return this.props.getSourceAndPopulateNamespaces(source.id)
     } else if (this.props.currentNamespace) {
-      return this.props.fetchNamespaceSyslogStatusAsync(
+      return this.props.populateNamespacesAsync(
+        this.props.currentSource,
         this.props.currentNamespace
       )
     }
@@ -1191,6 +1194,7 @@ const mapDispatchToProps = {
   getConfig: getLogConfigAsync,
   updateConfig: updateLogConfigAsync,
   notify: notifyAction,
+  populateNamespacesAsync,
 }
 
 export default withRouter(


### PR DESCRIPTION
Closes #5544

_Briefly describe your proposed changes:_
   * list of namespaces (database + retention policy pair) is fetched whever Log Viewer page is opened
      * it is also verified that the current namespace exists, the default namespace is selected otherwise
   * allow clearing local storage with `?clearLocalStorage` query, such as `http://localhost:8080/logs?clearLocalStorage
_What was the problem?_
   * list of databases was not refreshed from the server, local storage was used
_What was the solution?_
   * fetch the list on open of Log Viewer

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
