### PR TITLE
fix(server): use proxy from environment in HTTP clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 1. [#5830](https://github.com/influxdata/chronograf/pull/5830): Repair enforcement of one organization between multiple tabs.
 1. [#5836](https://github.com/influxdata/chronograf/pull/5836): Allow to save a new TICKscript.
+1. [#5842](https://github.com/influxdata/chronograf/pull/5842): Configure HTTP proxy from environment variables in HTTP clients.
 
 ### Other
 

--- a/cmd/chronoctl/token.go
+++ b/cmd/chronoctl/token.go
@@ -77,6 +77,7 @@ func getNonceMsg(url string, insecureSkipVerify bool) ([]byte, error) {
 
 	hc := &http.Client{
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify},
 		},
 	}

--- a/cmd/chronoctl/token.go
+++ b/cmd/chronoctl/token.go
@@ -32,7 +32,7 @@ type tokenCommand struct {
 func (t *tokenCommand) Execute(args []string) error {
 	key, err := parsePrivKey(string(t.PrivKeyFile))
 	if err != nil {
-		errExit(fmt.Errorf("Failed to parse RSA key: %s", err.Error()))
+		errExit(fmt.Errorf("failed to parse RSA key: %s", err.Error()))
 	}
 
 	msg, err := getNonceMsg(t.ChronoURL, t.SkipVerify)
@@ -42,7 +42,7 @@ func (t *tokenCommand) Execute(args []string) error {
 
 	dgst, err := signMsg(msg, key)
 	if err != nil {
-		errExit(fmt.Errorf("Failed to sign: %s", err.Error()))
+		errExit(fmt.Errorf("failed to sign: %s", err.Error()))
 	}
 
 	fmt.Println(base64.StdEncoding.EncodeToString(dgst))
@@ -51,19 +51,19 @@ func (t *tokenCommand) Execute(args []string) error {
 
 func parsePrivKey(privKeyFile string) (*rsa.PrivateKey, error) {
 	if privKeyFile == "" {
-		return nil, errors.New("No private key file specified")
+		return nil, errors.New("no private key file specified")
 	}
 
 	pemBytes, err := ioutil.ReadFile(string(privKeyFile))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to read file: %s", err.Error())
+		return nil, fmt.Errorf("failed to read file: %s", err.Error())
 	}
 
 	block, _ := pem.Decode(pemBytes)
 	if block == nil {
-		return nil, errors.New("No PEM formatted key found")
+		return nil, errors.New("no PEM formatted key found")
 	} else if block.Type != "RSA PRIVATE KEY" {
-		return nil, fmt.Errorf("Unsupported key type %q", block.Type)
+		return nil, fmt.Errorf("unsupported key type %q", block.Type)
 	}
 
 	return x509.ParsePKCS1PrivateKey(block.Bytes)
@@ -72,7 +72,7 @@ func parsePrivKey(privKeyFile string) (*rsa.PrivateKey, error) {
 func getNonceMsg(url string, insecureSkipVerify bool) ([]byte, error) {
 	req, err := http.NewRequest("GET", url+"/nonce", nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create request: %s", err.Error())
+		return nil, fmt.Errorf("failed to create request: %s", err.Error())
 	}
 
 	hc := &http.Client{
@@ -84,7 +84,7 @@ func getNonceMsg(url string, insecureSkipVerify bool) ([]byte, error) {
 
 	resp, err := hc.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get nonce: %s", err.Error())
+		return nil, fmt.Errorf("failed to get nonce: %s", err.Error())
 	}
 	defer resp.Body.Close()
 

--- a/flux/client.go
+++ b/flux/client.go
@@ -10,13 +10,13 @@ import (
 	"time"
 
 	"github.com/influxdata/chronograf"
-	"github.com/influxdata/chronograf/influx"
+	"github.com/influxdata/chronograf/util"
 )
 
 // Shared transports for all clients to prevent leaking connections.
 var (
-	skipVerifyTransport = influx.CreateTransport(true)
-	defaultTransport    = influx.CreateTransport(false)
+	skipVerifyTransport = util.CreateTransport(true)
+	defaultTransport    = util.CreateTransport(false)
 )
 
 // Client is how we interact with Flux.

--- a/flux/client.go
+++ b/flux/client.go
@@ -2,7 +2,6 @@ package flux
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"io/ioutil"
 	"net/http"
@@ -11,14 +10,13 @@ import (
 	"time"
 
 	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/influx"
 )
 
 // Shared transports for all clients to prevent leaking connections.
 var (
-	skipVerifyTransport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	defaultTransport = &http.Transport{}
+	skipVerifyTransport = influx.CreateTransport(true)
+	defaultTransport    = influx.CreateTransport(false)
 )
 
 // Client is how we interact with Flux.

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/id"
-	"github.com/influxdata/chronograf/influx"
+	"github.com/influxdata/chronograf/util"
 	client "github.com/influxdata/kapacitor/client/v1"
 )
 
@@ -22,8 +22,8 @@ const (
 )
 
 var (
-	skipVerifyTransport = influx.CreateTransport(true)
-	defaultTransport    = influx.CreateTransport(false)
+	skipVerifyTransport = util.CreateTransport(true)
+	defaultTransport    = util.CreateTransport(false)
 )
 
 // Client communicates to kapacitor

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -2,7 +2,6 @@ package kapacitor
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"regexp"
@@ -10,6 +9,7 @@ import (
 
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/id"
+	"github.com/influxdata/chronograf/influx"
 	client "github.com/influxdata/kapacitor/client/v1"
 )
 
@@ -22,10 +22,8 @@ const (
 )
 
 var (
-	skipVerifyTransport = &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-	}
-	defaultTransport = &http.Transport{}
+	skipVerifyTransport = influx.CreateTransport(true)
+	defaultTransport    = influx.CreateTransport(false)
 )
 
 // Client communicates to kapacitor

--- a/server/server.go
+++ b/server/server.go
@@ -692,14 +692,10 @@ func (s *Server) Serve(ctx context.Context) {
 		return
 	}
 
-	s.oauthClient = http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: s.GenericInsecure,
-				RootCAs:            certs,
-			},
-		},
-	}
+	transport := influx.CreateTransport(true)
+	transport.TLSClientConfig.InsecureSkipVerify = s.GenericInsecure
+	transport.TLSClientConfig.RootCAs = certs
+	s.oauthClient = http.Client{Transport: transport}
 
 	auth := oauth2.NewCookieJWT(s.TokenSecret, s.AuthDuration, s.InactivityDuration)
 	providerFuncs := []func(func(oauth2.Provider, oauth2.Mux)){

--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	clog "github.com/influxdata/chronograf/log"
 	"github.com/influxdata/chronograf/oauth2"
 	"github.com/influxdata/chronograf/server/config"
+	"github.com/influxdata/chronograf/util"
 	client "github.com/influxdata/usage-client/v1"
 	flags "github.com/jessevdk/go-flags"
 )
@@ -692,7 +693,7 @@ func (s *Server) Serve(ctx context.Context) {
 		return
 	}
 
-	transport := influx.CreateTransport(true)
+	transport := util.CreateTransport(true)
 	transport.TLSClientConfig.InsecureSkipVerify = s.GenericInsecure
 	transport.TLSClientConfig.RootCAs = certs
 	s.oauthClient = http.Client{Transport: transport}

--- a/util/http.go
+++ b/util/http.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"crypto/tls"
+	"net"
+	"net/http"
+	"time"
+)
+
+// CreateTransport creates a new HTTP transport. The supplied skipVerify parameter
+// turn off TLS verification when true.
+func CreateTransport(skipVerify bool) *http.Transport {
+	var transport *http.Transport
+	if cloneable, ok := http.DefaultTransport.(interface{ Clone() *http.Transport }); ok {
+		transport = cloneable.Clone() // available since go1.13
+	} else {
+		// This uses the same values as http.DefaultTransport
+		transport = &http.Transport{
+			Proxy: http.ProxyFromEnvironment,
+			DialContext: (&net.Dialer{
+				Timeout:   30 * time.Second,
+				KeepAlive: 30 * time.Second,
+				DualStack: true,
+			}).DialContext,
+			MaxIdleConns:          100,
+			IdleConnTimeout:       90 * time.Second,
+			TLSHandshakeTimeout:   10 * time.Second,
+			ExpectContinueTimeout: 1 * time.Second,
+		}
+	}
+	if skipVerify {
+		if transport.TLSClientConfig == nil {
+			transport.TLSClientConfig = &tls.Config{}
+		}
+		transport.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return transport
+}


### PR DESCRIPTION
This PR changes the configuration of HTTP clients to use a default client configuration that honors HTTP proxy settings from the [environment](https://pkg.go.dev/net/http#ProxyFromEnvironment). All places that missed such configuration were repaired
  - chronoctl tool's token command
  - server's OAuth client
  - kapacitor client
  - flux client

Additionality, the campground is cleaner herein so that it avoids circular dependencies and `staticcheck` errors.


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
