### PR TITLE
fix(server): load exported dashboard as a resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 1. [#5747](https://github.com/influxdata/chronograf/pull/5747): Manage individual execution status per query.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS ARM64 builds.
 1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard AS-IS in a resources directory.
+1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard in a resources directory.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,6 @@
 1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Detect actual flux support in flux proxy.
 1. [#5747](https://github.com/influxdata/chronograf/pull/5747): Manage individual execution status per query.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS ARM64 builds.
-1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard AS-IS in a resources directory.
 1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard in a resources directory.
 
 ### Other
@@ -52,7 +51,7 @@
 1. [#5730](https://github.com/influxdata/chronograf/pull/5730): Update license of dependencies.
 1. [#5750](https://github.com/influxdata/chronograf/pull/5750): Upgrade markdown renderer.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Upgrade golang to 1.16.
-1. [#5755](https://github.com/influxdata/chronograf/pull/5755): Upgrade builder to python3 to avoid python2 lts.
+1. [#5755](https://github.com/influxdata/chronograf/pull/5755): Upgrade builder to python3 to avoid python2 LTS.
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 1. [#5746](https://github.com/influxdata/chronograf/pull/5746): Write to buckets when Flux tab is selected.
 1. [#5740](https://github.com/influxdata/chronograf/pull/5740): Add Teams configuration and alert UI.
 1. [#5752](https://github.com/influxdata/chronograf/pull/5742): Add Zenoss configuration and alert UI.
+1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS arm64 builds.
 
 ### Bug Fixes
 
@@ -39,6 +40,7 @@
 1. [#5724](https://github.com/influxdata/chronograf/pull/5724): Detect actual flux support in flux proxy.
 1. [#5747](https://github.com/influxdata/chronograf/pull/5747): Manage individual execution status per query.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS ARM64 builds.
+1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard AS-IS in a resources directory.
 
 ### Other
 

--- a/filestore/dashboards.go
+++ b/filestore/dashboards.go
@@ -106,7 +106,7 @@ func (d *Dashboards) idToFile(id chronograf.DashboardID) (chronograf.Dashboard, 
 		}
 		file := path.Join(d.Dir, f.Name())
 		var dashboard chronograf.Dashboard
-		if err := load(file, &dashboard); err != nil {
+		if err := loadText(file, &dashboard); err != nil {
 			return chronograf.Dashboard{}, "", err
 		}
 		if dashboard.ID == id {

--- a/filestore/dashboards.go
+++ b/filestore/dashboards.go
@@ -64,9 +64,6 @@ func (d *Dashboards) All(ctx context.Context) ([]chronograf.Dashboard, error) {
 				}
 				dashboard = exportedDashboard.Dashboard
 			}
-			if dashboard.ID > 0 {
-				d.Logger.WithField("file", file).Info("Dashboard file should better contain negative ID to avoid clashes with a possible UI-created dashboard.")
-			}
 			dashboards = append(dashboards, dashboard)
 		}
 	}

--- a/filestore/dashboards.go
+++ b/filestore/dashboards.go
@@ -48,7 +48,7 @@ func (d *Dashboards) All(ctx context.Context) ([]chronograf.Dashboard, error) {
 		}
 		var dashboard chronograf.Dashboard
 		file := path.Join(d.Dir, file.Name())
-		if err := load(file, &dashboard); err != nil {
+		if err := loadText(file, &dashboard); err != nil {
 			d.Logger.WithField("file", file).Error("Dashboard file skipped, loading error: ", err)
 			continue // We want to load all files we can.
 		} else {
@@ -58,7 +58,7 @@ func (d *Dashboards) All(ctx context.Context) ([]chronograf.Dashboard, error) {
 				var exportedDashboard struct {
 					Dashboard chronograf.Dashboard `json:"dashboard"`
 				}
-				if err := load(file, &exportedDashboard); err != nil {
+				if err := loadText(file, &exportedDashboard); err != nil {
 					d.Logger.WithField("file", file).Error("Dashboard file skipped, loading error: ", err)
 					continue // We want to load all files we can.
 				}

--- a/filestore/dashboards_test.go
+++ b/filestore/dashboards_test.go
@@ -43,6 +43,21 @@ func TestDashboardsAll(t *testing.T) {
 		{
 			boards: []string{
 				`{
+	"meta": {"whatever": "is"},
+	"dashboard": {
+		"id": "-1",
+		"cells": [],
+		"templates": [],
+		"name": "test-wrapped-dashboard",
+		"organization": "default"
+	}
+}`,
+			},
+			err: false,
+		},
+		{
+			boards: []string{
+				`{
 	"id": "abc123",
 	"cells": [],
 	"templates": [],
@@ -75,6 +90,10 @@ func testDashboardAll(t *testing.T, i int, test dashAllTest) {
 		require.Equal(t, 0, len(dboards))
 	} else {
 		require.Equal(t, len(test.boards), len(dboards))
+		for _, b := range dboards {
+			require.NotEmpty(t, b.Name)
+			require.NotEqual(t, b.ID, 0)
+		}
 	}
 }
 

--- a/filestore/templates_test.go
+++ b/filestore/templates_test.go
@@ -51,13 +51,25 @@ func Test_templated(t *testing.T) {
 				filenames[i] = f.Name()
 				defer os.Remove(f.Name())
 			}
-			got, err := templated(tt.data, filenames...)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("templated() error = %v, wantErr %v", err, tt.wantErr)
-				return
+			{
+				got, err := templated(tt.data, filenames...)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("templated() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("templated() = %v, want %v", got, tt.want)
+				}
 			}
-			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("templated() = %v, want %v", got, tt.want)
+			{
+				got, err := textTemplated(tt.data, filenames...)
+				if (err != nil) != tt.wantErr {
+					t.Errorf("textTemplated() error = %v, wantErr %v", err, tt.wantErr)
+					return
+				}
+				if !reflect.DeepEqual(got, tt.want) {
+					t.Errorf("textTemplated() = %v, want %v", got, tt.want)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Closes #5756 #5477

_Briefly describe your proposed changes:_
   * Add ability to load dashboard of an exported data format
   * Load dashboard file as a text template (it was wrongly html, fixes #5477)
 
_What was the problem?_
   * Exported dashboard is not properly loaded as a resource on chronograf startup (#5756)
   * Dashboard is not properly loaded as a resource on chronograf startup (#5477)

_What was the solution?_
   * Support also data format of an exported dashboard. (#5756)
   * Load dashboard file as a text template (#5477)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
