### PR TITLE
feat(ui): Allow to test Alert handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 1. [#5752](https://github.com/influxdata/chronograf/pull/5742): Add Zenoss configuration and alert UI.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Add macOS arm64 builds.
 1. [#5767](https://github.com/influxdata/chronograf/pull/5767): Add Flux Tasks.
+1. [#5771](https://github.com/influxdata/chronograf/pull/5771): Allow to test Alert handlers.
 
 ### Bug Fixes
 

--- a/ui/src/kapacitor/components/HandlerOptions.js
+++ b/ui/src/kapacitor/components/HandlerOptions.js
@@ -36,6 +36,7 @@ class HandlerOptions extends Component {
       rule,
       updateDetails,
       onGoToConfig,
+      onTestHandler,
       validationError,
     } = this.props
     switch (selectedHandler && selectedHandler.type) {
@@ -73,6 +74,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('smtp')}
+            onTest={onTestHandler('smtp')}
             validationError={validationError}
             updateDetails={updateDetails}
             rule={rule}
@@ -84,6 +86,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('alerta')}
+            onTest={onTestHandler('alerta')}
             validationError={validationError}
           />
         )
@@ -93,6 +96,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('kafka')}
+            onTest={onTestHandler('kafka')}
             validationError={validationError}
           />
         )
@@ -102,6 +106,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('opsgenie')}
+            onTest={onTestHandler('opsgenie')}
             validationError={validationError}
           />
         )
@@ -111,6 +116,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('opsgenie2')}
+            onTest={onTestHandler('opsgenie2')}
             validationError={validationError}
           />
         )
@@ -120,6 +126,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('pagerduty')}
+            onTest={onTestHandler('pagerduty')}
             validationError={validationError}
           />
         )
@@ -129,6 +136,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('pagerduty2')}
+            onTest={onTestHandler('pagerduty2')}
             validationError={validationError}
           />
         )
@@ -138,6 +146,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('pushover')}
+            onTest={onTestHandler('pushover')}
             validationError={validationError}
           />
         )
@@ -147,6 +156,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('sensu')}
+            onTest={onTestHandler('sensu')}
             validationError={validationError}
           />
         )
@@ -156,6 +166,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('slack')}
+            onTest={onTestHandler('slack')}
             validationError={validationError}
           />
         )
@@ -165,6 +176,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('talk')}
+            onTest={onTestHandler('talk')}
             validationError={validationError}
           />
         )
@@ -174,6 +186,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('telegram')}
+            onTest={onTestHandler('telegram')}
             validationError={validationError}
           />
         )
@@ -183,6 +196,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('victorops')}
+            onTest={onTestHandler('victorops')}
             validationError={validationError}
           />
         )
@@ -192,6 +206,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('servicenow')}
+            onTest={onTestHandler('servicenow')}
             validationError={validationError}
           />
         )
@@ -201,6 +216,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('bigpanda')}
+            onTest={onTestHandler('bigpanda')}
             validationError={validationError}
           />
         )
@@ -210,6 +226,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('teams')}
+            onTest={onTestHandler('teams')}
             validationError={validationError}
           />
         )
@@ -219,6 +236,7 @@ class HandlerOptions extends Component {
             selectedHandler={selectedHandler}
             handleModifyHandler={handleModifyHandler}
             onGoToConfig={onGoToConfig('zenoss')}
+            onTest={onTestHandler('zenoss')}
             validationError={validationError}
           />
         )
@@ -236,6 +254,7 @@ HandlerOptions.propTypes = {
   updateDetails: func,
   rule: shape({}),
   onGoToConfig: func.isRequired,
+  onTestHandler: func.isRequired,
   validationError: string.isRequired,
 }
 

--- a/ui/src/kapacitor/components/KapacitorRule.tsx
+++ b/ui/src/kapacitor/components/KapacitorRule.tsx
@@ -148,6 +148,19 @@ class KapacitorRule extends Component<Props, State> {
     this.setState({timeRange})
   }
 
