### PR TITLE
fix: log remote URL when ping fails

### DIFF
--- a/server/sources.go
+++ b/server/sources.go
@@ -198,7 +198,7 @@ func (s *Service) sourceVersion(ctx context.Context, src *chronograf.Source) str
 	if err == nil {
 		return retVal
 	}
-	s.Logger.WithField("error", err.Error()).Info("Failed to retrieve database version")
+	s.Logger.WithField("error", err.Error()).WithField("url", src.URL).Info("Failed to retrieve database version")
 	if strings.HasPrefix(src.Version, "1.") || strings.HasPrefix(src.Version, "2.") {
 		// keep the client version unchanged
 		return src.Version


### PR DESCRIPTION
This PR adds remote IP to logs when ping fails.

  - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
