### PR TITLE
feat(server): optimize Alert Rules API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 1. [#5852](https://github.com/influxdata/chronograf/pull/5852): Add Flux Query Builder.
 1. [#5858](https://github.com/influxdata/chronograf/pull/5858): Use time range in flux Schema Explorer.
 1. [#5868](https://github.com/influxdata/chronograf/pull/5868): Move Flux Tasks to own page.
+1. [#5869](https://github.com/influxdata/chronograf/pull/5869): Optimize Alert Rules API.
 
 ### Bug Fixes
 

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"regexp"
-	"strings"
 
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/id"
@@ -68,8 +66,6 @@ type Task struct {
 	TICKScript chronograf.TICKScript // TICKScript is the running script
 }
 
-var reTaskName = regexp.MustCompile(`[\r\n]*var[ \t]+name[ \t]+=[ \t]+'([^\n]+)'[ \r\t]*\n`)
-
 // NewTask creates a task from a kapacitor client task
 func NewTask(task *client.Task) *Task {
 	return NewTaskWithParsing(task, true)
@@ -89,22 +85,16 @@ func NewTaskWithParsing(task *client.Task, parse bool) *Task {
 		// try to parse chronograf rule, tasks created from template cannot be chronograf rules
 		if parsedRule, err := Reverse(script); err == nil {
 			rule = parsedRule
+			// #5403 override name when defined in a variable
+			if nameVar, exists := task.Vars["name"]; exists {
+				if val, isString := nameVar.Value.(string); isString && val != "" {
+					rule.Name = val
+				}
+			}
 		}
 	}
 	if rule.Name == "" {
-		// try to parse Name from a line such as: `var name = 'Rule Name'
-		if matches := reTaskName.FindStringSubmatch(task.TICKscript); matches != nil {
-			rule.Name = strings.ReplaceAll(strings.ReplaceAll(matches[1], "\\'", "'"), "\\\\", "\\")
-		} else {
-			rule.Name = task.ID
-		}
-	}
-
-	// #5403 override name when defined in a variable
-	if nameVar, exists := task.Vars["name"]; exists {
-		if val, isString := nameVar.Value.(string); isString && val != "" {
-			rule.Name = val
-		}
+		rule.Name = GetAlertRuleName(task)
 	}
 
 	rule.Vars = task.Vars

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -323,7 +323,6 @@ func (c *Client) Get(ctx context.Context, id string) (*Task, error) {
 	if err != nil {
 		return nil, chronograf.ErrAlertNotFound
 	}
-	fmt.Println("!!!", task.ID, task.TemplateID)
 
 	return NewTask(&task), nil
 }

--- a/kapacitor/client.go
+++ b/kapacitor/client.go
@@ -279,13 +279,16 @@ func (c *Client) status(ctx context.Context, href string) (client.TaskStatus, er
 
 // All returns all tasks in kapacitor
 func (c *Client) All(ctx context.Context) (map[string]*Task, error) {
+	return c.List(ctx, &client.ListTasksOptions{})
+}
+
+// List kapacitor tasks according to options supplied
+func (c *Client) List(ctx context.Context, opts *client.ListTasksOptions) (map[string]*Task, error) {
 	kapa, err := c.kapaClient(c.URL, c.Username, c.Password, c.InsecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}
 
-	// Only get the status, id and link section back
-	opts := &client.ListTasksOptions{}
 	tasks, err := kapa.ListTasks(opts)
 	if err != nil {
 		return nil, err

--- a/kapacitor/kapa_client.go
+++ b/kapacitor/kapa_client.go
@@ -108,6 +108,7 @@ func (p *PaginatingKapaClient) generateKapacitorOptions(optChan chan client.List
 	}
 
 	opts.Limit = nextLimit()
+	opts.Pattern = "" // ignore pattern, these are used to filter by task ID, chronograf is however interrested in task name
 
 generateOpts:
 	for {

--- a/kapacitor/kapa_client.go
+++ b/kapacitor/kapa_client.go
@@ -1,6 +1,7 @@
 package kapacitor
 
 import (
+	"errors"
 	"math"
 	"regexp"
 	"strings"
@@ -29,6 +30,9 @@ type PaginatingKapaClient struct {
 // ListTasks lists all available tasks from Kapacitor, navigating pagination as
 // it fetches them
 func (p *PaginatingKapaClient) ListTasks(opts *client.ListTasksOptions) ([]client.Task, error) {
+	if opts.Pattern != "" && opts.Offset > 0 {
+		return nil, errors.New("offset paramater must be 0 when pattern parameter is supplied")
+	}
 	allTasks := make([]client.Task, 0, p.FetchRate)
 
 	optChan := make(chan client.ListTasksOptions)

--- a/kapacitor/kapa_client.go
+++ b/kapacitor/kapa_client.go
@@ -93,7 +93,7 @@ func (p *PaginatingKapaClient) fetchFromKapacitor(optChan chan client.ListTasksO
 // Limit and Offset parameters, and inserts them into the provided optChan
 func (p *PaginatingKapaClient) generateKapacitorOptions(optChan chan client.ListTasksOptions, opts client.ListTasksOptions, done chan struct{}) {
 	toFetchCount := opts.Limit
-	if toFetchCount <= 0 {
+	if toFetchCount <= 0 && opts.Pattern != "" {
 		toFetchCount = math.MaxInt
 	}
 

--- a/kapacitor/kapa_client_test.go
+++ b/kapacitor/kapa_client_test.go
@@ -124,3 +124,62 @@ func Test_Kapacitor_PaginatingKapaClient(t *testing.T) {
 	})
 
 }
+
+func Test_Kapacitor_GetAlertRuleName(t *testing.T) {
+	tests := []struct {
+		Task client.Task
+		Name string
+	}{
+		{
+			Task: client.Task{},
+			Name: "",
+		},
+		{
+			Task: client.Task{
+				ID: "abcd",
+			},
+			Name: "abcd",
+		},
+		{
+			Task: client.Task{
+				ID:         "abcd",
+				TICKscript: "var name = 'pavel'\n",
+			},
+			Name: "pavel",
+		},
+		{
+			Task: client.Task{
+				ID:         "abcd",
+				TICKscript: "var name = 'pavel'\n",
+				Vars: client.Vars{
+					"name": {
+						Type:  client.VarInt,
+						Value: 1,
+					},
+				},
+			},
+			Name: "pavel",
+		},
+		{
+			Task: client.Task{
+				ID:         "abcd",
+				TICKscript: "var name = 'pavel'\n",
+				Vars: client.Vars{
+					"name": {
+						Type:  client.VarString,
+						Value: "pepa",
+					},
+				},
+			},
+			Name: "pepa",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			retVal := kapacitor.GetAlertRuleName(&test.Task)
+			if retVal != test.Name {
+				t.Error("Expected: ", test.Name, " Received:", retVal)
+			}
+		})
+	}
+}

--- a/kapacitor/kapa_client_test.go
+++ b/kapacitor/kapa_client_test.go
@@ -112,5 +112,15 @@ func Test_Kapacitor_PaginatingKapaClient(t *testing.T) {
 			t.Error("PaginatingKapaClient: Expected to find no matching task but found: ", len(tasks))
 		}
 	})
+	t.Run("zero offset required with pattern specified", func(t *testing.T) {
+		opts := &client.ListTasksOptions{
+			Pattern: " ",
+			Offset:  1,
+		}
+		_, err := pkap.ListTasks(opts)
+		if err == nil {
+			t.Error("PaginatingKapaClient: Error expected but no error returned")
+		}
+	})
 
 }

--- a/server/kapacitors.go
+++ b/server/kapacitors.go
@@ -735,10 +735,10 @@ func (s *Service) KapacitorRulesGet(w http.ResponseWriter, r *http.Request) {
 	// parse parameters
 	params := r.URL.Query()
 	opts := client.ListTasksOptions{}
-	if _limit, err := strconv.ParseInt(params.Get("limit"), 0, 0); err != nil {
+	if _limit, err := strconv.ParseInt(params.Get("limit"), 0, 0); err == nil {
 		opts.Limit = int(_limit)
 	}
-	if _offset, err := strconv.ParseInt(params.Get("limit"), 0, 0); err != nil {
+	if _offset, err := strconv.ParseInt(params.Get("offset"), 0, 0); err == nil {
 		opts.Offset = int(_offset)
 	}
 	opts.Pattern = params.Get("pattern")
@@ -757,7 +757,7 @@ func (s *Service) KapacitorRulesGet(w http.ResponseWriter, r *http.Request) {
 	}
 
 	c := kapa.NewClient(srv.URL, srv.Username, srv.Password, srv.InsecureSkipVerify)
-	tasks, err := c.List(ctx, &opts)
+	tasks, err := c.List(ctx, &opts, params.Get("parse") != "0")
 	if err != nil {
 		Error(w, http.StatusInternalServerError, err.Error(), s.Logger)
 		return

--- a/server/kapacitors.go
+++ b/server/kapacitors.go
@@ -40,7 +40,7 @@ func (p *postKapacitorRequest) Valid(defaultOrgID string) error {
 		return fmt.Errorf("invalid source URI: %v", err)
 	}
 	if len(url.Scheme) == 0 {
-		return fmt.Errorf("Invalid URL; no URL scheme defined")
+		return fmt.Errorf("invalid URL; no URL scheme defined")
 	}
 
 	return nil
@@ -250,7 +250,7 @@ func (p *patchKapacitorRequest) Valid() error {
 			return fmt.Errorf("invalid source URI: %v", err)
 		}
 		if len(url.Scheme) == 0 {
-			return fmt.Errorf("Invalid URL; no URL scheme defined")
+			return fmt.Errorf("invalid URL; no URL scheme defined")
 		}
 	}
 	return nil
@@ -661,7 +661,7 @@ func (k *KapacitorStatus) Valid() error {
 	if k.Status == "enabled" || k.Status == "disabled" {
 		return nil
 	}
-	return fmt.Errorf("Invalid Kapacitor status: %s", k.Status)
+	return fmt.Errorf("invalid Kapacitor status: %s", k.Status)
 }
 
 // KapacitorRulesStatus proxies PATCH to kapacitor to enable/disable tasks

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -1476,6 +1476,27 @@
             "type": "string",
             "description": "ID of the kapacitor backend.",
             "required": true
+          },
+          {
+            "name": "pattern",
+            "in": "query",
+            "type": "string",
+            "description": "filter results to contain the specified value in the task name",
+            "required": false
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "type": "number",
+            "description": "limits results length, 0 to return unlimited results",
+            "required": false
+          },
+          {
+            "name": "parse",
+            "in": "query",
+            "type": "string",
+            "description": "can be '0' to skip parsing of TICKscript",
+            "required": false
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR enhances API that returns Alert Rules so that the UI can better and quickly respond. This PR is a part of a solution to #5460, the API now supports

- `limit` query parameter that can limit the result size and thus reduce the time that is spent during analysis of TICKscripts
- `pattern` query parameter that can filter alert rules to have a specific string value in alert rule names
- `parse` query parameter can turn off TICKScript parsing when set to `0` so that just TICKScipts can be returned much quicker

Tests were enhanced and swagger updated.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
