### PR TITLE
fix(ui): propagate all InfluxQL error messages to UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 1. [#5862](https://github.com/influxdata/chronograf/pull/5862): Respect BASE_PATH when serving API docs.
+1. [#5874](https://github.com/influxdata/chronograf/pull/5874): Propagate InfluxQL errors to UI.
 
 ### Other
 

--- a/ui/src/shared/components/QueryStatus.tsx
+++ b/ui/src/shared/components/QueryStatus.tsx
@@ -36,19 +36,19 @@ class QueryStatus extends PureComponent<Props> {
       <div className="query-editor--status">
         <span
           className={classnames('query-status-output', {
-            'query-status-output--error': status.error,
-            'query-status-output--success': status.success,
-            'query-status-output--warning': status.warn,
+            'query-status-output--error': !!status.error,
+            'query-status-output--success': !!status.success,
+            'query-status-output--warning': !!status.warn,
           })}
         >
           <span
             className={classnames('icon', {
-              stop: status.error,
-              checkmark: status.success,
-              'alert-triangle': status.warn,
+              stop: !!status.error,
+              checkmark: !!status.success,
+              'alert-triangle': !!status.warn,
             })}
           />
-          {status.error || status.warn || status.success}
+          {String(status.error || status.warn || status.success)}
         </span>
         {children}
       </div>

--- a/ui/src/utils/ajax.ts
+++ b/ui/src/utils/ajax.ts
@@ -183,9 +183,19 @@ export async function getAJAX<T = any>(url: string): Promise<{data: T}> {
       'response:',
       data
     )
-    return Promise.reject(
-      new Error(response.statusText || `error ${response.status}`)
-    )
+    let errorMessage = response.statusText || `error ${response.status}`
+    // try to parse error message from JSON payload
+    if (response.headers.get('content-type').includes('application/json')) {
+      try {
+        const {message} = JSON.parse(data)
+        if (message) {
+          errorMessage = message
+        }
+      } catch (e) {
+        // ignore silently, unrecognized error message
+      }
+    }
+    return Promise.reject(new Error(errorMessage))
   } catch (e) {
     console.error('failed to GET url:', url, 'error:', e)
     return Promise.reject(e)

--- a/ui/src/utils/ajax.ts
+++ b/ui/src/utils/ajax.ts
@@ -183,7 +183,9 @@ export async function getAJAX<T = any>(url: string): Promise<{data: T}> {
       'response:',
       data
     )
-    Promise.reject(new Error(response.statusText || `error ${response.status}`))
+    return Promise.reject(
+      new Error(response.statusText || `error ${response.status}`)
+    )
   } catch (e) {
     console.error('failed to GET url:', url, 'error:', e)
     return Promise.reject(e)

--- a/ui/src/worker/jobs/get.ts
+++ b/ui/src/worker/jobs/get.ts
@@ -20,9 +20,19 @@ const get = async (msg: Message): Promise<any> => {
       'response:',
       data
     )
-    return Promise.reject(
-      new Error(response.statusText || `error ${response.status}`)
-    )
+    let errorMessage = response.statusText || `error ${response.status}`
+    // try to parse error message from JSON payload
+    if (response.headers.get('content-type').includes('application/json')) {
+      try {
+        const {message} = JSON.parse(data)
+        if (message) {
+          errorMessage = message
+        }
+      } catch (e) {
+        // ignore silently, unrecognized error message
+      }
+    }
+    return Promise.reject(new Error(errorMessage))
   } catch (e) {
     console.error('failed to GET url:', url, 'error:', e)
     return Promise.reject(e)

--- a/ui/src/worker/jobs/get.ts
+++ b/ui/src/worker/jobs/get.ts
@@ -20,7 +20,9 @@ const get = async (msg: Message): Promise<any> => {
       'response:',
       data
     )
-    Promise.reject(new Error(response.statusText || `error ${response.status}`))
+    return Promise.reject(
+      new Error(response.statusText || `error ${response.status}`)
+    )
   } catch (e) {
     console.error('failed to GET url:', url, 'error:', e)
     return Promise.reject(e)

--- a/ui/src/worker/jobs/proxy.ts
+++ b/ui/src/worker/jobs/proxy.ts
@@ -32,7 +32,19 @@ const proxy = async (msg: ProxyMsg): Promise<{data: any}> => {
       'response:',
       data
     )
-    Promise.reject(response.statusText || `error ${response.status}`)
+    let errorMessage = response.statusText || `error ${response.status}`
+    // try to parse error message from JSON payload
+    if (response.headers.get('content-type').includes('application/json')) {
+      try {
+        const {message} = JSON.parse(data)
+        if (message) {
+          errorMessage = message
+        }
+      } catch (e) {
+        // ignore silently, unrecognized error message
+      }
+    }
+    return Promise.reject(errorMessage)
   } catch (e) {
     console.error('failed to POST url:', url, 'body:', body, 'error:', e)
     return Promise.reject(e.message ? e.message : String(e))


### PR DESCRIPTION
This PR enhances reporting of InfluxQL errors.

_Briefly describe your proposed changes:_
Parse and propagate InfluxQL (and also other HTTP) error messahes properly to UI
_What was the problem?_
1.9.3 does not explain invalid InfluxQL query:
![image](https://user-images.githubusercontent.com/16321466/156061841-283e7f76-fbec-4e89-abec-32992a8d9057.png)

_What was the solution?_
![image](https://user-images.githubusercontent.com/16321466/156061753-de8fc8b5-1fab-40fd-90a9-63a44c2a8e4b.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
