### PR TITLE
fix(ui): allow to parse flux range parameter as a number

### DIFF
--- a/ui/src/shared/parsing/flux/durations.ts
+++ b/ui/src/shared/parsing/flux/durations.ts
@@ -64,6 +64,7 @@ type RangeCallPropertyValue =
   | MinusUnaryExpression<DurationLiteral>
   | DurationLiteral
   | DateTimeLiteral
+  | IntegerLiteral
   | Identifier
   | DurationBinaryExpression
   | MemberExpression
@@ -97,6 +98,11 @@ type DurationUnit =
 
 interface DateTimeLiteral {
   type: 'DateTimeLiteral'
+  value: string
+}
+
+interface IntegerLiteral {
+  type: 'IntegerLiteral'
   value: string
 }
 
@@ -162,6 +168,8 @@ function propertyTime(
       return now + durationDuration(value)
     case 'DateTimeLiteral':
       return Date.parse(value.value)
+    case 'IntegerLiteral':
+      return new Date(+value.value * 1000).getTime()
     case 'Identifier':
       return propertyTime(ast, resolveDeclaration(ast, value.name), now)
     case 'MemberExpression':

--- a/ui/test/shared/parsing/flux/durations.ts
+++ b/ui/test/shared/parsing/flux/durations.ts
@@ -2421,7 +2421,7 @@ export const AST_TESTS: Array<[string, string, number, any]> = [
     AST_9,
   ],
   [
-    'basic absolure number query',
+    'basic absolute number query',
     'from(bucket: "b") |> range(start: 0, end: 10)',
     10000,
     AST_10,

--- a/ui/test/shared/parsing/flux/durations.ts
+++ b/ui/test/shared/parsing/flux/durations.ts
@@ -2281,6 +2281,89 @@ const AST_9 = {
   ],
 }
 
+const AST_10 = {
+  type: 'Program',
+  body: [
+    {
+      type: 'ExpressionStatement',
+      expression: {
+        type: 'PipeExpression',
+        argument: {
+          type: 'CallExpression',
+          callee: {
+            type: 'Identifier',
+            name: 'from',
+          },
+          arguments: [
+            {
+              type: 'ObjectExpression',
+              properties: [
+                {
+                  type: 'Property',
+                  key: {
+                    type: 'Identifier',
+                    location: {
+                      start: {line: 1, column: 6},
+                      end: {line: 1, column: 12},
+                      source: 'bucket',
+                    },
+                    name: 'bucket',
+                  },
+                  value: {
+                    type: 'StringLiteral',
+                    location: {
+                      start: {line: 1, column: 14},
+                      end: {line: 1, column: 17},
+                      source: '"b"',
+                    },
+                    value: 'b',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        call: {
+          type: 'CallExpression',
+          callee: {
+            type: 'Identifier',
+            name: 'range',
+          },
+          arguments: [
+            {
+              type: 'ObjectExpression',
+              properties: [
+                {
+                  type: 'Property',
+                  key: {
+                    type: 'Identifier',
+                    name: 'start',
+                  },
+                  value: {
+                    type: 'IntegerLiteral',
+                    value: '0',
+                  },
+                },
+                {
+                  type: 'Property',
+                  key: {
+                    type: 'Identifier',
+                    name: 'stop',
+                  },
+                  value: {
+                    type: 'IntegerLiteral',
+                    value: '10',
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      },
+    },
+  ],
+}
+
 export const AST_TESTS: Array<[string, string, number, any]> = [
   [
     'basic relative query',
@@ -2336,5 +2419,11 @@ export const AST_TESTS: Array<[string, string, number, any]> = [
     new Date('2021-09-20T14:50:00.000Z').getTime() -
       new Date('2020-09-20T14:50:00.000Z').getTime(),
     AST_9,
+  ],
+  [
+    'basic absolure number query',
+    'from(bucket: "b") |> range(start: 0, end: 10)',
+    10000,
+    AST_10,
   ],
 ]


### PR DESCRIPTION
This PR improves detection of the time range to include numbers in the flux [range](https://docs.influxdata.com/flux/v0.x/stdlib/universe/range/) function. `start` and `stop` parameters can be supplied as a number to represent seconds since epoch.

_Briefly describe your proposed changes:_
- improve implementation
- add test

_What was the problem?_

An example query:
```
from(bucket: "my-bucket/autogen")
  |> range(start: 0)
  |> filter(fn: (r) => r["_measurement"] == "measurement000")
```
Silently failed in the browser console with `failed to analyze query` message.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
