### PR TITLE
feat(ui): use time range in flux Schema Explorer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Features
 
+1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add flux query builder.
+1. [#5858](https://github.com/influxdata/chronograf/pull/5858): Use time range in flux Schema Explorer.
+
 ### Bug Fixes
 
 ### Other

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add flux query builder.
+1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add Flux Query Builder.
 1. [#5858](https://github.com/influxdata/chronograf/pull/5858): Use time range in flux Schema Explorer.
 
 ### Bug Fixes

--- a/ui/src/flux/components/DatabaseList.tsx
+++ b/ui/src/flux/components/DatabaseList.tsx
@@ -3,13 +3,14 @@ import React, {PureComponent} from 'react'
 import DatabaseListItem from 'src/flux/components/DatabaseListItem'
 
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 import {executeQuery} from 'src/shared/apis/flux/query'
 import {parseResponse} from 'src/shared/parsing/flux/response'
 import {isEqual} from 'lodash'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   notify: NotificationAction
 }
 
@@ -71,11 +72,17 @@ class DatabaseList extends PureComponent<Props, State> {
 
   public render() {
     const {databases} = this.state
-    const {source, notify} = this.props
+    const {source, timeRange, notify} = this.props
 
     return databases.map(db => {
       return (
-        <DatabaseListItem db={db} key={db} source={source} notify={notify} />
+        <DatabaseListItem
+          db={db}
+          key={db}
+          source={source}
+          timeRange={timeRange}
+          notify={notify}
+        />
       )
     })
   }

--- a/ui/src/flux/components/DatabaseListItem.tsx
+++ b/ui/src/flux/components/DatabaseListItem.tsx
@@ -61,12 +61,14 @@ class DatabaseListItem extends PureComponent<Props, State> {
           <SchemaExplorerTree
             bucket={db}
             source={source}
+            timeRange={timeRange}
             key={db + ':' + timeRange.lower + ':' + timeRange.upper}
           >
             {tree => (
               <SchemaItemCategories
                 db={db}
                 source={source}
+                timeRange={timeRange}
                 notify={notify}
                 categoryTree={tree}
               />

--- a/ui/src/flux/components/DatabaseListItem.tsx
+++ b/ui/src/flux/components/DatabaseListItem.tsx
@@ -8,12 +8,13 @@ import SchemaExplorerTree from 'src/flux/components/SchemaExplorerTree'
 import {OpenState} from 'src/flux/constants/explorer'
 
 // Types
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 import SchemaItemCategories from 'src/flux/components/SchemaItemCategories'
 
 interface Props {
   db: string
   source: Source
+  timeRange: TimeRange
   notify: NotificationAction
 }
 
@@ -49,7 +50,7 @@ class DatabaseListItem extends PureComponent<Props, State> {
   }
 
   private get categories(): JSX.Element {
-    const {db, source, notify} = this.props
+    const {db, source, timeRange, notify} = this.props
     const {opened} = this.state
     const isOpen = opened === OpenState.OPENED
     const isUnopen = opened === OpenState.UNOPENED
@@ -57,7 +58,11 @@ class DatabaseListItem extends PureComponent<Props, State> {
     if (!isUnopen) {
       return (
         <div className={`flux-schema--children ${isOpen ? '' : 'hidden'}`}>
-          <SchemaExplorerTree bucket={db} source={source} key={db}>
+          <SchemaExplorerTree
+            bucket={db}
+            source={source}
+            key={db + ':' + timeRange.lower + ':' + timeRange.upper}
+          >
             {tree => (
               <SchemaItemCategories
                 db={db}

--- a/ui/src/flux/components/FetchFields.tsx
+++ b/ui/src/flux/components/FetchFields.tsx
@@ -2,8 +2,7 @@
 import {PureComponent} from 'react'
 
 // Utils
-import {fieldsByMeasurement as fetchFieldsByMeasurementAsync} from 'src/shared/apis/flux/metaQueries'
-import {parseFieldsByMeasurements} from 'src/shared/parsing/flux/values'
+import {fetchFieldsByMeasurement} from 'src/shared/apis/flux/metaQueries'
 
 // Types
 import {Source, RemoteDataState} from 'src/types'
@@ -46,10 +45,9 @@ class FetchFields extends PureComponent<Props, State> {
     const {source, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const fieldsResults = await fetchFieldsByMeasurementAsync(source, bucket)
-
-      const {fields, fieldsByMeasurements} = parseFieldsByMeasurements(
-        fieldsResults
+      const {fields, fieldsByMeasurements} = await fetchFieldsByMeasurement(
+        source,
+        bucket
       )
 
       this.setState({

--- a/ui/src/flux/components/FetchFields.tsx
+++ b/ui/src/flux/components/FetchFields.tsx
@@ -5,10 +5,11 @@ import {PureComponent} from 'react'
 import {fetchFieldsByMeasurement} from 'src/shared/apis/flux/metaQueries'
 
 // Types
-import {Source, RemoteDataState} from 'src/types'
+import {Source, RemoteDataState, TimeRange} from 'src/types'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   bucket: string
   children: (fields, fieldsByMeasurement, fieldsLoading) => JSX.Element
 }
@@ -42,11 +43,12 @@ class FetchFields extends PureComponent<Props, State> {
   }
 
   private async fetchFields() {
-    const {source, bucket} = this.props
+    const {source, timeRange, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
       const {fields, fieldsByMeasurements} = await fetchFieldsByMeasurement(
         source,
+        timeRange,
         bucket
       )
 

--- a/ui/src/flux/components/FetchMeasurements.tsx
+++ b/ui/src/flux/components/FetchMeasurements.tsx
@@ -2,8 +2,7 @@
 import {PureComponent} from 'react'
 
 // Utils
-import {measurements as fetchMeasurementsAsync} from 'src/shared/apis/flux/metaQueries'
-import parseValuesColumn from 'src/shared/parsing/flux/values'
+import {fetchMeasurements} from 'src/shared/apis/flux/metaQueries'
 
 // Types
 import {Source, RemoteDataState} from 'src/types'
@@ -19,14 +18,6 @@ interface State {
   loading: RemoteDataState
 }
 
-export async function fetchFluxMeasurements(
-  source: Source,
-  bucket: string
-): Promise<string[]> {
-  const measurementResults = await fetchMeasurementsAsync(source, bucket)
-  return parseValuesColumn(measurementResults)
-}
-
 class FetchMeasurements extends PureComponent<Props, State> {
   constructor(props) {
     super(props)
@@ -36,18 +27,18 @@ class FetchMeasurements extends PureComponent<Props, State> {
     }
   }
   public componentDidMount() {
-    this.fetchMeasurements()
+    this.fetchData()
   }
 
   public render() {
     return this.props.children(this.state.measurements, this.state.loading)
   }
 
-  private async fetchMeasurements() {
+  private async fetchData() {
     const {source, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const measurements = await fetchFluxMeasurements(source, bucket)
+      const measurements = await fetchMeasurements(source, bucket)
       this.setState({measurements, loading: RemoteDataState.Done})
     } catch (error) {
       this.setState({loading: RemoteDataState.Error})

--- a/ui/src/flux/components/FetchMeasurements.tsx
+++ b/ui/src/flux/components/FetchMeasurements.tsx
@@ -5,10 +5,11 @@ import {PureComponent} from 'react'
 import {fetchMeasurements} from 'src/shared/apis/flux/metaQueries'
 
 // Types
-import {Source, RemoteDataState} from 'src/types'
+import {Source, RemoteDataState, TimeRange} from 'src/types'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   bucket: string
   children: (measurements, measurementsLoading) => JSX.Element
 }
@@ -35,10 +36,10 @@ class FetchMeasurements extends PureComponent<Props, State> {
   }
 
   private async fetchData() {
-    const {source, bucket} = this.props
+    const {source, timeRange, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const measurements = await fetchMeasurements(source, bucket)
+      const measurements = await fetchMeasurements(source, timeRange, bucket)
       this.setState({measurements, loading: RemoteDataState.Done})
     } catch (error) {
       this.setState({loading: RemoteDataState.Error})

--- a/ui/src/flux/components/FetchTagKeys.tsx
+++ b/ui/src/flux/components/FetchTagKeys.tsx
@@ -2,8 +2,7 @@
 import {PureComponent} from 'react'
 
 // Utils
-import parseValuesColumn from 'src/shared/parsing/flux/values'
-import {tagKeys as fetchTagKeysAsync} from 'src/shared/apis/flux/metaQueries'
+import {fetchTagKeys} from 'src/shared/apis/flux/metaQueries'
 
 // Types
 import {Source, RemoteDataState} from 'src/types'
@@ -29,21 +28,18 @@ class FetchTagKeys extends PureComponent<Props, State> {
   }
 
   public componentDidMount() {
-    this.fetchTagKeys()
+    this.fetchData()
   }
 
   public render() {
     return this.props.children(this.state.tagKeys, this.state.loading)
   }
 
-  private async fetchTagKeys() {
+  private async fetchData() {
     const {source, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const tagKeysResults = await fetchTagKeysAsync(source, bucket, [])
-
-      const tagKeys = parseValuesColumn(tagKeysResults)
-
+      const tagKeys = await fetchTagKeys(source, bucket)
       this.setState({tagKeys, loading: RemoteDataState.Done})
     } catch (error) {
       this.setState({loading: RemoteDataState.Error})

--- a/ui/src/flux/components/FetchTagKeys.tsx
+++ b/ui/src/flux/components/FetchTagKeys.tsx
@@ -5,10 +5,11 @@ import {PureComponent} from 'react'
 import {fetchTagKeys} from 'src/shared/apis/flux/metaQueries'
 
 // Types
-import {Source, RemoteDataState} from 'src/types'
+import {Source, RemoteDataState, TimeRange} from 'src/types'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   bucket: string
   children: (tagKeys, tagsLoading) => JSX.Element
 }
@@ -36,10 +37,10 @@ class FetchTagKeys extends PureComponent<Props, State> {
   }
 
   private async fetchData() {
-    const {source, bucket} = this.props
+    const {source, timeRange, bucket} = this.props
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const tagKeys = await fetchTagKeys(source, bucket)
+      const tagKeys = await fetchTagKeys(source, timeRange, bucket)
       this.setState({tagKeys, loading: RemoteDataState.Done})
     } catch (error) {
       this.setState({loading: RemoteDataState.Error})

--- a/ui/src/flux/components/FieldList.tsx
+++ b/ui/src/flux/components/FieldList.tsx
@@ -94,7 +94,9 @@ class FieldList extends PureComponent<Props, State> {
     return (
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
-          <div className="no-results">No more fields.</div>
+          <div className="no-results">
+            No fields in the selected time range.
+          </div>
         </div>
       </div>
     )

--- a/ui/src/flux/components/FieldList.tsx
+++ b/ui/src/flux/components/FieldList.tsx
@@ -94,9 +94,9 @@ class FieldList extends PureComponent<Props, State> {
     return (
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
-          <div className="no-results">
-            No fields in the selected time range.
-          </div>
+          <div className="no-results">{`No ${
+            term ? 'matching ' : ''
+          }fields in the selected time range.`}</div>
         </div>
       </div>
     )

--- a/ui/src/flux/components/MeasurementList.tsx
+++ b/ui/src/flux/components/MeasurementList.tsx
@@ -129,7 +129,9 @@ class MeasurementsList extends PureComponent<Props, State> {
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
           <div className="no-results">
-            No measurements in the selected time range.
+            {`No ${
+              term ? 'matching ' : ''
+            }measurements in the selected time range.`}
           </div>
         </div>
       </div>

--- a/ui/src/flux/components/MeasurementList.tsx
+++ b/ui/src/flux/components/MeasurementList.tsx
@@ -65,6 +65,7 @@ class MeasurementsList extends PureComponent<Props, State> {
     const {source, db, notify, loading} = this.props
     const {searchTerm} = this.state
     const measurementEntries = Object.entries(this.props.measurements)
+    measurementEntries.sort((a, b) => a[0].localeCompare(b[0]))
 
     if (loading === RemoteDataState.Error) {
       return (

--- a/ui/src/flux/components/MeasurementList.tsx
+++ b/ui/src/flux/components/MeasurementList.tsx
@@ -128,7 +128,9 @@ class MeasurementsList extends PureComponent<Props, State> {
     return (
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
-          <div className="no-results">No more measurements.</div>
+          <div className="no-results">
+            No measurements in the selected time range.
+          </div>
         </div>
       </div>
     )

--- a/ui/src/flux/components/SchemaExplorer.tsx
+++ b/ui/src/flux/components/SchemaExplorer.tsx
@@ -2,20 +2,21 @@ import React, {PureComponent} from 'react'
 
 import DatabaseList from 'src/flux/components/DatabaseList'
 import FancyScrollbar from 'src/shared/components/FancyScrollbar'
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   notify: NotificationAction
 }
 
 class SchemaExplorer extends PureComponent<Props> {
   public render() {
-    const {source, notify} = this.props
+    const {source, timeRange, notify} = this.props
     return (
       <div className="flux-schema-explorer">
         <FancyScrollbar>
-          <DatabaseList source={source} notify={notify} />
+          <DatabaseList source={source} timeRange={timeRange} notify={notify} />
         </FancyScrollbar>
       </div>
     )

--- a/ui/src/flux/components/SchemaExplorerTree.tsx
+++ b/ui/src/flux/components/SchemaExplorerTree.tsx
@@ -9,11 +9,12 @@ import FetchTagKeys from 'src/flux/components/FetchTagKeys'
 import FetchFields from 'src/flux/components/FetchFields'
 
 // Types
-import {Source, RemoteDataState} from 'src/types'
+import {Source, RemoteDataState, TimeRange} from 'src/types'
 
 interface Props {
   bucket: string
   source: Source
+  timeRange: TimeRange
   children: (tree: CategoryTree) => JSX.Element
 }
 
@@ -33,14 +34,18 @@ export interface CategoryTree {
 @ErrorHandling
 class SchemaExplorerTree extends PureComponent<Props> {
   public render() {
-    const {source, bucket} = this.props
+    const {source, timeRange, bucket} = this.props
 
     return (
-      <FetchMeasurements source={source} bucket={bucket}>
+      <FetchMeasurements source={source} timeRange={timeRange} bucket={bucket}>
         {(measurements, measurementsLoading) => (
-          <FetchTagKeys source={source} bucket={bucket}>
+          <FetchTagKeys source={source} timeRange={timeRange} bucket={bucket}>
             {(tagKeys, tagsLoading) => (
-              <FetchFields source={source} bucket={bucket}>
+              <FetchFields
+                source={source}
+                timeRange={timeRange}
+                bucket={bucket}
+              >
                 {(fields, fieldsByMeasurements, fieldsLoading) =>
                   this.props.children(
                     this.tree(

--- a/ui/src/flux/components/SchemaItemCategories.tsx
+++ b/ui/src/flux/components/SchemaItemCategories.tsx
@@ -8,11 +8,12 @@ import SchemaItemCategory, {
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // Types
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 import {CategoryTree} from 'src/flux/components/SchemaExplorerTree'
 
 interface Props {
   source: Source
+  timeRange: TimeRange
   db: string
   categoryTree: CategoryTree
   notify: NotificationAction
@@ -21,12 +22,13 @@ interface Props {
 @ErrorHandling
 class SchemaItemCategories extends PureComponent<Props> {
   public render() {
-    const {source, db, categoryTree, notify} = this.props
+    const {source, timeRange, db, categoryTree, notify} = this.props
 
     return (
       <>
         <SchemaItemCategory
           source={source}
+          timeRange={timeRange}
           db={db}
           type={CategoryType.Measurements}
           categoryTree={categoryTree}
@@ -34,6 +36,7 @@ class SchemaItemCategories extends PureComponent<Props> {
         />
         <SchemaItemCategory
           source={source}
+          timeRange={timeRange}
           db={db}
           type={CategoryType.Tags}
           categoryTree={categoryTree}
@@ -41,6 +44,7 @@ class SchemaItemCategories extends PureComponent<Props> {
         />
         <SchemaItemCategory
           source={source}
+          timeRange={timeRange}
           db={db}
           type={CategoryType.Fields}
           categoryTree={categoryTree}

--- a/ui/src/flux/components/SchemaItemCategory.tsx
+++ b/ui/src/flux/components/SchemaItemCategory.tsx
@@ -17,7 +17,7 @@ import {
 } from 'src/shared/utils/TimeMachineContext'
 
 // Types
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 import {CategoryTree} from 'src/flux/components/SchemaExplorerTree'
 
 export enum CategoryType {
@@ -32,6 +32,7 @@ interface ConnectedProps {
 
 interface PassedProps {
   source: Source
+  timeRange: TimeRange
   notify: NotificationAction
   db: string
   categoryTree: CategoryTree
@@ -93,7 +94,7 @@ class SchemaItemCategory extends PureComponent<
   }
 
   private get itemList(): JSX.Element {
-    const {type, db, source, notify, categoryTree} = this.props
+    const {type, db, timeRange, source, notify, categoryTree} = this.props
 
     switch (type) {
       case CategoryType.Measurements:
@@ -125,6 +126,7 @@ class SchemaItemCategory extends PureComponent<
           <TagKeyList
             db={db}
             source={source}
+            timeRange={timeRange}
             notify={notify}
             tagKeys={categoryTree.tagKeys}
             loading={categoryTree.tagsLoading}

--- a/ui/src/flux/components/SchemaItemCategory.tsx
+++ b/ui/src/flux/components/SchemaItemCategory.tsx
@@ -19,6 +19,7 @@ import {
 // Types
 import {Source, NotificationAction, TimeRange} from 'src/types'
 import {CategoryTree} from 'src/flux/components/SchemaExplorerTree'
+import TimeRangeLabel from 'src/shared/components/TimeRangeLabel'
 
 export enum CategoryType {
   Measurements = 'measurements',
@@ -71,6 +72,9 @@ class SchemaItemCategory extends PureComponent<
           <div className="flex-schema-item-group flux-schema-item--expandable">
             <div className="flux-schema--expander" />
             {this.categoryName}
+            <span className="flux-schema--type">
+              (<TimeRangeLabel timeRange={this.props.timeRange} />)
+            </span>
           </div>
         </div>
         {!isUnopened && (

--- a/ui/src/flux/components/TagKeyList.tsx
+++ b/ui/src/flux/components/TagKeyList.tsx
@@ -9,11 +9,12 @@ import LoaderSkeleton from 'src/flux/components/LoaderSkeleton'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 // types
-import {Source, NotificationAction, RemoteDataState} from 'src/types'
+import {Source, NotificationAction, RemoteDataState, TimeRange} from 'src/types'
 
 interface Props {
   db: string
   source: Source
+  timeRange: TimeRange
   tagKeys: string[]
   notify: NotificationAction
   loading: RemoteDataState
@@ -41,7 +42,7 @@ class TagKeyList extends PureComponent<Props, State> {
   }
 
   private get tagKeys(): JSX.Element | JSX.Element[] {
-    const {db, source, notify, loading} = this.props
+    const {db, source, timeRange, notify, loading} = this.props
 
     if (loading === RemoteDataState.Error) {
       return (
@@ -65,6 +66,7 @@ class TagKeyList extends PureComponent<Props, State> {
         <TagKeyListItem
           db={db}
           source={source}
+          timeRange={timeRange}
           tagKey={tagKey}
           key={tagKey}
           notify={notify}

--- a/ui/src/flux/components/TagKeyList.tsx
+++ b/ui/src/flux/components/TagKeyList.tsx
@@ -77,7 +77,9 @@ class TagKeyList extends PureComponent<Props, State> {
     return (
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
-          <div className="no-results">No more tag keys.</div>
+          <div className="no-results">
+            No tag keys in the selected time range.
+          </div>
         </div>
       </div>
     )

--- a/ui/src/flux/components/TagKeyListItem.tsx
+++ b/ui/src/flux/components/TagKeyListItem.tsx
@@ -11,11 +11,12 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import {OpenState} from 'src/flux/constants/explorer'
 
 // types
-import {Source, NotificationAction} from 'src/types'
+import {Source, NotificationAction, TimeRange} from 'src/types'
 
 interface Props {
   db: string
   source: Source
+  timeRange: TimeRange
   tagKey: string
   notify: NotificationAction
   onAddFilter?: (value: {[k: string]: string}) => void
@@ -36,7 +37,7 @@ class TagKeyListItem extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {db, source, tagKey, notify} = this.props
+    const {db, source, timeRange, tagKey, notify} = this.props
     const {opened} = this.state
     const isOpen = opened === OpenState.OPENED
     const isUnopen = opened === OpenState.UNOPENED
@@ -61,6 +62,7 @@ class TagKeyListItem extends PureComponent<Props, State> {
             <TagValueList
               db={db}
               source={source}
+              timeRange={timeRange}
               tagKey={tagKey}
               notify={notify}
               onAddFilter={this.props.onAddFilter}

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -7,10 +7,9 @@ import LoaderSkeleton from 'src/flux/components/LoaderSkeleton'
 import LoadingSpinner from 'src/flux/components/LoadingSpinner'
 
 // apis
-import {tagValues as fetchTagValues} from 'src/shared/apis/flux/metaQueries'
+import {fetchTagValues} from 'src/shared/apis/flux/metaQueries'
 
 // Utils
-import parseValuesColumn from 'src/shared/parsing/flux/values'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import DefaultDebouncer, {Debouncer} from 'src/shared/utils/debouncer'
 
@@ -56,7 +55,7 @@ class TagValueList extends PureComponent<Props, State> {
   public async componentDidMount() {
     this.setState({loading: RemoteDataState.Loading})
     try {
-      const tagValues = await this.fetchTagValues()
+      const tagValues = await this.fetchData()
       this.setState({
         tagValues,
         loading: RemoteDataState.Done,
@@ -166,20 +165,17 @@ class TagValueList extends PureComponent<Props, State> {
     return `Load next ${TAG_VALUES_LIMIT} values for ${tagKey}`
   }
 
-  private fetchTagValues = async (): Promise<string[]> => {
+  private fetchData = async (): Promise<string[]> => {
     const {source, db, tagKey} = this.props
     const {searchTerm, limit} = this.state
 
-    const response = await fetchTagValues({
+    return await fetchTagValues({
       source,
       bucket: db,
       tagKey,
       limit,
       searchTerm,
     })
-
-    const tagValues = parseValuesColumn(response)
-    return tagValues
   }
 
   private onSearch = (e: ChangeEvent<HTMLInputElement>) => {
@@ -190,7 +186,7 @@ class TagValueList extends PureComponent<Props, State> {
       () => {
         try {
           this.debouncer.call(async () => {
-            const tagValues = await this.fetchTagValues()
+            const tagValues = await this.fetchData()
             this.setState({tagValues})
           }, 50)
         } catch (error) {
@@ -219,7 +215,7 @@ class TagValueList extends PureComponent<Props, State> {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       async () => {
         try {
-          const tagValues = await this.fetchTagValues()
+          const tagValues = await this.fetchData()
           this.setState({
             tagValues,
             loading: RemoteDataState.Done,

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -14,13 +14,14 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import DefaultDebouncer, {Debouncer} from 'src/shared/utils/debouncer'
 
 // types
-import {Source, NotificationAction, RemoteDataState} from 'src/types'
+import {Source, NotificationAction, RemoteDataState, TimeRange} from 'src/types'
 
 const TAG_VALUES_LIMIT = 25
 
 interface Props {
   db: string
   source: Source
+  timeRange: TimeRange
   tagKey: string
   notify: NotificationAction
   onAddFilter?: (value: {[k: string]: string}) => void
@@ -166,11 +167,12 @@ class TagValueList extends PureComponent<Props, State> {
   }
 
   private fetchData = async (): Promise<string[]> => {
-    const {source, db, tagKey} = this.props
+    const {source, timeRange, db, tagKey} = this.props
     const {searchTerm, limit} = this.state
 
     return await fetchTagValues({
       source,
+      timeRange,
       bucket: db,
       tagKey,
       limit,

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -150,7 +150,9 @@ class TagValueList extends PureComponent<Props, State> {
     return (
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
-          <div className="no-results">No more tag values.</div>
+          <div className="no-results">
+            No tag values in the selected time range.
+          </div>
         </div>
       </div>
     )

--- a/ui/src/flux/components/TagValueList.tsx
+++ b/ui/src/flux/components/TagValueList.tsx
@@ -151,7 +151,9 @@ class TagValueList extends PureComponent<Props, State> {
       <div className="flux-schema-tree flux-schema--child">
         <div className="flux-schema--item no-hover" onClick={this.handleClick}>
           <div className="no-results">
-            No tag values in the selected time range.
+            {`No ${
+              term ? 'matching ' : ''
+            }tag values in the selected time range.`}
           </div>
         </div>
       </div>

--- a/ui/src/flux/helpers/rangeArguments.ts
+++ b/ui/src/flux/helpers/rangeArguments.ts
@@ -2,7 +2,7 @@ import {TimeRange} from 'src/types'
 
 export default function rangeArguments(timeRange: TimeRange): string {
   const start = timeRange.lowerFlux ? timeRange.lowerFlux : timeRange.lower
-  return timeRange.upper
+  return timeRange.upper && timeRange.upper !== 'now()'
     ? `start: ${start}, stop: ${timeRange.upper}`
     : `start: ${start}`
 }

--- a/ui/src/flux/helpers/rangeArguments.ts
+++ b/ui/src/flux/helpers/rangeArguments.ts
@@ -1,0 +1,8 @@
+import {TimeRange} from 'src/types'
+
+export default function rangeArguments(timeRange: TimeRange): string {
+  const start = timeRange.lowerFlux ? timeRange.lowerFlux : timeRange.lower
+  return timeRange.upper
+    ? `start: ${start}, stop: ${timeRange.upper}`
+    : `start: ${start}`
+}

--- a/ui/src/flux/helpers/recordProperty.ts
+++ b/ui/src/flux/helpers/recordProperty.ts
@@ -1,6 +1,8 @@
+import fluxString from './fluxString'
+
 export default function recordProperty(key: string) {
   if (key && /[^A-Za-z0-9_]/.test(key)) {
-    return `r.["${key}"]`
+    return `r.[${fluxString(key)}]`
   }
   return `r.${key}`
 }

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -8,12 +8,7 @@ export const measurements = async (
   source: Source,
   bucket: string
 ): Promise<any> => {
-  const script = `
-    import "influxdata/influxdb/v1"
-    v1.measurements(bucket:"${bucket}")
-    `
-
-  return proxy(source, script)
+  return tagValues({bucket, source, tagKey: '_measurement', limit: 0})
 }
 
 export const fields = async (
@@ -100,7 +95,7 @@ export const tagValues = async ({
     )} =~ /${searchTerm}/)`
   }
 
-  const limitFunc = count ? '' : `|> limit(n:${limit})`
+  const limitFunc = count || !limit ? '' : `|> limit(n:${limit})`
   const countFunc = count ? '|> count()' : ''
 
   const predicate = '(r) => true'

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -49,26 +49,19 @@ export const fieldsByMeasurement = async (
   return proxy(source, script)
 }
 
-export const tagKeys = async (
+export const fetchTagKeys = async (
   source: Source,
-  bucket: string,
-  filter: SchemaFilter[]
-): Promise<string> => {
-  let tagKeyFilter = ''
-
-  if (filter.length) {
-    const predicates = filter.map(({key}) => `r._value != ${fluxString(key)}`)
-    tagKeyFilter = `\n   |> filter(fn: (r) => (${predicates.join(' and ')}) )`
-  }
-
+  bucket: string
+): Promise<string[]> => {
   const script = `
 from(bucket:${fluxString(bucket)}) 
   |> range(start: -30d) 
   |> keys()
   |> keep(columns: ["_value"])
-  |> distinct()${tagKeyFilter}`
+  |> distinct()`
 
-  return proxy(source, script)
+  const response = await proxy(source, script)
+  return parseValuesColumn(response)
 }
 
 interface TagValuesParams {

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -88,7 +88,7 @@ export const fetchTagValues = async ({
   const countFunc = count ? '\n  |> count()' : ''
 
   const script = `
-from(bucket: "${bucket}")
+from(bucket:${fluxString(bucket)})
   |> range(${rangeArguments(timeRange)})
   |> keep(columns: [${fluxString(tagKey)}])
   |> group()

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -113,23 +113,6 @@ from(bucket: "${bucket}")
   return proxy(source, script)
 }
 
-export const tagsFromMeasurement = async (
-  source: Source,
-  bucket: string,
-  measurement: string
-): Promise<string> => {
-  const script = `
-    from(bucket:${fluxString(bucket)}}) 
-      |> range(start:-30d) 
-      |> filter(fn:(r) => r._measurement == ${fluxString(measurement)}") 
-      |> group() 
-      |> keys()
-      |> keep(columns: ["_value"])
-  `
-
-  return proxy(source, script)
-}
-
 export const proxy = async (source: Source, script: string) => {
   const mark = encodeURIComponent('?')
   const minimizedScript = script.replace(/\s/g, '') // server cannot handle whitespace

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -2,7 +2,6 @@ import _ from 'lodash'
 
 import AJAX from 'src/utils/ajax'
 import {Source, SchemaFilter} from 'src/types'
-import recordProperty from 'src/flux/helpers/recordProperty'
 import fluxString from 'src/flux/helpers/fluxString'
 import parseValuesColumn from 'src/shared/parsing/flux/values'
 
@@ -92,9 +91,7 @@ export const tagValues = async ({
 }: TagValuesParams): Promise<string> => {
   let regexFilter = ''
   if (searchTerm) {
-    regexFilter = `\n  |> filter(fn: (r) => ${recordProperty(
-      tagKey
-    )} =~ /${searchTerm}/)`
+    regexFilter = `\n  |> filter(fn: (r) => r["_value"] =~ /${searchTerm}/)`
   }
 
   const limitFunc = count || !limit ? '' : `\n  |> limit(n:${limit})`

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -18,21 +18,6 @@ export const fetchMeasurements = async (
   return parseValuesColumn(csvResponse)
 }
 
-export const fields = async (
-  source: Source,
-  bucket: string,
-  filter: SchemaFilter[],
-  limit: number
-): Promise<string> => {
-  return await tagValues({
-    bucket,
-    source,
-    tagKey: '_field',
-    limit,
-    filter,
-  })
-}
-
 // Fetch all the fields and their associated measurement
 export const fieldsByMeasurement = async (
   source: Source,

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -123,9 +123,9 @@ export const tagsFromMeasurement = async (
 
 export const proxy = async (source: Source, script: string) => {
   const mark = encodeURIComponent('?')
-  const garbage = script.replace(/\s/g, '') // server cannot handle whitespace
+  const minimizedScript = script.replace(/\s/g, '') // server cannot handle whitespace
   const dialect = {annotations: ['group', 'datatype', 'default']}
-  const data = {query: garbage, dialect}
+  const data = {query: minimizedScript, dialect}
   const base = source.links.flux
 
   try {

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -24,7 +24,7 @@ export const fields = async (
   bucket: string,
   filter: SchemaFilter[],
   limit: number
-): Promise<any> => {
+): Promise<string> => {
   return await tagValues({
     bucket,
     source,
@@ -38,7 +38,7 @@ export const fields = async (
 export const fieldsByMeasurement = async (
   source: Source,
   bucket: string
-): Promise<any> => {
+): Promise<string> => {
   const script = `
   from(bucket:${fluxString(bucket)})
     |> range(start: -30d)
@@ -54,7 +54,7 @@ export const tagKeys = async (
   source: Source,
   bucket: string,
   filter: SchemaFilter[]
-): Promise<any> => {
+): Promise<string> => {
   let tagKeyFilter = ''
 
   if (filter.length) {
@@ -89,7 +89,7 @@ export const tagValues = async ({
   limit,
   searchTerm = '',
   count = false,
-}: TagValuesParams): Promise<any> => {
+}: TagValuesParams): Promise<string> => {
   let regexFilter = ''
   if (searchTerm) {
     regexFilter = `\n  |> filter(fn: (r) => ${recordProperty(
@@ -117,7 +117,7 @@ export const tagsFromMeasurement = async (
   source: Source,
   bucket: string,
   measurement: string
-): Promise<any> => {
+): Promise<string> => {
   const script = `
     from(bucket:${fluxString(bucket)}}) 
       |> range(start:-30d) 

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -52,20 +52,15 @@ export const tagKeys = async (
   if (filter.length) {
     const predicates = filter.map(({key}) => `r._value != "${key}"`)
 
-    tagKeyFilter = `|> filter(fn: (r) => ${predicates.join(' and ')} )`
+    tagKeyFilter = `\n   |> filter(fn: (r) => (${predicates.join(' and ')}) )`
   }
 
-  const predicate = '(r) => true'
-
   const script = `
-    import "influxdata/influxdb/v1"
-    v1.tagKeys(
-      bucket: "${bucket}",
-      predicate: ${predicate},
-      start: -30d,
-    )
-    ${tagKeyFilter}
-    `
+from(bucket:"${bucket}") 
+  |> range(start: -30d) 
+  |> keys()
+  |> keep(columns: ["_value"])
+  |> distinct()${tagKeyFilter}`
 
   return proxy(source, script)
 }

--- a/ui/src/shared/apis/flux/metaQueries.ts
+++ b/ui/src/shared/apis/flux/metaQueries.ts
@@ -4,12 +4,19 @@ import AJAX from 'src/utils/ajax'
 import {Source, SchemaFilter} from 'src/types'
 import recordProperty from 'src/flux/helpers/recordProperty'
 import fluxString from 'src/flux/helpers/fluxString'
+import parseValuesColumn from 'src/shared/parsing/flux/values'
 
-export const measurements = async (
+export const fetchMeasurements = async (
   source: Source,
   bucket: string
-): Promise<any> => {
-  return tagValues({bucket, source, tagKey: '_measurement', limit: 0})
+): Promise<string[]> => {
+  const csvResponse = await tagValues({
+    bucket,
+    source,
+    tagKey: '_measurement',
+    limit: 0,
+  })
+  return parseValuesColumn(csvResponse)
 }
 
 export const fields = async (

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -100,7 +100,13 @@ class FluxQueryMaker extends PureComponent<Props, State> {
           size: leftSize,
           headerButtons: [],
           menuOptions: [],
-          render: () => <SchemaExplorer source={source} notify={notify} />,
+          render: () => (
+            <SchemaExplorer
+              source={source}
+              timeRange={timeRange}
+              notify={notify}
+            />
+          ),
           headerOrientation: HANDLE_VERTICAL,
         },
         {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
@@ -6,8 +6,9 @@ import {TimeRange, Source} from 'src/types'
 import {CancelBox} from 'src/types/promises'
 import {parseResponse} from 'src/shared/parsing/flux/response'
 import {BuilderTagsType} from '../types'
-import {formatTimeRangeArguments, tagToFlux} from '../util/generateFlux'
+import {tagToFlux} from '../util/generateFlux'
 import fluxString from 'src/flux/helpers/fluxString'
+import rangeArguments from 'src/flux/helpers/rangeArguments'
 
 const DEFAULT_TIME_RANGE: TimeRange = {lower: 'now() - 30d', lowerFlux: '-30d'}
 const DEFAULT_LIMIT = 200
@@ -44,7 +45,7 @@ export function findKeys({
 }: FindKeysOptions): CancelBox<string[]> {
   const tagFilter = formatTagFilter(tagsSelections)
   const previousKeyFilter = formatTagKeyFilterCall(tagsSelections)
-  const timeRangeArguments = formatTimeRangeArguments(timeRange)
+  const timeRangeArguments = rangeArguments(timeRange)
 
   // requires Flux package to work which we will put in the query
   const searchFilter = !searchTerm
@@ -85,7 +86,7 @@ export function findValues({
   limit = DEFAULT_LIMIT,
 }: FindValuesOptions): CancelBox<string[]> {
   const tagFilter = formatTagFilter(tagsSelections)
-  const timeRangeArguments = formatTimeRangeArguments(timeRange)
+  const timeRangeArguments = rangeArguments(timeRange)
 
   // requires Flux package to work which we will put in the query
   const searchFilter = !searchTerm

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/util/generateFlux.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/util/generateFlux.ts
@@ -1,14 +1,6 @@
 import fluxString from 'src/flux/helpers/fluxString'
-import {TimeRange} from 'src/types'
 import {BuilderTagsType, QueryBuilderState} from '../types'
 import {AGG_WINDOW_AUTO, FUNCTIONS} from './constants'
-
-export function formatTimeRangeArguments(timeRange: TimeRange): string {
-  const start = timeRange.lowerFlux ? timeRange.lowerFlux : timeRange.lower
-  return timeRange.upper
-    ? `start: ${start}, stop: ${timeRange.upper}`
-    : `start: ${start}`
-}
 
 export function tagToFlux(tag: BuilderTagsType) {
   return tag.tagValues

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -2,8 +2,6 @@ import React, {Component} from 'react'
 import PropTypes from 'prop-types'
 import classnames from 'classnames'
 import moment from 'moment'
-import {connect} from 'react-redux'
-import _ from 'lodash'
 
 import OnClickOutside from 'shared/components/OnClickOutside'
 import FancyScrollbar from 'shared/components/FancyScrollbar'
@@ -12,17 +10,8 @@ import CustomTimeRangeOverlay from 'shared/components/CustomTimeRangeOverlay'
 import {timeRanges} from 'shared/data/timeRanges'
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'shared/constants/index'
 import {ErrorHandling} from 'src/shared/decorators/errors'
-import {TimeZones} from 'src/types'
-
-const dateFormat = 'YYYY-MM-DD HH:mm'
+import TimeRangeLabel from './TimeRangeLabel'
 const emptyTime = {lower: '', upper: ''}
-const format = (t, timeZone) => {
-  const m = moment(t.replace(/'/g, ''))
-  if (timeZone === TimeZones.UTC) {
-    m.utc()
-  }
-  return m.format(dateFormat)
-}
 
 class TimeRangeDropdown extends Component {
   constructor(props) {
@@ -38,22 +27,6 @@ class TimeRangeDropdown extends Component {
       isCustomTimeRangeOpen: false,
       customTimeRange,
     }
-  }
-
-  findTimeRangeInputValue = ({upper, lower}) => {
-    if (upper && lower) {
-      if (upper === 'now()') {
-        return `${format(lower, this.props.timeZone)} - Now`
-      }
-
-      return `${format(lower, this.props.timeZone)} - ${format(
-        upper,
-        this.props.timeZone
-      )}`
-    }
-
-    const selected = timeRanges.find(range => range.lower === lower)
-    return selected ? selected.inputValue : 'Custom'
   }
 
   handleClickOutside = () => {
@@ -111,7 +84,7 @@ class TimeRangeDropdown extends Component {
           >
             <span className="icon clock" />
             <span className="dropdown-selected">
-              {this.findTimeRangeInputValue(selected)}
+              <TimeRangeLabel timeRange={selected} />
             </span>
             <span className="caret" />
           </div>
@@ -181,10 +154,6 @@ TimeRangeDropdown.propTypes = {
   onChooseTimeRange: func.isRequired,
   preventCustomTimeRange: bool,
   page: string,
-  timeZone: string,
 }
 
-const mstp = state => ({
-  timeZone: _.get(state, ['app', 'persisted', 'timeZone']),
-})
-export default connect(mstp)(OnClickOutside(ErrorHandling(TimeRangeDropdown)))
+export default OnClickOutside(ErrorHandling(TimeRangeDropdown))

--- a/ui/src/shared/components/TimeRangeLabel.tsx
+++ b/ui/src/shared/components/TimeRangeLabel.tsx
@@ -1,0 +1,37 @@
+import moment from 'moment'
+import {connect} from 'react-redux'
+
+import {timeRanges} from 'src/shared/data/timeRanges'
+import {TimeRange, TimeZones} from 'src/types'
+import _ from 'lodash'
+
+const dateFormat = 'YYYY-MM-DD HH:mm'
+const format = (t: string, timeZone: string) => {
+  const m = moment(t.replace(/'/g, ''))
+  if (timeZone === TimeZones.UTC) {
+    m.utc()
+  }
+  return m.format(dateFormat)
+}
+
+interface PassedProps {
+  timeRange: TimeRange
+}
+type Props = PassedProps & ReturnType<typeof mstp>
+
+const TimeRangeLabel = ({timeRange: {upper, lower}, timeZone}: Props) => {
+  if (upper && lower) {
+    if (upper === 'now()') {
+      return `${format(lower, timeZone)} - Now`
+    }
+
+    return `${format(lower, timeZone)} - ${format(upper, timeZone)}`
+  }
+  const selected = timeRanges.find(range => range.lower === lower)
+  return selected ? selected.inputValue : 'Custom'
+}
+
+const mstp = (state: any) => ({
+  timeZone: _.get(state, ['app', 'persisted', 'timeZone']) as TimeZones,
+})
+export default connect(mstp)(TimeRangeLabel)

--- a/ui/test/flux/helpers/rangeAguments.test.ts
+++ b/ui/test/flux/helpers/rangeAguments.test.ts
@@ -1,0 +1,12 @@
+import rangeArguments from 'src/flux/helpers/rangeArguments'
+
+describe('Flux.helpers.rangeArguments', () => {
+  it('formats relative time range', () => {
+    expect(rangeArguments({lower: 'xyz', lowerFlux: '-10s'})).toBe(
+      'start: -10s'
+    )
+  })
+  it('formats absolute time range', () => {
+    expect(rangeArguments({lower: 'a', upper: 'b'})).toBe('start: a, stop: b')
+  })
+})

--- a/ui/test/flux/helpers/rangeAguments.test.ts
+++ b/ui/test/flux/helpers/rangeAguments.test.ts
@@ -9,4 +9,7 @@ describe('Flux.helpers.rangeArguments', () => {
   it('formats absolute time range', () => {
     expect(rangeArguments({lower: 'a', upper: 'b'})).toBe('start: a, stop: b')
   })
+  it('formats absolute time range with upper now()', () => {
+    expect(rangeArguments({lower: 'a', upper: 'now()'})).toBe('start: a')
+  })
 })

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/util/generateFlux.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/util/generateFlux.test.ts
@@ -4,19 +4,10 @@ import {initialState as initialAggState} from 'src/shared/components/TimeMachine
 import {QueryBuilderState} from 'src/shared/components/TimeMachine/fluxQueryBuilder/types'
 import {
   buildQuery,
-  formatTimeRangeArguments,
   tagToFlux,
 } from 'src/shared/components/TimeMachine/fluxQueryBuilder/util/generateFlux'
 
 describe('fluxQueryBuilder/util/generateFlux', () => {
-  test('formatTimeRangeArguments', () => {
-    expect(formatTimeRangeArguments({lower: 'xyz', lowerFlux: '-10s'})).toBe(
-      'start: -10s'
-    )
-    expect(formatTimeRangeArguments({lower: 'a', upper: 'b'})).toBe(
-      'start: a, stop: b'
-    )
-  })
   test('tagToFlux', () => {
     expect(
       tagToFlux({


### PR DESCRIPTION
Closes #5849

_Briefly describe your proposed changes:_
Flux Schema Explorer shows data in the user-selected time range and also reacts upon change of the time range. Schema tree shows that its data are controlled by a selected time range, 

![SchemaExplorerTimeRange](https://user-images.githubusercontent.com/16321466/153336969-acd911f0-833d-452f-a9e9-9f76540c0ed6.gif)

Additionally
-  a deprecated [flux v1](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/v1/) package is not used, functions from flux universe are used instead. 
- schema metadata fetcher is refactored and simplified

_What was the problem?_
The explorer always used -30d as a time range to show schema data. It caused high latencies or timeouts in the schema queries over huge data sets. 

_What was the solution?_
The user can choose the time range for showing the Schema Explorer data and thus reduce the time required for schema queries. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass