### PR TITLE
fix(ui): repair retrieval of worker responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## v1.9.3
 
-### Features
-
 ### Bug Fixes
 
-### Other
+1. [#5845](https://github.com/influxdata/chronograf/pull/5845): Repair retrieval of background job results.
 
 ## v1.9.2 [2022-01-25]
 

--- a/ui/src/worker/JobManager.ts
+++ b/ui/src/worker/JobManager.ts
@@ -108,7 +108,7 @@ class JobManager {
 
   private fetchPayload = async (deferred, msg) => {
     try {
-      const payload = readPayload(msg)
+      const payload = await readPayload(msg)
       deferred.resolve(payload)
     } catch (e) {
       console.error(e)

--- a/ui/src/worker/utils/index.ts
+++ b/ui/src/worker/utils/index.ts
@@ -24,7 +24,7 @@ export const success = async (originMsg: Message, payload: any) => {
     origin: originMsg.id,
     result: 'success',
   }
-  writePayload(msg, payload)
+  await writePayload(msg, payload)
 
   postMessage(msg)
 }


### PR DESCRIPTION
Closes #5844 

_What was the problem?_
#5818 introduces a fix that changes the communication between the browser's main thread and background workers, it accidentally caused this defect. 'Key not found in database' error appears in browser's console and some random dashboard cells are not showing the data.

The result of an asynchronous computation between a worker and the main browser thread is passed in these steps
  1. generate a unique response ID
  2. asynchronously write (a possibly huge) response to the browser's indexedDB under the generated ID
  3. asynchronously let the main thread know that the requested computation is finished and the result can be retrieved using the ID
  4. browser main thread fetches the response by ID and updates UI components

The issue is that the code did not wait for step 2 to finish, the browser thread randomly fails in step 4 if the response is not fully written yet. Such a race obviously happens more likely with heavy asynchronous loads, such as loading the dashboard.

_What was the solution?_
Wait for the DB to store the response before letting know the browser's main thread that the response is ready.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
