### PR TITLE
fix(ui): enforce one organization between browser tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 1. [#5805](https://github.com/influxdata/chronograf/pull/5805): Make template tasks read-only.
 1. [#5806](https://github.com/influxdata/chronograf/pull/5806): Repair paginated retrival of flux tasks.
 1. [#5815](https://github.com/influxdata/chronograf/pull/5815): Update time range of flux queries on dashboard zoom.
+1. [#5808](https://github.com/influxdata/chronograf/pull/5808): Enforce one organization between browser tabs.
 
 ### Features
 

--- a/ui/src/store/configureStore.js
+++ b/ui/src/store/configureStore.js
@@ -2,6 +2,7 @@ import {createStore, applyMiddleware, compose} from 'redux'
 import {combineReducers} from 'redux'
 import {routerReducer, routerMiddleware} from 'react-router-redux'
 import thunkMiddleware from 'redux-thunk'
+import {get} from 'lodash'
 
 import errorsMiddleware from 'shared/middleware/errors'
 import {resizeLayout} from 'shared/middleware/resizeLayout'
@@ -36,6 +37,9 @@ const rootReducer = combineReducers({
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
+const KEY_ORG = 'orgchrono' // local storage key holding active organization
+let currentOrg // active organization, possibly empty or undefined
+
 export default function configureStore(initialState, browserHistory) {
   const routingMiddleware = routerMiddleware(browserHistory)
   const createPersistentStore = composeEnhancers(
@@ -45,12 +49,60 @@ export default function configureStore(initialState, browserHistory) {
       routingMiddleware,
       errorsMiddleware,
       queryStringConfig,
-      resizeLayout
+      resizeLayout,
+      signalizeChangedOrg
     )
   )(createStore)
+
+  // reload whenever current organization is changed from another tab/window
+  try {
+    currentOrg = window.localStorage.getItem(KEY_ORG)
+    window.addEventListener('storage', function (e) {
+      if (e.storageArea !== window.localStorage && e.key !== KEY_ORG) {
+        return
+      }
+      if (e.newValue !== currentOrg) {
+        // reload the page on organization change made from another tab
+        window.location.reload()
+      }
+    })
+  } catch (e) {
+    // ignore window.localStorage unavailability or getItem error
+    console.error(e)
+  }
 
   // https://github.com/elgerlambert/redux-localstorage/issues/42
   // createPersistantStore should ONLY take reducer and initialState
   // any store enhancers must be added to the compose() function.
   return createPersistentStore(rootReducer, initialState)
+}
+
+/**
+ * SignalizeChangedOrg is a redux middleware that
+ * stores current organization ID into localStorage so that
+ * browser windows/tabs can be notified about session change.
+ */
+const signalizeChangedOrg = () => next => action => {
+  next(action)
+
+  try {
+    if (action.type === 'ME_GET_COMPLETED') {
+      const orgId = get(
+        action,
+        ['payload', 'me', 'currentOrganization', 'id'],
+        ''
+      )
+      if (orgId !== currentOrg) {
+        currentOrg = orgId
+        window.localStorage.setItem(KEY_ORG, currentOrg)
+      }
+    }
+    if (action.type === 'AUTH_EXPIRED') {
+      currentOrg = ''
+      window.localStorage.setItem(KEY_ORG, currentOrg)
+    }
+  } catch (e) {
+    // ignore window.localStorage unavailability or setItem errors
+    console.error(e)
+  }
 }


### PR DESCRIPTION
Closes #5742

_Briefly describe your proposed changes:_
Inactive window/tab is forced to reload whenever the user logs out or changes the organization. This is done with the help of `window.localStorage` that holds current organization, browser tabs and windows are subscribed to organization changes.

_What was the problem?_
User's data including the current organization are part of the session between the chronograf UI and chronograf server. This session is shared between browser tabs/windows. Whenever the user change the organization, logs-in, log-out, the session changes but the other windows/tabs are not informed. At the end, it results in phantom data beeing shown in the inactive windows and random errors.

_What was the solution?_
A change of an active organization, as well as user logout/login forces all inactive windows/tab to reload.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
