### PR TITLE
fix(server): detect actual flux support in flux proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 1. [#5711](https://github.com/influxdata/chronograf/pull/5711): Add error handling to Alert History page.
 1. [#5716](https://github.com/influxdata/chronograf/pull/5716): Do not fetch tag values when no measurement tags are available.
 1. [#5722](https://github.com/influxdata/chronograf/pull/5722): Filter out roles with unknown organization reference.
+1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Enforce detection of flux when InfluxDB is passed via CLI.
+
 ### Other
 
 1. [#5685](https://github.com/influxdata/chronograf/pull/5685): Upgrade UI to TypeScript 4.2.2.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@
 1. [#5711](https://github.com/influxdata/chronograf/pull/5711): Add error handling to Alert History page.
 1. [#5716](https://github.com/influxdata/chronograf/pull/5716): Do not fetch tag values when no measurement tags are available.
 1. [#5722](https://github.com/influxdata/chronograf/pull/5722): Filter out roles with unknown organization reference.
-1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Enforce detection of flux when InfluxDB is passed via CLI.
+1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Detect actual flux support in flux proxy.
 
 ### Other
 

--- a/server/builders.go
+++ b/server/builders.go
@@ -138,6 +138,7 @@ func (fs *MultiSourceBuilder) Build(db chronograf.SourcesStore) (*multistore.Sou
 				Password: fs.InfluxDBPassword,
 				URL:      fs.InfluxDBURL,
 				Default:  true,
+				Version:  "unknown", // required in order to enforce detection of flux support, empty Version would imply OSS 2.x, see #5723
 			}}
 		stores = append([]chronograf.SourcesStore{influxStore}, stores...)
 	}

--- a/server/builders.go
+++ b/server/builders.go
@@ -138,7 +138,7 @@ func (fs *MultiSourceBuilder) Build(db chronograf.SourcesStore) (*multistore.Sou
 				Password: fs.InfluxDBPassword,
 				URL:      fs.InfluxDBURL,
 				Default:  true,
-				Version:  "unknown", // required in order to enforce detection of flux support, empty Version would imply OSS 2.x, see #5723
+				Version:  "unknown", // a real version is re-fetched at runtime; use "unknown" version as a fallback, empty version would imply OSS 2.x
 			}}
 		stores = append([]chronograf.SourcesStore{influxStore}, stores...)
 	}

--- a/server/flux.go
+++ b/server/flux.go
@@ -46,7 +46,7 @@ func (s *Service) Flux(w http.ResponseWriter, r *http.Request) {
 	httpAPIFlux := "/chronograf/v1/flux"
 	res := fluxResponse{
 		Links: fluxLinks{
-			Self:        fmt.Sprintf("%s", httpAPIFlux),
+			Self:        httpAPIFlux,
 			Suggestions: fmt.Sprintf("%s/suggestions", httpAPIFlux),
 		},
 	}

--- a/server/flux.go
+++ b/server/flux.go
@@ -137,7 +137,8 @@ func (s *Service) ProxyFlux(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	path := r.URL.Query().Get("path")
+	query := r.URL.Query()
+	path := query.Get("path")
 	if path == "" {
 		Error(w, http.StatusUnprocessableEntity, "path query parameter required", s.Logger)
 		return
@@ -148,6 +149,12 @@ func (s *Service) ProxyFlux(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		notFound(w, id, s.Logger)
 		return
+	}
+	version := query.Get("version")
+	if version != "" {
+		// the client knows the actual version of the source, the sources
+		// return from the server always go live to re-fetch their versions
+		src.Version = version
 	}
 
 	fluxEnabled, err := hasFlux(ctx, src)

--- a/ui/src/shared/apis/flux/query.ts
+++ b/ui/src/shared/apis/flux/query.ts
@@ -127,7 +127,7 @@ export const executeQuery = async (
   xhr.onerror = reject
 
   const path = encodeURIComponent(`/api/v2/query?organization=defaultorgname`)
-  const url = `${window.basepath}${source.links.flux}?path=${path}`
+  const url = `${window.basepath}${source.links.flux}?version=${source.version}&path=${path}`
   const dialect = {annotations: ['group', 'datatype', 'default']}
   const body = JSON.stringify({query, dialect})
 


### PR DESCRIPTION
Closes #5723

_Briefly describe your proposed changes:_
* the server's flux proxy accepts an actual version of the InfluxDB source that client knows from the `sources` response that always re-fetches server versions
* a server passed on CLI has an `unknown` version to explicitly inform that we don't know the version, the actual version is detected during runtime (if the InfluxDB is running), 

_What was the problem?_
The UI detects flux support from its server's `sources` response, it uses the persisted servers and updates their versions using live "pings" to know they actual versions. The flux proxy uses only the persisted version (the version from the last create/update) to know whether flux is supported.

_What was the solution?_
The actual source version is passed to Flux proxy, so it can then properly detect whether Flux is supported based on the actual version that is known to the client.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
