### PR TITLE
feat(tasks): distinguish template tasks in task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@
 1. [#5796](https://github.com/influxdata/chronograf/pull/5796): Avoid useless browser history change.
 1. [#5803](https://github.com/influxdata/chronograf/pull/5803): Repair time rendering in horizontal table.
 1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
-1. [#5805](https://github.com/influxdata/chronograf/pull/5805): Make templated tasks read-only.
+1. [#5805](https://github.com/influxdata/chronograf/pull/5805): Make template tasks read-only.
 1. [#5806](https://github.com/influxdata/chronograf/pull/5806): Repair paginated retrival of flux tasks.
 
 ### Features
+
+1. [#5807](https://github.com/influxdata/chronograf/pull/#5807): Distinguish template tasks in task list.
 
 ### Other
 

--- a/ui/src/kapacitor/components/TasksTable.tsx
+++ b/ui/src/kapacitor/components/TasksTable.tsx
@@ -62,7 +62,11 @@ export class TaskRow extends PureComponent<TaskRowProps> {
     return (
       <tr key={task.id}>
         <td style={{minWidth: colName}}>
-          <Link className="link-success" to={editLink}>
+          <Link
+            style={{color: task['template-id'] ? 'gray' : undefined}}
+            className="link-success"
+            to={editLink}
+          >
             {task.name}
           </Link>
         </td>


### PR DESCRIPTION
This PR visually distinguishes tasks that were created from a template in a chronograf task list. 

__Before this PR__
and before influxdata/kapacitor#2621 is merged:
1. A template task is processed on the chronograf server-side to check if it is a rule. It is never in fact.
   1. If a template task is recognized as a chronograf rule, it falsely appears under Alert Rules section.
2. A template task correctly appears in a TICKScripts section. It is however not distinguished from regular tasks that are editable, a template task is not.

![image](https://user-images.githubusercontent.com/16321466/132168875-26e64126-22b4-4b18-afe1-3746bf02eb2b.png)


__After this PR__
and  after influxdata/kapacitor#2621 is merged:
1. A template task is never processed on the chronograf server-side to check if it is a rule. It cannot appear in Alert Rules section.
2. Tickscript of a template task is visually recognized. It is read-only in chronograf since #5805 .

![image](https://user-images.githubusercontent.com/16321466/132168974-2dfff3e6-79f4-42a2-957c-d1c69ab63a73.png)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
