### PR TITLE
fix(ui/flux): skip missing values in line chart instead of returning zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 1. [#5810](https://github.com/influxdata/chronograf/pull/5810): Repair calculation of flux query range duration.
 1. [#5815](https://github.com/influxdata/chronograf/pull/5815): Update time range of flux queries on dashboard zoom.
 1. [#5818](https://github.com/influxdata/chronograf/pull/5818): Support Firefox private mode.
-
+1. [#5821](https://github.com/influxdata/chronograf/pull/5821): Skip missing values in line chart instead of returning zeros.
 
 ### Other
 

--- a/ui/src/worker/jobs/fluxTablesToDygraph.ts
+++ b/ui/src/worker/jobs/fluxTablesToDygraph.ts
@@ -36,7 +36,7 @@ export const fluxTablesToDygraphWork = (
 
       for (const [seriesName, value] of Object.entries(values)) {
         const i = allColumnNames.indexOf(seriesName) + DATE_INDEX_OFFSET
-        dygraphValuesByTime[date][i] = Number(value)
+        dygraphValuesByTime[date][i] = value === '' ? null : Number(value)
       }
     }
   }

--- a/ui/test/shared/parsing/flux/constants.ts
+++ b/ui/test/shared/parsing/flux/constants.ts
@@ -192,3 +192,14 @@ export const ERROR_RESPONSE = `#datatype,string,string
 #default,,
 ,error,reference
 ,${ERROR}`
+
+export const WINDOWED_WITH_EMPTY = `
+#group,false,false,true,true,false,false,true,true
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,double,string,string
+#default,_result,,,,,,,
+,result,table,_start,_stop,_time,_value,_field,_measurement
+,,0,2020-12-31T23:00:00Z,2021-01-01T04:00:00Z,2021-01-01T02:44:10Z,,value,temperature2
+,,0,2020-12-31T23:00:00Z,2021-01-01T04:00:00Z,2021-01-01T02:45:00Z,22,value,temperature2
+,,0,2020-12-31T23:00:00Z,2021-01-01T04:00:00Z,2021-01-01T02:45:50Z,,value,temperature2
+,,0,2020-12-31T23:00:00Z,2021-01-01T04:00:00Z,2021-01-01T02:46:40Z,23,value,temperature2
+,,0,2020-12-31T23:00:00Z,2021-01-01T04:00:00Z,2021-01-01T02:47:30Z,,value,temperature2`

--- a/ui/test/shared/parsing/flux/dygraph.test.ts
+++ b/ui/test/shared/parsing/flux/dygraph.test.ts
@@ -5,6 +5,7 @@ import {
   MISMATCHED,
   MULTI_VALUE_ROW,
   MIXED_DATATYPES,
+  WINDOWED_WITH_EMPTY,
 } from 'test/shared/parsing/flux/constants'
 
 describe('fluxTablesToDygraph', () => {
@@ -69,5 +70,18 @@ describe('fluxTablesToDygraph', () => {
       nonNumericColumns: ['my_fun_col'],
     }
     expect(actual).toEqual(expected)
+  })
+  it('returns null if value is not available', () => {
+    const fluxTables = parseResponse(WINDOWED_WITH_EMPTY)
+    const actual = fluxTablesToDygraph(fluxTables)
+    const expected = [
+      [new Date('2021-01-01T02:44:10Z'), null],
+      [new Date('2021-01-01T02:45:00Z'), 22],
+      [new Date('2021-01-01T02:45:50Z'), null],
+      [new Date('2021-01-01T02:46:40Z'), 23],
+      [new Date('2021-01-01T02:47:30Z'), null],
+    ]
+
+    expect(actual.dygraphsData).toEqual(expected)
   })
 })


### PR DESCRIPTION
Closes #5820

_Briefly describe your proposed changes:_
When a FLUX CSV response contains no value, the associated dygraph transformation returns `null` value for that time. This can happen when with `window`-ed data that can create empty values.

_What was the problem?_
`0` is returned when no _value is defined. UI renders a wrong zero value in such places.
![image](https://user-images.githubusercontent.com/16321466/135383033-2424a114-5f27-46b5-8653-991e189f7bf5.png)

_What was the solution?_
`null` value is returned when _value is not defined, it behaves the same way as InfluxQL result transformation.
![image](https://user-images.githubusercontent.com/16321466/135383134-49d17a6d-8311-4264-bf91-257df7ee966f.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
