### PR TITLE
fix(ui): filter out roles with unknown organization reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 1. [#5708](https://github.com/influxdata/chronograf/pull/5708): Improve detection of server type in Connection Wizard.
 1. [#5711](https://github.com/influxdata/chronograf/pull/5711): Add error handling to Alert History page.
 1. [#5716](https://github.com/influxdata/chronograf/pull/5716): Do not fetch tag values when no measurement tags are available.
-
+1. [#5722](https://github.com/influxdata/chronograf/pull/5722): Filter out roles with unknown organization reference.
 ### Other
 
 1. [#5685](https://github.com/influxdata/chronograf/pull/5685): Upgrade UI to TypeScript 4.2.2.

--- a/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
+++ b/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
@@ -132,10 +132,12 @@ export default class AllUsersTableRow extends Component<Props> {
   }
 
   private get userOrganizationTags() {
-    return this.userRoles.map((role: Role) => ({
-      ...role,
-      name: this.findOrganizationByRole(role).name,
-    }))
+    return this.userRoles
+      .map((role: Role) => ({
+        ...role,
+        name: this.findOrganizationByRole(role)?.name,
+      }))
+      .filter(x => x.name !== undefined)
   }
 
   private findOrganizationByRole(role: Role): Organization | null {

--- a/ui/src/admin/components/chronograf/UsersTableRow.tsx
+++ b/ui/src/admin/components/chronograf/UsersTableRow.tsx
@@ -48,7 +48,7 @@ class UsersTableRow extends PureComponent<Props> {
           <span className="chronograf-user--role">
             <Dropdown
               items={this.rolesDropdownItems}
-              selected={this.currentRole.name}
+              selected={this.currentRole?.name}
               onChoose={onChangeUserRole(user, this.currentRole)}
               buttonColor="btn-primary"
               buttonSize="btn-xs"


### PR DESCRIPTION
Closes #5720 

_Briefly describe your proposed changes:_
Chronograf user roles might reference an organization that was already deleted. The UI then fails to render `All Users` page of chronograf administration UI. This PR ensures that roles that reference an unknown organization (already deleted) are simply ignored in UI.

Additionally, a user update removes all existing user roles that reference an unknown organization.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
