### PR TITLE
feat(ui): add download button on query management page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## v1.9.2
 
+### Features
+
+1. [#5831](https://github.com/influxdata/chronograf/pull/5831): Add download button on query management page.
+
 ### Bug Fixes
 
 1. [#5830](https://github.com/influxdata/chronograf/pull/5830): Repair enforcement of one organization between multiple tabs.
- 
+
 ### Other
 
 1. [#5824](https://github.com/influxdata/chronograf/pull/5824): Move from `gogo/protobuf` to `google.golang.org/protobuf` for wire format messages.

--- a/ui/src/admin/containers/QueriesPage.js
+++ b/ui/src/admin/containers/QueriesPage.js
@@ -23,6 +23,8 @@ import {
 } from 'src/admin/actions/influxdb'
 
 import {notify as notifyAction} from 'shared/actions/notifications'
+import {Button, IconFont, ComponentStatus} from 'src/reusable_ui'
+import moment from 'moment'
 
 class QueriesPage extends Component {
   constructor(props) {
@@ -55,7 +57,16 @@ class QueriesPage extends Component {
       <div className="panel panel-solid">
         <div className="panel-heading">
           <h2 className="panel-title">{title}</h2>
-          <div style={{float: 'right'}}>
+          <div style={{float: 'right', display: 'flex'}}>
+            <div style={{marginRight: '5px'}}>
+              <Button
+                customClass="csv-export"
+                text="CSV"
+                icon={IconFont.Download}
+                status={ComponentStatus.Default}
+                onClick={this.downloadCSV}
+              />
+            </div>
             <AutoRefreshDropdown
               selected={updateInterval}
               onChoose={this.changeRefreshInterval}
@@ -135,6 +146,27 @@ class QueriesPage extends Component {
   handleKillQuery = query => {
     const {source, killQuery} = this.props
     killQuery(source.links.proxy, query)
+  }
+
+  downloadCSV = () => {
+    const queries = this.props.queries || {}
+    const csv = queries.reduce((acc, val) => {
+      const db = val.database.replace(/"/g, '""')
+      const query = val.query.replace(/"/g, '""')
+      return `${acc}"${db}","${query}",${val.duration}${'\n'}`
+    }, 'database,query,duration\n')
+    const blob = new Blob([csv], {type: 'text/csv'})
+    const a = document.createElement('a')
+
+    a.href = window.URL.createObjectURL(blob)
+    a.target = '_blank'
+    a.download = `${moment().format(
+      'YYYY-MM-DD-HH-mm-ss'
+    )} Chronograf Queries.csv`
+
+    document.body.appendChild(a)
+    a.click()
+    a.parentNode.removeChild(a)
   }
 }
 


### PR DESCRIPTION
Closes #5827

This PR adds `CSV download` button to `InfluxDB Admin`/`Queries` page. 
![image](https://user-images.githubusercontent.com/16321466/139715515-97c2060e-f5d1-4ca4-9ecb-cbf5311b8843.png)


- the download button is always enabled, it is consistent with the Explorer CSV download functionality
- user-visible data is always downloaded with the same ordering that appears on the page
- downloaded filename looks like `2021-11-01-18-25-55 Chronograf Queries.csv`

The file content looks like this:
```csv
database,query,duration
"my-bucket","SHOW QUERIES",387µs
"mydb","SHOW QUERIES",41µs
"telegraf","SHOW QUERIES",40µs
"_internal","SHOW QUERIES",33µs
"chronograf","SHOW QUERIES",20µs
"taskrun","SHOW QUERIES",17µs
```

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
