### PR TITLE
feat(kapacitor): name tickscript after a name variable when defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5784](https://github.com/influxdata/chronograf/pull/5784): Fix Safari display issues of a Single Stat.
 1. [#5792](https://github.com/influxdata/chronograf/pull/5792): Rename arm rpms with yum-compatible names.
+1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
 
 ### Features
 

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -92,6 +92,12 @@ func NewTask(task *client.Task) *Task {
 			Query: nil,
 		}
 	}
+	// #5403 override name when defined in a variable
+	if nameVar, exists := task.Vars["name"]; exists {
+		if val, isString := nameVar.Value.(string); isString && val != "" {
+			rule.Name = val
+		}
+	}
 
 	rule.ID = task.ID
 	rule.TICKScript = script


### PR DESCRIPTION
Closes #5403

_Briefly describe your proposed changes:_
A task name is taken from a `name` variable when defined. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
