### PR TITLE
feat(ui): separate flux tasks list from alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add Flux Query Builder.
 1. [#5858](https://github.com/influxdata/chronograf/pull/5858): Use time range in flux Schema Explorer.
+1. [#5868](https://github.com/influxdata/chronograf/pull/5868): Move Flux Tasks to own page.
 
 ### Bug Fixes
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -30,6 +30,7 @@ import {LogsPage} from 'src/logs'
 import AlertsApp from 'src/alerts'
 import {
   FluxTaskPage,
+  FluxTasksPage,
   KapacitorPage,
   KapacitorRulePage,
   KapacitorRulesPage,
@@ -188,6 +189,7 @@ class Root extends PureComponent<Record<string, never>, State> {
                 />
                 <Route path="alerts" component={AlertsApp} />
                 <Route path="alert-rules" component={KapacitorRulesPage} />
+                <Route path="flux-tasks" component={FluxTasksPage} />
                 <Route
                   path="kapacitors/:kid/alert-rules/:ruleID" // ruleID can be "new"
                   component={KapacitorRulePage}

--- a/ui/src/kapacitor/actions/view/index.js
+++ b/ui/src/kapacitor/actions/view/index.js
@@ -6,12 +6,15 @@ import {
   getRule as getRuleAJAX,
   deleteRule as deleteRuleAPI,
   updateRuleStatus as updateRuleStatusAPI,
-  updateFluxTaskStatus as updateFluxTaskStatusAPI,
-  deleteFluxTask as deleteFluxTaskAPI,
   createTask as createTaskAJAX,
   updateTask as updateTaskAJAX,
-  getFluxTasks,
 } from 'src/kapacitor/apis'
+import {
+  updateFluxTaskStatus as updateFluxTaskStatusAPI,
+  deleteFluxTask as deleteFluxTaskAPI,
+  getFluxTasks,
+} from 'src/kapacitor/apis/fluxTasks'
+
 import {errorThrown} from 'shared/actions/errors'
 
 import {

--- a/ui/src/kapacitor/apis/fluxTasks.ts
+++ b/ui/src/kapacitor/apis/fluxTasks.ts
@@ -4,7 +4,8 @@ import {FluxTask, Kapacitor} from 'src/types'
 
 const tasksBatchLimit = 500
 export const getFluxTasks = async (
-  kapacitor: Kapacitor
+  kapacitor: Kapacitor,
+  signal?: AbortSignal
 ): Promise<FluxTask[]> => {
   const taskIds: Record<string, FluxTask> = {}
   let lastID = ''
@@ -19,6 +20,7 @@ export const getFluxTasks = async (
         encodeURIComponent(
           `/kapacitor/v1/api/v2/tasks?limit=${tasksBatchLimit}&after=${lastID}`
         ),
+      signal,
     })
     if (!tasks || !tasks.length) {
       break

--- a/ui/src/kapacitor/apis/fluxTasks.ts
+++ b/ui/src/kapacitor/apis/fluxTasks.ts
@@ -1,0 +1,117 @@
+import AJAX from 'src/utils/ajax'
+import _, {values} from 'lodash'
+import {FluxTask, Kapacitor} from 'src/types'
+
+const tasksBatchLimit = 500
+export const getFluxTasks = async (
+  kapacitor: Kapacitor
+): Promise<FluxTask[]> => {
+  const taskIds: Record<string, FluxTask> = {}
+  let lastID = ''
+  for (;;) {
+    const {
+      data: {tasks},
+    } = await AJAX<{tasks: FluxTask[]}>({
+      method: 'GET',
+      url:
+        kapacitor.links.proxy +
+        '?path=' +
+        encodeURIComponent(
+          `/kapacitor/v1/api/v2/tasks?limit=${tasksBatchLimit}&after=${lastID}`
+        ),
+    })
+    if (!tasks || !tasks.length) {
+      break
+    }
+    lastID = tasks[tasks.length - 1].id
+    let noNewData = true
+    tasks.forEach(x => {
+      if (taskIds[x.id]) {
+        return
+      }
+      noNewData = false
+      taskIds[x.id] = x
+    })
+    if (noNewData) {
+      break
+    }
+    if (tasks.length < tasksBatchLimit) {
+      // less data returned, last chunk
+      break
+    }
+  }
+  return values(taskIds).sort((a, b) => a.name.localeCompare(b.name))
+}
+
+export const getFluxTask = async (
+  kapacitor: Kapacitor,
+  taskID: string
+): Promise<FluxTask> => {
+  const {data} = await AJAX({
+    method: 'GET',
+    url: kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}`,
+  })
+  return data
+}
+
+function friendlyID(id: number): string {
+  if (id > 25) {
+    return friendlyID(Math.trunc(id / 25)) + String.fromCharCode(id % 25)
+  }
+  return String.fromCharCode(65 + id)
+}
+export const getFluxTaskLogs = async (
+  kapacitor: Kapacitor,
+  taskID: string,
+  maxItems: number
+) => {
+  const {data} = await AJAX({
+    method: 'GET',
+    url:
+      kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}/runs`,
+  })
+  const logs = []
+  let nextClusterId = 0
+  const runsById = {}
+  _.each(_.get(data, ['runs'], []), run => {
+    runsById[run.id] = {
+      name: friendlyID(nextClusterId++),
+      lvl: run.status === 'failed' ? 'error' : 'info',
+    }
+    _.each(run.log, l => logs.push(l))
+  })
+
+  logs.sort((a, b) => b.time.localeCompare(a.time))
+  return logs.slice(0, maxItems).map(x => {
+    const runDetail = runsById[x.runID]
+    return {
+      id: `${x.runID}-${x.time}`,
+      key: `${x.runID}-${x.time}`,
+      service: 'flux_task',
+      lvl: runDetail.lvl,
+      ts: x.time,
+      msg: x.message,
+      tags: x.runID,
+      cluster: runDetail.name,
+    }
+  })
+}
+
+export const updateFluxTaskStatus = (
+  kapacitor: Kapacitor,
+  task: FluxTask,
+  status: string
+) => {
+  return AJAX({
+    method: 'PATCH',
+    url: kapacitor.links.proxy + '?path=' + task.links.self,
+    data: {status},
+  })
+}
+
+export const deleteFluxTask = (kapacitor: Kapacitor, task: FluxTask) => {
+  return AJAX({
+    method: 'DELETE',
+    url: kapacitor.links.proxy + '?path=' + task.links.self,
+  })
+}

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -66,6 +66,8 @@ export const getRules = kapacitor => {
   })
 }
 
+const tasksBatchLimit = 500
+
 export const getFluxTasks = async kapacitor => {
   const taskIds = {}
   let lastID = ''
@@ -78,7 +80,7 @@ export const getFluxTasks = async kapacitor => {
         kapacitor.links.proxy +
         '?path=' +
         encodeURIComponent(
-          `/kapacitor/v1/api/v2/tasks?limit=500&after=${lastID}`
+          `/kapacitor/v1/api/v2/tasks?limit=${tasksBatchLimit}&after=${lastID}`
         ),
     })
     if (!tasks || !tasks.length) {
@@ -94,6 +96,10 @@ export const getFluxTasks = async kapacitor => {
       taskIds[x.id] = x
     })
     if (noNewData) {
+      break
+    }
+    if (tasks.length < tasksBatchLimit) {
+      // less data returned, last chunk
       break
     }
   }

--- a/ui/src/kapacitor/apis/index.js
+++ b/ui/src/kapacitor/apis/index.js
@@ -1,5 +1,5 @@
 import AJAX from 'utils/ajax'
-import _, {cloneDeep, get, values} from 'lodash'
+import {cloneDeep, get} from 'lodash'
 
 const outRule = rule => {
   // fit into range
@@ -66,93 +66,6 @@ export const getRules = kapacitor => {
   })
 }
 
-const tasksBatchLimit = 500
-
-export const getFluxTasks = async kapacitor => {
-  const taskIds = {}
-  let lastID = ''
-  for (;;) {
-    const {
-      data: {tasks},
-    } = await AJAX({
-      method: 'GET',
-      url:
-        kapacitor.links.proxy +
-        '?path=' +
-        encodeURIComponent(
-          `/kapacitor/v1/api/v2/tasks?limit=${tasksBatchLimit}&after=${lastID}`
-        ),
-    })
-    if (!tasks || !tasks.length) {
-      break
-    }
-    lastID = tasks[tasks.length - 1].id
-    let noNewData = true
-    tasks.forEach(x => {
-      if (taskIds[x.id]) {
-        return
-      }
-      noNewData = false
-      taskIds[x.id] = x
-    })
-    if (noNewData) {
-      break
-    }
-    if (tasks.length < tasksBatchLimit) {
-      // less data returned, last chunk
-      break
-    }
-  }
-  return values(taskIds).sort((a, b) => a.name.localeCompare(b.name))
-}
-
-export const getFluxTask = async (kapacitor, taskID) => {
-  const {data} = await AJAX({
-    method: 'GET',
-    url: kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}`,
-  })
-  return data
-}
-
-function friendlyID(id) {
-  if (id > 25) {
-    return friendlyID(Math.trunc(id / 25)) + String.fromCharCode(id % 25)
-  }
-  return String.fromCharCode(65 + id)
-}
-export const getFluxTaskLogs = async (kapacitor, taskID, maxItems) => {
-  const {data} = await AJAX({
-    method: 'GET',
-    url:
-      kapacitor.links.proxy + `?path=/kapacitor/v1/api/v2/tasks/${taskID}/runs`,
-  })
-  const logs = []
-  let nextClusterId = 0
-  const runsById = {}
-  _.each(_.get(data, ['runs'], []), run => {
-    runsById[run.id] = {
-      name: friendlyID(nextClusterId++),
-      lvl: run.status === 'failed' ? 'error' : 'info',
-    }
-    _.each(run.log, l => logs.push(l))
-  })
-
-  logs.sort((a, b) => b.time.localeCompare(a.time))
-  return logs.slice(0, maxItems).map(x => {
-    const runDetail = runsById[x.runID]
-    return {
-      id: `${x.runID}-${x.time}`,
-      key: `${x.runID}-${x.time}`,
-      service: 'flux_task',
-      lvl: runDetail.lvl,
-      ts: x.time,
-      msg: x.message,
-      tags: x.runID,
-      cluster: runDetail.name,
-    }
-  })
-}
-
 export const getRule = async (kapacitor, ruleID) => {
   try {
     const response = await AJAX({
@@ -191,21 +104,6 @@ export const updateRuleStatus = (rule, status) => {
     method: 'PATCH',
     url: rule.links.self,
     data: {status},
-  })
-}
-
-export const updateFluxTaskStatus = (kapacitor, task, status) => {
-  return AJAX({
-    method: 'PATCH',
-    url: kapacitor.links.proxy + '?path=' + task.links.self,
-    data: {status},
-  })
-}
-
-export const deleteFluxTask = (kapacitor, task) => {
-  return AJAX({
-    method: 'DELETE',
-    url: kapacitor.links.proxy + '?path=' + task.links.self,
   })
 }
 

--- a/ui/src/kapacitor/components/KapacitorRules.tsx
+++ b/ui/src/kapacitor/components/KapacitorRules.tsx
@@ -3,7 +3,6 @@ import {Link} from 'react-router'
 
 import KapacitorRulesTable from 'src/kapacitor/components/KapacitorRulesTable'
 import TasksTable from 'src/kapacitor/components/TasksTable'
-import FluxTasksTable from 'src/kapacitor/components/FluxTasksTable'
 
 import {Source, AlertRule, Kapacitor, FluxTask} from 'src/types'
 
@@ -14,8 +13,6 @@ interface KapacitorRulesProps {
   fluxTasks: FluxTask[]
   onDelete: (rule: AlertRule) => void
   onChangeRuleStatus: (rule: AlertRule) => void
-  onChangeFluxTaskStatus: (task: FluxTask) => void
-  onDeleteFluxTask: (task: FluxTask) => void
 }
 
 const KapacitorRules: FC<KapacitorRulesProps> = ({
@@ -24,9 +21,6 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
   rules,
   onDelete,
   onChangeRuleStatus,
-  onChangeFluxTaskStatus,
-  onDeleteFluxTask,
-  fluxTasks = [],
 }) => {
   const builderRules = rules.filter((r: AlertRule) => r.query)
   const builderHeader = `${builderRules.length} Alert Rule${
@@ -35,9 +29,6 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
   const scriptsHeader = `${rules.length} TICKscript${
     rules.length === 1 ? '' : 's'
   }`
-  const fluxTasksHeader = fluxTasks
-    ? `${fluxTasks.length} Flux Task${fluxTasks.length === 1 ? '' : 's'}`
-    : `Flux Tasks`
   const kapacitorLink = `/sources/${source.id}/kapacitors/${kapacitor.id}`
 
   return (
@@ -82,21 +73,6 @@ const KapacitorRules: FC<KapacitorRulesProps> = ({
           />
         </div>
       </div>
-      {fluxTasks ? (
-        <div className="panel">
-          <div className="panel-heading">
-            <h2 className="panel-title">{fluxTasksHeader}</h2>
-          </div>
-          <div className="panel-body">
-            <FluxTasksTable
-              kapacitorLink={kapacitorLink}
-              tasks={fluxTasks}
-              onDelete={onDeleteFluxTask}
-              onChangeTaskStatus={onChangeFluxTaskStatus}
-            />
-          </div>
-        </div>
-      ) : null}
     </div>
   )
 }

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -25,6 +25,7 @@ import {
   notifyCopyToClipboardSuccess,
 } from 'src/shared/copy/notifications'
 import {updateFluxTaskStatus} from '../actions/view'
+import errorMessage from '../utils/errorMessage'
 
 interface Params {
   taskID: string
@@ -41,18 +42,6 @@ interface Props {
 
 const noop = () => undefined
 const numLogsToRender = 200
-function errorMessage(e: any): unknown {
-  if (!e) {
-    return e
-  }
-  if (e.message) {
-    return e.message
-  }
-  if (e.statusText) {
-    return e.statusText
-  }
-  return e
-}
 
 const LogsTable: FC<{task: FluxTask; kapacitor: Kapacitor}> = ({
   task,

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -16,7 +16,7 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import PageSpinner from 'src/shared/components/PageSpinner'
 
 import {Source, Kapacitor, FluxTask, LogItem} from 'src/types'
-import {getFluxTask, getFluxTaskLogs} from '../apis'
+import {getFluxTask, getFluxTaskLogs} from '../apis/fluxTasks'
 import LogsTableRow from '../components/LogsTableRow'
 import {useDispatch} from 'react-redux'
 import {notify} from 'src/shared/actions/notifications'

--- a/ui/src/kapacitor/containers/FluxTaskPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTaskPage.tsx
@@ -289,9 +289,9 @@ const FluxTaskPage: FC<Props> = ({source, params: {taskID, kid}, router}) => {
           </Radio>
           <button
             className="btn btn-default btn-sm"
-            title="Return to Tasks"
+            title="Return to Flux Tasks"
             onClick={() => {
-              router.push(`/sources/${source.id}/alert-rules`)
+              router.push(`/sources/${source.id}/flux-tasks`)
             }}
           >
             Exit

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -2,7 +2,11 @@ import React, {useEffect, useMemo, useState} from 'react'
 import {FluxTask, Kapacitor, Source} from 'src/types'
 import KapacitorScopedPage from './KapacitorScopedPage'
 import {useDispatch} from 'react-redux'
-import {deleteFluxTask, getFluxTasks, updateFluxTaskStatus} from '../apis'
+import {
+  deleteFluxTask,
+  getFluxTasks,
+  updateFluxTaskStatus,
+} from '../apis/fluxTasks'
 import errorMessage from '../utils/errorMessage'
 import PageSpinner from 'src/shared/components/PageSpinner'
 import FluxTasksTable from '../components/FluxTasksTable'
@@ -32,7 +36,7 @@ const Contents = ({
     setLoading(true)
     const fetchData = async () => {
       try {
-        const data = (await getFluxTasks(kapacitor)) as FluxTask[]
+        const data = await getFluxTasks(kapacitor)
         setAllList(data)
       } catch (e) {
         if (e.status === 404) {

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -91,6 +91,7 @@ const Contents = ({
             className="form-control input-sm"
             placeholder="Filter by name"
             value={nameFilter}
+            disabled={loading}
             onChange={e => {
               setNameFilter(e.target.value)
             }}

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -14,6 +14,7 @@ import {
   notifyFluxTaskStatusUpdateFailed,
 } from 'src/shared/copy/notifications'
 import useDebounce from '../../utils/useDebounce'
+import {Button, ButtonShape, IconFont} from 'src/reusable_ui'
 
 const Contents = ({
   kapacitor,
@@ -84,7 +85,7 @@ const Contents = ({
   }
   return (
     <div className="panel">
-      <div className="panel-heading">
+      <div className="panel-heading" style={{gap: '5px'}}>
         <div className="search-widget" style={{flexGrow: 1}}>
           <input
             type="text"
@@ -98,6 +99,12 @@ const Contents = ({
           />
           <span className="icon search" />
         </div>
+        <Button
+          titleText="Reload"
+          shape={ButtonShape.Square}
+          icon={IconFont.Refresh}
+          onClick={() => setReloadRequired(reloadRequired + 1)}
+        />
       </div>
       <div className="panel-body">
         {loading ? (

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -159,7 +159,7 @@ const Contents = ({
 
 const FluxTasksPage = ({source: src}: {source: Source}) => {
   return (
-    <KapacitorScopedPage source={src} title="Flux Tasks">
+    <KapacitorScopedPage source={src} title="Manage Flux Tasks">
       {(kapacitor: Kapacitor, source: Source) => (
         <Contents kapacitor={kapacitor} source={source} />
       )}

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -108,7 +108,7 @@ const Contents = ({
             onDelete={(task: FluxTask) => {
               deleteFluxTask(kapacitor, task)
                 .then(() => {
-                  setReloadRequired(reloadRequired + 1)
+                  setAllList(allList.filter(x => x.id === task.id))
                   dispatch(notify(notifyAlertRuleDeleted(task.name)))
                 })
                 .catch(() => {

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -109,7 +109,7 @@ const Contents = ({
           <span className="icon search" />
         </div>
         <Button
-          titleText="Reload"
+          titleText="Reload Flux Tasks"
           shape={ButtonShape.Square}
           icon={IconFont.Refresh}
           onClick={() => setReloadRequired(reloadRequired + 1)}

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -1,0 +1,150 @@
+import React, {useEffect, useState} from 'react'
+import {FluxTask, Kapacitor, Source} from 'src/types'
+import KapacitorScopedPage from './KapacitorScopedPage'
+import {useDispatch} from 'react-redux'
+import {deleteFluxTask, getFluxTasks, updateFluxTaskStatus} from '../apis'
+import errorMessage from '../utils/errorMessage'
+import PageSpinner from 'src/shared/components/PageSpinner'
+import FluxTasksTable from '../components/FluxTasksTable'
+import {notify} from 'src/shared/actions/notifications'
+import {
+  notifyAlertRuleDeleted,
+  notifyAlertRuleDeleteFailed,
+  notifyFluxTaskStatusUpdated,
+  notifyFluxTaskStatusUpdateFailed,
+} from 'src/shared/copy/notifications'
+import useDebounce from '../../utils/useDebounce'
+
+const Contents = ({
+  kapacitor,
+  source,
+}: {
+  kapacitor: Kapacitor
+  source: Source
+}) => {
+  const [loading, setLoading] = useState(true)
+  const [nameFilter, setNameFilter] = useState('')
+  const [reloadRequired, setReloadRequired] = useState(0)
+  const [error, setError] = useState(undefined)
+  const [list, setList] = useState<FluxTask[] | null>(null)
+  const dispatch = useDispatch()
+  const filter = useDebounce(nameFilter)
+  useEffect(() => {
+    setLoading(true)
+    const fetchData = async () => {
+      try {
+        let data = (await getFluxTasks(kapacitor)) as FluxTask[]
+        if (data && filter) {
+          data = data.filter(x => x.name.includes(filter))
+        }
+        setList(data)
+      } catch (e) {
+        if (e.status === 404) {
+          setList(null)
+        } else {
+          console.error(e)
+          setError(
+            new Error(
+              e?.data?.message
+                ? e.data.message
+                : `Cannot load flux task: ${errorMessage(e)}`
+            )
+          )
+        }
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [kapacitor, reloadRequired, filter])
+
+  if (error) {
+    return (
+      <div className="panel panel-solid">
+        <div className="panel-body">
+          <p className="unexpected_error">{error.toString()}</p>
+        </div>
+      </div>
+    )
+  }
+  if (list === null) {
+    return (
+      <div className="panel panel-solid">
+        <div className="panel-body">
+          <p className="unexpected_error">
+            No flux tasks are available. Kapacitor 1.6+ is required with Flux
+            tasks enabled.
+          </p>
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className="panel">
+      <div className="panel-heading">
+        <div className="search-widget" style={{flexGrow: 1}}>
+          <input
+            type="text"
+            className="form-control input-sm"
+            placeholder="Search name"
+            value={nameFilter}
+            onChange={e => {
+              setNameFilter(e.target.value)
+            }}
+          />
+          <span className="icon search" />
+        </div>
+      </div>
+      <div className="panel-body">
+        {loading ? (
+          <PageSpinner />
+        ) : (
+          <FluxTasksTable
+            kapacitorLink={`/sources/${source.id}/kapacitors/${kapacitor.id}`}
+            tasks={list}
+            onDelete={(task: FluxTask) => {
+              deleteFluxTask(kapacitor, task)
+                .then(() => {
+                  setReloadRequired(reloadRequired + 1)
+                  dispatch(notify(notifyAlertRuleDeleted(task.name)))
+                })
+                .catch(() => {
+                  dispatch(notify(notifyAlertRuleDeleteFailed(task.name)))
+                })
+            }}
+            onChangeTaskStatus={(task: FluxTask) => {
+              const status = task.status === 'active' ? 'inactive' : 'active'
+              updateFluxTaskStatus(kapacitor, task, status)
+                .then(() => {
+                  setList(
+                    list.map(x => (x.id === task.id ? {...task, status} : x))
+                  )
+                  dispatch(
+                    notify(notifyFluxTaskStatusUpdated(task.name, status))
+                  )
+                })
+                .catch(() => {
+                  dispatch(
+                    notify(notifyFluxTaskStatusUpdateFailed(task.name, status))
+                  )
+                  return false
+                })
+            }}
+          />
+        )}
+      </div>
+    </div>
+  )
+}
+
+const FluxTasksPage = ({source: src}: {source: Source}) => {
+  return (
+    <KapacitorScopedPage source={src} title="Flux Tasks">
+      {(kapacitor: Kapacitor, source: Source) => (
+        <Contents kapacitor={kapacitor} source={source} />
+      )}
+    </KapacitorScopedPage>
+  )
+}
+
+export default FluxTasksPage

--- a/ui/src/kapacitor/containers/FluxTasksPage.tsx
+++ b/ui/src/kapacitor/containers/FluxTasksPage.tsx
@@ -125,7 +125,7 @@ const Contents = ({
             onDelete={(task: FluxTask) => {
               deleteFluxTask(kapacitor, task)
                 .then(() => {
-                  setAllList(allList.filter(x => x.id === task.id))
+                  setAllList(allList.filter(x => x.id !== task.id))
                   dispatch(notify(notifyAlertRuleDeleted(task.name)))
                 })
                 .catch(() => {

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -6,7 +6,7 @@ import {connect} from 'react-redux'
 import {pingKapacitor} from 'src/shared/apis'
 
 // Utils
-import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+import activeKapacitorFromSources from 'src/kapacitor/utils/activeKapacitorFromSources'
 import {notifyKapacitorConnectionFailed} from 'src/shared/copy/notifications'
 
 // Actions
@@ -162,7 +162,7 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
 
   private get kapacitor(): Kapacitor {
     const {sources, source} = this.props
-    return ActiveKapacitorFromSources(source, sources)
+    return activeKapacitorFromSources(source, sources)
   }
 
   private handleSetActiveKapacitor = async (

--- a/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorRulesPage.tsx
@@ -44,15 +44,8 @@ interface Props {
   notify: (message: Notification | NotificationFunc) => void
   updateRuleStatus: (rule: AlertRule, status: string) => void
   updateRuleStatusSuccess: (id: string, status: string) => void
-  updateFluxTaskStatus: (
-    kapacitor: Kapacitor,
-    task: FluxTask,
-    status: string
-  ) => void
   fetchKapacitors: sourcesActions.FetchKapacitorsAsync
   setActiveKapacitor: sourcesActions.SetActiveKapacitorAsync
-  fetchFluxTasks: (kapacitor: Kapacitor) => void
-  deleteFluxTask: (kapacitor: Kapacitor, task: FluxTask) => void
   rules: AlertRule[]
   fluxTasks: FluxTask[]
 }
@@ -122,8 +115,6 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
         fluxTasks={fluxTasks}
         onDelete={this.handleDeleteRule}
         onChangeRuleStatus={this.handleRuleStatus}
-        onChangeFluxTaskStatus={this.handleFluxTaskStatus}
-        onDeleteFluxTask={this.handleDeleteFluxTask}
       />
     )
   }
@@ -179,7 +170,6 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
     try {
       await this.props.fetchRules(kapacitor)
       await pingKapacitor(kapacitor)
-      await this.props.fetchFluxTasks(kapacitor)
     } catch (error) {
       this.props.notify(notifyKapacitorConnectionFailed())
     }
@@ -217,18 +207,6 @@ export class KapacitorRulesPage extends PureComponent<Props, State> {
     updateRuleStatus(rule, status)
     updateRuleStatusSuccess(rule.id, status)
   }
-
-  private handleFluxTaskStatus = (task: FluxTask) => {
-    const {updateFluxTaskStatus} = this.props
-    const status = task.status === 'active' ? 'inactive' : 'active'
-
-    updateFluxTaskStatus(this.kapacitor, task, status)
-  }
-
-  private handleDeleteFluxTask = (task: FluxTask) => {
-    const {deleteFluxTask} = this.props
-    deleteFluxTask(this.kapacitor, task)
-  }
 }
 
 const mstp = ({rules, sources, fluxTasks}) => ({
@@ -241,13 +219,10 @@ const mdtp = {
   fetchRules: kapacitorActions.fetchRules,
   deleteRule: kapacitorActions.deleteRule,
   updateRuleStatus: kapacitorActions.updateRuleStatus,
-  updateFluxTaskStatus: kapacitorActions.updateFluxTaskStatus,
   updateRuleStatusSuccess: kapacitorActions.updateRuleStatusSuccess,
   fetchKapacitors: sourcesActions.fetchKapacitorsAsync,
   setActiveKapacitor: sourcesActions.setActiveKapacitorAsync,
   notify: notifyAction,
-  fetchFluxTasks: kapacitorActions.fetchFluxTasks,
-  deleteFluxTask: kapacitorActions.deleteFluxTask,
 }
 
 export default connect(mstp, mdtp)(KapacitorRulesPage)

--- a/ui/src/kapacitor/containers/KapacitorScopedPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorScopedPage.tsx
@@ -1,0 +1,131 @@
+// Libraries
+import React, {PureComponent} from 'react'
+import {connect} from 'react-redux'
+
+// APIs
+import {getKapacitors, pingKapacitor} from 'src/shared/apis'
+
+// Utils
+import {notifyKapacitorConnectionFailed} from 'src/shared/copy/notifications'
+
+// Actions
+import {notify as notifyAction} from 'src/shared/actions/notifications'
+import {setActiveKapacitorAsync} from 'src/shared/actions/sources'
+
+// Components
+import QuestionMarkTooltip from 'src/shared/components/QuestionMarkTooltip'
+import {Page, Spinner} from 'src/reusable_ui'
+import Dropdown from 'src/reusable_ui/components/dropdowns/Dropdown'
+
+// Types
+import {Source, Kapacitor, RemoteDataState} from 'src/types'
+
+// Decorators
+import {ErrorHandling} from 'src/shared/decorators/errors'
+import NoKapacitorError from 'src/shared/components/NoKapacitorError'
+
+interface Props {
+  // connected props
+  notify: typeof mdtp.notify
+  setActiveKapacitor: typeof mdtp.setActiveKapacitor
+
+  // owen props
+  title: string
+  source: Source
+  tooltip?: string
+  children: (kapacitor: Kapacitor, source: Source) => JSX.Element
+}
+
+interface State {
+  loading: RemoteDataState
+  kapacitors?: Kapacitor[]
+  kapacitor?: Kapacitor
+  error?: Error
+}
+
+@ErrorHandling
+export class KapacitorScopedPage extends PureComponent<Props, State> {
+  constructor(props: Props) {
+    super(props)
+    this.state = {
+      loading: RemoteDataState.NotStarted,
+    }
+  }
+
+  public componentDidMount() {
+    const {source} = this.props
+    this.setState({loading: RemoteDataState.Loading})
+    getKapacitors(source).then(kapacitors => {
+      const kapacitor =
+        kapacitors && kapacitors.length
+          ? kapacitors.find(x => x.active) || kapacitors[0]
+          : undefined
+
+      this.setState({kapacitors, kapacitor, loading: RemoteDataState.Done})
+    })
+  }
+
+  public render() {
+    const {tooltip, title, source, children} = this.props
+    const {loading, kapacitor, kapacitors} = this.state
+    return (
+      <Page className={kapacitor ? '' : 'empty-tasks-page'}>
+        <Page.Header>
+          <Page.Header.Left>
+            <Page.Title title={kapacitor ? `${title} on` : title} />
+            {kapacitor ? (
+              <Dropdown
+                customClass="kapacitor-switcher"
+                onChange={this.handleSetActiveKapacitor}
+                widthPixels={330}
+                selectedID={kapacitor.id}
+              >
+                {kapacitors.map(k => (
+                  <Dropdown.Item key={k.id} id={k.id} value={k.id}>
+                    {`${k.name} @ ${k.url}`}
+                  </Dropdown.Item>
+                ))}
+              </Dropdown>
+            ) : undefined}
+          </Page.Header.Left>
+          <Page.Header.Right showSourceIndicator={true}>
+            {tooltip ? (
+              <QuestionMarkTooltip
+                tipID="manage-tasks--tooltip"
+                tipContent={tooltip}
+              />
+            ) : undefined}
+          </Page.Header.Right>
+        </Page.Header>
+        <Page.Contents>
+          <Spinner loading={loading}>
+            {kapacitor ? (
+              children(kapacitor, source)
+            ) : (
+              <NoKapacitorError source={source} />
+            )}
+          </Spinner>
+        </Page.Contents>
+      </Page>
+    )
+  }
+
+  private handleSetActiveKapacitor = async (
+    kapacitorID: string
+  ): Promise<void> => {
+    const {setActiveKapacitor} = this.props
+    const {kapacitors} = this.state
+    const toKapacitor = kapacitors.find(k => k.id === kapacitorID)
+    setActiveKapacitor(toKapacitor)
+    pingKapacitor(toKapacitor).catch(() => {
+      this.props.notify(notifyKapacitorConnectionFailed())
+    })
+  }
+}
+
+const mdtp = {
+  notify: notifyAction,
+  setActiveKapacitor: setActiveKapacitorAsync,
+}
+
+export default connect(null, mdtp)(KapacitorScopedPage)

--- a/ui/src/kapacitor/containers/KapacitorScopedPage.tsx
+++ b/ui/src/kapacitor/containers/KapacitorScopedPage.tsx
@@ -60,7 +60,11 @@ export class KapacitorScopedPage extends PureComponent<Props, State> {
         kapacitors && kapacitors.length
           ? kapacitors.find(x => x.active) || kapacitors[0]
           : undefined
-
+      if (kapacitor) {
+        pingKapacitor(kapacitor).catch(() => {
+          this.props.notify(notifyKapacitorConnectionFailed())
+        })
+      }
       this.setState({kapacitors, kapacitor, loading: RemoteDataState.Done})
     })
   }

--- a/ui/src/kapacitor/index.js
+++ b/ui/src/kapacitor/index.js
@@ -3,6 +3,7 @@ import KapacitorRulePage from './containers/KapacitorRulePage'
 import KapacitorRulesPage from './containers/KapacitorRulesPage'
 import TickscriptPage from './containers/TickscriptPage'
 import FluxTaskPage from './containers/FluxTaskPage'
+import FluxTasksPage from './containers/FluxTasksPage'
 
 export {
   KapacitorPage,
@@ -10,4 +11,5 @@ export {
   KapacitorRulesPage,
   TickscriptPage,
   FluxTaskPage,
+  FluxTasksPage,
 }

--- a/ui/src/kapacitor/utils/activeKapacitorFromSources.ts
+++ b/ui/src/kapacitor/utils/activeKapacitorFromSources.ts
@@ -1,6 +1,6 @@
 import {Source, Kapacitor} from 'src/types'
 
-const ActiveKapacitorFromSources = (
+const activeKapacitorFromSources = (
   source: Source,
   sources: Source[]
 ): Kapacitor => {
@@ -17,4 +17,4 @@ const ActiveKapacitorFromSources = (
   return kapacitors.find(k => k.active) || kapacitors[0]
 }
 
-export default ActiveKapacitorFromSources
+export default activeKapacitorFromSources

--- a/ui/src/kapacitor/utils/errorMessage.ts
+++ b/ui/src/kapacitor/utils/errorMessage.ts
@@ -1,0 +1,12 @@
+export default function errorMessage(e: any): unknown {
+  if (!e) {
+    return e
+  }
+  if (e.message) {
+    return e.message
+  }
+  if (e.statusText) {
+    return e.statusText
+  }
+  return e
+}

--- a/ui/src/side_nav/components/NavItems.tsx
+++ b/ui/src/side_nav/components/NavItems.tsx
@@ -73,13 +73,18 @@ interface NavBlockProps {
   location?: string
   className?: string
   highlightWhen: string[]
+  highlightUnless?: string[]
 }
 
 class NavBlock extends PureComponent<NavBlockProps> {
   public render() {
-    const {location, className, highlightWhen} = this.props
-    const {length} = _.intersection(_.split(location, '/'), highlightWhen)
-    const isActive = !!length
+    const {location, className, highlightWhen, highlightUnless} = this.props
+    const locationParts = _.split(location, '/')
+    const {length} = _.intersection(locationParts, highlightWhen)
+    let isActive = !!length
+    if (isActive && highlightUnless) {
+      isActive = !_.intersection(locationParts, highlightUnless)
+    }
 
     const children = React.Children.map(
       this.props.children,

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -103,6 +103,7 @@ class SideNav extends PureComponent<Props> {
             'alerts',
             'alert-rules',
             'tickscript',
+            'tickscripts',
             'flux-tasks',
             'fluxtasks',
           ]}
@@ -169,6 +170,7 @@ class SideNav extends PureComponent<Props> {
         </Authorized>
         <NavBlock
           highlightWhen={['manage-sources', 'kapacitors']}
+          highlightUnless={['alert-rules', 'tickscripts', 'fluxtasks']}
           icon="wrench"
           link={`${sourcePrefix}/manage-sources`}
           location={location}

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -99,7 +99,13 @@ class SideNav extends PureComponent<Props> {
           <NavHeader link={`${sourcePrefix}/dashboards`} title="Dashboards" />
         </NavBlock>
         <NavBlock
-          highlightWhen={['alerts', 'alert-rules', 'tickscript']}
+          highlightWhen={[
+            'alerts',
+            'alert-rules',
+            'tickscript',
+            'flux-tasks',
+            'fluxtasks',
+          ]}
           icon="alerts"
           link={`${sourcePrefix}/alert-rules`}
           location={location}

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -114,6 +114,9 @@ class SideNav extends PureComponent<Props> {
           <NavListItem link={`${sourcePrefix}/alert-rules`}>
             Manage Tasks
           </NavListItem>
+          <NavListItem link={`${sourcePrefix}/flux-tasks`}>
+            Flux Tasks
+          </NavListItem>
           <NavListItem link={`${sourcePrefix}/alerts`}>
             Alert History
           </NavListItem>

--- a/ui/src/sources/components/KapacitorStep.tsx
+++ b/ui/src/sources/components/KapacitorStep.tsx
@@ -10,7 +10,7 @@ import KapacitorDropdown from 'src/sources/components/KapacitorDropdown'
 import KapacitorForm from 'src/sources/components/KapacitorForm'
 
 // Utils
-import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+import activeKapacitorFromSources from 'src/kapacitor/utils/activeKapacitorFromSources'
 
 // Actions
 import {notify as notifyAction} from 'src/shared/actions/notifications'
@@ -76,7 +76,7 @@ class KapacitorStep extends Component<Props, State> {
     super(props)
 
     const activeKapacitor =
-      ActiveKapacitorFromSources(props.source, props.sources) || props.kapacitor
+      activeKapacitorFromSources(props.source, props.sources) || props.kapacitor
 
     let kapacitor = syncHostnames(props.source, DEFAULT_KAPACITOR)
 
@@ -183,7 +183,7 @@ class KapacitorStep extends Component<Props, State> {
     const {source, sources} = this.props
     const {kapacitor} = this.state
 
-    const activeKapacitor = ActiveKapacitorFromSources(source, sources)
+    const activeKapacitor = activeKapacitorFromSources(source, sources)
     return !_.isEqual(activeKapacitor, kapacitor)
   }
 

--- a/ui/src/utils/ajax.ts
+++ b/ui/src/utils/ajax.ts
@@ -137,9 +137,9 @@ async function AJAX<T = any>(
   if (fetchResponse.status === 204) {
     data = ''
   } else {
-    const isText = (fetchResponse.headers.get('content-type') || '').includes(
-      'text/'
-    )
+    const isText = (
+      fetchResponse.headers.get('content-type') || 'text/'
+    ).includes('text/')
     data = isText ? await fetchResponse.text() : await fetchResponse.json()
   }
   const headers = {}

--- a/ui/src/utils/useDebounce.ts
+++ b/ui/src/utils/useDebounce.ts
@@ -1,0 +1,21 @@
+import {useEffect, useRef, useState} from 'react'
+
+const DEFAULT_DELAY = 500
+function useDebounce<T>(value: T, delay = DEFAULT_DELAY): T {
+  const [debounced, setDebounced] = useState(value)
+  const first = useRef(true)
+  useEffect(() => {
+    if (first.current) {
+      setDebounced(value)
+      first.current = false
+      return
+    }
+    const handler = setTimeout(() => {
+      setDebounced(value)
+    }, delay)
+    return () => clearTimeout(handler)
+  }, [value, delay])
+  return debounced
+}
+
+export default useDebounce

--- a/ui/test/kapacitor/utils/ActiveKapacitorFromSources.ts
+++ b/ui/test/kapacitor/utils/ActiveKapacitorFromSources.ts
@@ -1,4 +1,4 @@
-import ActiveKapacitorFromSources from 'src/kapacitor/utils/ActiveKapacitorFromSources'
+import activeKapacitorFromSources from 'src/kapacitor/utils/activeKapacitorFromSources'
 import {source, kapacitor} from 'mocks/dummy'
 
 describe('ActiveKapacitorFromSources', () => {
@@ -25,7 +25,7 @@ describe('ActiveKapacitorFromSources', () => {
       kapacitors: [expectedKap, createKapacitor({name: 'bar', active: false})],
     })
 
-    const actualKap = ActiveKapacitorFromSources(activeSource, sources)
+    const actualKap = activeKapacitorFromSources(activeSource, sources)
 
     expect(actualKap).toBe(expectedKap)
   })
@@ -41,7 +41,7 @@ describe('ActiveKapacitorFromSources', () => {
       ],
     })
 
-    const actualKap = ActiveKapacitorFromSources(activeSource, sources)
+    const actualKap = activeKapacitorFromSources(activeSource, sources)
 
     expect(actualKap).toBe(expectedKap)
   })


### PR DESCRIPTION
This PR separates/moves kapacitor's flux task list from the alerts page to a separate page, it is a required pre-requisite to #5460.

- `Flux Tasks` is a new menu item in the side bar:
![image](https://user-images.githubusercontent.com/16321466/154642012-56c1b29e-3097-4b07-854b-81dddc147c2d.png)
- The page contains a table of Flux Tasks that was before on the Alert Rules page
![image](https://user-images.githubusercontent.com/16321466/154642308-a747aca3-384b-46a0-9ae9-34d58e1fc48c.png)
- The Page let the user also filter Flux tasks by name and perform a manual Refresh
- Flux tasks are available since Kapacitor 1.6 and must be enabled in its config, the UI
![image](https://user-images.githubusercontent.com/16321466/154642847-87b155f7-5799-45e9-80b9-144494d3f25d.png)
- Exiting a page of a particular Flux Task editor returns the user to the Flux Tasks page (was Alert Rules)

Additionally, the sidebar was fixed so that `Alerting` is highlighted when flux tasks, kapactior alert tule or TICKScript pages are shown.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
