### PR TITLE
fix(ui): update time range in flux queries on dashboard zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [#5804](https://github.com/influxdata/chronograf/pull/5804): Name tickscript after a `name` task variable, when defined.
 1. [#5805](https://github.com/influxdata/chronograf/pull/5805): Make templated tasks read-only.
 1. [#5806](https://github.com/influxdata/chronograf/pull/5806): Repair paginated retrival of flux tasks.
+1. [#5815](https://github.com/influxdata/chronograf/pull/5815): Update time range of flux queries on dashboard zoom.
 
 ### Features
 

--- a/ui/src/flux/helpers/templates.ts
+++ b/ui/src/flux/helpers/templates.ts
@@ -1,6 +1,10 @@
-import {Template, TimeRange} from 'src/types'
+import {Template, TemplateValueType, TimeRange} from 'src/types'
 import {computeInterval} from 'src/tempVars/utils/replace'
-import {DEFAULT_DURATION_MS} from 'src/shared/constants'
+import {
+  DEFAULT_DURATION_MS,
+  TEMP_VAR_DASHBOARD_TIME,
+  TEMP_VAR_UPPER_DASHBOARD_TIME,
+} from 'src/shared/constants'
 import {extractImports} from 'src/shared/parsing/flux/extractImports'
 import {getMinDuration} from 'src/shared/parsing/flux/durations'
 import fluxString from './fluxString'
@@ -59,6 +63,30 @@ function fluxVariables(
     return `dashboardTime = ${lower}\nupperDashboardTime = ${upper}\nautoInterval = ${interval}ms\nv = {${extraVars} timeRangeStart: dashboardTime , timeRangeStop: upperDashboardTime , windowPeriod: autoInterval }`
   }
   return `dashboardTime = ${lower}\nupperDashboardTime = ${upper}\nv = {${extraVars} timeRangeStart: dashboardTime , timeRangeStop: upperDashboardTime }`
+}
+
+/**
+ * Extracts exact time range from `dashboardTime` and `upperDashboardTime` variables or returns undefined.
+ */
+export function extractExactTimeRange(
+  templates: Template[]
+): TimeRange | undefined {
+  const lower = templates.find(x => x.tempVar === TEMP_VAR_DASHBOARD_TIME)
+  const upper = templates.find(x => x.tempVar === TEMP_VAR_UPPER_DASHBOARD_TIME)
+  if (!lower || !upper) {
+    return undefined
+  }
+
+  if (
+    lower.values?.[0]?.type === TemplateValueType.TimeStamp &&
+    upper.values?.[0]?.type === TemplateValueType.TimeStamp
+  ) {
+    return {
+      lower: lower.values?.[0]?.value,
+      upper: upper.values?.[0]?.value,
+    }
+  }
+  return undefined
 }
 
 export const renderTemplatesInScript = async (

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -16,7 +16,10 @@ import {notify} from 'src/shared/actions/notifications'
 import {fluxResponseTruncatedError} from 'src/shared/copy/notifications'
 import {getDeep} from 'src/utils/wrappers'
 import {restartable} from 'src/shared/utils/restartable'
-import {renderTemplatesInScript} from 'src/flux/helpers/templates'
+import {
+  extractExactTimeRange,
+  renderTemplatesInScript,
+} from 'src/flux/helpers/templates'
 import {parseResponse} from 'src/shared/parsing/flux/response'
 import DefaultDebouncer, {Debouncer} from 'src/shared/utils/debouncer'
 import {DEFAULT_X_PIXELS} from 'src/shared/constants'
@@ -281,7 +284,7 @@ class TimeSeries extends PureComponent<Props, State> {
 
     const renderedScript = await renderTemplatesInScript(
       script,
-      timeRange,
+      extractExactTimeRange(templates) || timeRange, // zoom functionality updates templates, prefer zoomed time range in flux
       templates,
       fluxASTLink
     )

--- a/ui/test/flux/helpers/templates.test.ts
+++ b/ui/test/flux/helpers/templates.test.ts
@@ -1,4 +1,7 @@
-import {renderTemplatesInScript} from 'src/flux/helpers/templates'
+import {
+  extractExactTimeRange,
+  renderTemplatesInScript,
+} from 'src/flux/helpers/templates'
 import {Template, TemplateType, TemplateValueType} from 'src/types'
 
 const allTemplateTypes: Template[] = [
@@ -283,5 +286,114 @@ describe('Flux.helpers.renderTemplatesInScript', () => {
     expected +=
       '\n\nfrom(bucket: "a") |> range(start: 0) |> aggregateWindow(every: v.windowPeriod, fn: mean)'
     expect(actual).toEqual(expected)
+  })
+})
+
+describe('extractExactTimeRange', () => {
+  it('extracts no value for unknown exact range', async () => {
+    const tests: Template[][] = [
+      [],
+      [
+        {
+          id: 'dashtime',
+          tempVar: ':dashboardTime:',
+          type: TemplateType.TimeStamp,
+          label: '',
+          values: [
+            {
+              value: '2021-01-01T00:45:07.929Z',
+              type: TemplateValueType.TimeStamp,
+              selected: true,
+              localSelected: true,
+            },
+          ],
+        },
+      ],
+      [
+        {
+          id: 'upperdashtime',
+          tempVar: ':upperDashboardTime:',
+          type: TemplateType.TimeStamp,
+          label: '',
+          values: [
+            {
+              value: '2021-01-01T00:46:18.532Z',
+              type: TemplateValueType.TimeStamp,
+              selected: true,
+              localSelected: true,
+            },
+          ],
+        },
+      ],
+      [
+        {
+          id: 'dashtime',
+          tempVar: ':dashboardTime:',
+          type: TemplateType.Constant,
+          label: '',
+          values: [
+            {
+              value: 'now() - 5m',
+              type: TemplateValueType.Constant,
+              selected: true,
+              localSelected: true,
+            },
+          ],
+        },
+        {
+          id: 'upperdashtime',
+          tempVar: ':upperDashboardTime:',
+          type: TemplateType.Constant,
+          label: '',
+          values: [
+            {
+              value: 'now()',
+              type: TemplateValueType.Constant,
+              selected: true,
+              localSelected: true,
+            },
+          ],
+        },
+      ],
+    ]
+    tests.forEach(t => {
+      expect(extractExactTimeRange(t)).toEqual(undefined)
+    })
+  })
+  it('extracts valid time range for an exact range', async () => {
+    const templates = [
+      {
+        id: 'dashtime',
+        tempVar: ':dashboardTime:',
+        type: TemplateType.TimeStamp,
+        label: '',
+        values: [
+          {
+            value: '2021-01-01T00:45:07.929Z',
+            type: TemplateValueType.TimeStamp,
+            selected: true,
+            localSelected: true,
+          },
+        ],
+      },
+      {
+        id: 'upperdashtime',
+        tempVar: ':upperDashboardTime:',
+        type: TemplateType.TimeStamp,
+        label: '',
+        values: [
+          {
+            value: '2021-01-01T00:46:18.532Z',
+            type: TemplateValueType.TimeStamp,
+            selected: true,
+            localSelected: true,
+          },
+        ],
+      },
+    ]
+    expect(extractExactTimeRange(templates)).toEqual({
+      lower: '2021-01-01T00:45:07.929Z',
+      upper: '2021-01-01T00:46:18.532Z',
+    })
   })
 })


### PR DESCRIPTION
Closes #5814

_Briefly describe your proposed changes:_
When zooming a cell, a cell's flux query is rerun with zoomed time interval parameters, the same way as the InfluxQL query already does.

_What was the problem?_
The time interval of a zoomed area was not applied to a flux query, zoom functionality thus only zoomed data for computed for the whole time range.
![ZoomFlux_beforeFix](https://user-images.githubusercontent.com/16321466/134514366-4f40cbd2-76db-4e1c-ba60-ab91bab0309b.gif)

_What was the solution?_
A zoomed action re-fetches the data with zoom time range.
![ZoomFlux_afterFix](https://user-images.githubusercontent.com/16321466/134514131-a1b1f33e-27d8-4a23-a313-58b2b4c09001.gif)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
