### PR TITLE
feat(ui): Flux tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 1. [#5740](https://github.com/influxdata/chronograf/pull/5740): Add Teams configuration and alert UI.
 1. [#5752](https://github.com/influxdata/chronograf/pull/5742): Add Zenoss configuration and alert UI.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS arm64 builds.
+1. [#5767](https://github.com/influxdata/chronograf/pull/5767): Add Flux Tasks.
 
 ### Bug Fixes
 

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -27,6 +27,7 @@ interface Props {
   onSubmitScript: () => void
   suggestions: Suggestion[]
   onCursorChange?: (position: Position) => void
+  readOnly?: boolean
 }
 
 interface Widget extends LineWidget {
@@ -85,12 +86,12 @@ class FluxScriptEditor extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {children} = this.props
+    const {children, readOnly} = this.props
 
     const options = {
       tabIndex: 1,
       mode: 'flux',
-      readonly: false,
+      readOnly: !!readOnly,
       lineNumbers: true,
       autoRefresh: true,
       indentUnit: 2,
@@ -101,6 +102,7 @@ class FluxScriptEditor extends PureComponent<Props, State> {
       gutters: ['error-gutter'],
       autoFocus: true,
     }
+    console.log(options)
 
     return (
       <div className="flux-script-editor" onMouseEnter={this.handleMouseEnter}>

--- a/ui/src/flux/components/FluxScriptEditor.tsx
+++ b/ui/src/flux/components/FluxScriptEditor.tsx
@@ -102,7 +102,6 @@ class FluxScriptEditor extends PureComponent<Props, State> {
       gutters: ['error-gutter'],
       autoFocus: true,
     }
-    console.log(options)
 
     return (
       <div className="flux-script-editor" onMouseEnter={this.handleMouseEnter}>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -29,6 +29,7 @@ import {DashboardsPage, DashboardPage} from 'src/dashboards'
 import {LogsPage} from 'src/logs'
 import AlertsApp from 'src/alerts'
 import {
+  FluxTaskPage,
   KapacitorPage,
   KapacitorRulePage,
   KapacitorRulesPage,
@@ -198,6 +199,10 @@ class Root extends PureComponent<Record<string, never>, State> {
                 <Route
                   path="kapacitors/:kid/tickscripts/:ruleID" // ruleID can be "new"
                   component={TickscriptPage}
+                />
+                <Route
+                  path="kapacitors/:kid/fluxtasks/:taskID"
+                  component={FluxTaskPage}
                 />
                 <Route path="kapacitors/new" component={KapacitorPage} />
                 <Route path="kapacitors/:id/edit" component={KapacitorPage} />

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -19,6 +19,8 @@ import {
   notifyAlertRuleDeleteFailed,
   notifyAlertRuleStatusUpdated,
   notifyAlertRuleStatusUpdateFailed,
+  notifyFluxTaskStatusUpdated,
+  notifyFluxTaskStatusUpdateFailed,
   notifyTickScriptCreated,
   notifyTickscriptCreationFailed,
   notifyTickscriptUpdated,
@@ -244,10 +246,10 @@ export const updateFluxTaskStatus = (kapacitor, task, status) => dispatch => {
   updateFluxTaskStatusAPI(kapacitor, task, status)
     .then(() => {
       dispatch(updateFluxTaskStatusSuccess(task, status))
-      dispatch(notify(notifyAlertRuleStatusUpdated(task.name, status)))
+      dispatch(notify(notifyFluxTaskStatusUpdated(task.name, status)))
     })
     .catch(() => {
-      dispatch(notify(notifyAlertRuleStatusUpdateFailed(task.name, status)))
+      dispatch(notify(notifyFluxTaskStatusUpdateFailed(task.name, status)))
     })
 }
 

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -243,14 +243,23 @@ export const updateRuleStatus = (rule, status) => dispatch => {
     })
 }
 
-export const updateFluxTaskStatus = (kapacitor, task, status) => dispatch => {
-  updateFluxTaskStatusAPI(kapacitor, task, status)
+export const updateFluxTaskStatus = (
+  kapacitor,
+  task,
+  status,
+  notifySuccess = true
+) => dispatch => {
+  return updateFluxTaskStatusAPI(kapacitor, task, status)
     .then(() => {
       dispatch(updateFluxTaskStatusSuccess(task, status))
-      dispatch(notify(notifyFluxTaskStatusUpdated(task.name, status)))
+      if (notifySuccess) {
+        dispatch(notify(notifyFluxTaskStatusUpdated(task.name, status)))
+      }
+      return true
     })
     .catch(() => {
       dispatch(notify(notifyFluxTaskStatusUpdateFailed(task.name, status)))
+      return false
     })
 }
 

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -7,6 +7,7 @@ import {
   deleteRule as deleteRuleAPI,
   updateRuleStatus as updateRuleStatusAPI,
   updateFluxTaskStatus as updateFluxTaskStatusAPI,
+  deleteFluxTask as deleteFluxTaskAPI,
   createTask as createTaskAJAX,
   updateTask as updateTaskAJAX,
   getFluxTasks,
@@ -110,6 +111,7 @@ export const fetchFluxTasks = kapacitor => async dispatch => {
     } = await getFluxTasks(kapacitor)
     dispatch({type: 'LOAD_FLUX_TASKS', payload: {tasks}})
   } catch (error) {
+    dispatch({type: 'LOAD_FLUX_TASKS', payload: {tasks: null}})
     dispatch(errorThrown(error))
   }
 }
@@ -184,6 +186,13 @@ export const deleteRuleSuccess = ruleID => ({
   },
 })
 
+export const deleteFluxTaskSuccess = taskId => ({
+  type: 'DELETE_FLUX_TASK_SUCCESS',
+  payload: {
+    taskId,
+  },
+})
+
 export const updateRuleStatusSuccess = (ruleID, status) => ({
   type: 'UPDATE_RULE_STATUS_SUCCESS',
   payload: {
@@ -208,6 +217,16 @@ export const deleteRule = rule => dispatch => {
     })
     .catch(() => {
       dispatch(notify(notifyAlertRuleDeleteFailed(rule.name)))
+    })
+}
+export const deleteFluxTask = (kapacitor, task) => dispatch => {
+  deleteFluxTaskAPI(kapacitor, task)
+    .then(() => {
+      dispatch(deleteFluxTaskSuccess(task.id))
+      dispatch(notify(notifyAlertRuleDeleted(task.name)))
+    })
+    .catch(() => {
+      dispatch(notify(notifyAlertRuleDeleteFailed(task.name)))
     })
 }
 

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -108,13 +108,14 @@ export const fetchRules = kapacitor => async dispatch => {
 
 export const fetchFluxTasks = kapacitor => async dispatch => {
   try {
-    const {
-      data: {tasks},
-    } = await getFluxTasks(kapacitor)
+    const tasks = await getFluxTasks(kapacitor)
     dispatch({type: 'LOAD_FLUX_TASKS', payload: {tasks}})
   } catch (error) {
     dispatch({type: 'LOAD_FLUX_TASKS', payload: {tasks: null}})
-    dispatch(errorThrown(error))
+    // dispatch an error unless flux tasks are disabled/not supported
+    if (error.status !== 404) {
+      dispatch(errorThrown(error))
+    }
   }
 }
 

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -6,8 +6,10 @@ import {
   getRule as getRuleAJAX,
   deleteRule as deleteRuleAPI,
   updateRuleStatus as updateRuleStatusAPI,
+  updateFluxTaskStatus as updateFluxTaskStatusAPI,
   createTask as createTaskAJAX,
   updateTask as updateTaskAJAX,
+  getFluxTasks,
 } from 'src/kapacitor/apis'
 import {errorThrown} from 'shared/actions/errors'
 
@@ -101,6 +103,17 @@ export const fetchRules = kapacitor => async dispatch => {
   }
 }
 
+export const fetchFluxTasks = kapacitor => async dispatch => {
+  try {
+    const {
+      data: {tasks},
+    } = await getFluxTasks(kapacitor)
+    dispatch({type: 'LOAD_FLUX_TASKS', payload: {tasks}})
+  } catch (error) {
+    dispatch(errorThrown(error))
+  }
+}
+
 export const chooseTrigger = (ruleID, trigger) => ({
   type: 'CHOOSE_TRIGGER',
   payload: {
@@ -179,6 +192,14 @@ export const updateRuleStatusSuccess = (ruleID, status) => ({
   },
 })
 
+export const updateFluxTaskStatusSuccess = (task, status) => ({
+  type: 'UPDATE_FLUX_TASK_STATUS_SUCCESS',
+  payload: {
+    task,
+    status,
+  },
+})
+
 export const deleteRule = rule => dispatch => {
   deleteRuleAPI(rule)
     .then(() => {
@@ -197,6 +218,17 @@ export const updateRuleStatus = (rule, status) => dispatch => {
     })
     .catch(() => {
       dispatch(notify(notifyAlertRuleStatusUpdateFailed(rule.name, status)))
+    })
+}
+
+export const updateFluxTaskStatus = (kapacitor, task, status) => dispatch => {
+  updateFluxTaskStatusAPI(kapacitor, task, status)
+    .then(() => {
+      dispatch(updateFluxTaskStatusSuccess(task, status))
+      dispatch(notify(notifyAlertRuleStatusUpdated(task.name, status)))
+    })
+    .catch(() => {
+      dispatch(notify(notifyAlertRuleStatusUpdateFailed(task.name, status)))
     })
 }
 

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -122,6 +122,13 @@ export const updateFluxTaskStatus = (kapacitor, task, status) => {
   })
 }
 
+export const deleteFluxTask = (kapacitor, task) => {
+  return AJAX({
+    method: 'DELETE',
+    url: kapacitor.links.proxy + '?path=' + task.links.self,
+  })
+}
+
 export const createTask = async (kapacitor, {id, dbrps, tickscript, type}) => {
   try {
     return await AJAX({

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -97,6 +97,14 @@ export const getFluxTasks = async kapacitor => {
   return values(taskIds).sort((a, b) => a.name.localeCompare(b.name))
 }
 
+export const getFluxTask = async (kapacitor, taskID) => {
+  const {data} = await AJAX({
+    method: 'GET',
+    url: kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}`,
+  })
+  return data
+}
+
 export const getRule = async (kapacitor, ruleID) => {
   try {
     const response = await AJAX({

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -105,6 +105,12 @@ export const getFluxTask = async (kapacitor, taskID) => {
   return data
 }
 
+function friendlyID(id) {
+  if (id > 25) {
+    return friendlyID(Math.trunc(id / 25)) + String.fromCharCode(id % 25)
+  }
+  return String.fromCharCode(65 + id)
+}
 export const getFluxTaskLogs = async (kapacitor, taskID, maxItems) => {
   const {data} = await AJAX({
     method: 'GET',
@@ -113,14 +119,19 @@ export const getFluxTaskLogs = async (kapacitor, taskID, maxItems) => {
   })
   const logs = _.get(data, ['events'], [])
   logs.sort((a, b) => b.time.localeCompare(a.time))
+  let nextClusterId = 0
+  const runIdToClusterId = {}
   return logs.slice(0, maxItems).map(x => ({
     id: `${x.runID}-${x.time}`,
     key: `${x.runID}-${x.time}`,
     service: 'flux_task',
-    lvl: 'info',
+    lvl: 'error',
     ts: x.time,
     msg: x.message,
     tags: x.runID,
+    cluster:
+      runIdToClusterId[x.runID] ||
+      (runIdToClusterId[x.runID] = friendlyID(nextClusterId++)),
   }))
 }
 

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -1,5 +1,5 @@
 import AJAX from 'utils/ajax'
-import {cloneDeep, get, values} from 'lodash'
+import _, {cloneDeep, get, values} from 'lodash'
 
 const outRule = rule => {
   // fit into range
@@ -103,6 +103,25 @@ export const getFluxTask = async (kapacitor, taskID) => {
     url: kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}`,
   })
   return data
+}
+
+export const getFluxTaskLogs = async (kapacitor, taskID, maxItems) => {
+  const {data} = await AJAX({
+    method: 'GET',
+    url:
+      kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}/logs`,
+  })
+  const logs = _.get(data, ['events'], [])
+  logs.sort((a, b) => b.time.localeCompare(a.time))
+  return logs.slice(0, maxItems).map(x => ({
+    id: `${x.runID}-${x.time}`,
+    key: `${x.runID}-${x.time}`,
+    service: 'flux_task',
+    lvl: 'info',
+    ts: x.time,
+    msg: x.message,
+    tags: x.runID,
+  }))
 }
 
 export const getRule = async (kapacitor, ruleID) => {

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -66,6 +66,13 @@ export const getRules = kapacitor => {
   })
 }
 
+export const getFluxTasks = kapacitor => {
+  return AJAX({
+    method: 'GET',
+    url: kapacitor.links.proxy + '?path=/kapacitor/v1/api/v2/tasks?limit=500',
+  })
+}
+
 export const getRule = async (kapacitor, ruleID) => {
   try {
     const response = await AJAX({
@@ -103,6 +110,14 @@ export const updateRuleStatus = (rule, status) => {
   return AJAX({
     method: 'PATCH',
     url: rule.links.self,
+    data: {status},
+  })
+}
+
+export const updateFluxTaskStatus = (kapacitor, task, status) => {
+  return AJAX({
+    method: 'PATCH',
+    url: kapacitor.links.proxy + '?path=' + task.links.self,
     data: {status},
   })
 }

--- a/ui/src/kapacitor/components/FluxTasksTable.tsx
+++ b/ui/src/kapacitor/components/FluxTasksTable.tsx
@@ -1,0 +1,89 @@
+import React, {FC} from 'react'
+import _ from 'lodash'
+
+import {FluxTask} from 'src/types'
+
+import ConfirmButton from 'src/shared/components/ConfirmButton'
+import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
+const {colName, colEnabled, colActions} = TASKS_TABLE
+
+interface FluxTasksTableProps {
+  tasks: FluxTask[]
+  kapacitorLink: string
+  onChangeTaskStatus: (task: FluxTask) => void
+  onDelete: (task: FluxTask) => void
+}
+
+interface FluxTaskRowProps {
+  task: FluxTask
+  onChangeTaskStatus: (rule: FluxTask) => void
+  onDelete: (rule: FluxTask) => void
+}
+
+const FluxTaskRow: FC<FluxTaskRowProps> = ({
+  task,
+  onChangeTaskStatus,
+  onDelete,
+}) => (
+  <tr key={task.id}>
+    <td style={{minWidth: colName}}>{task.name}</td>
+    <td style={{width: colEnabled}} className="text-center">
+      <div className="dark-checkbox">
+        <input
+          id={`kapacitor-task-row-task-enabled ${task.id}`}
+          className="form-control-static"
+          type="checkbox"
+          checked={task.status === 'active'}
+          onChange={() => onChangeTaskStatus(task)}
+        />
+        <label htmlFor={`kapacitor-task-row-task-enabled ${task.id}`} />
+      </div>
+    </td>
+    <td style={{width: colActions}} className="text-right">
+      <ConfirmButton
+        text="Delete"
+        type="btn-danger"
+        size="btn-xs"
+        customClass="table--show-on-row-hover"
+        confirmAction={() => onDelete(task)}
+      />
+    </td>
+  </tr>
+)
+
+const FluxTasksTable: FC<FluxTasksTableProps> = ({
+  tasks,
+  onDelete,
+  onChangeTaskStatus,
+}) => {
+  if (!tasks) {
+    return undefined
+  }
+  return (
+    <table className="table v-center table-highlight">
+      <thead>
+        <tr>
+          <th style={{minWidth: colName}}>Name</th>
+          <th style={{width: colEnabled}} className="text-center">
+            Task Active
+          </th>
+          <th style={{width: colActions}} />
+        </tr>
+      </thead>
+      <tbody>
+        {_.sortBy(tasks, t => t.name.toLowerCase()).map(task => {
+          return (
+            <FluxTaskRow
+              key={task.id}
+              task={task}
+              onDelete={onDelete}
+              onChangeTaskStatus={onChangeTaskStatus}
+            />
+          )
+        })}
+      </tbody>
+    </table>
+  )
+}
+
+export default FluxTasksTable

--- a/ui/src/kapacitor/components/FluxTasksTable.tsx
+++ b/ui/src/kapacitor/components/FluxTasksTable.tsx
@@ -57,7 +57,7 @@ const FluxTasksTable: FC<FluxTasksTableProps> = ({
   onChangeTaskStatus,
 }) => {
   if (!tasks) {
-    return undefined
+    return null
   }
   return (
     <table className="table v-center table-highlight">

--- a/ui/src/kapacitor/components/FluxTasksTable.tsx
+++ b/ui/src/kapacitor/components/FluxTasksTable.tsx
@@ -5,6 +5,7 @@ import {FluxTask} from 'src/types'
 
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
+import {Link} from 'react-router'
 const {colName, colEnabled, colActions} = TASKS_TABLE
 
 interface FluxTasksTableProps {
@@ -16,17 +17,21 @@ interface FluxTasksTableProps {
 
 interface FluxTaskRowProps {
   task: FluxTask
+  viewLink: string
   onChangeTaskStatus: (rule: FluxTask) => void
   onDelete: (rule: FluxTask) => void
 }
 
 const FluxTaskRow: FC<FluxTaskRowProps> = ({
   task,
+  viewLink,
   onChangeTaskStatus,
   onDelete,
 }) => (
   <tr key={task.id}>
-    <td style={{minWidth: colName}}>{task.name}</td>
+    <td style={{minWidth: colName}}>
+      <Link to={viewLink}>{task.name}</Link>
+    </td>
     <td style={{width: colEnabled}} className="text-center">
       <div className="dark-checkbox">
         <input
@@ -53,6 +58,7 @@ const FluxTaskRow: FC<FluxTaskRowProps> = ({
 
 const FluxTasksTable: FC<FluxTasksTableProps> = ({
   tasks,
+  kapacitorLink,
   onDelete,
   onChangeTaskStatus,
 }) => {
@@ -75,6 +81,7 @@ const FluxTasksTable: FC<FluxTasksTableProps> = ({
           return (
             <FluxTaskRow
               key={task.id}
+              viewLink={`${kapacitorLink}/fluxtasks/${task.id}`}
               task={task}
               onDelete={onDelete}
               onChangeTaskStatus={onChangeTaskStatus}

--- a/ui/src/kapacitor/components/FluxTasksTable.tsx
+++ b/ui/src/kapacitor/components/FluxTasksTable.tsx
@@ -6,7 +6,7 @@ import {FluxTask} from 'src/types'
 import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {TASKS_TABLE} from 'src/kapacitor/constants/tableSizing'
 import {Link} from 'react-router'
-const {colName, colEnabled, colActions} = TASKS_TABLE
+const {colName, colEnabled, colActions, colEvery, colCron} = TASKS_TABLE
 
 interface FluxTasksTableProps {
   tasks: FluxTask[]
@@ -32,6 +32,8 @@ const FluxTaskRow: FC<FluxTaskRowProps> = ({
     <td style={{minWidth: colName}}>
       <Link to={viewLink}>{task.name}</Link>
     </td>
+    <td style={{width: colEvery}}>{task.every || ''}</td>
+    <td style={{width: colCron}}>{task.cron || ''}</td>
     <td style={{width: colEnabled}} className="text-center">
       <div className="dark-checkbox">
         <input
@@ -70,6 +72,8 @@ const FluxTasksTable: FC<FluxTasksTableProps> = ({
       <thead>
         <tr>
           <th style={{minWidth: colName}}>Name</th>
+          <th style={{minWidth: colEvery}}>Every</th>
+          <th style={{minWidth: colCron}}>Cron</th>
           <th style={{width: colEnabled}} className="text-center">
             Task Active
           </th>

--- a/ui/src/kapacitor/components/KapacitorRules.tsx
+++ b/ui/src/kapacitor/components/KapacitorRules.tsx
@@ -1,25 +1,30 @@
-import React, {FunctionComponent} from 'react'
+import React, {FC} from 'react'
 import {Link} from 'react-router'
 
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import TasksTable from 'src/kapacitor/components/TasksTable'
+import FluxTasksTable from 'src/kapacitor/components/FluxTasksTable'
 
-import {Source, AlertRule, Kapacitor} from 'src/types'
+import {Source, AlertRule, Kapacitor, FluxTask} from 'src/types'
 
 interface KapacitorRulesProps {
   source: Source
   kapacitor: Kapacitor
   rules: AlertRule[]
+  fluxTasks: FluxTask[]
   onDelete: (rule: AlertRule) => void
   onChangeRuleStatus: (rule: AlertRule) => void
+  onChangeFluxTaskStatus: (task: FluxTask) => void
 }
 
-const KapacitorRules: FunctionComponent<KapacitorRulesProps> = ({
+const KapacitorRules: FC<KapacitorRulesProps> = ({
   source,
   kapacitor,
   rules,
   onDelete,
   onChangeRuleStatus,
+  onChangeFluxTaskStatus,
+  fluxTasks = [],
 }) => {
   const builderRules = rules.filter((r: AlertRule) => r.query)
   const builderHeader = `${builderRules.length} Alert Rule${
@@ -27,6 +32,9 @@ const KapacitorRules: FunctionComponent<KapacitorRulesProps> = ({
   }`
   const scriptsHeader = `${rules.length} TICKscript${
     rules.length === 1 ? '' : 's'
+  }`
+  const fluxTasksHeader = `${fluxTasks.length} Flux Task${
+    fluxTasks.length === 1 ? '' : 's'
   }`
   const kapacitorLink = `/sources/${source.id}/kapacitors/${kapacitor.id}`
 
@@ -69,6 +77,21 @@ const KapacitorRules: FunctionComponent<KapacitorRulesProps> = ({
             tasks={rules}
             onDelete={onDelete}
             onChangeRuleStatus={onChangeRuleStatus}
+          />
+        </div>
+      </div>
+      <div className="panel">
+        <div className="panel-heading">
+          <h2 className="panel-title">{fluxTasksHeader}</h2>
+        </div>
+        <div className="panel-body">
+          <FluxTasksTable
+            kapacitorLink={kapacitorLink}
+            tasks={fluxTasks}
+            // eslint-disable-next-line no-console
+            onDelete={console.log}
+            // eslint-disable-next-line no-console
+            onChangeTaskStatus={onChangeFluxTaskStatus}
           />
         </div>
       </div>

--- a/ui/src/kapacitor/components/KapacitorRules.tsx
+++ b/ui/src/kapacitor/components/KapacitorRules.tsx
@@ -15,6 +15,7 @@ interface KapacitorRulesProps {
   onDelete: (rule: AlertRule) => void
   onChangeRuleStatus: (rule: AlertRule) => void
   onChangeFluxTaskStatus: (task: FluxTask) => void
+  onDeleteFluxTask: (task: FluxTask) => void
 }
 
 const KapacitorRules: FC<KapacitorRulesProps> = ({
@@ -24,6 +25,7 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
   onDelete,
   onChangeRuleStatus,
   onChangeFluxTaskStatus,
+  onDeleteFluxTask,
   fluxTasks = [],
 }) => {
   const builderRules = rules.filter((r: AlertRule) => r.query)
@@ -33,9 +35,9 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
   const scriptsHeader = `${rules.length} TICKscript${
     rules.length === 1 ? '' : 's'
   }`
-  const fluxTasksHeader = `${fluxTasks.length} Flux Task${
-    fluxTasks.length === 1 ? '' : 's'
-  }`
+  const fluxTasksHeader = fluxTasks
+    ? `${fluxTasks.length} Flux Task${fluxTasks.length === 1 ? '' : 's'}`
+    : `Flux Tasks`
   const kapacitorLink = `/sources/${source.id}/kapacitors/${kapacitor.id}`
 
   return (
@@ -80,21 +82,21 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
           />
         </div>
       </div>
-      <div className="panel">
-        <div className="panel-heading">
-          <h2 className="panel-title">{fluxTasksHeader}</h2>
+      {fluxTasks ? (
+        <div className="panel">
+          <div className="panel-heading">
+            <h2 className="panel-title">{fluxTasksHeader}</h2>
+          </div>
+          <div className="panel-body">
+            <FluxTasksTable
+              kapacitorLink={kapacitorLink}
+              tasks={fluxTasks}
+              onDelete={onDeleteFluxTask}
+              onChangeTaskStatus={onChangeFluxTaskStatus}
+            />
+          </div>
         </div>
-        <div className="panel-body">
-          <FluxTasksTable
-            kapacitorLink={kapacitorLink}
-            tasks={fluxTasks}
-            // eslint-disable-next-line no-console
-            onDelete={console.log}
-            // eslint-disable-next-line no-console
-            onChangeTaskStatus={onChangeFluxTaskStatus}
-          />
-        </div>
-      </div>
+      ) : null}
     </div>
   )
 }

--- a/ui/src/kapacitor/components/LogItemFluxTask.tsx
+++ b/ui/src/kapacitor/components/LogItemFluxTask.tsx
@@ -1,0 +1,23 @@
+import React, {FunctionComponent} from 'react'
+
+import {LogItem} from 'src/types/kapacitor'
+
+interface Props {
+  logItem: LogItem
+}
+
+const LogItemSession: FunctionComponent<Props> = ({logItem}) => (
+  <div className="logs-table--row">
+    <div className="logs-table--divider">
+      <div className={`logs-table--level ${logItem.lvl}`} />
+      <div className="logs-table--timestamp">
+        {logItem.ts} (runID: {logItem.tags})
+      </div>
+    </div>
+    <div className="logs-table--details">
+      <div className="logs-table--session">{logItem.msg}</div>
+    </div>
+  </div>
+)
+
+export default LogItemSession

--- a/ui/src/kapacitor/components/LogItemFluxTask.tsx
+++ b/ui/src/kapacitor/components/LogItemFluxTask.tsx
@@ -11,7 +11,10 @@ const LogItemSession: FunctionComponent<Props> = ({logItem}) => (
     <div className="logs-table--divider">
       <div className={`logs-table--level ${logItem.lvl}`} />
       <div className="logs-table--timestamp">
-        {logItem.ts} (runID: {logItem.tags})
+        {logItem.ts} /{' '}
+        <i title={`friendly ID of a run name, full runID is: ${logItem.tags}`}>
+          {logItem.cluster || logItem.tags}
+        </i>
       </div>
     </div>
     <div className="logs-table--details">

--- a/ui/src/kapacitor/components/LogItemFluxTask.tsx
+++ b/ui/src/kapacitor/components/LogItemFluxTask.tsx
@@ -12,7 +12,7 @@ const LogItemSession: FunctionComponent<Props> = ({logItem}) => {
     taskRun = (
       <>
         {' / '}
-        <i title={`friendly ID of a run name, full runID is: ${logItem.tags}`}>
+        <i title={`friendly task run name, runID: ${logItem.tags}`}>
           {logItem.cluster || logItem.tags}
         </i>
       </>

--- a/ui/src/kapacitor/components/LogItemFluxTask.tsx
+++ b/ui/src/kapacitor/components/LogItemFluxTask.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, ReactNode} from 'react'
 
 import {LogItem} from 'src/types/kapacitor'
 
@@ -6,21 +6,32 @@ interface Props {
   logItem: LogItem
 }
 
-const LogItemSession: FunctionComponent<Props> = ({logItem}) => (
-  <div className="logs-table--row">
-    <div className="logs-table--divider">
-      <div className={`logs-table--level ${logItem.lvl}`} />
-      <div className="logs-table--timestamp">
-        {logItem.ts} /{' '}
+const LogItemSession: FunctionComponent<Props> = ({logItem}) => {
+  let taskRun: string | ReactNode = ''
+  if (logItem.cluster) {
+    taskRun = (
+      <>
+        {' / '}
         <i title={`friendly ID of a run name, full runID is: ${logItem.tags}`}>
           {logItem.cluster || logItem.tags}
         </i>
+      </>
+    )
+  }
+
+  return (
+    <div className="logs-table--row">
+      <div className="logs-table--divider">
+        <div className={`logs-table--level ${logItem.lvl}`} />
+        <div className="logs-table--timestamp">
+          {logItem.ts} {taskRun}
+        </div>
+      </div>
+      <div className="logs-table--details">
+        <div className="logs-table--session">{logItem.msg}</div>
       </div>
     </div>
-    <div className="logs-table--details">
-      <div className="logs-table--session">{logItem.msg}</div>
-    </div>
-  </div>
-)
+  )
+}
 
 export default LogItemSession

--- a/ui/src/kapacitor/components/LogsTableRow.tsx
+++ b/ui/src/kapacitor/components/LogsTableRow.tsx
@@ -9,6 +9,7 @@ import LogItemKapacitorDebug from 'src/kapacitor/components/LogItemKapacitorDebu
 import LogItemInfluxDBDebug from 'src/kapacitor/components/LogItemInfluxDBDebug'
 
 import {LogItem} from 'src/types/kapacitor'
+import LogItemFluxTask from './LogItemFluxTask'
 
 interface Props {
   logItem: LogItem
@@ -38,6 +39,9 @@ const LogsTableRow: FunctionComponent<Props> = ({logItem}) => {
   }
   if (logItem.service === 'influxdb' && logItem.lvl === 'debug') {
     return <LogItemInfluxDBDebug logItem={logItem} />
+  }
+  if (logItem.service === 'flux_task') {
+    return <LogItemFluxTask logItem={logItem} />
   }
 
   return (

--- a/ui/src/kapacitor/constants/tableSizing.ts
+++ b/ui/src/kapacitor/constants/tableSizing.ts
@@ -6,4 +6,6 @@ export const TASKS_TABLE = {
   colEnabled: '95px',
   colActions: '68px',
   colType: '90px',
+  colEvery: '90px',
+  colCron: '90px',
 }

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -62,7 +62,6 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
   if (error) {
     contents = <p className="unexpected_error">{error.toString()}</p>
   } else if (loading) {
-    // TODO render loading
     contents = (
       <div className="panel panel-solid">
         <div className="panel-body">
@@ -71,11 +70,14 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
       </div>
     )
   } else if (task) {
-    // TODO render task
     contents = (
-      <div>
-        <textarea defaultValue={task.flux}></textarea>
-      </div>
+      <>
+        <textarea
+          readOnly={true}
+          className="fluxtask-editor"
+          defaultValue={task.flux}
+        ></textarea>
+      </>
     )
   }
 
@@ -97,7 +99,9 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
           </button>
         </Page.Header.Right>
       </Page.Header>
-      <div className="page-contents--split">{contents}/</div>
+      <div className="page-contents--split">
+        <div className="fluxtask">{contents}</div>
+      </div>
     </Page>
   )
 }

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -159,7 +159,8 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
     contents = (
       <>
         <div className="fluxtask-controls">
-          {task.name} <i>{task.status}</i>
+          <h1 className="tickscript-controls--name">{task.name}</h1>
+          <i>{task.status}</i>
         </div>
         <div className="fluxtask-editor">
           <FluxScriptEditor

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -1,0 +1,94 @@
+import React, {FC, useEffect, useState} from 'react'
+import {Page} from 'src/reusable_ui'
+
+import {getActiveKapacitor, getKapacitor} from 'src/shared/apis'
+
+import {Source, Kapacitor, FluxTask} from 'src/types'
+import {getFluxTask} from '../apis'
+
+interface Params {
+  taskID: string
+  kid?: string // kapacitor id
+}
+
+interface Props {
+  source: Source
+  params: Params
+  router: {
+    push: (path: string) => void
+  }
+}
+
+const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(undefined)
+  const [task, setTask] = useState<FluxTask | undefined>(undefined)
+  useEffect(() => {
+    setLoading(true)
+    const fetchDevices = async () => {
+      try {
+        let kapa: Kapacitor
+        if (kid) {
+          kapa = await getActiveKapacitor(source)
+        } else {
+          kapa = await getKapacitor(source, kid)
+        }
+        if (!kapa) {
+          setError(new Error('Kapacitor not found!'))
+          return
+        }
+        const taskVal = await getFluxTask(kapa, taskID)
+        if (!taskVal) {
+          setError(new Error(`Task identified by ${taskID} not found!`))
+          return
+        }
+        setTask(taskVal)
+      } catch (e) {
+        setError(new Error('Cannot load flux task: ' + e))
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchDevices()
+  }, [kid, taskID])
+
+  let contents = null
+  if (error) {
+    // TODO render error
+    contents = <div>{error}</div>
+  } else if (loading) {
+    // TODO render loading
+    contents = <div>{loading}</div>
+  } else if (task) {
+    // TODO render task
+    contents = (
+      <div>
+        <textarea defaultValue={task.flux}></textarea>
+      </div>
+    )
+  }
+
+  return (
+    <Page>
+      <Page.Header>
+        <Page.Header.Left>
+          <Page.Title title="Flux Task" />
+        </Page.Header.Left>
+        <Page.Header.Right showSourceIndicator={true}>
+          <button
+            className="btn btn-default btn-sm"
+            title="Return to Tasks"
+            onClick={() => {
+              router.push(`/sources/${source.id}/alert-rules`)
+            }}
+          >
+            Exit
+          </button>
+        </Page.Header.Right>
+      </Page.Header>
+      <Page.Contents>{contents}</Page.Contents>
+    </Page>
+  )
+}
+
+export default FluxTaskPage

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -1,4 +1,5 @@
 import React, {FC, useEffect, useState} from 'react'
+import FluxScriptEditor from 'src/flux/components/FluxScriptEditor'
 import {Page} from 'src/reusable_ui'
 
 import {getActiveKapacitor, getKapacitor} from 'src/shared/apis'
@@ -19,6 +20,8 @@ interface Props {
     push: (path: string) => void
   }
 }
+
+const noop = () => undefined
 
 const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
   const [loading, setLoading] = useState(true)
@@ -71,13 +74,21 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
     )
   } else if (task) {
     contents = (
-      <>
-        <textarea
-          readOnly={true}
-          className="fluxtask-editor"
-          defaultValue={task.flux}
-        ></textarea>
-      </>
+      <FluxScriptEditor
+        onChangeScript={noop}
+        onSubmitScript={noop}
+        onCursorChange={noop}
+        suggestions={[]}
+        status={{text: '', type: 'success'}}
+        script={task.flux}
+        visibility="visible"
+        readOnly={true}
+      />
+      // <textarea
+      //   readOnly={true}
+      //   className="fluxtask-editor"
+      //   defaultValue={task.flux}
+      // ></textarea>
     )
   }
 

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -311,8 +311,7 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
       </Page.Header>
       <div className="page-contents--split">
         <div
-          className="fluxtask"
-          style={{maxWidth: areLogsVisible ? '50%' : '100%'}}
+          className={`fluxtask ${areLogsVisible ? 'fluxtask--withLogs' : ''}`}
         >
           {contents}
         </div>

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -157,16 +157,23 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
     )
   } else if (task) {
     contents = (
-      <FluxScriptEditor
-        onChangeScript={noop}
-        onSubmitScript={noop}
-        onCursorChange={noop}
-        suggestions={[]}
-        status={{text: '', type: 'success'}}
-        script={task.flux}
-        visibility="visible"
-        readOnly={true}
-      />
+      <>
+        <div className="fluxtask-controls">
+          {task.name} <i>{task.status}</i>
+        </div>
+        <div className="fluxtask-editor">
+          <FluxScriptEditor
+            onChangeScript={noop}
+            onSubmitScript={noop}
+            onCursorChange={noop}
+            suggestions={[]}
+            status={{text: '', type: 'success'}}
+            script={task.flux}
+            visibility="visible"
+            readOnly={true}
+          />
+        </div>
+      </>
     )
   }
 

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   ComponentColor,
   ComponentSize,
+  ComponentStatus,
   IconFont,
   Page,
   Radio,
@@ -126,6 +127,9 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
   >([undefined, undefined])
   const [areLogsVisible, setLogsVisible] = useState<boolean>(false)
   const dispatch = useDispatch()
+  const [changeStatus, setChangeStatus] = useState<ComponentStatus>(
+    ComponentStatus.Default
+  )
   useEffect(() => {
     setLoading(true)
     const fetchData = async () => {
@@ -209,13 +213,16 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
               color={active ? ComponentColor.Default : ComponentColor.Success}
               titleText="Change task status"
               text={active ? 'Deactivate' : 'Activate'}
-              onClick={() =>
+              status={changeStatus}
+              onClick={() => {
+                setChangeStatus(ComponentStatus.Loading)
                 updateFluxTaskStatus(
                   kapacitor,
                   task,
                   active ? 'inactive' : 'active',
                   false
                 )(dispatch).then((success: boolean) => {
+                  setChangeStatus(ComponentStatus.Default)
                   if (success) {
                     setData([
                       kapacitor,
@@ -223,7 +230,7 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
                     ])
                   }
                 })
-              }
+              }}
             />
           </div>
         </div>

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -2,6 +2,7 @@ import React, {FC, useEffect, useState} from 'react'
 import {Page} from 'src/reusable_ui'
 
 import {getActiveKapacitor, getKapacitor} from 'src/shared/apis'
+import PageSpinner from 'src/shared/components/PageSpinner'
 
 import {Source, Kapacitor, FluxTask} from 'src/types'
 import {getFluxTask} from '../apis'
@@ -62,7 +63,13 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
     contents = <p className="unexpected_error">{error.toString()}</p>
   } else if (loading) {
     // TODO render loading
-    contents = <div>{loading}</div>
+    contents = (
+      <div className="panel panel-solid">
+        <div className="panel-body">
+          <PageSpinner />
+        </div>
+      </div>
+    )
   } else if (task) {
     // TODO render task
     contents = (
@@ -73,8 +80,8 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
   }
 
   return (
-    <Page>
-      <Page.Header>
+    <Page className="tickscript-editor-page">
+      <Page.Header fullWidth={true}>
         <Page.Header.Left>
           <Page.Title title="Flux Task" />
         </Page.Header.Left>
@@ -90,7 +97,7 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
           </button>
         </Page.Header.Right>
       </Page.Header>
-      <Page.Contents>{contents}</Page.Contents>
+      <div className="page-contents--split">{contents}/</div>
     </Page>
   )
 }

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -44,7 +44,12 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
         }
         setTask(taskVal)
       } catch (e) {
-        setError(new Error('Cannot load flux task: ' + e))
+        console.error(e)
+        setError(
+          new Error(
+            e?.data?.message ? e.data.message : `Cannot load flux task: ${e}`
+          )
+        )
       } finally {
         setLoading(false)
       }
@@ -54,8 +59,7 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
 
   let contents = null
   if (error) {
-    // TODO render error
-    contents = <div>{error}</div>
+    contents = <p className="unexpected_error">{error.toString()}</p>
   } else if (loading) {
     // TODO render loading
     contents = <div>{loading}</div>

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -190,7 +190,7 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
               active={!areLogsVisible}
               value={false}
               onClick={setLogsVisible}
-              titleText="Show just the TICKscript Editor"
+              titleText="Show just the Flux Task Script"
             >
               Script
             </Radio.Button>

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -52,6 +52,7 @@ interface Props {
   fetchKapacitors: sourcesActions.FetchKapacitorsAsync
   setActiveKapacitor: sourcesActions.SetActiveKapacitorAsync
   fetchFluxTasks: (kapacitor: Kapacitor) => void
+  deleteFluxTask: (kapacitor: Kapacitor, task: FluxTask) => void
   rules: AlertRule[]
   fluxTasks: FluxTask[]
 }
@@ -122,6 +123,7 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
         onDelete={this.handleDeleteRule}
         onChangeRuleStatus={this.handleRuleStatus}
         onChangeFluxTaskStatus={this.handleFluxTaskStatus}
+        onDeleteFluxTask={this.handleDeleteFluxTask}
       />
     )
   }
@@ -223,6 +225,11 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
 
     updateFluxTaskStatus(this.kapacitor, task, status)
   }
+
+  private handleDeleteFluxTask = (task: FluxTask) => {
+    const {deleteFluxTask} = this.props
+    deleteFluxTask(this.kapacitor, task)
+  }
 }
 
 const mstp = ({rules, sources, fluxTasks}) => ({
@@ -241,6 +248,7 @@ const mdtp = {
   setActiveKapacitor: sourcesActions.setActiveKapacitorAsync,
   notify: notifyAction,
   fetchFluxTasks: kapacitorActions.fetchFluxTasks,
+  deleteFluxTask: kapacitorActions.deleteFluxTask,
 }
 
 export default connect(mstp, mdtp)(KapacitorRulesPage)

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -178,8 +178,8 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
   private pingAndFetchRules = async (kapacitor: Kapacitor): Promise<void> => {
     try {
       await this.props.fetchRules(kapacitor)
-      await this.props.fetchFluxTasks(kapacitor)
       await pingKapacitor(kapacitor)
+      await this.props.fetchFluxTasks(kapacitor)
     } catch (error) {
       this.props.notify(notifyKapacitorConnectionFailed())
     }

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -181,7 +181,6 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
       await this.props.fetchFluxTasks(kapacitor)
       await pingKapacitor(kapacitor)
     } catch (error) {
-      console.error(error)
       this.props.notify(notifyKapacitorConnectionFailed())
     }
   }

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -129,7 +129,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
     } = this.props
 
     let kapacitor: Kapacitor
-    if (kid) {
+    if (!kid) {
       kapacitor = await getActiveKapacitor(source)
     } else {
       kapacitor = await getKapacitor(source, kid)

--- a/ui/src/kapacitor/index.js
+++ b/ui/src/kapacitor/index.js
@@ -2,5 +2,12 @@ import KapacitorPage from './containers/KapacitorPage'
 import KapacitorRulePage from './containers/KapacitorRulePage'
 import KapacitorRulesPage from './containers/KapacitorRulesPage'
 import TickscriptPage from './containers/TickscriptPage'
+import FluxTaskPage from './containers/FluxTaskPage'
 
-export {KapacitorPage, KapacitorRulePage, KapacitorRulesPage, TickscriptPage}
+export {
+  KapacitorPage,
+  KapacitorRulePage,
+  KapacitorRulesPage,
+  TickscriptPage,
+  FluxTaskPage,
+}

--- a/ui/src/kapacitor/reducers/fluxTasks.js
+++ b/ui/src/kapacitor/reducers/fluxTasks.js
@@ -1,0 +1,17 @@
+export default function fluxTasks(state = [], action) {
+  switch (action.type) {
+    case 'LOAD_FLUX_TASKS': {
+      return action.payload.tasks
+    }
+    case 'UPDATE_FLUX_TASK_STATUS_SUCCESS': {
+      const {task, status} = action.payload
+      return state.map(t => {
+        if (task.id === t.id) {
+          return {...task, status}
+        }
+        return t
+      })
+    }
+  }
+  return state
+}

--- a/ui/src/kapacitor/reducers/fluxTasks.js
+++ b/ui/src/kapacitor/reducers/fluxTasks.js
@@ -12,6 +12,10 @@ export default function fluxTasks(state = [], action) {
         return t
       })
     }
+    case 'DELETE_FLUX_TASK_SUCCESS': {
+      const {taskId} = action.payload
+      return state.filter(t => t.id !== taskId)
+    }
   }
   return state
 }

--- a/ui/src/kapacitor/reducers/index.js
+++ b/ui/src/kapacitor/reducers/index.js
@@ -1,7 +1,9 @@
 import kapacitorQueryConfigs from './queryConfigs'
 import rules from './rules'
+import fluxTasks from './fluxTasks'
 
 export default {
   kapacitorQueryConfigs,
   rules,
+  fluxTasks,
 }

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -644,12 +644,28 @@ export const notifyAlertRuleStatusUpdated = (
   message: `${ruleName} ${updatedStatus} successfully.`,
 })
 
+export const notifyFluxTaskStatusUpdated = (
+  taskName: string,
+  updatedStatus: string
+): Notification => ({
+  ...defaultSuccessNotification,
+  message: `${taskName} is now ${updatedStatus}.`,
+})
+
 export const notifyAlertRuleStatusUpdateFailed = (
   ruleName: string,
   updatedStatus: string
 ): Notification => ({
   ...defaultSuccessNotification,
   message: `${ruleName} could not be ${updatedStatus}.`,
+})
+
+export const notifyFluxTaskStatusUpdateFailed = (
+  taskName: string,
+  updatedStatus: string
+): Notification => ({
+  ...defaultSuccessNotification,
+  message: `${taskName} could not be made ${updatedStatus}.`,
 })
 
 export const notifyAlertRuleRequiresQuery = (): string =>

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -833,20 +833,24 @@ export const validateSuccess = (): Notification => ({
 })
 
 export const notifyCopyToClipboardSuccess = (
-  text: string,
+  text: string | null,
   title: string = ''
 ): Notification => ({
   ...defaultSuccessNotification,
   icon: 'dash-h',
-  message: `${title}'${text}' has been copied to clipboard.`,
+  message: `${title}${
+    text === null ? '' : "'" + text + "'"
+  } has been copied to clipboard.`,
 })
 
 export const notifyCopyToClipboardFailed = (
-  text: string,
+  text: string | null,
   title: string = ''
 ): Notification => ({
   ...defaultErrorNotification,
-  message: `${title}'${text}' was not copied to clipboard.`,
+  message: `${title}${
+    text === null ? '' : "'" + text + "'"
+  } was not copied to clipboard.`,
 })
 
 export const notifyFluxNameAlreadyTaken = (fluxName: string): Notification => ({

--- a/ui/src/style/chronograf.scss
+++ b/ui/src/style/chronograf.scss
@@ -124,6 +124,7 @@
 @import 'pages/admin';
 @import 'pages/users';
 @import 'pages/tickscript-editor';
+@import 'pages/fluxtask-detail';
 @import 'pages/time-machine';
 @import 'pages/manage-providers';
 @import 'pages/logs-viewer';

--- a/ui/src/style/components/code-mirror/_time-machine.scss
+++ b/ui/src/style/components/code-mirror/_time-machine.scss
@@ -7,7 +7,6 @@
 .cm-s-time-machine {
   background-color: $g1-raven;
   color: $g11-sidewalk;
-  padding-right: 16px;
 
   .cm-variable {
     color: $c-pool;

--- a/ui/src/style/pages/fluxtask-detail.scss
+++ b/ui/src/style/pages/fluxtask-detail.scss
@@ -4,6 +4,12 @@ $fluxtask-controls-height: 60px;
   flex: 1 0 0;
   position: relative;
 }
+.fluxtask.fluxtask--withLogs {
+  max-width: 50%;
+  .fluxtask-controls {
+    padding: 0 20px 0 60px;
+  }
+}
 .fluxtask-controls,
 .fluxtask-editor {
   // cannot use 100%, since it does not work in FireFox

--- a/ui/src/style/pages/fluxtask-detail.scss
+++ b/ui/src/style/pages/fluxtask-detail.scss
@@ -1,0 +1,24 @@
+/*
+    Styles for fluxtask Editor
+    ----------------------------------------------------------------------------
+*/
+
+.fluxtask {
+  flex: 1 0 0;
+  position: relative;
+  max-width: 100%;
+}
+.fluxtask-editor {
+  // cannot use 100%, since it does not work in FireFox
+  // see https://github.com/influxdata/chronograf/issues/5037
+  width: calc(100vw - 60px);
+}
+.fluxtask-editor {
+  height: 100%;
+}
+.page.fluxtask-editor-page {
+  // The default page layout (flex) does not work well on FireFox, the height of fluxtask-editor grows
+  // with 20+ lines, see #5494. Since the heights and widths of all elements in this page are set,
+  // changing to block layout fixes it.   
+  display: block;
+}

--- a/ui/src/style/pages/fluxtask-detail.scss
+++ b/ui/src/style/pages/fluxtask-detail.scss
@@ -1,20 +1,26 @@
-/*
-    Styles for fluxtask Editor
-    ----------------------------------------------------------------------------
-*/
+$fluxtask-controls-height: 60px;
 
 .fluxtask {
   flex: 1 0 0;
   position: relative;
-  max-width: 100%;
 }
+.fluxtask-controls,
 .fluxtask-editor {
   // cannot use 100%, since it does not work in FireFox
   // see https://github.com/influxdata/chronograf/issues/5037
   width: calc(100vw - 60px);
+  max-width: 100%
+}
+.fluxtask-controls {
+  padding: 0 60px;
+  display: flex;
+  align-items: center;
+  height: $fluxtask-controls-height;
+  justify-content: space-between;
+  background-color: $g3-castle;
 }
 .fluxtask-editor {
-  height: 100%;
+  height: calc(100% - #{$fluxtask-controls-height});
 }
 .page.fluxtask-editor-page {
   // The default page layout (flex) does not work well on FireFox, the height of fluxtask-editor grows

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -96,6 +96,18 @@ export interface FluxTask {
   readonly lastRunError?: string
   readonly createdAt?: string
   readonly updatedAt?: string
+  readonly links?: {
+    /** URL for this check */
+    self?: string
+    /** URL to retrieve labels for this check */
+    labels?: string
+    /** URL to retrieve members for this check */
+    members?: string
+    /** URL to retrieve owners for this check */
+    owners?: string
+    /** URL to retrieve flux script for this check */
+    query?: string
+  }
 }
 
 type TICKScript = string

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -66,6 +66,38 @@ export interface Task {
   type: string
 }
 
+export type TaskStatusType = 'active' | 'inactive'
+export interface FluxTask {
+  readonly id: string
+  /** The type of task, this can be used for filtering tasks on list actions. */
+  type?: string
+  /** The ID of the organization that owns this Task. */
+  orgID: string
+  /** The name of the organization that owns this Task. */
+  org?: string
+  /** The name of the task. */
+  name: string
+  /** An optional description of the task. */
+  description?: string
+  status?: TaskStatusType
+  /** The ID of the authorization used when this task communicates with the query engine. */
+  authorizationID?: string
+  /** The Flux script to run for this task. */
+  flux: string
+  /** A simple task repetition schedule; parsed from Flux. */
+  every?: string
+  /** A task repetition schedule in the form '* * * * * *'; parsed from Flux. */
+  cron?: string
+  /** Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default. */
+  offset?: string
+  /** Timestamp of latest scheduled, completed run, RFC3339. */
+  readonly latestCompleted?: string
+  readonly lastRunStatus?: 'failed' | 'success' | 'canceled'
+  readonly lastRunError?: string
+  readonly createdAt?: string
+  readonly updatedAt?: string
+}
+
 type TICKScript = string
 
 // AlertNodes defines all possible kapacitor interactions with an alert.

--- a/ui/test/kapacitor/components/KapacitorRules.test.tsx
+++ b/ui/test/kapacitor/components/KapacitorRules.test.tsx
@@ -17,6 +17,9 @@ describe('Kapacitor.Containers.KapacitorRules', () => {
     loading: false,
     onDelete: () => {},
     onChangeRuleStatus: () => {},
+    fluxTasks: null,
+    onChangeFluxTaskStatus: () => undefined,
+    onDeleteFluxTask: () => undefined,
   }
 
   describe('rendering', () => {

--- a/ui/test/kapacitor/reducers/fluxTasks.test.js
+++ b/ui/test/kapacitor/reducers/fluxTasks.test.js
@@ -1,0 +1,43 @@
+import reducer from 'src/kapacitor/reducers/fluxTasks'
+
+import {
+  deleteFluxTaskSuccess,
+  updateFluxTaskStatusSuccess,
+} from 'src/kapacitor/actions/view'
+
+describe('Kapacitor.Reducers.fluxTasks', () => {
+  it('creates a default state', () => {
+    const state = reducer(undefined, {type: '@@INIT'})
+    expect(state).toEqual([])
+  })
+  it('it can delete a task', () => {
+    const initialState = [
+      {
+        id: 'a',
+      },
+      {
+        id: 'b',
+      },
+    ]
+
+    const newState = reducer(initialState, deleteFluxTaskSuccess('b'))
+    expect(newState).toEqual([{id: 'a'}])
+  })
+
+  it('it updates task status', () => {
+    const initialState = [
+      {
+        id: 'a',
+      },
+      {
+        id: 'b',
+      },
+    ]
+
+    const newState = reducer(
+      initialState,
+      updateFluxTaskStatusSuccess({id: 'b', status: 'active'}, 'inactive')
+    )
+    expect(newState).toEqual([{id: 'a'}, {id: 'b', status: 'inactive'}])
+  })
+})


### PR DESCRIPTION
Closes #5663

_Briefly describe your proposed changes:_
Add Flux Tasks UI (when enabled in kapacitor config and generally supported (1.6+))
- list flux tasks + delete a flux task, change task status
- show task details with highlighted flux script + copy to clipboard, change task status
- show task logs with friendly task run names (appear after timestamp in a log row) 

![fluxTasks5](https://user-images.githubusercontent.com/16321466/121906479-73802d80-cd2b-11eb-918b-d43d568e87ea.gif)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
