### PR TITLE
feat(oauth/github): allow to specify URL for github enterprise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 1. [#5704](https://github.com/influxdata/chronograf/pull/5704): Allow to filter fields in Query Builder UI.
 1. [#5712](https://github.com/influxdata/chronograf/pull/5712): Allow to change write precission.
 1. [#5710](https://github.com/influxdata/chronograf/pull/5710): Add PKCE to OAuth integrations.
+1. [#5713](https://github.com/influxdata/chronograf/pull/5710): Support GitHub Enterprise in the existing GitHub OAuth integration.
 
 ### Other
 

--- a/server/server.go
+++ b/server/server.go
@@ -80,6 +80,7 @@ type Server struct {
 	GithubClientID     string   `short:"i" long:"github-client-id" description:"Github Client ID for OAuth 2 support" env:"GH_CLIENT_ID"`
 	GithubClientSecret string   `short:"s" long:"github-client-secret" description:"Github Client Secret for OAuth 2 support" env:"GH_CLIENT_SECRET"`
 	GithubOrgs         []string `short:"o" long:"github-organization" description:"Github organization user is required to have active membership" env:"GH_ORGS" env-delim:","`
+	GithubURL          string   `long:"github-url" description:"Github base URL must be specified for Github Enterprise." default:"https://github.com" env:"GH_URL"`
 
 	EtcdEndpoints      []string       `short:"e" long:"etcd-endpoints" description:"List of etcd endpoints" env:"ETCD_ENDPOINTS" env-delim:","`
 	EtcdUsername       string         `long:"etcd-username" description:"Username to log into etcd." env:"ETCD_USERNAME"`
@@ -334,6 +335,7 @@ func (s *Server) githubOAuth(logger chronograf.Logger, auth oauth2.Authenticator
 		ClientID:     s.GithubClientID,
 		ClientSecret: s.GithubClientSecret,
 		Orgs:         s.GithubOrgs,
+		BaseURL:      s.GithubURL,
 		Logger:       logger,
 	}
 	jwt := oauth2.NewJWT(s.TokenSecret, s.JwksURL)


### PR DESCRIPTION
Closes #5483

_Briefly describe your proposed changes:_
This PR allows configuring `github` base URL using `GH_URL` environment variable or `--github-url` flag for chronograf cli. Users can then setup OAuth with github enterprise servers that have different URL (for example `https://github.domain.io`)

_What was the problem?_
OAuth integrations with github always use `https://github.com` base URL.
_What was the solution?_
Users can specify custom github URL.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
