### PR TITLE
feat(ui): allow to send multiple queries to dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 1. [#5728](https://github.com/influxdata/chronograf/pull/5728): Improve InfluxDB Admin | Queries page.
 1. [#5726](https://github.com/influxdata/chronograf/pull/5726): Allow to setup InfluxDB v2 connection from chronograf command-line.
 1. [#5735](https://github.com/influxdata/chronograf/pull/5735): Allow to add custom auto-refresh intervals.
+1. [#5737](https://github.com/influxdata/chronograf/pull/5737): Allow to send multiple queries to dashboard.
 
 ### Bug Fixes
 

--- a/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
+++ b/ui/src/data_explorer/components/SendToDashboardOverlay.tsx
@@ -320,7 +320,7 @@ class SendToDashboardOverlay extends PureComponent<Props, State> {
 
     const isFluxQuery = queryType === QueryType.Flux
 
-    let newCellQueries
+    let newCellQueries: CellQuery[]
 
     if (isFluxQuery) {
       newCellQueries = [

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -114,6 +114,7 @@ interface State {
   isSendToDashboardVisible: boolean
   isStaticLegend: boolean
   isComponentMounted: boolean
+  activeQueryIndex: number
 }
 
 @ErrorHandling
@@ -126,6 +127,7 @@ export class DataExplorer extends PureComponent<Props, State> {
       isSendToDashboardVisible: false,
       isStaticLegend: false,
       isComponentMounted: false,
+      activeQueryIndex: 0,
     }
 
     props.onResetTimeMachine()
@@ -199,6 +201,7 @@ export class DataExplorer extends PureComponent<Props, State> {
             updateSourceLink={updateSourceLink}
             onResetFocus={this.handleResetFocus}
             onToggleStaticLegend={this.handleToggleStaticLegend}
+            onActiveQueryIndexChange={this.onActiveQueryIndexChange}
             refresh={autoRefresh}
           >
             {(activeEditorTab, onSetActiveEditorTab) => (
@@ -407,8 +410,14 @@ export class DataExplorer extends PureComponent<Props, State> {
 
   private get activeQueryConfig(): QueryConfig {
     const {queryDrafts} = this.props
-
-    return _.get(queryDrafts, '0.queryConfig')
+    if (queryDrafts === undefined || queryDrafts.length === 0) {
+      return undefined
+    }
+    const {activeQueryIndex} = this.state
+    if (activeQueryIndex < queryDrafts.length) {
+      return queryDrafts[activeQueryIndex].queryConfig
+    }
+    return queryDrafts[0].queryConfig
   }
 
   private get rawText(): string {
@@ -429,6 +438,10 @@ export class DataExplorer extends PureComponent<Props, State> {
 
   private handleToggleStaticLegend = (isStaticLegend: boolean): void => {
     this.setState({isStaticLegend})
+  }
+
+  private onActiveQueryIndexChange = (activeQueryIndex: number): void => {
+    this.setState({activeQueryIndex})
   }
 
   private handleResetFocus = () => {

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -11,7 +11,6 @@ import _ from 'lodash'
 import {stripPrefix} from 'src/utils/basepath'
 import {GlobalAutoRefresher} from 'src/utils/AutoRefresher'
 import {getConfig} from 'src/dashboards/utils/cellGetters'
-import {buildRawText} from 'src/utils/influxql'
 import {defaultQueryDraft} from 'src/shared/utils/timeMachine'
 import {
   TimeMachineContainer,
@@ -321,21 +320,22 @@ export class DataExplorer extends PureComponent<Props, State> {
       sendDashboardCell,
       handleGetDashboards,
       notify,
-      draftScript,
     } = this.props
 
-    const {isSendToDashboardVisible, isStaticLegend} = this.state
+    const {
+      isSendToDashboardVisible,
+      isStaticLegend,
+      activeQueryIndex,
+    } = this.state
     return (
       <Authorized requiredRole={EDITOR_ROLE}>
         <OverlayTechnology visible={isSendToDashboardVisible}>
           <SendToDashboardOverlay
             notify={notify}
             onCancel={this.toggleSendToDashboard}
-            queryConfig={this.activeQueryConfig}
-            script={draftScript}
             source={source}
-            rawText={this.rawText}
             dashboards={dashboards}
+            activeQueryIndex={activeQueryIndex}
             handleGetDashboards={handleGetDashboards}
             sendDashboardCell={sendDashboardCell}
             isStaticLegend={isStaticLegend}
@@ -406,28 +406,6 @@ export class DataExplorer extends PureComponent<Props, State> {
 
   private get selectedDatabase(): string {
     return _.get(this.props.queryConfigs, ['0', 'database'], null)
-  }
-
-  private get activeQueryConfig(): QueryConfig {
-    const {queryDrafts} = this.props
-    if (queryDrafts === undefined || queryDrafts.length === 0) {
-      return undefined
-    }
-    const {activeQueryIndex} = this.state
-    if (activeQueryIndex < queryDrafts.length) {
-      return queryDrafts[activeQueryIndex].queryConfig
-    }
-    return queryDrafts[0].queryConfig
-  }
-
-  private get rawText(): string {
-    const {timeRange} = this.props
-
-    if (this.activeQueryConfig) {
-      return buildRawText(this.activeQueryConfig, timeRange)
-    }
-
-    return ''
   }
 
   private toggleSendToDashboard = () => {

--- a/ui/src/shared/components/TimeMachine/TimeMachine.tsx
+++ b/ui/src/shared/components/TimeMachine/TimeMachine.tsx
@@ -93,6 +93,7 @@ interface PassedProps {
   ) => JSX.Element
   queryStatus: QueryStatus
   onUpdateScriptStatus?: (status: ScriptStatus) => void
+  onActiveQueryIndexChange?: (activeQueryIndex: number) => void
   refresh: RefreshRate
 }
 
@@ -540,6 +541,10 @@ class TimeMachine extends PureComponent<Props, State> {
 
   private handleSetActiveQueryIndex = (activeQueryIndex): void => {
     this.setState({activeQueryIndex})
+    const {onActiveQueryIndexChange} = this.props
+    if (onActiveQueryIndexChange) {
+      onActiveQueryIndexChange(activeQueryIndex)
+    }
   }
 
   private handleSetActiveEditorTab = (tabName: CEOTabs): void => {


### PR DESCRIPTION
Closes #5703

_Briefly describe your proposed changes:_

1. Use query from an active tab OOTB
2. Let the user choose whether to send the active query, or all queries

![sendToDashboard](https://user-images.githubusercontent.com/16321466/115724071-e6e76d80-a380-11eb-85ba-cc237562be98.gif)

_What was the problem?_

   * only the query from the first query tab was used, without letting the user know
   * it was not clear what is exactly being sent to a dashboard

_What was the solution?_

   * active tab query is used, it is a default option
   * the user can choose whether to send only an active query or all queries

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