+  private applyRuleWorkarounds(updatedRule: any): void {
+    // defect #5768 - naming issue
+    if (updatedRule.alertNodes?.teams?.length) {
+      const teams = (updatedRule.alertNodes.teams[0] as unknown) as Record<
+        string,
+        unknown
+      >
+      if (teams['channel-url']) {
+        teams.channel_url = teams['channel-url']
+      }
+    }
+  }
+
   private handleCreate = (pathname?: string) => {
     const {notify, queryConfigs, rule, source, router, kapacitor} = this.props
 
@@ -155,6 +168,7 @@ class KapacitorRule extends Component<Props, State> {
       query: queryConfigs[rule.queryID],
     })
     delete newRule.queryID
+    this.applyRuleWorkarounds(newRule)
 
     createRule(kapacitor, newRule)
       .then(() => {
@@ -171,7 +185,7 @@ class KapacitorRule extends Component<Props, State> {
     const updatedRule = Object.assign({}, rule, {
       query: queryConfigs[rule.queryID],
     })
-
+    this.applyRuleWorkarounds(updatedRule)
     editRule(updatedRule)
       .then(() => {
         router.push(pathname || `/sources/${source.id}/alert-rules`)

--- a/ui/src/kapacitor/components/KapacitorRule.tsx
+++ b/ui/src/kapacitor/components/KapacitorRule.tsx
@@ -25,6 +25,8 @@ import {
   notifyAlertRuleRequiresQuery,
   notifyAlertRuleRequiresConditionValue,
   notifyAlertRuleDeadmanInvalid,
+  notifyTestAlertSent,
+  notifyTestAlertFailed,
 } from 'src/shared/copy/notifications'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
@@ -41,6 +43,7 @@ import {
   KapacitorQueryConfigActions,
   KapacitorRuleActions,
 } from 'src/types/actions'
+import {testAlertOutput} from 'src/shared/apis'
 
 interface Props {
   source: Source
@@ -130,6 +133,7 @@ class KapacitorRule extends Component<Props, State> {
               ruleActions={ruleActions}
               handlersFromConfig={handlersFromConfig}
               onGoToConfig={this.handleSaveToConfig}
+              onTestHandler={this.handleTestHandler}
               validationError={this.validationError}
             />
             <RuleMessage rule={rule} ruleActions={ruleActions} />
@@ -174,7 +178,9 @@ class KapacitorRule extends Component<Props, State> {
         notify(notifyAlertRuleUpdated(rule.name))
       })
       .catch(e => {
-        notify(notifyAlertRuleUpdateFailed(rule.name, e.data.message))
+        notify(
+          notifyAlertRuleUpdateFailed(rule.name, e?.data?.message || String(e))
+        )
       })
   }
 
@@ -202,6 +208,49 @@ class KapacitorRule extends Component<Props, State> {
       this.handleCreate(pathname)
     } else {
       this.handleEdit(pathname)
+    }
+  }
+  private handleTestHandler = (configName: string) => async (
+    handler: Record<string, unknown>,
+    toTestProperty: Record<string, string> = {}
+  ) => {
+    const testData = Object.keys(handler).reduce<Record<string, unknown>>(
+      (acc, key) => {
+        // ignore: 'type' is created by UI, 'enabled' is not used by testing
+        if (key === 'enabled' || key === 'type') {
+          return acc
+        }
+        if (key === '_type') {
+          acc.type = handler._type
+          return acc
+        }
+        if (toTestProperty[key]) {
+          acc[toTestProperty[key]] = handler[key]
+          return acc
+        }
+        // common property
+        acc[key] = handler[key]
+        // there are naming problems in kapacitor, - and _ are used inconsistently in tickscript and testing options
+        acc[key.replace('-', '_')] = acc[key]
+        acc[key.replace('_', '-')] = acc[key]
+        return acc
+      },
+      {}
+    )
+    try {
+      const {data} = await testAlertOutput(
+        this.props.kapacitor,
+        configName,
+        testData,
+        testData
+      )
+      if (data.success) {
+        this.props.notify(notifyTestAlertSent(configName))
+      } else {
+        this.props.notify(notifyTestAlertFailed(configName, data.message))
+      }
+    } catch (error) {
+      this.props.notify(notifyTestAlertFailed(configName))
     }
   }
 

--- a/ui/src/kapacitor/components/RuleHandlers.tsx
+++ b/ui/src/kapacitor/components/RuleHandlers.tsx
@@ -27,6 +27,9 @@ interface Props {
   ruleActions: RuleActions
   handlersFromConfig: Handler[]
   onGoToConfig: (configName: string) => void
+  onTestHandler: (
+    configName: string
+  ) => (handler: Record<string, unknown>) => void
   validationError: string
 }
 
@@ -85,6 +88,7 @@ class RuleHandlers extends PureComponent<Props, State> {
       rule,
       ruleActions,
       onGoToConfig,
+      onTestHandler,
       validationError,
       handlersFromConfig,
     } = this.props
@@ -152,6 +156,7 @@ class RuleHandlers extends PureComponent<Props, State> {
                 updateDetails={ruleActions.updateDetails}
                 rule={rule}
                 onGoToConfig={onGoToConfig}
+                onTestHandler={onTestHandler}
                 validationError={validationError}
               />
             </div>

--- a/ui/src/kapacitor/components/handlers/AlertaHandler.js
+++ b/ui/src/kapacitor/components/handlers/AlertaHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const AlertaHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const AlertaHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/AlertaHandler.js
+++ b/ui/src/kapacitor/components/handlers/AlertaHandler.js
@@ -8,6 +8,7 @@ const AlertaHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const AlertaHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/BigPandaHandler.js
+++ b/ui/src/kapacitor/components/handlers/BigPandaHandler.js
@@ -8,6 +8,7 @@ const BigPandaHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const BigPandaHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/BigPandaHandler.js
+++ b/ui/src/kapacitor/components/handlers/BigPandaHandler.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
+
 const BigPandaHandler = ({
   selectedHandler,
   handleModifyHandler,
@@ -13,12 +15,10 @@ const BigPandaHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/EmailHandler.js
+++ b/ui/src/kapacitor/components/handlers/EmailHandler.js
@@ -11,6 +11,7 @@ const EmailHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -20,6 +21,7 @@ const EmailHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/EmailHandler.js
+++ b/ui/src/kapacitor/components/handlers/EmailHandler.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
 import RuleDetailsText from 'src/kapacitor/components/RuleDetailsText'
+import HandlerActions from './HandlerActions'
 
 const EmailHandler = ({
   rule,
@@ -17,12 +18,10 @@ const EmailHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/HandlerActions.tsx
+++ b/ui/src/kapacitor/components/handlers/HandlerActions.tsx
@@ -2,13 +2,26 @@ import React, {FC} from 'react'
 
 const HandlerActions: FC<{
   onGoToConfig: () => void
+  onTest: () => void
   validationError: string
-}> = ({onGoToConfig, validationError}) => (
-  <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-    <span className="icon cog-thick" />
-    {validationError
-      ? 'Exit this Rule and Edit Configuration'
-      : 'Save this Rule and Edit Configuration'}
-  </div>
+}> = ({onGoToConfig, onTest, validationError}) => (
+  <>
+    <div
+      className="btn btn-primary"
+      onClick={e => {
+        e.preventDefault()
+        onTest()
+      }}
+    >
+      <span className="icon pulse-c" />
+      Send Test Alert
+    </div>
+    <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
+      <span className="icon cog-thick" />
+      {validationError
+        ? 'Exit this Rule and Edit Configuration'
+        : 'Save this Rule and Edit Configuration'}
+    </div>
+  </>
 )
 export default HandlerActions

--- a/ui/src/kapacitor/components/handlers/HandlerActions.tsx
+++ b/ui/src/kapacitor/components/handlers/HandlerActions.tsx
@@ -1,0 +1,14 @@
+import React, {FC} from 'react'
+
+const HandlerActions: FC<{
+  onGoToConfig: () => void
+  validationError: string
+}> = ({onGoToConfig, validationError}) => (
+  <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
+    <span className="icon cog-thick" />
+    {validationError
+      ? 'Exit this Rule and Edit Configuration'
+      : 'Save this Rule and Edit Configuration'}
+  </div>
+)
+export default HandlerActions

--- a/ui/src/kapacitor/components/handlers/HandlerActions.tsx
+++ b/ui/src/kapacitor/components/handlers/HandlerActions.tsx
@@ -5,9 +5,9 @@ const HandlerActions: FC<{
   onTest: () => void
   validationError: string
 }> = ({onGoToConfig, onTest, validationError}) => (
-  <>
+  <div style={{display: 'flex'}}>
     <div
-      className="btn btn-primary"
+      className="btn btn-primary btn-sm"
       onClick={e => {
         e.preventDefault()
         onTest()
@@ -22,6 +22,6 @@ const HandlerActions: FC<{
         ? 'Exit this Rule and Edit Configuration'
         : 'Save this Rule and Edit Configuration'}
     </div>
-  </>
+  </div>
 )
 export default HandlerActions

--- a/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
+++ b/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
@@ -27,6 +27,7 @@ interface Props {
     headerIndex: number
   ) => void
   onGoToConfig: () => void
+  onTest: (handler: Record<string, unknown>) => void
   validationError: string
 }
 
@@ -34,6 +35,7 @@ const KafkaHandler: FunctionComponent<Props> = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) => {
   const handler = {...selectedHandler, cluster: selectedHandler.id}
@@ -47,6 +49,7 @@ const KafkaHandler: FunctionComponent<Props> = ({
             Parameters for this Alert Handler
             <HandlerActions
               onGoToConfig={onGoToConfig}
+              onTest={() => onTest(handler)}
               validationError={validationError}
             />
           </h4>

--- a/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
+++ b/ui/src/kapacitor/components/handlers/KafkaHandler.tsx
@@ -2,6 +2,7 @@ import React, {FunctionComponent} from 'react'
 
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 interface Handler {
   alias: string
@@ -39,23 +40,15 @@ const KafkaHandler: FunctionComponent<Props> = ({
   handleModifyHandler(handler, 'cluster', false, 0)
 
   if (selectedHandler.enabled) {
-    let goToConfigText
-
-    if (validationError) {
-      goToConfigText = 'Exit this Rule and Edit Configuration'
-    } else {
-      goToConfigText = 'Save this Rule and Edit Configuration'
-    }
-
     return (
       <div className="endpoint-tab-contents">
         <div className="endpoint-tab--parameters">
           <h4 className="u-flex u-jc-space-between">
             Parameters for this Alert Handler
-            <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-              <span className="icon cog-thick" />
-              {goToConfigText}
-            </div>
+            <HandlerActions
+              onGoToConfig={onGoToConfig}
+              validationError={validationError}
+            />
           </h4>
           <div className="faux-form">
             <HandlerInput

--- a/ui/src/kapacitor/components/handlers/OpsgenieHandler.js
+++ b/ui/src/kapacitor/components/handlers/OpsgenieHandler.js
@@ -8,6 +8,7 @@ const OpsgenieHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const OpsgenieHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/OpsgenieHandler.js
+++ b/ui/src/kapacitor/components/handlers/OpsgenieHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const OpsgenieHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const OpsgenieHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
+++ b/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
@@ -1,6 +1,7 @@
 import React, {FunctionComponent} from 'react'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 interface Props {
   selectedHandler: {
@@ -18,21 +19,15 @@ const Pagerduty2Handler: FunctionComponent<Props> = ({
   validationError,
 }) => {
   if (selectedHandler.enabled) {
-    let goToConfigText
-    if (validationError) {
-      goToConfigText = 'Exit this Rule and Edit Configuration'
-    } else {
-      goToConfigText = 'Save this Rule and Edit Configuration'
-    }
     return (
       <div className="endpoint-tab-contents">
         <div className="endpoint-tab--parameters">
           <h4 className="u-flex u-jc-space-between">
             Parameters from Kapacitor Configuration
-            <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-              <span className="icon cog-thick" />
-              {goToConfigText}
-            </div>
+            <HandlerActions
+              onGoToConfig={onGoToConfig}
+              validationError={validationError}
+            />
           </h4>
           <HandlerInput
             selectedHandler={selectedHandler}

--- a/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
+++ b/ui/src/kapacitor/components/handlers/Pagerduty2Handler.tsx
@@ -9,6 +9,7 @@ interface Props {
   }
   handleModifyHandler: () => void
   onGoToConfig: () => void
+  onTest: (handler: Record<string, unknown>) => void
   validationError: string
 }
 
@@ -16,6 +17,7 @@ const Pagerduty2Handler: FunctionComponent<Props> = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) => {
   if (selectedHandler.enabled) {
@@ -26,6 +28,7 @@ const Pagerduty2Handler: FunctionComponent<Props> = ({
             Parameters from Kapacitor Configuration
             <HandlerActions
               onGoToConfig={onGoToConfig}
+              onTest={() => onTest(selectedHandler)}
               validationError={validationError}
             />
           </h4>

--- a/ui/src/kapacitor/components/handlers/PagerdutyHandler.js
+++ b/ui/src/kapacitor/components/handlers/PagerdutyHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const PagerdutyHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const PagerdutyHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <HandlerInput
           selectedHandler={selectedHandler}

--- a/ui/src/kapacitor/components/handlers/PagerdutyHandler.js
+++ b/ui/src/kapacitor/components/handlers/PagerdutyHandler.js
@@ -8,6 +8,7 @@ const PagerdutyHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const PagerdutyHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/PushoverHandler.js
+++ b/ui/src/kapacitor/components/handlers/PushoverHandler.js
@@ -8,6 +8,7 @@ const PushoverHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const PushoverHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/PushoverHandler.js
+++ b/ui/src/kapacitor/components/handlers/PushoverHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const PushoverHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const PushoverHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/SensuHandler.js
+++ b/ui/src/kapacitor/components/handlers/SensuHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const SensuHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const SensuHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/SensuHandler.js
+++ b/ui/src/kapacitor/components/handlers/SensuHandler.js
@@ -8,6 +8,7 @@ const SensuHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const SensuHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/ServiceNowHandler.js
+++ b/ui/src/kapacitor/components/handlers/ServiceNowHandler.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
+
 const ServiceNowHandler = ({
   selectedHandler,
   handleModifyHandler,
@@ -13,12 +15,10 @@ const ServiceNowHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/ServiceNowHandler.js
+++ b/ui/src/kapacitor/components/handlers/ServiceNowHandler.js
@@ -8,6 +8,7 @@ const ServiceNowHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const ServiceNowHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/SlackHandler.js
+++ b/ui/src/kapacitor/components/handlers/SlackHandler.js
@@ -8,6 +8,7 @@ const SlackHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const SlackHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/SlackHandler.js
+++ b/ui/src/kapacitor/components/handlers/SlackHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const SlackHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const SlackHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/TalkHandler.js
+++ b/ui/src/kapacitor/components/handlers/TalkHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const TalkHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const TalkHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/TalkHandler.js
+++ b/ui/src/kapacitor/components/handlers/TalkHandler.js
@@ -8,6 +8,7 @@ const TalkHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const TalkHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/TeamsHandler.js
+++ b/ui/src/kapacitor/components/handlers/TeamsHandler.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
+
 const TeamsHandler = ({
   selectedHandler,
   handleModifyHandler,
@@ -13,12 +15,10 @@ const TeamsHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameter Overriding Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/TeamsHandler.js
+++ b/ui/src/kapacitor/components/handlers/TeamsHandler.js
@@ -8,6 +8,7 @@ const TeamsHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,7 @@ const TeamsHandler = ({
           Parameter Overriding Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/TelegramHandler.js
+++ b/ui/src/kapacitor/components/handlers/TelegramHandler.js
@@ -9,6 +9,7 @@ const TelegramHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -18,6 +19,7 @@ const TelegramHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() => onTest(selectedHandler)}
             validationError={validationError}
           />
         </h4>

--- a/ui/src/kapacitor/components/handlers/TelegramHandler.js
+++ b/ui/src/kapacitor/components/handlers/TelegramHandler.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerCheckbox from 'src/kapacitor/components/HandlerCheckbox'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const TelegramHandler = ({
   selectedHandler,
@@ -15,12 +16,10 @@ const TelegramHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/VictoropsHandler.js
+++ b/ui/src/kapacitor/components/handlers/VictoropsHandler.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
 
 const VictoropsHandler = ({
   selectedHandler,
@@ -14,12 +15,10 @@ const VictoropsHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/VictoropsHandler.js
+++ b/ui/src/kapacitor/components/handlers/VictoropsHandler.js
@@ -8,6 +8,7 @@ const VictoropsHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -18,6 +19,7 @@ const VictoropsHandler = ({
           <HandlerActions
             onGoToConfig={onGoToConfig}
             validationError={validationError}
+            onTest={() => onTest(selectedHandler)}
           />
         </h4>
         <div className="faux-form">

--- a/ui/src/kapacitor/components/handlers/ZenossHandler.js
+++ b/ui/src/kapacitor/components/handlers/ZenossHandler.js
@@ -2,6 +2,8 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import HandlerInput from 'src/kapacitor/components/HandlerInput'
 import HandlerEmpty from 'src/kapacitor/components/HandlerEmpty'
+import HandlerActions from './HandlerActions'
+
 const ZenossHandler = ({
   selectedHandler,
   handleModifyHandler,
@@ -13,12 +15,10 @@ const ZenossHandler = ({
       <div className="endpoint-tab--parameters">
         <h4 className="u-flex u-jc-space-between">
           Parameters from Kapacitor Configuration
-          <div className="btn btn-default btn-sm" onClick={onGoToConfig}>
-            <span className="icon cog-thick" />
-            {validationError
-              ? 'Exit this Rule and Edit Configuration'
-              : 'Save this Rule and Edit Configuration'}
-          </div>
+          <HandlerActions
+            onGoToConfig={onGoToConfig}
+            validationError={validationError}
+          />
         </h4>
         <div className="faux-form">
           <HandlerInput

--- a/ui/src/kapacitor/components/handlers/ZenossHandler.js
+++ b/ui/src/kapacitor/components/handlers/ZenossHandler.js
@@ -8,6 +8,7 @@ const ZenossHandler = ({
   selectedHandler,
   handleModifyHandler,
   onGoToConfig,
+  onTest,
   validationError,
 }) =>
   selectedHandler.enabled ? (
@@ -17,6 +18,12 @@ const ZenossHandler = ({
           Parameters from Kapacitor Configuration
           <HandlerActions
             onGoToConfig={onGoToConfig}
+            onTest={() =>
+              onTest(selectedHandler, {
+                evclass: 'eventclass',
+                evclasskey: 'eventclasskey',
+              })
+            }
             validationError={validationError}
           />
         </h4>


### PR DESCRIPTION
Closes #2620 #5768

_Briefly describe your proposed changes:_
`Send Test Event` button added to every alert handler section that supports it:

![sendTestAlert](https://user-images.githubusercontent.com/16321466/121945188-c8379e80-cd53-11eb-9411-5c2a1b6b8bd7.gif)

It performs the same job as the kapacitor configuration's `Send Test Event` handler, but the visible additional UI options are also used in the notification. The naming inconsistencies in kapacitor (tickscript, config and testing properties of the same semantics have slightly different names) are also solved in this PR.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
