### PR TITLE
fix(ui/tickscript): make db names visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 1. [#5758](https://github.com/influxdata/chronograf/pull/5758): Parse exported dashboard in a resources directory.
 1. [#5757](https://github.com/influxdata/chronograf/pull/5757): Enforce unique dashboard variable names.
 1. [#5769](https://github.com/influxdata/chronograf/pull/5769): Don't modify query passed to a Dashboard page using a `query` URL parameter.
+1. [#5774](https://github.com/influxdata/chronograf/pull/5774): Show full DB names in TICKScript editor dropdown.
 
 
 ### Other

--- a/ui/src/kapacitor/components/TickscriptEditorControls.tsx
+++ b/ui/src/kapacitor/components/TickscriptEditorControls.tsx
@@ -32,6 +32,7 @@ class TickscriptEditorControls extends Component<Props> {
           <MultiSelectDBDropdown
             selectedItems={this.addName(task.dbrps)}
             onApply={onSelectDbrps}
+            rightAligned={true}
           />
         </div>
       </div>

--- a/ui/src/shared/components/MultiSelectDBDropdown.js
+++ b/ui/src/shared/components/MultiSelectDBDropdown.js
@@ -21,7 +21,7 @@ class MultiSelectDBDropdown extends Component {
 
   render() {
     const {dbrps} = this.state
-    const {onApply, selectedItems} = this.props
+    const {onApply, selectedItems, rightAligned} = this.props
     const label = 'Select databases'
 
     return (
@@ -31,6 +31,7 @@ class MultiSelectDBDropdown extends Component {
         onApply={onApply}
         isApplyShown={false}
         selectedItems={selectedItems}
+        rightAligned={rightAligned}
       />
     )
   }

--- a/ui/src/shared/components/MultiSelectDropdown.js
+++ b/ui/src/shared/components/MultiSelectDropdown.js
@@ -109,10 +109,14 @@ class MultiSelectDropdown extends Component {
   }
 
   renderMenu() {
-    const {items, isApplyShown} = this.props
+    const {items, isApplyShown, rightAligned} = this.props
 
     return (
-      <ul className="dropdown-menu">
+      <ul
+        className={classnames('dropdown-menu', {
+          'dropdown--right': rightAligned,
+        })}
+      >
         {isApplyShown && (
           <li className="multi-select--apply">
             <button className="btn btn-xs btn-info" onClick={this.handleApply}>

--- a/ui/src/style/theme/_dropdowns.scss
+++ b/ui/src/style/theme/_dropdowns.scss
@@ -189,6 +189,9 @@ $dropdown-purple-header: $c-potassium;
   display: none;
   position: absolute;
   top: 100%;
+  &.dropdown--right {
+    right: 0px
+  }
 }
 .dropdown.open {
   z-index: 9999;


### PR DESCRIPTION
Closes #5773

_Briefly describe your proposed changes:_
TICKScript's "Select Databases" dropdown menu is aligned to the right side of the dropdown and expands to the left so that even long database names are visible.

![image](https://user-images.githubusercontent.com/16321466/122330312-3dad9580-cf33-11eb-9371-03970a19720c.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
