### PR TITLE
chore: upgrade golang to 1.16, add macOS arm64 build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ version: 2
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20201214
+      DOCKER_TAG: chronograf-20210521
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -56,7 +56,7 @@ jobs:
 
   deploy-nightly:
     environment:
-      DOCKER_TAG: chronograf-20201214
+      DOCKER_TAG: chronograf-20210521
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -84,7 +84,7 @@ jobs:
 
   deploy-pre-release:
     environment:
-      DOCKER_TAG: chronograf-20201214
+      DOCKER_TAG: chronograf-20210521
       GO111MODULE: "ON"
     machine: true
     steps:
@@ -114,7 +114,7 @@ jobs:
 
   deploy-release:
     environment:
-      DOCKER_TAG: chronograf-20201214
+      DOCKER_TAG: chronograf-20210521
       GO111MODULE: "ON"
     machine: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 1. [#5722](https://github.com/influxdata/chronograf/pull/5722): Filter out roles with unknown organization reference.
 1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Detect actual flux support in flux proxy.
 1. [#5747](https://github.com/influxdata/chronograf/pull/5747): Manage individual execution status per query.
+1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS arm64 builds.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 1. [#5706](https://github.com/influxdata/chronograf/pull/5706): Improve communication with InfluxDB Enterprise.
 1. [#5730](https://github.com/influxdata/chronograf/pull/5730): Update license of dependencies.
 1. [#5750](https://github.com/influxdata/chronograf/pull/5750): Upgrade markdown renderer.
+1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Upgrade golang to 1.16.
 
 ### Breaking Changes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ To add a dependency via Yarn, for example, run `yarn add <dependency>` from with
 
 ## Installing Go
 
-Chronograf requires Go 1.15 or higher.
+Chronograf requires Go 1.16 or higher.
 
 ## Installing & Using Dep
 

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ docker pull chronograf:latest
 
 ### From Source
 
-* Chronograf works with go 1.15+, node 12 LTS, and yarn 1.7+.
+* Chronograf works with go 1.16+, node 12 LTS, and yarn 1.7+.
 * Chronograf requires [Kapacitor](https://github.com/influxdata/kapacitor)
   1.5.x+ to create and store alerts.
 
-1. [Install Go 1.15](https://golang.org/doc/install)
+1. [Install Go 1.16](https://golang.org/doc/install)
 1. [Install Node (version 12 LTS)](https://nodejs.org/en/about/releases/)
 1. [Install yarn](https://yarnpkg.com/docs/install)
 1. [Setup your GOPATH](https://golang.org/doc/code.html#GOPATH)

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ docker pull chronograf:latest
   1.5.x+ to create and store alerts.
 
 1. [Install Go 1.16](https://golang.org/doc/install)
-1. [Install Node (version 12 LTS)](https://nodejs.org/en/about/releases/)
+1. [Install Node (version 14 LTS)](https://nodejs.org/en/about/releases/)
 1. [Install yarn](https://yarnpkg.com/docs/install)
 1. [Setup your GOPATH](https://golang.org/doc/code.html#GOPATH)
 1. Build the Chronograf package:

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -33,7 +33,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.15.5
+ENV GO_VERSION 1.16.4
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -12,11 +12,12 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     ruby-dev \
     rpm \
     zip \
-    python-pip \
+    python3-pip \
     autoconf \
     libtool
 
-RUN pip install boto requests python-jose --upgrade
+#RUN pip install pyrsistent==0.16.1
+RUN pip3 install boto requests python-jose --upgrade
 RUN gem install fpm
 
 # Install node

--- a/etc/build.py
+++ b/etc/build.py
@@ -90,7 +90,7 @@ targets = {
 }
 
 supported_builds = {
-    'darwin': [ "amd64" ],
+    'darwin': [ "amd64" , "arm64" ],
     'windows': [ "amd64" ],
     'linux': [ "amd64", "i386", "armhf", "arm64", "armel", "static_i386", "static_amd64" ]
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/chronograf
 
-go 1.15
+go 1.16
 
 require (
 	cloud.google.com/go/bigtable v1.10.0 // indirect


### PR DESCRIPTION
This PR upgrades golang to 1.16, changes the build image to use golang 1.16 and produce also darwin-arm64 builds.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
