### PR TITLE
fix(security): upgrade jwt  to resolve CVE-2020-26160

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5784](https://github.com/influxdata/chronograf/pull/5784): Fix Safari display issues of a Single Stat.
 1. [#5787](https://github.com/influxdata/chronograf/pull/5787): Upgrade bluemonday to resolve CVE-2021-29272.
+1. [#5788](https://github.com/influxdata/chronograf/pull/5784): Upgrade jwt to resolve CVE-2020-26160.
 1. [#5792](https://github.com/influxdata/chronograf/pull/5792): Rename arm rpms with yum-compatible names.
 1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
 

--- a/LICENSE_OF_DEPENDENCIES.md
+++ b/LICENSE_OF_DEPENDENCIES.md
@@ -10,7 +10,7 @@
 * github.com/coreos/go-systemd [Apache-2.0](https://github.com/coreos/go-systemd/blob/master/LICENSE)
 * github.com/coreos/pkg/capnslog [Apache-2.0](https://github.com/coreos/pkg/blob/master/LICENSE)
 * github.com/davecgh/go-spew/spew [ISC](https://github.com/davecgh/go-spew/blob/master/LICENSE)
-* github.com/dgrijalva/jwt-go [MIT](https://github.com/dgrijalva/jwt-go/blob/master/LICENSE)
+* github.com/golang-jwt/jwt/v4 [MIT](github.com/golang-jwt/jwt/blob/main/LICENSE)
 * github.com/dustin/go-humanize [MIT](https://github.com/dustin/go-humanize/blob/master/LICENSE)
 * github.com/eclipse/paho.mqtt.golang [EPL-1.0](https://github.com/eclipse/paho.mqtt.golang/blob/master/LICENSE)
 * github.com/elazarl/go-bindata-assetfs [BSD-2-Clause](https://github.com/elazarl/go-bindata-assetfs/blob/master/LICENSE)

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,9 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/bouk/httprouter v0.0.0-20160817010721-ee8b3818a7f5
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/elazarl/go-bindata-assetfs v1.0.0
 	github.com/gogo/protobuf v1.3.2
+	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -253,7 +253,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/denisenkom/go-mssqldb v0.10.0 h1:QykgLZBorFE95+gO3u9esLd0BmbvpWp0/waNNZfHBM8=
 github.com/denisenkom/go-mssqldb v0.10.0/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
-github.com/dgrijalva/jwt-go v3.0.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-bits v0.0.0-20180113010104-bd8a69a71dc2/go.mod h1:/9UYwwvZuEgp+mQ4960SHWCU1FS+FgdFX+m5ExFByNs=
@@ -378,6 +377,8 @@ github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
+github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe h1:lXe2qZdvpiX5WZkZR4hgp4KJVfY3nMkvmwbVkpv1rVY=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=

--- a/influx/authorization.go
+++ b/influx/authorization.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 	"time"
 
-	jwt "github.com/dgrijalva/jwt-go"
+	jwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
 )
 

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/influx"
 	"github.com/influxdata/chronograf/log"

--- a/oauth2/cookies_test.go
+++ b/oauth2/cookies_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 )
 
 type MockTokenizer struct {

--- a/oauth2/generic.go
+++ b/oauth2/generic.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
 	"golang.org/x/oauth2"
 )

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/lestrrat-go/jwx/jwk"
 )
 

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 	"golang.org/x/oauth2"
 )
 

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -10,7 +10,7 @@ import (
 
 	goauth "golang.org/x/oauth2"
 
-	gojwt "github.com/dgrijalva/jwt-go"
+	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
 )
 


### PR DESCRIPTION
This PR replaces `github.com/dgrijalva/jwt-go` with `github.com/golang-jwt/jwt/v4` in order to fix a security issue that is better described in https://github.com/influxdata/chronograf/security/dependabot/go.mod/github.com%2Fdgrijalva%2Fjwt-go/closed

_Briefly describe your proposed changes:_
_What was the problem?_
_What was the solution?_

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
 