### PR TITLE
feat: allow to add custom auto refresh intervals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 1. [#5713](https://github.com/influxdata/chronograf/pull/5713): Support GitHub Enterprise in the existing GitHub OAuth integration.
 1. [#5728](https://github.com/influxdata/chronograf/pull/5728): Improve InfluxDB Admin | Queries page.
 1. [#5726](https://github.com/influxdata/chronograf/pull/5726): Allow to setup InfluxDB v2 connection from chronograf command-line.
+1. [#5735](https://github.com/influxdata/chronograf/pull/5735): Allow to add custom auto-refresh intervals.
 
 ### Bug Fixes
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -962,6 +962,7 @@ type BuildStore interface {
 type Environment struct {
 	TelegrafSystemInterval time.Duration `json:"telegrafSystemInterval"`
 	HostPageDisabled       bool          `json:"HostPageDisabled"`
+	CustomAutoRefresh      string        `json:"customAutoRefresh,omitempty"`
 }
 
 // KVClient defines what each kv store should be capable of.

--- a/server/env.go
+++ b/server/env.go
@@ -10,6 +10,7 @@ type envResponse struct {
 	Links                  selfLinks `json:"links"`
 	TelegrafSystemInterval string    `json:"telegrafSystemInterval"`
 	HostPageDisabled       bool      `json:"hostPageDisabled"`
+	CustomAutoRefresh      string    `json:"customAutoRefresh,omitempty"`
 }
 
 func newEnvResponse(env chronograf.Environment) *envResponse {
@@ -19,6 +20,7 @@ func newEnvResponse(env chronograf.Environment) *envResponse {
 		},
 		TelegrafSystemInterval: env.TelegrafSystemInterval.String(),
 		HostPageDisabled:       env.HostPageDisabled,
+		CustomAutoRefresh:      env.CustomAutoRefresh,
 	}
 }
 

--- a/server/env_test.go
+++ b/server/env_test.go
@@ -38,6 +38,20 @@ func TestEnvironment(t *testing.T) {
 				body:        `{"links":{"self":"/chronograf/v1/env"},"telegrafSystemInterval":"1m0s","hostPageDisabled":false}`,
 			},
 		},
+		{
+			name: "Get environment with CustomAutoRefresh",
+			fields: fields{
+				Environment: chronograf.Environment{
+					TelegrafSystemInterval: 2 * time.Minute,
+					CustomAutoRefresh:      "500ms=500",
+				},
+			},
+			wants: wants{
+				statusCode:  200,
+				contentType: "application/json",
+				body:        `{"links":{"self":"/chronograf/v1/env"},"telegrafSystemInterval":"2m0s","hostPageDisabled":false,"customAutoRefresh": "500ms=500"}`,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/server.go
+++ b/server/server.go
@@ -133,7 +133,7 @@ type Server struct {
 
 	HostPageDisabled  bool   `short:"H" long:"host-page-disabled" description:"Disable the host list page" env:"HOST_PAGE_DISABLED"`
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
-	CustomAutoRefresh string `long:"custom-auto-refresh" description:"Adds custom auto refresh options using comma-separated label=milliseconds pairs" env:"CUSTOM_AUTO_REFRESH"`
+	CustomAutoRefresh string `long:"custom-auto-refresh" description:"Adds custom auto refresh options using semicolon separated list of label=milliseconds pairs" env:"CUSTOM_AUTO_REFRESH"`
 	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
 	Basepath          string `short:"p" long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted. (Note: PREFIX_ROUTES has been deprecated. Now, if basepath is set, all routes will be prefixed with it.)" env:"BASE_PATH"`
 	ShowVersion       bool   `short:"v" long:"version" description:"Show Chronograf version info"`

--- a/server/server.go
+++ b/server/server.go
@@ -133,6 +133,7 @@ type Server struct {
 
 	HostPageDisabled  bool   `short:"H" long:"host-page-disabled" description:"Disable the host list page" env:"HOST_PAGE_DISABLED"`
 	ReportingDisabled bool   `short:"r" long:"reporting-disabled" description:"Disable reporting of usage stats (os,arch,version,cluster_id,uptime) once every 24hr" env:"REPORTING_DISABLED"`
+	CustomAutoRefresh string `long:"custom-auto-refresh" description:"Adds custom auto refresh options using comma-separated label=milliseconds pairs" env:"CUSTOM_AUTO_REFRESH"`
 	LogLevel          string `short:"l" long:"log-level" value-name:"choice" choice:"debug" choice:"info" choice:"error" default:"info" description:"Set the logging level" env:"LOG_LEVEL"`
 	Basepath          string `short:"p" long:"basepath" description:"A URL path prefix under which all chronograf routes will be mounted. (Note: PREFIX_ROUTES has been deprecated. Now, if basepath is set, all routes will be prefixed with it.)" env:"BASE_PATH"`
 	ShowVersion       bool   `short:"v" long:"version" description:"Show Chronograf version info"`
@@ -665,6 +666,7 @@ func (s *Server) Serve(ctx context.Context) {
 	service.Env = chronograf.Environment{
 		TelegrafSystemInterval: s.TelegrafSystemInterval,
 		HostPageDisabled:       s.HostPageDisabled,
+		CustomAutoRefresh:      s.CustomAutoRefresh,
 	}
 
 	if !validBasepath(s.Basepath) {

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -42,7 +42,8 @@ import {interval, DASHBOARD_LAYOUT_ROW_HEIGHT} from 'src/shared/constants'
 import {FORMAT_INFLUXQL} from 'src/shared/data/timeRanges'
 import {EMPTY_LINKS} from 'src/dashboards/constants/dashboardHeader'
 import {getNewDashboardCell} from 'src/dashboards/utils/cellGetters'
-import autoRefreshOptions, {
+import {
+  getAutoRefreshOptions,
   AutoRefreshOption,
 } from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
 
@@ -149,6 +150,7 @@ class DashboardPage extends Component<Props, State> {
     let pollRefreshRate = refreshRate
     let localStorageRefresh
 
+    const autoRefreshOptions = getAutoRefreshOptions()
     if (urlSelectedRefresh) {
       const option = autoRefreshOptions.find(
         r => r.label.toLowerCase() === urlSelectedRefresh[1].toLowerCase()
@@ -202,7 +204,7 @@ class DashboardPage extends Component<Props, State> {
 
     const prevPath = getDeep(prevProps.location, 'pathname', null)
     const thisPath = getDeep(this.props.location, 'pathname', null)
-    const localStorageRefresh = autoRefreshOptions.find(
+    const localStorageRefresh = getAutoRefreshOptions().find(
       r => r.milliseconds === refreshRate
     )
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -55,6 +55,7 @@ import 'src/style/chronograf.scss'
 import {HEARTBEAT_INTERVAL} from 'src/shared/constants'
 
 import * as ErrorsModels from 'src/types/errors'
+import {setCustomAutoRefreshOptions} from './shared/components/dropdown_auto_refresh/autoRefreshOptions'
 
 const errorsQueue = []
 
@@ -103,6 +104,7 @@ const populateEnv = async url => {
   try {
     const envVars = await getEnv(url)
     dispatch(setHostPageDisplayStatus(envVars.hostPageDisabled))
+    setCustomAutoRefreshOptions(envVars.customAutoRefresh)
   } catch (error) {
     console.error('Error fetching envVars', error)
   }

--- a/ui/src/shared/apis/env.ts
+++ b/ui/src/shared/apis/env.ts
@@ -3,6 +3,7 @@ import AJAX from 'src/utils/ajax'
 const DEFAULT_ENVS = {
   telegrafSystemInterval: '1m',
   hostPageDisabled: false,
+  customAutoRefresh: undefined,
 }
 
 export const getEnv = async url => {

--- a/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
+++ b/ui/src/shared/components/dropdown_auto_refresh/AutoRefreshDropdown.tsx
@@ -6,7 +6,8 @@ import classnames from 'classnames'
 import {Dropdown, Button, ButtonShape, IconFont} from 'src/reusable_ui'
 
 // Constants
-import autoRefreshOptions, {
+import {
+  getAutoRefreshOptions,
   AutoRefreshOption,
   AutoRefreshOptionType,
 } from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
@@ -43,7 +44,7 @@ class AutoRefreshDropdown extends Component<Props> {
           onChange={this.handleDropdownChange}
           selectedID={this.selectedID}
         >
-          {autoRefreshOptions.map(option => {
+          {getAutoRefreshOptions().map(option => {
             if (option.type === AutoRefreshOptionType.Header) {
               return (
                 <Dropdown.Divider
@@ -101,7 +102,7 @@ class AutoRefreshDropdown extends Component<Props> {
 
   private get selectedID(): string {
     const {selected} = this.props
-    const selectedOption = autoRefreshOptions.find(
+    const selectedOption = getAutoRefreshOptions().find(
       option => option.milliseconds === selected
     )
 

--- a/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
+++ b/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
@@ -17,7 +17,7 @@ export const autoRefreshOptionPaused: AutoRefreshOption = {
   type: AutoRefreshOptionType.Option,
 }
 
-const autoRefreshOptions: AutoRefreshOption[] = [
+let autoRefreshOptions: AutoRefreshOption[] = [
   {
     id: 'auto-refresh-header',
     milliseconds: 9999,
@@ -57,4 +57,44 @@ const autoRefreshOptions: AutoRefreshOption[] = [
   },
 ]
 
-export default autoRefreshOptions
+/** setCustomAutoRefreshOptions allows to set custom auto-refresh options */
+export function setCustomAutoRefreshOptions(customSpec: string | undefined) {
+  if (!customSpec) {
+    return
+  }
+  // 1st filter all custom options
+  autoRefreshOptions = autoRefreshOptions.filter(x => x.id.startsWith('custom'))
+  const [header, paused, ...other] = autoRefreshOptions
+  const customOptions: AutoRefreshOption[] = customSpec
+    .split(',')
+    .reduce((acc, singleSpec) => {
+      try {
+        const [a, b] = singleSpec.split['=']
+        const label = a.trim()
+        const milliseconds = parseInt(b, 10)
+        acc.push({
+          id: `custom-refresh-${label}`,
+          milliseconds,
+          label,
+          type: AutoRefreshOptionType.Option,
+        })
+      } catch (e) {
+        console.warn(
+          'Unable to parse custom autoRefreshOption, it should have format `label=milliseconds`',
+          e
+        )
+      }
+      return acc
+    }, [] as AutoRefreshOption[])
+  return [
+    header,
+    paused,
+    [...other, ...customOptions].sort(
+      (a, b) => a.milliseconds - b.milliseconds
+    ),
+  ]
+}
+
+export function getAutoRefreshOptions(): AutoRefreshOption[] {
+  return autoRefreshOptions
+}

--- a/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
+++ b/ui/src/shared/components/dropdown_auto_refresh/autoRefreshOptions.ts
@@ -65,7 +65,7 @@ export function setCustomAutoRefreshOptions(customSpec: string | undefined) {
   }
   const [header, paused, ...otherDefault] = defaultAutoRefreshOptions
   const customOptions: AutoRefreshOption[] = customSpec
-    .split(',')
+    .split(';')
     .reduce((acc, singleSpec) => {
       if (!singleSpec) {
         return acc // ignore empty values

--- a/ui/test/shared/components/dropdown_auto_refresh/autoRefreshOptions.test.ts
+++ b/ui/test/shared/components/dropdown_auto_refresh/autoRefreshOptions.test.ts
@@ -1,0 +1,197 @@
+import {
+  autoRefreshOptionPaused,
+  AutoRefreshOptionType,
+  getAutoRefreshOptions,
+  setCustomAutoRefreshOptions,
+} from 'src/shared/components/dropdown_auto_refresh/autoRefreshOptions'
+
+describe('setCustomAutoRefreshOptions', () => {
+  beforeEach(() => {
+    // remove all custom refresh options
+    setCustomAutoRefreshOptions('')
+  })
+  it('returns unchanged auto-refresh options withou customization', () => {
+    const previousOpts = [...getAutoRefreshOptions()]
+    setCustomAutoRefreshOptions(undefined)
+    const newOpts = [...getAutoRefreshOptions()]
+
+    expect(newOpts).toEqual(previousOpts)
+  })
+  it('returns sorted auto-refresh options with single customization', () => {
+    setCustomAutoRefreshOptions('12s=12000')
+    const newOpts = getAutoRefreshOptions()
+    expect(newOpts).toEqual([
+      {
+        id: 'auto-refresh-header',
+        milliseconds: 9999,
+        label: 'Refresh',
+        type: AutoRefreshOptionType.Header,
+      },
+      autoRefreshOptionPaused,
+      {
+        id: 'auto-refresh-5s',
+        milliseconds: 5000,
+        label: '5s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-10s',
+        milliseconds: 10000,
+        label: '10s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'custom-refresh-12s',
+        milliseconds: 12000,
+        label: '12s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-15s',
+        milliseconds: 15000,
+        label: '15s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-30s',
+        milliseconds: 30000,
+        label: '30s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-60s',
+        milliseconds: 60000,
+        label: '60s',
+        type: AutoRefreshOptionType.Option,
+      },
+    ])
+  })
+  it('returns sorted auto-refresh options with more customizations', () => {
+    setCustomAutoRefreshOptions('500ms=500,12s=12000,5m=300000')
+    const newOpts = getAutoRefreshOptions()
+    expect(newOpts).toEqual([
+      {
+        id: 'auto-refresh-header',
+        milliseconds: 9999,
+        label: 'Refresh',
+        type: AutoRefreshOptionType.Header,
+      },
+      autoRefreshOptionPaused,
+      {
+        id: 'custom-refresh-500ms',
+        milliseconds: 500,
+        label: '500ms',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-5s',
+        milliseconds: 5000,
+        label: '5s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-10s',
+        milliseconds: 10000,
+        label: '10s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'custom-refresh-12s',
+        milliseconds: 12000,
+        label: '12s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-15s',
+        milliseconds: 15000,
+        label: '15s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-30s',
+        milliseconds: 30000,
+        label: '30s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'auto-refresh-60s',
+        milliseconds: 60000,
+        label: '60s',
+        type: AutoRefreshOptionType.Option,
+      },
+      {
+        id: 'custom-refresh-5m',
+        milliseconds: 300000,
+        label: '5m',
+        type: AutoRefreshOptionType.Option,
+      },
+    ])
+  })
+  it('ignores empty or invalid customization parts', () => {
+    let warnings = 0
+    const origConsoleWarn = console.warn
+    console.warn = () => (warnings += 1)
+    try {
+      setCustomAutoRefreshOptions(' 12s=12000, ,a=, b=10')
+      const newOpts = getAutoRefreshOptions()
+      expect(warnings).toBe(3) // '','a=','b=10'
+      expect(newOpts).toEqual([
+        {
+          id: 'auto-refresh-header',
+          milliseconds: 9999,
+          label: 'Refresh',
+          type: AutoRefreshOptionType.Header,
+        },
+        autoRefreshOptionPaused,
+        {
+          id: 'auto-refresh-5s',
+          milliseconds: 5000,
+          label: '5s',
+          type: AutoRefreshOptionType.Option,
+        },
+        {
+          id: 'auto-refresh-10s',
+          milliseconds: 10000,
+          label: '10s',
+          type: AutoRefreshOptionType.Option,
+        },
+        {
+          id: 'custom-refresh-12s',
+          milliseconds: 12000,
+          label: '12s',
+          type: AutoRefreshOptionType.Option,
+        },
+        {
+          id: 'auto-refresh-15s',
+          milliseconds: 15000,
+          label: '15s',
+          type: AutoRefreshOptionType.Option,
+        },
+        {
+          id: 'auto-refresh-30s',
+          milliseconds: 30000,
+          label: '30s',
+          type: AutoRefreshOptionType.Option,
+        },
+        {
+          id: 'auto-refresh-60s',
+          milliseconds: 60000,
+          label: '60s',
+          type: AutoRefreshOptionType.Option,
+        },
+      ])
+    } finally {
+      console.warn(origConsoleWarn)
+    }
+  })
+  it('removes all custom auto refresh intervals with empty spec', () => {
+    // setting empty spec reset customizations
+    const origSize = getAutoRefreshOptions().length
+    setCustomAutoRefreshOptions('12s=12000,5m=300000')
+    const opts1 = getAutoRefreshOptions()
+    expect(opts1.length).toBe(origSize + 2)
+    setCustomAutoRefreshOptions('')
+    const opts2 = getAutoRefreshOptions()
+    expect(opts2.length).toBe(origSize)
+  })
+})

--- a/ui/test/shared/components/dropdown_auto_refresh/autoRefreshOptions.test.ts
+++ b/ui/test/shared/components/dropdown_auto_refresh/autoRefreshOptions.test.ts
@@ -67,7 +67,7 @@ describe('setCustomAutoRefreshOptions', () => {
     ])
   })
   it('returns sorted auto-refresh options with more customizations', () => {
-    setCustomAutoRefreshOptions('500ms=500,12s=12000,5m=300000')
+    setCustomAutoRefreshOptions('500ms=500;12s=12000;5m=300000')
     const newOpts = getAutoRefreshOptions()
     expect(newOpts).toEqual([
       {
@@ -132,9 +132,9 @@ describe('setCustomAutoRefreshOptions', () => {
     const origConsoleWarn = console.warn
     console.warn = () => (warnings += 1)
     try {
-      setCustomAutoRefreshOptions(' 12s=12000, ,a=, b=10')
+      setCustomAutoRefreshOptions(' 12s=12000;; ;a=; b=10')
       const newOpts = getAutoRefreshOptions()
-      expect(warnings).toBe(3) // '','a=','b=10'
+      expect(warnings).toBe(3) // ' ','a=','b=10'
       expect(newOpts).toEqual([
         {
           id: 'auto-refresh-header',
@@ -187,7 +187,7 @@ describe('setCustomAutoRefreshOptions', () => {
   it('removes all custom auto refresh intervals with empty spec', () => {
     // setting empty spec reset customizations
     const origSize = getAutoRefreshOptions().length
-    setCustomAutoRefreshOptions('12s=12000,5m=300000')
+    setCustomAutoRefreshOptions('12s=12000;5m=300000')
     const opts1 = getAutoRefreshOptions()
     expect(opts1.length).toBe(origSize + 2)
     setCustomAutoRefreshOptions('')


### PR DESCRIPTION
Closes #5734

_Briefly describe your proposed changes:_
Chronograf can be started with custom auto-refresh intervals, which are merged into the default auto-refresh intervals (in a time-sorted order)

```
	CustomAutoRefresh string `long:"custom-auto-refresh" description:"Adds custom auto refresh options using semicolon separated list of label=milliseconds pairs" env:"CUSTOM_AUTO_REFRESH"`
```

Examples`:
```bash
export CUSTOM_AUTO_REFRESH="500ms=500;1s=1000"
./chronograf 
``` 
```bash
export CUSTOM_AUTO_REFRESH="500ms=500;1s=1000"
./chronograf --custom-auto-refresh "500ms=500;1s=1000"
``` 

both extends auto-refresh interval options in Dashboards and Data Explorer:
![image](https://user-images.githubusercontent.com/16321466/115347972-59562300-a1b2-11eb-809c-b32926fdecb1.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
