### PR TITLE
fix(ui): keep original influxQL query if it can't be converted to queryConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS ARM64 builds.
 1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard in a resources directory.
 1. [#5757](https://github.com/influxdata/chronograf/pull/5757): Enforce unique dashboard variable names.
+1. [#5769](https://github.com/influxdata/chronograf/pull/5769): Don't modify query passed to a Dashboard page using a `query` URL parameter.
 
 
 ### Other

--- a/ui/src/dashboards/utils/cellGetters.ts
+++ b/ui/src/dashboards/utils/cellGetters.ts
@@ -184,6 +184,11 @@ export const getConfig = async (
   const {queryConfig} = queries.find(q => q.id === id)
   const range = getRangeForOriginalQuery(query, queryConfig.range)
 
+  if (queryConfig.rawText) {
+    // the query cannot be parsed to query config successfully
+    // return back the raw query
+    queryConfig.rawText = query
+  }
   return {
     ...queryConfig,
     originalQuery: query,


### PR DESCRIPTION
Closes #5766

_Briefly describe your proposed changes:_
If an explorer's page `query` URL parameter can't be parsed to a query config (i.e. something that can be manipulated with additional UI controls), the original (from URL parameter) query is kept as-is. It now works fine the same way as if the query is hand-edited in the UI.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
