### PR TITLE
fix: displaying SingleStat in Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Bug Fixes
 
+1. [#5784](https://github.com/influxdata/chronograf/pull/5784): Fix Safari display issues of the Single Stat
+
 ### Features
 
 ### Other

--- a/ui/src/shared/components/SingleStat.tsx
+++ b/ui/src/shared/components/SingleStat.tsx
@@ -240,7 +240,12 @@ class SingleStat extends PureComponent<Props, State> {
 
     return (
       <div className="single-stat--resizer">
-        <svg width="100%" height="100%" viewBox={viewBox}>
+        <svg
+          width="100%"
+          height="100%"
+          viewBox={viewBox}
+          style={{display: 'block'}}
+        >
           <text
             className="single-stat--text"
             fontSize="87"


### PR DESCRIPTION
Closes #5782 

_Briefly describe your proposed changes:_

Set `svg` element as a `Flex` item.

_What was the problem?_

The Safari didn't render `SingleStat` cell - https://www.google.com/search?rls=en&q=svg+text+safari+flex.

_What was the solution?_

Set `style: block` to `svg` elemenent.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
