### PR TITLE
fix(server): respect BASE_PATH when serving API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+1. [#5862](https://github.com/influxdata/chronograf/pull/5862): Respect BASE_PATH when serving API docs.
+
 ### Other
 
 1. [#5851](https://github.com/influxdata/chronograf/pull/5851): Remove fixed-table-2 to resolve CVE-2022-0235.

--- a/server/mux.go
+++ b/server/mux.go
@@ -149,7 +149,7 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 
 	/* Documentation */
 	router.GET("/swagger.json", Spec())
-	router.GET("/docs", Redoc("/swagger.json"))
+	router.GET("/docs", Redoc("swagger.json"))
 
 	/* Health */
 	router.GET("/ping", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(http.StatusOK) })


### PR DESCRIPTION
Absolute path to swagger.json in the served docs route did not respect BASE_PATH from config.
Changed to relative path to resolve.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass