### PR TITLE
fix(ui/flux): rename Query Editor to Script Editor, Query Builder to Script Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 1. [#5862](https://github.com/influxdata/chronograf/pull/5862): Respect BASE_PATH when serving API docs.
 1. [#5874](https://github.com/influxdata/chronograf/pull/5874): Propagate InfluxQL errors to UI.
-1. [#5878](https://github.com/influxdata/chronograf/pull/5878): Rename Flux Query Editor to Flux Script Editor.
+1. [#5878](https://github.com/influxdata/chronograf/pull/5878): Rename Flux Query to Flux Script.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 1. [#5862](https://github.com/influxdata/chronograf/pull/5862): Respect BASE_PATH when serving API docs.
 1. [#5874](https://github.com/influxdata/chronograf/pull/5874): Propagate InfluxQL errors to UI.
+1. [#5878](https://github.com/influxdata/chronograf/pull/5878): Rename Flux Query Editor to Flux Script Editor.
 
 ### Other
 

--- a/ui/src/flux/components/FluxEditor.tsx
+++ b/ui/src/flux/components/FluxEditor.tsx
@@ -49,9 +49,9 @@ class FluxEditor extends PureComponent<Props> {
               <p>
                 New to Flux? Give the{' '}
                 <Button
-                  text={'Query Builder'}
+                  text={'Script Builder'}
                   color={ComponentColor.Primary}
-                  titleText={'Open Flux Query Builder'}
+                  titleText={'Open Flux Script Builder'}
                   size={ComponentSize.Large}
                   onClick={onShowWizard}
                 />{' '}

--- a/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
+++ b/ui/src/shared/components/TimeMachine/FluxQueryMaker.tsx
@@ -117,7 +117,7 @@ class FluxQueryMaker extends PureComponent<Props, State> {
           headerButtons: [
             <Button
               key={0}
-              text={'Query Builder'}
+              text={'Script Builder'}
               onClick={this.handleShowWizard}
               size={ComponentSize.ExtraSmall}
             />,

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/FluxQueryBuilder.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/FluxQueryBuilder.tsx
@@ -84,8 +84,8 @@ const FluxQueryBuilder = ({
             <Button
               size={ComponentSize.ExtraSmall}
               onClick={onShowEditor}
-              text="Query Editor"
-              titleText="Switch to Flux Query Editor"
+              text="Script Editor"
+              titleText="Switch to Flux Script Editor"
             />
             <Button
               shape={ButtonShape.Square}


### PR DESCRIPTION
The button that switches to Flux editor is herein `Script Editor` (was Query Editor). The buttons that switche to Flux builder are herein `Script Builder` (was `Query Builder`)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
