### PR TITLE
feat(ui): support Firefox in private mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#5808](https://github.com/influxdata/chronograf/pull/5808): Enforce one organization between browser tabs.
 1. [#5810](https://github.com/influxdata/chronograf/pull/5810): Repair calculation of flux query range duration.
 1. [#5815](https://github.com/influxdata/chronograf/pull/5815): Update time range of flux queries on dashboard zoom.
+1. [#5818](https://github.com/influxdata/chronograf/pull/5818): Support Firefox private mode.
 
 
 ### Other
@@ -22,7 +23,7 @@
 
 ### Features
 
-1. [#5807](https://github.com/influxdata/chronograf/pull/#5807): Distinguish template tasks in task list.
+1. [#5807](https://github.com/influxdata/chronograf/pull/5807): Distinguish template tasks in task list.
 
 ### Other
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,7 @@
     "@types/dygraphs": "^1.1.6",
     "@types/enzyme": "^3.1.13",
     "@types/jest": "^26.0.20",
-    "@types/levelup": "^0.0.30",
+    "@types/levelup": "^4.3.3",
     "@types/lodash": "^4.14.104",
     "@types/node": "^9.4.6",
     "@types/papaparse": "^4.1.34",

--- a/ui/src/worker/Database.ts
+++ b/ui/src/worker/Database.ts
@@ -6,7 +6,7 @@ let DB
 levelup(encoding(level('worker'), {valueEncoding: 'json'}), (err, db) => {
   DB = db
   if (err) {
-    // index DB not available, can happen in private modes
+    // can happen in Firefox private mode
     // eslint-disable-next-line no-console
     console.debug('IndexedDB is not available')
   }
@@ -18,12 +18,13 @@ interface DBMessage {
 }
 
 export const writePayload = async (msg: DBMessage, payload: any) => {
-  try {
-    if (DB) {
-      return DB.put(msg.id, payload)
+  if (DB) {
+    try {
+      await DB.put(msg.id, payload)
+      return
+    } catch (e) {
+      console.error('Unable to write to IndexedDB', e)
     }
-  } catch (e) {
-    // unable to write to DB
   }
   msg.payload = payload
 }

--- a/ui/src/worker/Database.ts
+++ b/ui/src/worker/Database.ts
@@ -2,4 +2,38 @@ import levelup from 'levelup'
 import encoding from 'encoding-down'
 import level from 'level-js'
 
-export default levelup(encoding(level('worker'), {valueEncoding: 'json'}))
+let DB
+levelup(encoding(level('worker'), {valueEncoding: 'json'}), (err, db) => {
+  DB = db
+  if (err) {
+    // index DB not available, can happen in private modes
+    // eslint-disable-next-line no-console
+    console.debug('IndexedDB is not available')
+  }
+})
+
+interface DBMessage {
+  id: string
+  payload?: any
+}
+
+export const writePayload = async (msg: DBMessage, payload: any) => {
+  try {
+    if (DB) {
+      return DB.put(msg.id, payload)
+    }
+  } catch (e) {
+    // unable to write to DB
+  }
+  msg.payload = payload
+}
+
+export const readPayload = async (msg: DBMessage): Promise<any> => {
+  if (msg.payload || !DB) {
+    return msg.payload
+  }
+  const payload = await DB.get(msg.id)
+  await DB.del(msg.id)
+
+  return payload
+}

--- a/ui/src/worker/utils/index.ts
+++ b/ui/src/worker/utils/index.ts
@@ -1,18 +1,10 @@
-import DB from 'src/worker/Database'
+import {readPayload, writePayload} from 'src/worker/Database'
 import uuid from 'uuid'
 
 import {Message} from 'src/worker/types'
 
-export const removeData = async (msg: Message): Promise<void> => {
-  await DB.del(msg.id)
-}
-
 export const fetchData = async (msg: Message): Promise<any> => {
-  const result = await DB.get(msg.id)
-
-  await removeData(msg)
-
-  return result
+  return readPayload(msg)
 }
 
 export const error = (msg: Message, err: Error) => {
@@ -26,14 +18,13 @@ export const error = (msg: Message, err: Error) => {
   })
 }
 
-export const success = async (msg: Message, payload: any) => {
-  const id = uuid.v4()
-
-  await DB.put(id, payload)
-
-  postMessage({
-    id,
-    origin: msg.id,
+export const success = async (originMsg: Message, payload: any) => {
+  const msg = {
+    id: uuid.v4(),
+    origin: originMsg.id,
     result: 'success',
-  })
+  }
+  writePayload(msg, payload)
+
+  postMessage(msg)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1428,6 +1428,11 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
+"@types/abstract-leveldown@*":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@types/abstract-leveldown/-/abstract-leveldown-5.0.2.tgz#ee81917fe38f770e29eec8139b6f16ee4a8b0a5f"
+  integrity sha512-+jA1XXF3jsz+Z7FcuiNqgK53hTa/luglT2TyTpKPqoYbxVY+mCPF22Rm+q3KPBrMHJwNXFrTViHszBOfU4vftQ==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.12"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.12.tgz#4d8e9e51eb265552a7e4f1ff2219ab6133bdfb2d"
@@ -1571,11 +1576,18 @@
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
 
-"@types/levelup@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-0.0.30.tgz#869dd7a82cdbe5983e737006a1ff4e42fac97ca7"
-  integrity sha1-hp3XqCzb5Zg+c3AGof9OQvrJfKc=
+"@types/level-errors@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/level-errors/-/level-errors-3.0.0.tgz#15c1f4915a5ef763b51651b15e90f6dc081b96a8"
+  integrity sha512-/lMtoq/Cf/2DVOm6zE6ORyOM+3ZVm/BvzEZVxUhf6bgh8ZHglXlBqxbxSlJeVp8FCbD3IVvk/VbsaNmDjrQvqQ==
+
+"@types/levelup@^4.3.3":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@types/levelup/-/levelup-4.3.3.tgz#4dc2b77db079b1cf855562ad52321aa4241b8ef4"
+  integrity sha512-K+OTIjJcZHVlZQN1HmU64VtrC0jC3dXWQozuEIR9zVvltIk90zaGPM2AgT+fIkChpzHhFE3YnvFLCbLtzAmexA==
   dependencies:
+    "@types/abstract-leveldown" "*"
+    "@types/level-errors" "*"
     "@types/node" "*"
 
 "@types/lodash@^4.14.104":


### PR DESCRIPTION
Closes #5817

_Briefly describe your proposed changes:_
The code detects whether IndexedDB is available. If it is not, the payload data between workers and the UI are posted in messages. There was probably a good reason for using IndexedDB to exchange messages, it can save memory and avoid OOM when workers/UI are under pressure. IndexedDB is thus still a default choice to avoid regression issues on all currently working browsers.

_What was the problem?_
IndexDB cannot be opened when in private mode (Firefox), the UI application fails on it. I may be eventually supported once https://bugzilla.mozilla.org/show_bug.cgi?id=1639542 is implemented.

_What was the solution?_
Fallback to a standard message exchange when IndexedDB is not available.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
