### PR TITLE
feat(ui/explore): add more meta query templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Event Handler configuration UI.
 1. [#5675](https://github.com/influxdata/chronograf/pull/5675): Add ServiceNow Alert Handler configuration UI.
 1. [#5681](https://github.com/influxdata/chronograf/pull/5681): Allow to hide/show histogram in Log Viewer.
+1. [#5687](https://github.com/influxdata/chronograf/pull/5687): Add more meta query templates to Explore UI.
 
 ### Other
 

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -249,6 +249,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     query: 'SHOW DIAGNOSTICS',
     type: DropdownChildTypes.Item,
   },
+  {
+    id: 'Show Subscriptions',
+    text: 'Show Subscriptions',
+    query: 'SHOW SUBSCRIPTIONS',
+    type: DropdownChildTypes.Item,
+  },
 ]
 
 export const WRITE_DATA_DOCS_LINK =

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -244,6 +244,16 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     type: DropdownChildTypes.Divider,
   },
   {
+    id: 'Explain',
+    text: 'Explain',
+    query: 'EXPLAIN SELECT * FROM "db_name"."rp_name"."measurement"',
+    type: DropdownChildTypes.Item,
+  },
+  {
+    id: `mqtd-divider-8`,
+    type: DropdownChildTypes.Divider,
+  },
+  {
     id: 'Show Stats',
     text: 'Show Stats',
     query: 'SHOW STATS',

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -250,6 +250,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     type: DropdownChildTypes.Item,
   },
   {
+    id: 'Explain Analyze',
+    text: 'Explain Analyze',
+    query: 'EXPLAIN ANALYZE SELECT * FROM "db_name"."rp_name"."measurement"',
+    type: DropdownChildTypes.Item,
+  },
+  {
     id: `mqtd-divider-8`,
     type: DropdownChildTypes.Divider,
   },

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -255,6 +255,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     query: 'SHOW SUBSCRIPTIONS',
     type: DropdownChildTypes.Item,
   },
+  {
+    id: 'Show Queries',
+    text: 'Show Queries',
+    query: 'SHOW QUERIES',
+    type: DropdownChildTypes.Item,
+  },
 ]
 
 export const WRITE_DATA_DOCS_LINK =

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -267,6 +267,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     query: 'SHOW QUERIES',
     type: DropdownChildTypes.Item,
   },
+  {
+    id: 'Show Shards',
+    text: 'Show Shards',
+    query: 'SHOW SHARDS',
+    type: DropdownChildTypes.Item,
+  },
 ]
 
 export const WRITE_DATA_DOCS_LINK =

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -273,6 +273,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     query: 'SHOW SHARDS',
     type: DropdownChildTypes.Item,
   },
+  {
+    id: 'Show Shard Groups',
+    text: 'Show Shard Groups',
+    query: 'SHOW SHARD GROUPS',
+    type: DropdownChildTypes.Item,
+  },
 ]
 
 export const WRITE_DATA_DOCS_LINK =

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -191,6 +191,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     type: DropdownChildTypes.Item,
   },
   {
+    id: 'Show Grants',
+    text: 'Show Grants',
+    query: 'SHOW GRANTS FOR "username"',
+    type: DropdownChildTypes.Item,
+  },
+  {
     id: 'Create User',
     text: 'Create User',
     query: 'CREATE USER "username" WITH PASSWORD \'password\'',

--- a/ui/src/data_explorer/constants/index.ts
+++ b/ui/src/data_explorer/constants/index.ts
@@ -99,6 +99,12 @@ export const METAQUERY_TEMPLATE_OPTIONS: Array<
     type: DropdownChildTypes.Divider,
   },
   {
+    id: 'Show Field Keys',
+    text: 'Show Field Keys',
+    query: 'SHOW FIELD KEYS ON "db_name"',
+    type: DropdownChildTypes.Item,
+  },
+  {
     id: 'Show Field Key Cardinality',
     text: 'Show Field Key Cardinality',
     query: 'SHOW FIELD KEY CARDINALITY ON "db_name"',


### PR DESCRIPTION
Closes #5661

This PR adds the following Metaquery Templates to Explorer UI:

   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-field-keys
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-subscriptions
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-shards
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-shard-groups
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-queries
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#show-grants
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#explain
   * https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#explain-analyze

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
