### PR TITLE
feat(ui): allow to filter fields in query builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 1. [#5688](https://github.com/influxdata/chronograf/pull/5688): Add UI variables to flux query execution.
 1. [#5697](https://github.com/influxdata/chronograf/pull/5697): Allow to define dashboard variables using flux.
 1. [#5700](https://github.com/influxdata/chronograf/pull/5700): Remove HipChat alerts.
+1. [#5704](https://github.com/influxdata/chronograf/pull/5704): Allow to filter fields in Query Builder UI.
 
 ### Other
 

--- a/ui/src/data_explorer/components/FieldListItem.tsx
+++ b/ui/src/data_explorer/components/FieldListItem.tsx
@@ -3,12 +3,12 @@ import classnames from 'classnames'
 import _ from 'lodash'
 
 import FunctionSelector from 'src/shared/components/FunctionSelector'
-import {firstFieldName} from 'src/shared/reducers/helpers/fields'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 import {ApplyFuncsToFieldArgs, Field, FieldFunc, FuncArg} from 'src/types'
 
 interface Props {
+  fieldName: string
   fieldFuncs: FieldFunc[]
   isSelected: boolean
   onToggleField: (field: Field) => void
@@ -32,9 +32,14 @@ class FieldListItem extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {isKapacitorRule, isSelected, funcs, isDisabled} = this.props
+    const {
+      isKapacitorRule,
+      isSelected,
+      fieldName,
+      funcs,
+      isDisabled,
+    } = this.props
     const {isOpen} = this.state
-    const fieldName = this.getFieldName()
 
     let fieldFuncsLabel
     const num = funcs.length
@@ -104,16 +109,14 @@ class FieldListItem extends PureComponent<Props, State> {
   }
 
   private handleToggleField = (): void => {
-    const {onToggleField} = this.props
-    const value = this.getFieldName()
+    const {onToggleField, fieldName} = this.props
 
-    onToggleField({value, type: 'field'})
+    onToggleField({value: fieldName, type: 'field'})
     this.close()
   }
 
   private handleApplyFunctions = (selectedFuncs: string[]) => {
-    const {onApplyFuncsToField} = this.props
-    const fieldName = this.getFieldName()
+    const {onApplyFuncsToField, fieldName} = this.props
     const field: Field = {value: fieldName, type: 'field'}
 
     onApplyFuncsToField({
@@ -127,15 +130,6 @@ class FieldListItem extends PureComponent<Props, State> {
     value,
     type: 'func',
   })
-
-  private getFieldName = (): string => {
-    const {fieldFuncs} = this.props
-    const fieldFunc = _.head(fieldFuncs)
-
-    return _.get(fieldFunc, 'type') === 'field'
-      ? _.get(fieldFunc, 'value')
-      : firstFieldName(_.get(fieldFunc, 'args'))
-  }
 }
 
 export default FieldListItem

--- a/ui/src/data_explorer/components/FieldListItem.tsx
+++ b/ui/src/data_explorer/components/FieldListItem.tsx
@@ -1,6 +1,5 @@
 import React, {PureComponent, MouseEvent} from 'react'
 import classnames from 'classnames'
-import _ from 'lodash'
 
 import FunctionSelector from 'src/shared/components/FunctionSelector'
 import {ErrorHandling} from 'src/shared/decorators/errors'

--- a/ui/src/shared/components/FieldList.tsx
+++ b/ui/src/shared/components/FieldList.tsx
@@ -22,6 +22,7 @@ import {
   numFunctions,
   getFieldsWithName,
   getFuncsByFieldName,
+  getFieldName,
 } from 'src/shared/reducers/helpers/fields'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -147,7 +148,7 @@ class FieldList extends PureComponent<Props, State> {
                   fieldFunc.value,
                   fields
                 )
-
+                const fieldName = getFieldName(fieldFunc)
                 const funcs: FieldFunc[] = getFuncsByFieldName(
                   fieldFunc.value,
                   fields
@@ -162,6 +163,7 @@ class FieldList extends PureComponent<Props, State> {
                     onToggleField={this.handleToggleField}
                     onApplyFuncsToField={this.handleApplyFuncs}
                     isSelected={!!selectedFields.length}
+                    fieldName={fieldName}
                     fieldFuncs={fieldFuncs}
                     funcs={functionNames(funcs)}
                     isKapacitorRule={isKapacitorRule}

--- a/ui/src/shared/components/FieldList.tsx
+++ b/ui/src/shared/components/FieldList.tsx
@@ -25,6 +25,7 @@ import {
   getFieldName,
 } from 'src/shared/reducers/helpers/fields'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import QueryBuilderFilter from './QueryBuilderFilter'
 
 interface GroupByOption extends GroupBy {
   menuOption: string
@@ -56,6 +57,7 @@ interface Props {
 }
 
 interface State {
+  filterText: string
   fields: Field[]
 }
 
@@ -69,6 +71,7 @@ class FieldList extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
     this.state = {
+      filterText: '',
       fields: [],
     }
   }
@@ -132,7 +135,13 @@ class FieldList extends PureComponent<Props, State> {
               onGroupByTime={this.handleGroupByTime}
               isDisabled={isDisabled}
             />
-          ) : null}
+          ) : (
+            <QueryBuilderFilter
+              filterText={this.state.filterText}
+              onEscape={this.handleEscapeFilter}
+              onFilterText={this.handleFilterText}
+            ></QueryBuilderFilter>
+          )}
         </div>
         {noDBorMeas ? (
           <div className="query-builder--list-empty">
@@ -142,40 +151,83 @@ class FieldList extends PureComponent<Props, State> {
           </div>
         ) : (
           <div className="query-builder--list">
-            <FancyScrollbar>
-              {this.state.fields.map((fieldFunc, i) => {
-                const selectedFields = getFieldsWithName(
-                  fieldFunc.value,
-                  fields
-                )
-                const fieldName = getFieldName(fieldFunc)
-                const funcs: FieldFunc[] = getFuncsByFieldName(
-                  fieldFunc.value,
-                  fields
-                )
-                const fieldFuncs = selectedFields.length
-                  ? selectedFields
-                  : [fieldFunc]
+            <div>
+              <FancyScrollbar>
+                {this.state.fields.map((fieldFunc, i) => {
+                  const selectedFields = getFieldsWithName(
+                    fieldFunc.value,
+                    fields
+                  )
+                  const fieldName = getFieldName(fieldFunc)
+                  if (
+                    this.state.filterText &&
+                    !selectedFields.length &&
+                    !fieldName
+                      .toLowerCase()
+                      .includes(this.state.filterText.toLowerCase())
+                  ) {
+                    // do not render the item unless it is selected or matches filter
+                    return
+                  }
 
-                return (
-                  <FieldListItem
-                    key={i}
-                    onToggleField={this.handleToggleField}
-                    onApplyFuncsToField={this.handleApplyFuncs}
-                    isSelected={!!selectedFields.length}
-                    fieldName={fieldName}
-                    fieldFuncs={fieldFuncs}
-                    funcs={functionNames(funcs)}
-                    isKapacitorRule={isKapacitorRule}
-                    isDisabled={isDisabled}
-                  />
-                )
-              })}
-            </FancyScrollbar>
+                  const funcs: FieldFunc[] = getFuncsByFieldName(
+                    fieldFunc.value,
+                    fields
+                  )
+                  const fieldFuncs = selectedFields.length
+                    ? selectedFields
+                    : [fieldFunc]
+
+                  return (
+                    <FieldListItem
+                      key={i}
+                      onToggleField={this.handleToggleField}
+                      onApplyFuncsToField={this.handleApplyFuncs}
+                      isSelected={!!selectedFields.length}
+                      fieldName={fieldName}
+                      fieldFuncs={fieldFuncs}
+                      funcs={functionNames(funcs)}
+                      isKapacitorRule={isKapacitorRule}
+                      isDisabled={isDisabled}
+                    />
+                  )
+                })}
+              </FancyScrollbar>
+            </div>
           </div>
         )}
+        {hasAggregates ? (
+          <div
+            className="query-builder--heading"
+            style={{backgroundColor: 'transparent'}}
+          >
+            <QueryBuilderFilter
+              filterText={this.state.filterText}
+              onEscape={this.handleEscapeFilter}
+              onFilterText={this.handleFilterText}
+            ></QueryBuilderFilter>
+          </div>
+        ) : undefined}
       </div>
     )
+  }
+
+  private handleFilterText = (e: React.FormEvent<HTMLInputElement>) => {
+    e.stopPropagation()
+    const filterText = e.currentTarget.value
+    this.setState({
+      filterText,
+    })
+  }
+  private handleEscapeFilter = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key !== 'Escape') {
+      return
+    }
+
+    e.stopPropagation()
+    this.setState({
+      filterText: '',
+    })
   }
 
   private handleGroupByTime = (groupBy: GroupByOption): void => {

--- a/ui/src/shared/components/MeasurementList.tsx
+++ b/ui/src/shared/components/MeasurementList.tsx
@@ -9,7 +9,7 @@ import showMeasurementsParser from 'src/shared/parsing/showMeasurements'
 import {QueryConfig, Source, Tag} from 'src/types'
 
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
-import MeasurementListFilter from 'src/shared/components/MeasurementListFilter'
+import QueryBuilderFilter from 'src/shared/components/QueryBuilderFilter'
 import MeasurementListItem from 'src/shared/components/MeasurementListItem'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -136,7 +136,7 @@ class MeasurementList extends PureComponent<Props, State> {
         <div className="query-builder--heading">
           <span>Measurements & Tags</span>
           {database && (
-            <MeasurementListFilter
+            <QueryBuilderFilter
               onEscape={this.handleEscape}
               onFilterText={this.handleFilterText}
               filterText={this.state.filterText}

--- a/ui/src/shared/components/QueryBuilderFilter.tsx
+++ b/ui/src/shared/components/QueryBuilderFilter.tsx
@@ -6,7 +6,7 @@ interface Props {
   onFilterText: (e: React.InputHTMLAttributes<HTMLInputElement>) => void
 }
 
-const MeasurementListFilter: FunctionComponent<Props> = ({
+const QueryBuilderFilter: FunctionComponent<Props> = ({
   onEscape,
   onFilterText,
   filterText,
@@ -26,4 +26,4 @@ const MeasurementListFilter: FunctionComponent<Props> = ({
   </div>
 )
 
-export default MeasurementListFilter
+export default QueryBuilderFilter

--- a/ui/src/shared/reducers/helpers/fields.js
+++ b/ui/src/shared/reducers/helpers/fields.js
@@ -87,3 +87,10 @@ export const removeField = (fieldName, fields) => {
     return [...acc, f]
   }, [])
 }
+
+// Gets field name out of the field func supplied
+export function getFieldName(fieldFunc) {
+  return _.get(fieldFunc, 'type') === 'field'
+    ? _.get(fieldFunc, 'value')
+    : firstFieldName(_.get(fieldFunc, 'args'))
+}

--- a/ui/test/shared/components/MeasurementList.test.tsx
+++ b/ui/test/shared/components/MeasurementList.test.tsx
@@ -1,7 +1,7 @@
 import {shallow} from 'enzyme'
 import React from 'react'
 import MeasurementList from 'src/shared/components/MeasurementList'
-import MeasurementListFilter from 'src/shared/components/MeasurementListFilter'
+import QueryBuilderFilter from 'src/shared/components/QueryBuilderFilter'
 import MeasurementListItem from 'src/shared/components/MeasurementListItem'
 import {query, source} from 'test/resources'
 
@@ -55,7 +55,7 @@ describe('Shared.Components.MeasurementList', () => {
 
       it('renders <MeasurementListFilter/> to the page', () => {
         const {wrapper} = setup()
-        const filter = wrapper.find(MeasurementListFilter)
+        const filter = wrapper.find(QueryBuilderFilter)
 
         expect(filter.exists()).toBe(true)
       })
@@ -69,7 +69,7 @@ describe('Shared.Components.MeasurementList', () => {
       const event = {target: {value: 'f'}, stopPropagation: () => {}}
       wrapper.setState({filtered: measurements, measurements})
 
-      const filter = wrapper.find(MeasurementListFilter)
+      const filter = wrapper.find(QueryBuilderFilter)
       const input = filter.dive().find('input')
       input.simulate('change', event)
       wrapper.update()


### PR DESCRIPTION
Closes #5528

_Briefly describe your proposed changes:_
A new Filter was added to the Fields column of InfluxQL query builder:
![image](https://user-images.githubusercontent.com/16321466/111337904-c4be4980-8676-11eb-85e8-5e953afff3e7.png)
If no field is aggregated the filter UI appears in the Fields column header, otherwise it appears at the bottom of the Fields column:
![image](https://user-images.githubusercontent.com/16321466/111338447-3c8c7400-8677-11eb-945c-c1d268cd1b6b.png)
All selected fields are always displayed (independently on the filter value), the filter is case insensitive and matches any character sequence in a field name:
![image](https://user-images.githubusercontent.com/16321466/111438556-abfc7500-8704-11eb-8f81-9712035bbb2d.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
