### PR TITLE
feat(ui): TICKscript page can open Alert Rule Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#5868](https://github.com/influxdata/chronograf/pull/5868): Move Flux Tasks to own page.
 1. [#5869](https://github.com/influxdata/chronograf/pull/5869): Optimize Alert Rules API.
 1. [#5871](https://github.com/influxdata/chronograf/pull/5871): Add TICKscipts page.
+1. [#5872](https://github.com/influxdata/chronograf/pull/5872): Open Alert Rule Builder from a TICKscript page.
 
 ### Bug Fixes
 

--- a/ui/src/kapacitor/components/KapacitorRule.tsx
+++ b/ui/src/kapacitor/components/KapacitorRule.tsx
@@ -162,7 +162,7 @@ class KapacitorRule extends Component<Props, State> {
   }
 
   private handleCreate = (pathname?: string) => {
-    const {notify, queryConfigs, rule, source, router, kapacitor} = this.props
+    const {notify, queryConfigs, rule, kapacitor} = this.props
 
     const newRule = Object.assign({}, rule, {
       query: queryConfigs[rule.queryID],
@@ -172,7 +172,7 @@ class KapacitorRule extends Component<Props, State> {
 
     createRule(kapacitor, newRule)
       .then(() => {
-        router.push(pathname || `/sources/${source.id}/alert-rules`)
+        this.exitPage(pathname)
         notify(notifyAlertRuleCreated(newRule.name))
       })
       .catch(e => {
@@ -181,14 +181,14 @@ class KapacitorRule extends Component<Props, State> {
   }
 
   private handleEdit = (pathname?: string) => {
-    const {notify, queryConfigs, rule, router, source} = this.props
+    const {notify, queryConfigs, rule} = this.props
     const updatedRule = Object.assign({}, rule, {
       query: queryConfigs[rule.queryID],
     })
     this.applyRuleWorkarounds(updatedRule)
     editRule(updatedRule)
       .then(() => {
-        router.push(pathname || `/sources/${source.id}/alert-rules`)
+        this.exitPage(pathname)
         notify(notifyAlertRuleUpdated(rule.name))
       })
       .catch(e => {
@@ -196,6 +196,20 @@ class KapacitorRule extends Component<Props, State> {
           notifyAlertRuleUpdateFailed(rule.name, e?.data?.message || String(e))
         )
       })
+  }
+
+  private exitPage(pathname?: string) {
+    const {source, router} = this.props
+    if (pathname) {
+      return router.push(pathname)
+    }
+    const location = (router as any).location
+    if (location?.query?.l === 't') {
+      return router.push(
+        `/sources/${source.id}/tickscripts${location?.search || ''}`
+      )
+    }
+    router.push(pathname || `/sources/${source.id}/alert-rules`)
   }
 
   private handleSave = () => {

--- a/ui/src/kapacitor/components/Tickscript.tsx
+++ b/ui/src/kapacitor/components/Tickscript.tsx
@@ -28,6 +28,7 @@ interface Props {
   onChangeName: (name: string) => void
   isNewTickscript: boolean
   unsavedChanges: boolean
+  onOpenBuilderUI: () => void
 }
 
 @ErrorHandling
@@ -48,6 +49,7 @@ class Tickscript extends PureComponent<Props> {
       areLogsVisible,
       areLogsEnabled,
       onToggleLogsVisibility,
+      onOpenBuilderUI,
     } = this.props
     return (
       <Page className="tickscript-editor-page">
@@ -55,6 +57,7 @@ class Tickscript extends PureComponent<Props> {
           task={task}
           onSave={onSave}
           onExit={onExit}
+          onOpenBuilderUI={onOpenBuilderUI}
           unsavedChanges={unsavedChanges}
           areLogsVisible={areLogsVisible}
           areLogsEnabled={areLogsEnabled}

--- a/ui/src/kapacitor/components/TickscriptHeader.tsx
+++ b/ui/src/kapacitor/components/TickscriptHeader.tsx
@@ -3,7 +3,8 @@ import React, {Component} from 'react'
 import {Page} from 'src/reusable_ui'
 import LogsToggle from 'src/kapacitor/components/LogsToggle'
 import ConfirmButton from 'src/shared/components/ConfirmButton'
-import TickscriptSave, {Task} from 'src/kapacitor/components/TickscriptSave'
+import TickscriptSave from 'src/kapacitor/components/TickscriptSave'
+import {Task} from 'src/types'
 
 interface Props {
   task: Task
@@ -14,6 +15,7 @@ interface Props {
   onSave: () => void
   onExit: () => void
   onToggleLogsVisibility: (visibility: boolean) => void
+  onOpenBuilderUI: () => void
 }
 
 class TickscriptHeader extends Component<Props> {
@@ -26,6 +28,7 @@ class TickscriptHeader extends Component<Props> {
       areLogsEnabled,
       areLogsVisible,
       onToggleLogsVisibility,
+      onOpenBuilderUI,
     } = this.props
 
     return (
@@ -34,6 +37,25 @@ class TickscriptHeader extends Component<Props> {
           <Page.Title title="TICKscript Editor" />
         </Page.Header.Left>
         <Page.Header.Right showSourceIndicator={true}>
+          {!!task.query && !task.templateID ? (
+            <button
+              className="btn btn-sm btn-primary"
+              title="Open TICKscript in Alert Rule Builder"
+              onClick={onOpenBuilderUI}
+            >
+              Alert Rule Builder
+            </button>
+          ) : undefined}
+          {isNewTickscript ? (
+            <button
+              className="btn btn-sm btn-default"
+              title="Use Alert Rule Builder to create a new TICKscript"
+              onClick={onOpenBuilderUI}
+            >
+              Alert Rule Builder
+            </button>
+          ) : undefined}
+
           <LogsToggle
             areLogsEnabled={areLogsEnabled}
             areLogsVisible={areLogsVisible}

--- a/ui/src/kapacitor/containers/TickscriptPage.tsx
+++ b/ui/src/kapacitor/containers/TickscriptPage.tsx
@@ -151,6 +151,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
         type,
         'template-id': templateID,
         vars,
+        query,
       } = this.props.rules.find(r => r.id === ruleID)
 
       this.setState({
@@ -163,6 +164,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
           id,
           templateID,
           vars,
+          query,
         },
       })
     }
@@ -197,6 +199,7 @@ export class TickscriptPage extends PureComponent<Props, State> {
         logs={logs}
         onSave={this.handleSave}
         onExit={this.handleExit}
+        onOpenBuilderUI={this.handleOpenBuilderUI}
         unsavedChanges={unsavedChanges}
         areLogsVisible={areLogsVisible}
         areLogsEnabled={areLogsEnabled}
@@ -271,6 +274,19 @@ export class TickscriptPage extends PureComponent<Props, State> {
       console.error(error)
       throw error
     }
+  }
+
+  private handleOpenBuilderUI = () => {
+    const {
+      params: {ruleID},
+      source: {id: sourceID},
+      router,
+    } = this.props
+    const {kapacitor} = this.state
+    router.push(
+      // prettier-ignore
+      `/sources/${sourceID}/kapacitors/${kapacitor.id}/alert-rules/${ruleID}${router.location.search}`
+    )
   }
 
   private handleExit = () => {

--- a/ui/src/types/kapacitor.ts
+++ b/ui/src/types/kapacitor.ts
@@ -70,6 +70,7 @@ export interface Task {
   type: string
   templateID?: string
   vars?: Record<string, {type: string; value: unknown}>
+  query?: QueryConfig
 }
 
 export type TaskStatusType = 'active' | 'inactive'

--- a/ui/test/kapacitor/components/TickscriptHeader.test.tsx
+++ b/ui/test/kapacitor/components/TickscriptHeader.test.tsx
@@ -19,6 +19,7 @@ const setup = (override?) => {
     onToggleLogsVisibility: () => {},
     onSave: () => {},
     onExit: () => {},
+    onOpenBuilderUI: () => {},
     areLogsVisible: false,
     areLogsEnabled: false,
     task: {


### PR DESCRIPTION
This is PR is built on top of #5871 to contribute to a solution to #5460 .  It adds a new `Alert Rule Builder` button on the TICKscript page for a new TICKscript and all TICKscripts that are compatible with Alert Rule Builder UI.

* it is visually recommended to use Alert Rule Builder for compatible TICKscripts (blue button)
![image](https://user-images.githubusercontent.com/16321466/155945085-3c19a576-0655-4c46-82e3-9f3ddf8d82b7.png)

* the same button appears (in default colour) when creating a new TICKscript
![image](https://user-images.githubusercontent.com/16321466/155945248-674cf19f-d587-47fc-b79c-35c820276014.png)

* No `Alert Rule Builder` button appears if the TICKscript cannot be edited (not compatible) with the builder UI 

The `Save` action in Alert Builder UI lands in the `TICKscripts` page if the user browsed the TICKscript from the TICKscripts page. The new TICKscripts page thus provides complete management of all types of Alert Rules and the existing `Alert Rules` page (that suffers from performance issues described by #5460) is not used when the user starts with the `TICKscripts` page.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
