### PR TITLE
fix(kapacitor): repair paginated retrieval of flux tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5784](https://github.com/influxdata/chronograf/pull/5784): Fix Safari display issues of a Single Stat.
 1. [#5792](https://github.com/influxdata/chronograf/pull/5792): Rename arm rpms with yum-compatible names.
 1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
+1. [#5806](https://github.com/influxdata/chronograf/pull/5806): Repair paginated retrival of flux tasks.
 
 ### Features
 

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -76,7 +76,10 @@ export const getFluxTasks = async kapacitor => {
       method: 'GET',
       url:
         kapacitor.links.proxy +
-        `?path=/kapacitor/v1/api/v2/tasks?limit=500&after=${lastID}`,
+        '?path=' +
+        encodeURIComponent(
+          `/kapacitor/v1/api/v2/tasks?limit=500&after=${lastID}`
+        ),
     })
     if (!tasks || !tasks.length) {
       break


### PR DESCRIPTION
This PR fixes retrieval of all flux tasks.

_What was the problem?_
The pagination `after` parameter was lost in the communication with the kapacitor proxy. At most 500 tasks are then returned by the proxy.

_What was the solution?_
The proxy `path` parameter is URI encoded, so that it is properly read by kapactior proxy 
 
  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  