### PR TITLE
fix(ui): prefer field when adding a new tag selector

### DIFF
--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
@@ -64,6 +64,16 @@ const TagSelector = (props: Props) => {
   )
 }
 
+function tagSearchPlaceholder(key: string): string {
+  if (key === '_measurement') {
+    return 'Search measurements'
+  }
+  if (key === '_field') {
+    return 'Search fields'
+  }
+  return `Search ${key} tag values`
+}
+
 const TagSelectorBody = (props: Props) => {
   const {
     aggregateFunctionType,
@@ -122,7 +132,7 @@ const TagSelectorBody = (props: Props) => {
   const placeholderText =
     aggregateFunctionType === 'group'
       ? 'Search group column values'
-      : `Search ${key} tag values`
+      : tagSearchPlaceholder(key)
   return (
     <>
       <BuilderCard.Menu testID={`tag-selector--container`}>

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/actions/thunks.ts
@@ -83,13 +83,10 @@ export const loadTagSelectorThunk = (
 
         if (tagIndex === 0 && keys.includes('_measurement')) {
           defaultKey = '_measurement'
+        } else if (keys.includes('_field')) {
+          defaultKey = '_field'
         } else {
           defaultKey = keys[0]
-          // auto-select _field as the last option, older InfluxDB v1
-          // will returns tags values with preceeding _field tag selector
-          if (defaultKey === '_field' && keys.length > 1) {
-            defaultKey = keys[1]
-          }
         }
 
         dispatch(tagActions.selectKey(tagIndex, defaultKey))

--- a/ui/src/shared/parsing/flux/durations.ts
+++ b/ui/src/shared/parsing/flux/durations.ts
@@ -64,7 +64,6 @@ type RangeCallPropertyValue =
   | MinusUnaryExpression<DurationLiteral>
   | DurationLiteral
   | DateTimeLiteral
-  | IntegerLiteral
   | Identifier
   | DurationBinaryExpression
   | MemberExpression
@@ -98,11 +97,6 @@ type DurationUnit =
 
 interface DateTimeLiteral {
   type: 'DateTimeLiteral'
-  value: string
-}
-
-interface IntegerLiteral {
-  type: 'IntegerLiteral'
   value: string
 }
 
@@ -168,8 +162,6 @@ function propertyTime(
       return now + durationDuration(value)
     case 'DateTimeLiteral':
       return Date.parse(value.value)
-    case 'IntegerLiteral':
-      return new Date(+value.value * 1000).getTime()
     case 'Identifier':
       return propertyTime(ast, resolveDeclaration(ast, value.name), now)
     case 'MemberExpression':

--- a/ui/src/shared/parsing/flux/durations.ts
+++ b/ui/src/shared/parsing/flux/durations.ts
@@ -64,6 +64,7 @@ type RangeCallPropertyValue =
   | MinusUnaryExpression<DurationLiteral>
   | DurationLiteral
   | DateTimeLiteral
+  | IntegerLiteral
   | Identifier
   | DurationBinaryExpression
   | MemberExpression
@@ -97,6 +98,11 @@ type DurationUnit =
 
 interface DateTimeLiteral {
   type: 'DateTimeLiteral'
+  value: string
+}
+
+interface IntegerLiteral {
+  type: 'IntegerLiteral'
   value: string
 }
 
@@ -162,6 +168,8 @@ function propertyTime(
       return now + durationDuration(value)
     case 'DateTimeLiteral':
       return Date.parse(value.value)
+    case 'IntegerLiteral':
+      return new Date(+value.value * 1000).getTime()
     case 'Identifier':
       return propertyTime(ast, resolveDeclaration(ast, value.name), now)
     case 'MemberExpression':


### PR DESCRIPTION
This PR improves the flux query builder so that
1. `_measurement` and `_field` tag selectors are initially pre-selected
2. search placeholders are improved
![image](https://user-images.githubusercontent.com/16321466/157657573-8f15338e-e161-4cb7-90d4-e9f93c40fc77.png)
before this PR, it was:
![image](https://user-images.githubusercontent.com/16321466/157657641-2401b967-120f-4f12-abca-14fb1ce7c41b.png)



  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
