### PR TITLE
fix(docker): use environment variables to specify default chronograf arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,7 @@
 1. [#5757](https://github.com/influxdata/chronograf/pull/5757): Enforce unique dashboard variable names.
 1. [#5769](https://github.com/influxdata/chronograf/pull/5769): Don't modify query passed to a Dashboard page using a `query` URL parameter.
 1. [#5774](https://github.com/influxdata/chronograf/pull/5774): Show full DB names in TICKScript editor dropdown.
-
+1. [#5778](https://github.com/influxdata/chronograf/pull/5778): Use docker environment variables to specify default chronograf arguments.
 
 ### Other
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine:3.12
 
 ENV PROTOBOARDS_PATH /usr/share/chronograf/protoboards
 ENV CANNED_PATH /usr/share/chronograf/canned
+ENV RESOURCES_PATH /usr/share/chronograf/resources
 ENV BOLT_PATH /var/lib/chronograf/chronograf-v1.db
 
 RUN apk add --update ca-certificates && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM alpine:3.12
-MAINTAINER Chris Goller <chris@influxdb.com>
 
 ENV PROTOBOARDS_PATH /usr/share/chronograf/protoboards
+ENV CANNED_PATH /usr/share/chronograf/canned
+ENV BOLT_PATH /var/lib/chronograf/chronograf-v1.db
 
 RUN apk add --update ca-certificates && \
     rm /var/cache/apk/*
@@ -16,4 +17,4 @@ ADD agpl-3.0.md /usr/share/chronograf/agpl-3.0.md
 EXPOSE 8888
 VOLUME ["/usr/share/chronograf", "/var/lib/chronograf"]
 
-CMD ["/usr/bin/chronograf", "-b", "/var/lib/chronograf/chronograf-v1.db", "-c", "/usr/share/chronograf/canned"]
+CMD ["/usr/bin/chronograf"]


### PR DESCRIPTION
Closes #5762

_Briefly describe your proposed changes:_
chronograf default options are specified using environment variables.

_What was the problem?_
Users that specify custom command-line options cannot know that they have to add the default options from a Docker file, so they don't and are then surprised to lose the defaults.

_What was the solution?_
The defaults are specified in environment variables.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
