### PR TITLE
fix(ui): avoid useless browser history change in explorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [#5788](https://github.com/influxdata/chronograf/pull/5784): Upgrade jwt to resolve CVE-2020-26160.
 1. [#5792](https://github.com/influxdata/chronograf/pull/5792): Rename arm rpms with yum-compatible names.
 1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
+1. [#5796](https://github.com/influxdata/chronograf/pull/5796): Avoid useless browser history change.
 
 ### Features
 

--- a/ui/src/data_explorer/containers/DataExplorer.tsx
+++ b/ui/src/data_explorer/containers/DataExplorer.tsx
@@ -298,7 +298,9 @@ export class DataExplorer extends PureComponent<Props, State> {
     const pathname = stripPrefix(location.pathname)
     const search = queryParams ? `?${qs.stringify(queryParams)}` : ''
 
-    router.push(pathname + search)
+    if (location.search !== search) {
+      router.push(pathname + search)
+    }
   }
 
   private get writeDataForm(): JSX.Element {


### PR DESCRIPTION
Closes #5795

This PR contains makes sure that the browser history is not extended without a change in influxQL/flux query.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
