### PR TITLE
fix(ui): repair multiple tabs organization sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### Bug Fixes
 
-### Features
-
+1. [#5830](https://github.com/influxdata/chronograf/pull/5830): Repair enforcement of one organization between multiple tabs.
+ 
 ### Other
 
 1. [#5824](https://github.com/influxdata/chronograf/pull/5824): Move from `gogo/protobuf` to `google.golang.org/protobuf` for wire format messages.

--- a/ui/src/store/configureStore.js
+++ b/ui/src/store/configureStore.js
@@ -38,7 +38,7 @@ const rootReducer = combineReducers({
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose
 
 const KEY_ORG = 'orgchrono' // local storage key holding active organization
-let currentOrg // active organization, possibly empty or undefined
+let currentOrg = '' // active organization, possibly empty or undefined
 
 export default function configureStore(initialState, browserHistory) {
   const routingMiddleware = routerMiddleware(browserHistory)
@@ -56,9 +56,9 @@ export default function configureStore(initialState, browserHistory) {
 
   // reload whenever current organization is changed from another tab/window
   try {
-    currentOrg = window.localStorage.getItem(KEY_ORG)
+    currentOrg = window.localStorage.getItem(KEY_ORG) || ''
     window.addEventListener('storage', function (e) {
-      if (e.storageArea !== window.localStorage && e.key !== KEY_ORG) {
+      if (e.storageArea !== window.localStorage || e.key !== KEY_ORG) {
         return
       }
       if (e.newValue !== currentOrg) {


### PR DESCRIPTION
Closes #5826

The detection of multiple tabs with different chronograf organizations in 1.9.1 was wrong, it is fixed herein.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass