### PR TITLE
feat(fluxWizard): allow to load more keys/values when showing truncated results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add Flux Query Builder.
 1. [#5858](https://github.com/influxdata/chronograf/pull/5858): Use time range in flux Schema Explorer.
+1. [#5861](https://github.com/influxdata/chronograf/pull/5861): Allow to load truncated data in Flux Query Builder.
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/DropdownMenu.tsx
+++ b/ui/src/shared/components/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent} from 'react'
+import React, {FunctionComponent, MouseEvent} from 'react'
 import {Link} from 'react-router'
 
 import classnames from 'classnames'
@@ -24,15 +24,26 @@ interface AddNew {
   url?: string
   text: string
   handler?: () => void
+  stopPropagation?: boolean
 }
 
-const AddNewButton: FunctionComponent<AddNew> = ({url, text, handler}) => {
+const AddNewButton: FunctionComponent<AddNew> = ({
+  url,
+  text,
+  handler,
+  stopPropagation,
+}) => {
   if (handler) {
     return (
       <li className="multi-select--apply">
         <Button
           text={text}
-          onClick={handler}
+          onClick={(e: MouseEvent) => {
+            if (stopPropagation) {
+              e.stopPropagation()
+            }
+            handler()
+          }}
           color={ComponentColor.Default}
           size={ComponentSize.ExtraSmall}
           shape={ButtonShape.StretchToFit}

--- a/ui/src/shared/components/DropdownMenu.tsx
+++ b/ui/src/shared/components/DropdownMenu.tsx
@@ -127,6 +127,7 @@ const DropdownMenu: FunctionComponent<Props> = ({
             url={addNew.url}
             text={addNew.text}
             handler={addNew.handler}
+            stopPropagation={addNew.stopPropagation}
           />
         )}
       </FancyScrollbar>

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
@@ -25,6 +25,8 @@ import {
   increaseKeysLimit,
   increaseValuesLimit,
 } from './actions/tags'
+import {ButtonShape, ComponentSize, IconFont} from 'src/reusable_ui/types'
+import {Button} from 'src/reusable_ui'
 
 const SEARCH_DEBOUNCE_MS = 400
 
@@ -71,6 +73,7 @@ const TagSelectorBody = (props: Props) => {
     onSelectKey,
     valuesSearchTerm,
     onChangeValuesSearchTerm,
+    onIncreaseValuesLimit,
     onSearchValues,
     keysSearchTerm,
     onChangeKeysSearchTerm,
@@ -109,6 +112,10 @@ const TagSelectorBody = (props: Props) => {
   function onLoadMoreKeys() {
     onIncreaseKeysLimit()
     debouncer.call(() => onSearchKeys(), SEARCH_DEBOUNCE_MS)
+  }
+  function onLoadMoreValues() {
+    onIncreaseValuesLimit()
+    debouncer.call(() => onSearchValues(), SEARCH_DEBOUNCE_MS)
   }
 
   const placeholderText =
@@ -170,12 +177,12 @@ const TagSelectorBody = (props: Props) => {
           />
         ) : undefined}
       </BuilderCard.Menu>
-      <TagSelectorValues {...props} />
+      <TagSelectorValues {...props} onLoadMoreValues={onLoadMoreValues} />
     </>
   )
 }
 
-const TagSelectorValues = (props: Props) => {
+const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
   const {
     aggregateFunctionType,
     keysStatus,
@@ -186,6 +193,7 @@ const TagSelectorValues = (props: Props) => {
     valuesTruncated,
     tagValues: selectedValues,
     onSelectValues,
+    onLoadMoreValues,
   } = props
   if (aggregateFunctionType === 'filter') {
     if (keysStatus === RemoteDataState.NotStarted) {
@@ -259,7 +267,16 @@ const TagSelectorValues = (props: Props) => {
         })}
         {valuesTruncated && aggregateFunctionType === 'filter' ? (
           <div className="flux-query-builder--list-item" key={`__truncated`}>
-            Truncated
+            <Button
+              text="Load More Values"
+              onClick={e => {
+                e.stopPropagation()
+                onLoadMoreValues()
+              }}
+              size={ComponentSize.ExtraSmall}
+              shape={ButtonShape.StretchToFit}
+              icon={IconFont.Plus}
+            />
           </div>
         ) : undefined}
       </div>

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -128,19 +128,13 @@ export function setValuesStatus(tagIndex: number, status: RemoteDataState) {
   }
 }
 
-export function setKeys(
-  tagIndex: number,
-  keys: string[],
-  truncated: boolean,
-  limit: number
-) {
+export function setKeys(tagIndex: number, keys: string[], truncated: boolean) {
   return {
     type: 'FQB_TAG_KEYS' as const,
     payload: {
       tagIndex,
       keys,
       truncated,
-      limit,
     },
   }
 }
@@ -148,8 +142,7 @@ export function setKeys(
 export function setValues(
   tagIndex: number,
   values: string[],
-  truncated: boolean,
-  limit: number
+  truncated: boolean
 ) {
   return {
     type: 'FQB_TAG_VALUES' as const,
@@ -157,7 +150,6 @@ export function setValues(
       tagIndex,
       values,
       truncated,
-      limit,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -128,13 +128,19 @@ export function setValuesStatus(tagIndex: number, status: RemoteDataState) {
   }
 }
 
-export function setKeys(tagIndex: number, keys: string[], truncated: boolean) {
+export function setKeys(
+  tagIndex: number,
+  keys: string[],
+  truncated: boolean,
+  limit: number
+) {
   return {
     type: 'FQB_TAG_KEYS' as const,
     payload: {
       tagIndex,
       keys,
-      keysTruncated: truncated,
+      truncated,
+      limit,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -128,12 +128,13 @@ export function setValuesStatus(tagIndex: number, status: RemoteDataState) {
   }
 }
 
-export function setKeys(tagIndex: number, keys: string[]) {
+export function setKeys(tagIndex: number, keys: string[], truncated: boolean) {
   return {
     type: 'FQB_TAG_KEYS' as const,
     payload: {
       tagIndex,
       keys,
+      keysTruncated: truncated,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -6,9 +6,11 @@ export type TagSelectorAction =
   | ReturnType<typeof changeFunctionType>
   | ReturnType<typeof selectKey>
   | ReturnType<typeof changeKeysSearchTerm>
+  | ReturnType<typeof increaseKeysLimit>
   | ReturnType<typeof searchKeys>
   | ReturnType<typeof selectValues>
   | ReturnType<typeof changeValuesSearchTerm>
+  | ReturnType<typeof increaseValuesLimit>
   | ReturnType<typeof searchValues>
   | ReturnType<typeof setKeysStatus>
   | ReturnType<typeof setKeys>
@@ -70,6 +72,15 @@ export function changeKeysSearchTerm(tagIndex: number, term: string) {
   }
 }
 
+export function increaseKeysLimit(tagIndex: number) {
+  return {
+    type: 'FQB_TAG_INC_KEYS_LIMIT' as const,
+    payload: {
+      tagIndex,
+    },
+  }
+}
+
 export function searchKeys(tagIndex: number) {
   return {
     type: 'FQB_TAG_SEARCH_KEY' as const,
@@ -95,6 +106,15 @@ export function changeValuesSearchTerm(tagIndex: number, term: string) {
     payload: {
       tagIndex,
       term,
+    },
+  }
+}
+
+export function increaseValuesLimit(tagIndex: number) {
+  return {
+    type: 'FQB_TAG_INC_VALUES_LIMIT' as const,
+    payload: {
+      tagIndex,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -148,14 +148,16 @@ export function setKeys(
 export function setValues(
   tagIndex: number,
   values: string[],
-  truncated: boolean
+  truncated: boolean,
+  limit: number
 ) {
   return {
     type: 'FQB_TAG_VALUES' as const,
     payload: {
       tagIndex,
       values,
-      valuesTruncated: truncated,
+      truncated,
+      limit,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags.ts
@@ -139,12 +139,17 @@ export function setKeys(tagIndex: number, keys: string[], truncated: boolean) {
   }
 }
 
-export function setValues(tagIndex: number, values: string[]) {
+export function setValues(
+  tagIndex: number,
+  values: string[],
+  truncated: boolean
+) {
   return {
     type: 'FQB_TAG_VALUES' as const,
     payload: {
       tagIndex,
       values,
+      valuesTruncated: truncated,
     },
   }
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -139,6 +139,7 @@ const loadTagSelectorValuesThunk = (
 
   try {
     let values: string[]
+    let valuesTruncated = false
     const originalSelected = tagState.tagValues || []
     let selectedValues = originalSelected
     if (tagState.aggregateFunctionType === 'filter') {
@@ -155,6 +156,7 @@ const loadTagSelectorValuesThunk = (
           timeRange,
         })
         values = data.result
+        valuesTruncated = data.truncated
         for (const selectedValue of tagState.tagValues) {
           // Even if the selected values didn't come back in the results, let them
           // be selected anyway
@@ -179,7 +181,7 @@ const loadTagSelectorValuesThunk = (
       selectedValues = tagState.tagValues.filter(x => values.includes(x))
     }
 
-    dispatch(tagActions.setValues(tagIndex, values))
+    dispatch(tagActions.setValues(tagIndex, values, valuesTruncated))
     if (selectedValues !== originalSelected) {
       dispatch(tagActions.selectValues(tagIndex, selectedValues))
     }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -99,9 +99,7 @@ export const loadTagSelectorThunk = (
         keys.unshift(key)
       }
 
-      dispatch(
-        tagActions.setKeys(tagIndex, keys, truncated, tagState.keysLimit)
-      )
+      dispatch(tagActions.setKeys(tagIndex, keys, truncated))
     }
     dispatch(loadTagSelectorValuesThunk(source, timeRange, tagIndex))
   } catch (e) {
@@ -184,14 +182,7 @@ const loadTagSelectorValuesThunk = (
       selectedValues = tagState.tagValues.filter(x => values.includes(x))
     }
 
-    dispatch(
-      tagActions.setValues(
-        tagIndex,
-        values,
-        valuesTruncated,
-        tagState.valuesLimit
-      )
-    )
+    dispatch(tagActions.setValues(tagIndex, values, valuesTruncated))
     if (selectedValues !== originalSelected) {
       dispatch(tagActions.selectValues(tagIndex, selectedValues))
     }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -62,7 +62,7 @@ export const loadTagSelectorThunk = (
     if (tagState.aggregateFunctionType === 'filter') {
       const searchTerm = tagState.keysSearchTerm
       dispatch(tagActions.setKeysStatus(tagIndex, RemoteDataState.Loading))
-      const keys = await queryBuilderFetcher.findKeys(tagIndex, {
+      const {result: keys} = await queryBuilderFetcher.findKeys(tagIndex, {
         source,
         bucket: selectedBucket,
         searchTerm,
@@ -141,7 +141,7 @@ const loadTagSelectorValuesThunk = (
     if (tagState.aggregateFunctionType === 'filter') {
       dispatch(tagActions.setValuesStatus(tagIndex, RemoteDataState.Loading))
       if (tagState.tagKey) {
-        values = await queryBuilderFetcher.findValues(tagIndex, {
+        const data = await queryBuilderFetcher.findValues(tagIndex, {
           source,
           bucket: selectedBucket,
           tagsSelections: tags
@@ -151,6 +151,7 @@ const loadTagSelectorValuesThunk = (
           searchTerm: tagState.valuesSearchTerm,
           timeRange,
         })
+        values = data.result
         for (const selectedValue of tagState.tagValues) {
           // Even if the selected values didn't come back in the results, let them
           // be selected anyway
@@ -205,7 +206,9 @@ export const loadBucketsThunk = (
   dispatch(bucketActions.setBucketsStatus(RemoteDataState.Loading))
 
   try {
-    const allBuckets = await queryBuilderFetcher.findBuckets(source)
+    const {result: allBuckets} = await queryBuilderFetcher.findBuckets(source, {
+      limit: -1,
+    })
 
     const systemBuckets = allBuckets.filter(b => b.startsWith('_'))
     const userBuckets = allBuckets.filter(b => !b.startsWith('_'))

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -72,6 +72,7 @@ export const loadTagSelectorThunk = (
           tagsSelections: tags
             .slice(0, tagIndex)
             .filter(x => x.aggregateFunctionType === 'filter'),
+          limit: tagState.keysLimit,
         }
       )
 
@@ -98,7 +99,9 @@ export const loadTagSelectorThunk = (
         keys.unshift(key)
       }
 
-      dispatch(tagActions.setKeys(tagIndex, keys, truncated))
+      dispatch(
+        tagActions.setKeys(tagIndex, keys, truncated, tagState.keysLimit)
+      )
     }
     dispatch(loadTagSelectorValuesThunk(source, timeRange, tagIndex))
   } catch (e) {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -213,9 +213,7 @@ export const loadBucketsThunk = (
   dispatch(bucketActions.setBucketsStatus(RemoteDataState.Loading))
 
   try {
-    const {result: allBuckets} = await queryBuilderFetcher.findBuckets(source, {
-      limit: -1,
-    })
+    const {result: allBuckets} = await queryBuilderFetcher.findBuckets(source)
 
     const systemBuckets = allBuckets.filter(b => b.startsWith('_'))
     const userBuckets = allBuckets.filter(b => !b.startsWith('_'))

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -62,15 +62,18 @@ export const loadTagSelectorThunk = (
     if (tagState.aggregateFunctionType === 'filter') {
       const searchTerm = tagState.keysSearchTerm
       dispatch(tagActions.setKeysStatus(tagIndex, RemoteDataState.Loading))
-      const {result: keys} = await queryBuilderFetcher.findKeys(tagIndex, {
-        source,
-        bucket: selectedBucket,
-        searchTerm,
-        timeRange,
-        tagsSelections: tags
-          .slice(0, tagIndex)
-          .filter(x => x.aggregateFunctionType === 'filter'),
-      })
+      const {result: keys, truncated} = await queryBuilderFetcher.findKeys(
+        tagIndex,
+        {
+          source,
+          bucket: selectedBucket,
+          searchTerm,
+          timeRange,
+          tagsSelections: tags
+            .slice(0, tagIndex)
+            .filter(x => x.aggregateFunctionType === 'filter'),
+        }
+      )
 
       const {tagKey: key} = tagState
 
@@ -95,7 +98,7 @@ export const loadTagSelectorThunk = (
         keys.unshift(key)
       }
 
-      dispatch(tagActions.setKeys(tagIndex, keys))
+      dispatch(tagActions.setKeys(tagIndex, keys, truncated))
     }
     dispatch(loadTagSelectorValuesThunk(source, timeRange, tagIndex))
   } catch (e) {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -155,6 +155,7 @@ const loadTagSelectorValuesThunk = (
           key: tagState.tagKey,
           searchTerm: tagState.valuesSearchTerm,
           timeRange,
+          limit: tagState.valuesLimit,
         })
         values = data.result
         valuesTruncated = data.truncated

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -184,7 +184,14 @@ const loadTagSelectorValuesThunk = (
       selectedValues = tagState.tagValues.filter(x => values.includes(x))
     }
 
-    dispatch(tagActions.setValues(tagIndex, values, valuesTruncated))
+    dispatch(
+      tagActions.setValues(
+        tagIndex,
+        values,
+        valuesTruncated,
+        tagState.valuesLimit
+      )
+    )
     if (selectedValues !== originalSelected) {
       dispatch(tagActions.selectValues(tagIndex, selectedValues))
     }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
@@ -20,8 +20,7 @@ export interface FindBucketsOptions {
 
 export function findBuckets(source: Source): CancelBox<string[]> {
   const query = `buckets()
-  |> sort(columns: ["name"])
-  |> limit(n: ${DEFAULT_LIMIT})`
+  |> sort(columns: ["name"])`
 
   return extractBoxedCol(runQuery(source, query), 'name')
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
@@ -14,12 +14,12 @@ const DEFAULT_TIME_RANGE: TimeRange = {lower: 'now() - 30d', lowerFlux: '-30d'}
 export const FQB_RESULTS_LIMIT = 200
 
 export interface FindBucketsOptions {
-  limit?: number
+  limit: number
 }
 
 export function findBuckets(
   source: Source,
-  {limit = FQB_RESULTS_LIMIT}: FindBucketsOptions
+  {limit}: FindBucketsOptions
 ): CancelBox<TruncatedResult<string[]>> {
   const query = `buckets()
   |> sort(columns: ["name"])${limit > 0 ? ` |> limit(n: ${limit})` : ''}`

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
@@ -33,7 +33,7 @@ export interface FindKeysOptions {
   tagsSelections: BuilderTagsType[]
   searchTerm?: string
   timeRange?: TimeRange
-  limit?: number
+  limit: number
 }
 
 export interface TruncatedResult<T> {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries.ts
@@ -22,7 +22,7 @@ export function findBuckets(
   {limit = FQB_RESULTS_LIMIT}: FindBucketsOptions
 ): CancelBox<TruncatedResult<string[]>> {
   const query = `buckets()
-  |> sort(columns: ["name"])${limit ? ` |> limit(n: ${limit})` : ''}`
+  |> sort(columns: ["name"])${limit > 0 ? ` |> limit(n: ${limit})` : ''}`
 
   return extractBoxedCol(runQuery(source, query), 'name', limit)
 }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/queryBuilderFetcher.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/apis/queryBuilderFetcher.ts
@@ -33,11 +33,15 @@ class QueryBuilderFetcher {
 
   public async findBuckets(
     source: Source,
-    limit?: FindBucketsOptions
+    options?: FindBucketsOptions
   ): Promise<TruncatedResult<string[]>> {
     this.cancelFindBuckets()
 
-    const cachedResult = this.findBucketsCache[source.id]
+    const cacheKey = JSON.stringify({
+      id: source.id,
+      limit: options.limit,
+    })
+    const cachedResult = this.findBucketsCache[cacheKey]
 
     if (cachedResult) {
       return Promise.resolve({
@@ -46,12 +50,12 @@ class QueryBuilderFetcher {
       })
     }
 
-    const pendingResult = findBuckets(source, limit)
+    const pendingResult = findBuckets(source, options)
     this.findBucketsQuery = pendingResult
 
     pendingResult.promise
       .then(t => {
-        this.findBucketsCache[source.id] = {
+        this.findBucketsCache[cacheKey] = {
           result: t.result,
           truncated: t.truncated,
         }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -22,6 +22,7 @@ export function initialSelectorState(
     valuesStatus: undefined,
     valuesTruncated: false,
     tagValues: [],
+    valuesLimit: FQB_RESULTS_LIMIT,
   }
 }
 
@@ -139,7 +140,8 @@ const aggregationReducer = (
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         values: action.payload.values,
         valuesStatus: RemoteDataState.Done,
-        valuesTruncated: action.payload.valuesTruncated,
+        valuesTruncated: action.payload.truncated,
+        valuesLimit: action.payload.limit,
       }))
     }
   }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -18,6 +18,7 @@ export function initialSelectorState(
     values: [],
     valuesSearchTerm: '',
     valuesStatus: undefined,
+    valuesTruncated: false,
     tagValues: [],
   }
 }
@@ -135,6 +136,7 @@ const aggregationReducer = (
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         values: action.payload.values,
         valuesStatus: RemoteDataState.Done,
+        valuesTruncated: action.payload.valuesTruncated,
       }))
     }
   }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -80,6 +80,11 @@ const aggregationReducer = (
         valuesSearchTerm: action.payload.term,
       }))
     }
+    case 'FQB_TAG_INC_KEYS_LIMIT': {
+      return changeTagSelector(state, action.payload.tagIndex, tagState => ({
+        keysLimit: (tagState.keysLimit || 0) + FQB_RESULTS_LIMIT,
+      }))
+    }
     case 'FQB_TAG_SELECT_KEY': {
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         tagKey: action.payload.key,
@@ -100,6 +105,11 @@ const aggregationReducer = (
     case 'FQB_TAG_SEARCH_VALUES': {
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         valuesStatus: RemoteDataState.Loading,
+      }))
+    }
+    case 'FQB_TAG_INC_VALUES_LIMIT': {
+      return changeTagSelector(state, action.payload.tagIndex, tagState => ({
+        valuesLimit: (tagState.valuesLimit || 0) + FQB_RESULTS_LIMIT,
       }))
     }
     case 'FQB_TAG_KEY_STATUS': {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -1,6 +1,7 @@
 import {TagSelectorAction} from '../actions/tags'
 import {TagSelectorState} from '../types'
 import {BuilderAggregateFunctionType, RemoteDataState} from 'src/types'
+import {FQB_RESULTS_LIMIT} from '../apis/fluxQueries'
 
 export const initialState: TagSelectorState[] = []
 export function initialSelectorState(
@@ -14,6 +15,7 @@ export function initialSelectorState(
     keysSearchTerm: '',
     keysStatus: RemoteDataState.NotStarted,
     keysTruncated: false,
+    keysLimit: FQB_RESULTS_LIMIT,
     tagKey: '',
     values: [],
     valuesSearchTerm: '',
@@ -129,7 +131,8 @@ const aggregationReducer = (
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         keys: action.payload.keys,
         keysStatus: RemoteDataState.Done,
-        keysTruncated: action.payload.keysTruncated,
+        keysTruncated: action.payload.truncated,
+        keysLimit: action.payload.limit,
       }))
     }
     case 'FQB_TAG_VALUES': {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -133,7 +133,6 @@ const aggregationReducer = (
         keys: action.payload.keys,
         keysStatus: RemoteDataState.Done,
         keysTruncated: action.payload.truncated,
-        keysLimit: action.payload.limit,
       }))
     }
     case 'FQB_TAG_VALUES': {
@@ -141,7 +140,6 @@ const aggregationReducer = (
         values: action.payload.values,
         valuesStatus: RemoteDataState.Done,
         valuesTruncated: action.payload.truncated,
-        valuesLimit: action.payload.limit,
       }))
     }
   }

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.ts
@@ -13,6 +13,7 @@ export function initialSelectorState(
     keys: [],
     keysSearchTerm: '',
     keysStatus: RemoteDataState.NotStarted,
+    keysTruncated: false,
     tagKey: '',
     values: [],
     valuesSearchTerm: '',
@@ -127,6 +128,7 @@ const aggregationReducer = (
       return changeTagSelector(state, action.payload.tagIndex, () => ({
         keys: action.payload.keys,
         keysStatus: RemoteDataState.Done,
+        keysTruncated: action.payload.keysTruncated,
       }))
     }
     case 'FQB_TAG_VALUES': {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
@@ -25,6 +25,7 @@ export interface TagSelectorState extends BuilderTagsType {
   keys: string[]
   keysSearchTerm: string
   keysTruncated: boolean
+  keysLimit: number
 
   valuesSearchTerm: string
   valuesStatus?: RemoteDataState

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
@@ -31,6 +31,7 @@ export interface TagSelectorState extends BuilderTagsType {
   valuesStatus?: RemoteDataState
   values: string[]
   valuesTruncated: boolean
+  valuesLimit: number
 }
 
 export interface BuilderTagsType {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
@@ -29,6 +29,7 @@ export interface TagSelectorState extends BuilderTagsType {
   valuesSearchTerm: string
   valuesStatus?: RemoteDataState
   values: string[]
+  valuesTruncated: boolean
 }
 
 export interface BuilderTagsType {

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/types/index.ts
@@ -24,6 +24,7 @@ export interface TagSelectorState extends BuilderTagsType {
   keysStatus: RemoteDataState
   keys: string[]
   keysSearchTerm: string
+  keysTruncated: boolean
 
   valuesSearchTerm: string
   valuesStatus?: RemoteDataState

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -19,8 +19,11 @@ import {
   searchValues,
   setKeysStatus,
   setValuesStatus,
+  increaseKeysLimit,
+  increaseValuesLimit,
 } from 'src/shared/components/TimeMachine/fluxQueryBuilder/actions/tags'
 import {BuilderAggregateFunctionType, RemoteDataState} from 'src/types'
+import {FQB_RESULTS_LIMIT} from 'src/shared/components/TimeMachine/fluxQueryBuilder/apis/fluxQueries'
 
 describe('fluxQueryBuilder/reducers/tags', () => {
   it('has empty initial state', () => {
@@ -80,6 +83,26 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     expect(reducedState).toEqual([
       state[0],
       {...state[1], valuesSearchTerm: newVal},
+    ])
+    expect(Object.is(state, reducedState)).toBe(false)
+    expect(Object.is(state[1], reducedState[1])).toBe(false)
+  })
+  it('should handle increaseKeysLimit', () => {
+    const state = [initialSelectorState(0), initialSelectorState(1)]
+    const reducedState = reducer(state, increaseKeysLimit(1))
+    expect(reducedState).toEqual([
+      state[0],
+      {...state[1], keysLimit: state[1].keysLimit + FQB_RESULTS_LIMIT},
+    ])
+    expect(Object.is(state, reducedState)).toBe(false)
+    expect(Object.is(state[1], reducedState[1])).toBe(false)
+  })
+  it('should handle increaseValuesLimit', () => {
+    const state = [initialSelectorState(0), initialSelectorState(1)]
+    const reducedState = reducer(state, increaseValuesLimit(1))
+    expect(reducedState).toEqual([
+      state[0],
+      {...state[1], valuesLimit: state[1].valuesLimit + FQB_RESULTS_LIMIT},
     ])
     expect(Object.is(state, reducedState)).toBe(false)
     expect(Object.is(state[1], reducedState[1])).toBe(false)

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -104,7 +104,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     ;[true, false].forEach(truncated => {
       const newVal = ['newK']
       const state = [initialSelectorState(0), initialSelectorState(1)]
-      const reducedState = reducer(state, setKeys(1, newVal, truncated, 400))
+      const reducedState = reducer(state, setKeys(1, newVal, truncated))
       expect(reducedState).toEqual([
         state[0],
         {
@@ -112,7 +112,6 @@ describe('fluxQueryBuilder/reducers/tags', () => {
           keys: newVal,
           keysTruncated: truncated,
           keysStatus: RemoteDataState.Done,
-          keysLimit: 400,
         },
       ])
       expect(Object.is(state, reducedState)).toBe(false)
@@ -123,7 +122,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     ;[true, false].forEach(truncated => {
       const newVal = ['newV']
       const state = [initialSelectorState(0), initialSelectorState(1)]
-      const reducedState = reducer(state, setValues(1, newVal, truncated, 400))
+      const reducedState = reducer(state, setValues(1, newVal, truncated))
       expect(reducedState).toEqual([
         state[0],
         {
@@ -131,7 +130,6 @@ describe('fluxQueryBuilder/reducers/tags', () => {
           values: newVal,
           valuesTruncated: truncated,
           valuesStatus: RemoteDataState.Done,
-          valuesLimit: 400,
         },
       ])
       expect(Object.is(state, reducedState)).toBe(false)

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -119,15 +119,22 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     })
   })
   it('should handle setValues', () => {
-    const newVal = ['newV']
-    const state = [initialSelectorState(0), initialSelectorState(1)]
-    const reducedState = reducer(state, setValues(1, newVal))
-    expect(reducedState).toEqual([
-      state[0],
-      {...state[1], values: newVal, valuesStatus: RemoteDataState.Done},
-    ])
-    expect(Object.is(state, reducedState)).toBe(false)
-    expect(Object.is(state[1], reducedState[1])).toBe(false)
+    ;[true, false].forEach(truncated => {
+      const newVal = ['newV']
+      const state = [initialSelectorState(0), initialSelectorState(1)]
+      const reducedState = reducer(state, setValues(1, newVal, truncated))
+      expect(reducedState).toEqual([
+        state[0],
+        {
+          ...state[1],
+          values: newVal,
+          valuesTruncated: truncated,
+          valuesStatus: RemoteDataState.Done,
+        },
+      ])
+      expect(Object.is(state, reducedState)).toBe(false)
+      expect(Object.is(state[1], reducedState[1])).toBe(false)
+    })
   })
   it('should ignore searchKeys', () => {
     const state = [initialSelectorState(0), initialSelectorState(1)]

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -104,7 +104,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     ;[true, false].forEach(truncated => {
       const newVal = ['newK']
       const state = [initialSelectorState(0), initialSelectorState(1)]
-      const reducedState = reducer(state, setKeys(1, newVal, truncated))
+      const reducedState = reducer(state, setKeys(1, newVal, truncated, 400))
       expect(reducedState).toEqual([
         state[0],
         {
@@ -112,6 +112,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
           keys: newVal,
           keysTruncated: truncated,
           keysStatus: RemoteDataState.Done,
+          keysLimit: 400,
         },
       ])
       expect(Object.is(state, reducedState)).toBe(false)

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -101,15 +101,22 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     expect(Object.is(state[1], reducedState[1])).toBe(false)
   })
   it('should handle setKeys', () => {
-    const newVal = ['newK']
-    const state = [initialSelectorState(0), initialSelectorState(1)]
-    const reducedState = reducer(state, setKeys(1, newVal))
-    expect(reducedState).toEqual([
-      state[0],
-      {...state[1], keys: newVal, keysStatus: RemoteDataState.Done},
-    ])
-    expect(Object.is(state, reducedState)).toBe(false)
-    expect(Object.is(state[1], reducedState[1])).toBe(false)
+    ;[true, false].forEach(truncated => {
+      const newVal = ['newK']
+      const state = [initialSelectorState(0), initialSelectorState(1)]
+      const reducedState = reducer(state, setKeys(1, newVal, truncated))
+      expect(reducedState).toEqual([
+        state[0],
+        {
+          ...state[1],
+          keys: newVal,
+          keysTruncated: truncated,
+          keysStatus: RemoteDataState.Done,
+        },
+      ])
+      expect(Object.is(state, reducedState)).toBe(false)
+      expect(Object.is(state[1], reducedState[1])).toBe(false)
+    })
   })
   it('should handle setValues', () => {
     const newVal = ['newV']

--- a/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
+++ b/ui/test/shared/components/TimeMachine/fluxQueryBuilder/reducers/tags.test.ts
@@ -123,7 +123,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
     ;[true, false].forEach(truncated => {
       const newVal = ['newV']
       const state = [initialSelectorState(0), initialSelectorState(1)]
-      const reducedState = reducer(state, setValues(1, newVal, truncated))
+      const reducedState = reducer(state, setValues(1, newVal, truncated, 400))
       expect(reducedState).toEqual([
         state[0],
         {
@@ -131,6 +131,7 @@ describe('fluxQueryBuilder/reducers/tags', () => {
           values: newVal,
           valuesTruncated: truncated,
           valuesStatus: RemoteDataState.Done,
+          valuesLimit: 400,
         },
       ])
       expect(Object.is(state, reducedState)).toBe(false)


### PR DESCRIPTION
Closes #5853

_Briefly describe your proposed changes:_

- the user can load more tag keys if the shown list is truncated
![image](https://user-images.githubusercontent.com/16321466/153760075-83498445-cbe8-47a0-84b5-add5164067cf.png)
- the user can load more tag values if the shown list is truncated
![image](https://user-images.githubusercontent.com/16321466/153760169-12338558-2e02-4073-a31f-04665a1e73b7.png)
- all buckets are always shown

The lists are initially limited to 200 values, and their size is incremented by 200 upon user request


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
