### PR TITLE
feat(ui/explorer): use v2 write API with buckets when Flux tab is selected 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 1. [#5726](https://github.com/influxdata/chronograf/pull/5726): Allow to setup InfluxDB v2 connection from chronograf command-line.
 1. [#5735](https://github.com/influxdata/chronograf/pull/5735): Allow to add custom auto-refresh intervals.
 1. [#5737](https://github.com/influxdata/chronograf/pull/5737): Allow to send multiple queries to dashboard.
+1. [#5746](https://github.com/influxdata/chronograf/pull/5746): Write to buckets when Flux tab is selected.
 
 ### Bug Fixes
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -495,15 +495,15 @@ func paramID(key string, r *http.Request) (int, error) {
 	return id, nil
 }
 
-func paramInt64(key string, r *http.Request) (int64, error) {
-	ctx := r.Context()
-	param := httprouter.GetParamFromContext(ctx, key)
-	v, err := strconv.ParseInt(param, 10, 64)
-	if err != nil {
-		return -1, fmt.Errorf("Error converting parameter %s", param)
-	}
-	return v, nil
-}
+// func paramInt64(key string, r *http.Request) (int64, error) {
+// 	ctx := r.Context()
+// 	param := httprouter.GetParamFromContext(ctx, key)
+// 	v, err := strconv.ParseInt(param, 10, 64)
+// 	if err != nil {
+// 		return -1, fmt.Errorf("Error converting parameter %s", param)
+// 	}
+// 	return v, nil
+// }
 
 func paramStr(key string, r *http.Request) (string, error) {
 	ctx := r.Context()

--- a/ui/src/data_explorer/actions/view/write.ts
+++ b/ui/src/data_explorer/actions/view/write.ts
@@ -18,7 +18,11 @@ export const writeLineProtocolAsync = (
     await writeLineProtocolAJAX(source, db, data, precision)
     dispatch(notify(notifyDataWritten()))
   } catch (response) {
-    dispatch(notify(notifyDataWriteFailed(response.data.error)))
+    dispatch(
+      notify(
+        notifyDataWriteFailed(response.data?.error || response.data?.message)
+      )
+    )
     throw response
   }
 }

--- a/ui/src/data_explorer/actions/view/write.ts
+++ b/ui/src/data_explorer/actions/view/write.ts
@@ -12,10 +12,11 @@ export const writeLineProtocolAsync = (
   source: Source,
   db: string,
   data: string,
-  precision?: string
+  precision?: string,
+  v2?: boolean
 ) => async (dispatch): Promise<void> => {
   try {
-    await writeLineProtocolAJAX(source, db, data, precision)
+    await writeLineProtocolAJAX(source, db, data, precision, v2)
     dispatch(notify(notifyDataWritten()))
   } catch (response) {
     dispatch(

--- a/ui/src/data_explorer/apis/index.ts
+++ b/ui/src/data_explorer/apis/index.ts
@@ -5,10 +5,11 @@ export const writeLineProtocol = async (
   source: Source,
   db: string,
   data: string,
-  precision?: string
+  precision?: string,
+  v2?: boolean
 ): Promise<void> => {
   const url = `${source.links.write}?db=${db}&precision=${
     precision ? precision : 'ns'
-  }`
+  }${v2 ? '&v=2' : ''}`
   await AJAX({url, method: 'POST', data})
 }

--- a/ui/src/data_explorer/components/WriteDataForm.tsx
+++ b/ui/src/data_explorer/components/WriteDataForm.tsx
@@ -150,7 +150,7 @@ class WriteDataForm extends PureComponent<Props, State> {
       window.location.reload()
     } catch (error) {
       this.setState({isUploading: false})
-      console.error(error.data.error)
+      console.error(error.data)
     }
   }
 

--- a/ui/src/data_explorer/components/WriteDataForm.tsx
+++ b/ui/src/data_explorer/components/WriteDataForm.tsx
@@ -22,11 +22,13 @@ interface Props {
   selectedDatabase: string
   onClose: () => void
   errorThrown: () => void
+  useV2: boolean
   writeLineProtocol: (
     source: Source,
     database: string,
     content: string,
-    precision?: string
+    precision?: string,
+    useV2?: boolean
   ) => void
 }
 
@@ -62,7 +64,7 @@ class WriteDataForm extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {onClose, errorThrown, source} = this.props
+    const {onClose, errorThrown, source, useV2} = this.props
     const {dragClass} = this.state
 
     return (
@@ -81,6 +83,7 @@ class WriteDataForm extends PureComponent<Props, State> {
             onClose={onClose}
             errorThrown={errorThrown}
             onToggleMode={this.handleToggleMode}
+            useBuckets={useV2}
             handlePrecisionChange={this.handlePrecisionChange}
             handleSelectDatabase={this.handleSelectDatabase}
           />
@@ -119,7 +122,7 @@ class WriteDataForm extends PureComponent<Props, State> {
   }
 
   private handleSubmit = async () => {
-    const {onClose, source, writeLineProtocol} = this.props
+    const {onClose, source, writeLineProtocol, useV2} = this.props
     const {
       inputContent,
       uploadContent,
@@ -135,7 +138,13 @@ class WriteDataForm extends PureComponent<Props, State> {
     this.setState({isUploading: true})
 
     try {
-      await writeLineProtocol(source, selectedDatabase, content, precision)
+      await writeLineProtocol(
+        source,
+        selectedDatabase,
+        content,
+        precision,
+        useV2
+      )
       this.setState({isUploading: false})
       onClose()
       window.location.reload()

--- a/ui/src/data_explorer/components/WriteDataHeader.tsx
+++ b/ui/src/data_explorer/components/WriteDataHeader.tsx
@@ -15,6 +15,7 @@ interface Props {
   onClose: () => void
   mode: string
   source: Source
+  useBuckets: boolean
 }
 
 class WriteDataHeader extends PureComponent<Props> {
@@ -26,6 +27,7 @@ class WriteDataHeader extends PureComponent<Props> {
       onClose,
       source,
       precision,
+      useBuckets,
     } = this.props
 
     return (
@@ -36,6 +38,7 @@ class WriteDataHeader extends PureComponent<Props> {
             source={source}
             onSelectDatabase={handleSelectDatabase}
             database={selectedDatabase}
+            useBuckets={useBuckets}
             onErrorThrown={errorThrown}
           />
           {this.modeSelector}

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -297,7 +297,7 @@ export class DataExplorer extends PureComponent<Props, State> {
   }
 
   private get writeDataForm(): JSX.Element {
-    const {source, errorThrownAction, writeLineProtocol} = this.props
+    const {source, errorThrownAction, writeLineProtocol, queryType} = this.props
 
     const {isWriteFormVisible} = this.state
     return (
@@ -308,6 +308,7 @@ export class DataExplorer extends PureComponent<Props, State> {
           selectedDatabase={this.selectedDatabase}
           onClose={this.handleCloseWriteData}
           writeLineProtocol={writeLineProtocol}
+          useV2={queryType === 'flux'}
         />
       </OverlayTechnology>
     )

--- a/ui/src/shared/components/DatabaseDropdown.tsx
+++ b/ui/src/shared/components/DatabaseDropdown.tsx
@@ -102,7 +102,9 @@ class DatabaseDropdown extends Component<Props, State> {
         return
       }
     }
-    const nonSystemDatabases = databases.filter(name => name !== '_internal')
+    const nonSystemDatabases = databases.filter(
+      name => !name.startsWith('_internal')
+    )
 
     this.setState({
       databases: nonSystemDatabases,


### PR DESCRIPTION
Closes #5745

This PR changes the Explorer's Write Data Form to use InfluxDB v2 write API when the Explorer's Flux tab is selected. Users can still write to a database (using V1 write API) with InfluxQL tab selected. 

![writeToBuckets](https://user-images.githubusercontent.com/16321466/116963240-989f6c00-aca8-11eb-8759-1fbfa85ee662.gif)

As a consequence, this PR also allows to write data to InfluxDB v2 without the need to do V1 DBRP mappings.   

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
