### PR TITLE
chore(python3): Upgrade builder to python3 to avoid python2 lts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ version: 2
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20210521
+      DOCKER_TAG: chronograf-20210527
       GO111MODULE: "ON"
     machine: true
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 1. [#5730](https://github.com/influxdata/chronograf/pull/5730): Update license of dependencies.
 1. [#5750](https://github.com/influxdata/chronograf/pull/5750): Upgrade markdown renderer.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Upgrade golang to 1.16.
+1. [#5755](https://github.com/influxdata/chronograf/pull/5755): Upgrade builder to python3 to avoid python2 lts
 
 ### Breaking Changes
 

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     apt-transport-https \
-    python-dev \
+    python3-dev \
     wget \
     curl \
     git \
@@ -16,7 +16,6 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     autoconf \
     libtool
 
-#RUN pip install pyrsistent==0.16.1
 RUN pip3 install boto requests python-jose --upgrade
 RUN gem install fpm
 

--- a/etc/build.py
+++ b/etc/build.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python -u
+#!/usr/bin/python3 -u
 
 import sys
 import os

--- a/etc/scripts/docker/run.sh
+++ b/etc/scripts/docker/run.sh
@@ -14,7 +14,7 @@ test -z $SSH_KEY_PATH && SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 echo "Using SSH key located at: $SSH_KEY_PATH"
 
 # Default docker tag if not specified
-test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20201214"
+test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20210527"
 
 docker run \
        -e AWS_ACCESS_KEY_ID \


### PR DESCRIPTION
Closes #5755 

_Briefly describe your proposed changes:_

Upgrade build.py to use python3 at chronograf build time.

_What was the problem?_

DEPRECATION: Python 2.7 reached the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 is no longer maintained. pip 21.0 will drop support for Python 2.7 in January 2021. More details about Python 2 support in pip can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support pip 21.0 will remove support for this functionality.

_What was the solution?_

To avoid differences in the builds between circle-ci and non circle ci environments, usage of python3 seems to be a good step to achieve deterministic builds across environments.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [-] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [-] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
