### PR TITLE
feat: add Teams UI

### DIFF
--- a/kapacitor.go
+++ b/kapacitor.go
@@ -160,8 +160,6 @@ type BigPanda struct {
 // Teams properties
 type Teams struct {
 	ChannelURL string `json:"channel-url"` // override configuration
-	Team       string `json:"team"`
-	Channel    string `json:"channel"`
 }
 
 // MarshalJSON converts AlertNodes to JSON

--- a/kapacitor.go
+++ b/kapacitor.go
@@ -25,6 +25,7 @@ type AlertNodes struct {
 	Kafka              []*Kafka      `json:"kafka"`            // Kafka will send alert to all Kafka
 	ServiceNow         []*ServiceNow `json:"serviceNow"`       // ServiceNow alert options
 	BigPanda           []*BigPanda   `json:"bigPanda"`         // BigPanda alert options
+	Teams              []*Teams      `json:"teams"`            // Teams alert options
 }
 
 // Post will POST alerts to a destination URL
@@ -154,6 +155,13 @@ type BigPanda struct {
 	AppKey            string `json:"app-key"`
 	PrimaryProperty   string `json:"primary-property"`
 	SecondaryProperty string `json:"secondary-property"`
+}
+
+// Teams properties
+type Teams struct {
+	ChannelURL string `json:"channel-url"` // override configuration
+	Team       string `json:"team"`
+	Channel    string `json:"channel"`
 }
 
 // MarshalJSON converts AlertNodes to JSON

--- a/kapacitor/alerts_test.go
+++ b/kapacitor/alerts_test.go
@@ -186,7 +186,7 @@ func TestAlertServices(t *testing.T) {
 		},
 		{
 			name: "Test Teams",
-			skip: "Parsing is not implemented yet in the kapactior pipeline!",
+			skip: "Parsing is not implemented properly in the kapacitor, fixed by https://github.com/influxdata/kapacitor/pull/2542!",
 			rule: chronograf.AlertRule{
 				AlertNodes: chronograf.AlertNodes{
 					Teams: []*chronograf.Teams{{

--- a/kapacitor/alerts_test.go
+++ b/kapacitor/alerts_test.go
@@ -9,6 +9,7 @@ import (
 func TestAlertServices(t *testing.T) {
 	tests := []struct {
 		name    string
+		skip    string
 		rule    chronograf.AlertRule
 		want    chronograf.TICKScript
 		wantErr bool
@@ -183,9 +184,31 @@ func TestAlertServices(t *testing.T) {
         .secondaryProperty('c')
 `,
 		},
+		{
+			name: "Test Teams",
+			skip: "Parsing is not implemented yet in the kapactior pipeline!",
+			rule: chronograf.AlertRule{
+				AlertNodes: chronograf.AlertNodes{
+					Teams: []*chronograf.Teams{{
+						Team:       "teams.microsoft.com/team/",
+						Channel:    "#channel",
+						ChannelURL: "https://outlook.office.com/webhook/...",
+					}},
+				},
+			},
+			want: `alert()
+        .teams()
+        .channelURL('https://outlook.office.com/webhook/...')
+        .team('teams.microsoft.com/team/')
+        .channel('#channel')
+`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.skip != "" {
+				t.Skip(tt.skip)
+			}
 			got, err := AlertServices(tt.rule)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("%q. AlertServices() error = %v, wantErr %v", tt.name, err, tt.wantErr)

--- a/kapacitor/alerts_test.go
+++ b/kapacitor/alerts_test.go
@@ -190,8 +190,6 @@ func TestAlertServices(t *testing.T) {
 			rule: chronograf.AlertRule{
 				AlertNodes: chronograf.AlertNodes{
 					Teams: []*chronograf.Teams{{
-						Team:       "teams.microsoft.com/team/",
-						Channel:    "#channel",
 						ChannelURL: "https://outlook.office.com/webhook/...",
 					}},
 				},
@@ -199,8 +197,6 @@ func TestAlertServices(t *testing.T) {
 			want: `alert()
         .teams()
         .channelURL('https://outlook.office.com/webhook/...')
-        .team('teams.microsoft.com/team/')
-        .channel('#channel')
 `,
 		},
 	}

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -4518,7 +4518,8 @@
               "telegram",
               "tcp",
               "serviceNow",
-              "bigPanda"
+              "bigPanda",
+              "teams"
             ]
           }
         },

--- a/ui/src/kapacitor/components/AlertTabs.tsx
+++ b/ui/src/kapacitor/components/AlertTabs.tsx
@@ -34,6 +34,7 @@ import {
   KafkaConfigs,
   ServiceNowConfig,
   BigPandaConfig,
+  TeamsConfig,
 } from './config'
 
 import {
@@ -93,6 +94,8 @@ interface Sections {
   talk: Section
   telegram: Section
   victorops: Section
+  bipanda: Section
+  teams: Section
 }
 
 interface Props {
@@ -403,6 +406,15 @@ class AlertTabs extends PureComponent<Props, State> {
             config={this.getSectionElement(configSections, AlertTypes.bigpanda)}
             onTest={this.handleTestConfig(AlertTypes.bigpanda)}
             enabled={this.getConfigEnabled(configSections, AlertTypes.bigpanda)}
+          />
+        )
+      case AlertTypes.teams:
+        return (
+          <TeamsConfig
+            onSave={this.handleSaveConfig(AlertTypes.teams)}
+            config={this.getSectionElement(configSections, AlertTypes.teams)}
+            onTest={this.handleTestConfig(AlertTypes.teams)}
+            enabled={this.getConfigEnabled(configSections, AlertTypes.teams)}
           />
         )
     }

--- a/ui/src/kapacitor/components/HandlerOptions.js
+++ b/ui/src/kapacitor/components/HandlerOptions.js
@@ -19,6 +19,7 @@ import {
   VictoropsHandler,
   ServiceNowHandler,
   BigPandaHandler,
+  TeamsHandler,
 } from 'src/kapacitor/components/handlers'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -199,6 +200,15 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('bigpanda')}
+            validationError={validationError}
+          />
+        )
+      case 'teams':
+        return (
+          <TeamsHandler
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            onGoToConfig={onGoToConfig('teams')}
             validationError={validationError}
           />
         )

--- a/ui/src/kapacitor/components/config/TeamsConfig.tsx
+++ b/ui/src/kapacitor/components/config/TeamsConfig.tsx
@@ -1,0 +1,112 @@
+import _ from 'lodash'
+import React, {PureComponent, ChangeEvent} from 'react'
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import {TeamsProperties} from 'src/types/kapacitor'
+
+interface Config {
+  options: {
+    'channel-url': string
+  }
+}
+
+interface Props {
+  config: Config
+  onSave: (properties: TeamsProperties) => Promise<boolean>
+  onTest: (event: React.MouseEvent<HTMLButtonElement>) => void
+  enabled: boolean
+}
+
+interface State {
+  testEnabled: boolean
+  enabled: boolean
+}
+
+@ErrorHandling
+class TeamsConfig extends PureComponent<Props, State> {
+  private channelURL: HTMLInputElement
+
+  constructor(props) {
+    super(props)
+    this.state = {
+      testEnabled: this.props.enabled,
+      enabled: _.get(this.props, 'config.options.enabled', false),
+    }
+  }
+
+  public render() {
+    const {'channel-url': channelURL} = this.props.config.options
+    const {enabled} = this.state
+
+    return (
+      <form onSubmit={this.handleSubmit}>
+        <div className="form-group col-xs-12">
+          <label htmlFor="source">Channel URL</label>
+          <input
+            className="form-control"
+            id="url"
+            type="text"
+            ref={r => (this.channelURL = r)}
+            defaultValue={channelURL || ''}
+            onChange={this.disableTest}
+          />
+        </div>
+
+        <div className="form-group col-xs-12">
+          <div className="form-control-static">
+            <input
+              type="checkbox"
+              id="disabled"
+              checked={enabled}
+              onChange={this.handleEnabledChange}
+            />
+            <label htmlFor="disabled">Configuration Enabled</label>
+          </div>
+        </div>
+
+        <div className="form-group form-group-submit col-xs-12 text-center">
+          <button
+            className="btn btn-primary"
+            type="submit"
+            disabled={this.state.testEnabled}
+          >
+            <span className="icon checkmark" />
+            Save Changes
+          </button>
+          <button
+            className="btn btn-primary"
+            disabled={!this.state.testEnabled || !enabled}
+            onClick={this.props.onTest}
+          >
+            <span className="icon pulse-c" />
+            Send Test Event
+          </button>
+        </div>
+      </form>
+    )
+  }
+
+  private handleEnabledChange = (e: ChangeEvent<HTMLInputElement>) => {
+    this.setState({enabled: e.target.checked})
+    this.disableTest()
+  }
+
+  private handleSubmit = async e => {
+    e.preventDefault()
+
+    const properties: TeamsProperties = {
+      'channel-url': this.channelURL.value,
+      enabled: this.state.enabled,
+    }
+
+    const success = await this.props.onSave(properties)
+    if (success) {
+      this.setState({testEnabled: true})
+    }
+  }
+
+  private disableTest = () => {
+    this.setState({testEnabled: false})
+  }
+}
+
+export default TeamsConfig

--- a/ui/src/kapacitor/components/config/index.js
+++ b/ui/src/kapacitor/components/config/index.js
@@ -14,6 +14,7 @@ import SlackConfigs from './SlackConfigs'
 import KafkaConfigs from './KafkaConfigs'
 import ServiceNowConfig from './ServiceNowConfig'
 import BigPandaConfig from './BigPandaConfig'
+import TeamsConfig from './TeamsConfig'
 
 export {
   AlertaConfig,
@@ -32,4 +33,5 @@ export {
   KafkaConfigs,
   ServiceNowConfig,
   BigPandaConfig,
+  TeamsConfig,
 }

--- a/ui/src/kapacitor/components/handlers/TeamsHandler.js
+++ b/ui/src/kapacitor/components/handlers/TeamsHandler.js
@@ -1,0 +1,51 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import HandlerInput from 'src/kapacitor/components/HandlerInput'
+import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+const TeamsHandler = ({
+  selectedHandler,
+  handleModifyHandler,
+  onGoToConfig,
+  validationError,
+}) =>
+  selectedHandler.enabled ? (
+    <div className="endpoint-tab-contents">
+      <div className="endpoint-tab--parameters">
+        <h4 className="u-flex u-jc-space-between">
+          Parameters from Kapacitor Configuration
+          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
+            <span className="icon cog-thick" />
+            {validationError
+              ? 'Exit this Rule and Edit Configuration'
+              : 'Save this Rule and Edit Configuration'}
+          </div>
+        </h4>
+        <div className="faux-form">
+          <HandlerInput
+            selectedHandler={selectedHandler}
+            handleModifyHandler={handleModifyHandler}
+            fieldName="channel-url"
+            fieldDisplay="Channel URL:"
+            placeholder="ex: https://outlook.office.com/webhook/..."
+            fieldColumns="col-md-12"
+          />
+        </div>
+      </div>
+    </div>
+  ) : (
+    <HandlerEmpty
+      onGoToConfig={onGoToConfig}
+      validationError={validationError}
+    />
+  )
+
+const {func, shape, string} = PropTypes
+
+TeamsHandler.propTypes = {
+  selectedHandler: shape({}).isRequired,
+  handleModifyHandler: func.isRequired,
+  onGoToConfig: func.isRequired,
+  validationError: string.isRequired,
+}
+
+export default TeamsHandler

--- a/ui/src/kapacitor/components/handlers/index.js
+++ b/ui/src/kapacitor/components/handlers/index.js
@@ -16,6 +16,7 @@ import TelegramHandler from './TelegramHandler'
 import VictoropsHandler from './VictoropsHandler'
 import ServiceNowHandler from './ServiceNowHandler'
 import BigPandaHandler from './BigPandaHandler'
+import TeamsHandler from './TeamsHandler'
 
 export {
   PostHandler,
@@ -36,4 +37,5 @@ export {
   VictoropsHandler,
   ServiceNowHandler,
   BigPandaHandler,
+  TeamsHandler,
 }

--- a/ui/src/kapacitor/constants/index.ts
+++ b/ui/src/kapacitor/constants/index.ts
@@ -33,6 +33,7 @@ export enum AlertTypes {
   log = 'log',
   servicenow = 'servicenow',
   bigpanda = 'bigpanda',
+  teams = 'teams',
 }
 
 export enum AlertDisplayText {

--- a/ui/src/kapacitor/constants/index.ts
+++ b/ui/src/kapacitor/constants/index.ts
@@ -51,6 +51,7 @@ export enum AlertDisplayText {
   victorops = 'VictorOps',
   servicenow = 'ServiceNow',
   bigpanda = 'BigPanda',
+  teams = 'Teams',
 }
 
 export const SupportedServices: string[] = [
@@ -67,6 +68,7 @@ export const SupportedServices: string[] = [
   'slack',
   'smtp',
   'talk',
+  'teams',
   'telegram',
   'victorops',
 ]
@@ -215,6 +217,7 @@ export const MAP_KEYS_FROM_CONFIG: KeyMappings = {
   victorops: 'victorOps',
   servicenow: 'serviceNow',
   bigpanda: 'bigPanda',
+  teams: 'teams',
 }
 
 // ALERTS_FROM_CONFIG the array of fields to accept from Kapacitor Config
@@ -243,6 +246,7 @@ export const ALERTS_FROM_CONFIG: FieldsFromConfigAlerts = {
   // mqtt:[]
   serviceNow: ['url', 'source', 'username', 'password'],
   bigPanda: ['app-key'],
+  teams: ['channel-url'],
 }
 
 export const MAP_FIELD_KEYS_FROM_CONFIG: ConfigKeyMaps = {
@@ -268,6 +272,7 @@ export const MAP_FIELD_KEYS_FROM_CONFIG: ConfigKeyMaps = {
   // mqtt: {}
   serviceNow: {},
   bigPanda: {},
+  teams: {},
 }
 
 // HANDLERS_TO_RULE returns array of fields that may be updated for each alert on rule.
@@ -312,4 +317,5 @@ export const HANDLERS_TO_RULE_THEM_ALL: FieldsFromAllAlerts = {
     '_type', // serviceNow type, remapped from type on the wire
   ],
   bigPanda: ['app-key', 'primary-property', 'secondary-property'],
+  teams: ['channel-url'],
 }

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -156,6 +156,11 @@ interface BigPanda {
   'secondary-property': string
 }
 
+// Teams alert options
+interface Teams {
+  'channel-url': string
+}
+
 // PagerDuty sends alerts to the pagerduty.com service
 interface PagerDuty {
   serviceKey: string
@@ -277,6 +282,7 @@ export interface KeyMappings {
   victorops: string
   servicenow: string
   bigpanda: string
+  teams: string
 }
 
 export interface FieldsFromConfigAlerts {
@@ -295,6 +301,7 @@ export interface FieldsFromConfigAlerts {
   victorOps: string[]
   serviceNow: string[]
   bigPanda: string[]
+  teams: string[]
 }
 
 export interface FieldsFromAllAlerts extends FieldsFromConfigAlerts {
@@ -442,6 +449,11 @@ export interface BigPandaProperties {
   enabled: boolean
 }
 
+export interface TeamsProperties {
+  'channel-url': string
+  enabled: boolean
+}
+
 export type ServiceProperties =
   | AlertaProperties
   | KafkaProperties
@@ -457,6 +469,7 @@ export type ServiceProperties =
   | VictorOpsProperties
   | ServiceNowProperties
   | BigPandaProperties
+  | TeamsProperties
 
 export type SpecificConfigOptions = Partial<SlackProperties & KafkaProperties>
 


### PR DESCRIPTION
Closes #5732

This PR adds 
__Teams Configuration UI__
![image](https://user-images.githubusercontent.com/16321466/109820836-aba8a800-7c35-11eb-9955-bff4918686c6.png)

__Teams Alert configuration UI__
![image](https://user-images.githubusercontent.com/16321466/109965470-4dd89680-7cef-11eb-9ad5-fdbf99ef67d8.png)


It also:
   * provides serialization/parsing of Teams alert properties from/to TICKScript (server side)
   * updates swagger

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
