### PR TITLE
feat(ui/flux): highlight that Script Builder keys/values depend on the selected time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 1. [#5871](https://github.com/influxdata/chronograf/pull/5871): Add TICKscipts page.
 1. [#5872](https://github.com/influxdata/chronograf/pull/5872): Open Alert Rule Builder from a TICKscript page.
 1. [#5879](https://github.com/influxdata/chronograf/pull/5879): Remove Manage Tasks page, add Alert Rules page.
+1. [#5881](https://github.com/influxdata/chronograf/pull/5881): Highlight that Script Builder keys/values depend on the selected time range.
+
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/FluxQueryBuilder.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/FluxQueryBuilder.tsx
@@ -25,8 +25,9 @@ import {
 import {QueryBuilderState, TimeMachineQueryProps} from './types'
 import {addTagSelectorThunk} from './actions/thunks'
 import timeRangeWindowPeriod from './util/timeRangeWindowPeriod'
-import {RemoteDataState} from 'src/types'
+import {RemoteDataState, TimeZones} from 'src/types'
 import {buildQuery} from './util/generateFlux'
+import {timeRangeLabel} from '../../TimeRangeLabel'
 
 interface OwnProps extends TimeMachineQueryProps {
   onSubmit: (script: string) => void
@@ -42,14 +43,19 @@ const FluxQueryBuilder = ({
   tags,
   isRunnable,
   builderState,
+  timeZone,
   notify,
   onSubmit,
   onShowEditor,
   onAddTagSelector,
 }: Props) => {
-  const defaultPeriod = useMemo(() => timeRangeWindowPeriod(timeRange), [
-    timeRange,
-  ])
+  const [defaultPeriod, timeRangeText] = useMemo(
+    () => [
+      timeRangeWindowPeriod(timeRange),
+      timeRangeLabel({timeRange, timeZone}),
+    ],
+    [timeRange, timeZone]
+  )
 
   return (
     <div className="flux-query-builder" data-testid="flux-query-builder">
@@ -64,6 +70,7 @@ const FluxQueryBuilder = ({
               <TagSelector
                 source={source}
                 timeRange={timeRange}
+                timeRangeText={timeRangeText}
                 key={tag.tagIndex}
                 tagIndex={tag.tagIndex}
               />
@@ -150,9 +157,11 @@ const FluxQueryBuilder = ({
 }
 const mstp = (state: any) => {
   const fluxQueryBuilder = state?.fluxQueryBuilder as QueryBuilderState
+  const timeZone = state?.app?.persisted?.timeZone as TimeZones
   return {
     builderState: fluxQueryBuilder,
     tags: fluxQueryBuilder.tags,
+    timeZone,
     isRunnable:
       fluxQueryBuilder.buckets.status === RemoteDataState.Done &&
       !!fluxQueryBuilder.buckets.selectedBucket,

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
@@ -40,7 +40,9 @@ function renderType(type: BuilderAggregateFunctionType) {
 }
 
 type Callbacks = ReturnType<typeof mdtp>
-type Props = TagSelectorState & Callbacks & TimeMachineQueryProps
+type Props = TagSelectorState &
+  Callbacks &
+  TimeMachineQueryProps & {timeRangeText: string}
 
 const TagSelector = (props: Props) => {
   const {
@@ -92,6 +94,7 @@ const TagSelectorBody = (props: Props) => {
     onIncreaseKeysLimit,
     onSearchKeys,
     tagValues: selectedValues,
+    timeRangeText,
   } = props
   if (aggregateFunctionType === 'filter') {
     if (keysStatus === RemoteDataState.Error) {
@@ -108,7 +111,7 @@ const TagSelectorBody = (props: Props) => {
           No tag keys found{' '}
           <small>
             in the current{' '}
-            <a href="#" onClick={hightlightDropdown}>
+            <a href="#" onClick={hightlightDropdown} title={timeRangeText}>
               time range
             </a>
           </small>
@@ -212,6 +215,7 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
     tagValues: selectedValues,
     onSelectValues,
     onLoadMoreValues,
+    timeRangeText,
   } = props
   if (aggregateFunctionType === 'filter') {
     if (keysStatus === RemoteDataState.NotStarted) {
@@ -268,7 +272,7 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
           No values found{' '}
           <small>
             in the current{' '}
-            <a href="#" onClick={hightlightDropdown}>
+            <a href="#" onClick={hightlightDropdown} title={timeRangeText}>
               time range
             </a>
           </small>
@@ -302,7 +306,7 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
           )
         })}
         {valuesTruncated && aggregateFunctionType === 'filter' ? (
-          <div className="flux-query-builder--list-item" key={`__truncated`}>
+          <div className="flux-query-builder--list-item" key="__truncated">
             {valuesStatus !== RemoteDataState.Loading ? (
               <Button
                 text="Load More Values"
@@ -319,6 +323,14 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
             )}
           </div>
         ) : undefined}
+        <div className="flux-query-builder--list-item" key="__infomsg">
+          <small style={{textAlign: 'center', width: '100%'}}>
+            keys/values depend on{' '}
+            <a href="#" onClick={hightlightDropdown} title={timeRangeText}>
+              time range
+            </a>
+          </small>
+        </div>
       </div>
     </BuilderCard.Body>
   )

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
@@ -323,7 +323,11 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
             )}
           </div>
         ) : undefined}
-        <div className="flux-query-builder--list-item" key="__infomsg">
+        <div
+          className="flux-query-builder--list-item"
+          key="__infomsg"
+          style={{cursor: 'default'}}
+        >
           <small style={{textAlign: 'center', width: '100%'}}>
             keys/values depend on{' '}
             <a href="#" onClick={hightlightDropdown} title={timeRangeText}>

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/TagSelector.tsx
@@ -28,6 +28,7 @@ import {
 import {ButtonShape, ComponentSize, IconFont} from 'src/reusable_ui/types'
 import {Button} from 'src/reusable_ui'
 import LoadingSpinner from 'src/reusable_ui/components/spinners/LoadingSpinner'
+import {hightlightDropdown} from '../../TimeRangeDropdown'
 
 const SEARCH_DEBOUNCE_MS = 400
 
@@ -104,7 +105,13 @@ const TagSelectorBody = (props: Props) => {
     ) {
       return (
         <BuilderCard.Empty testID="empty-tag-keys">
-          No tag keys found <small>in the current time range</small>
+          No tag keys found{' '}
+          <small>
+            in the current{' '}
+            <a href="#" onClick={hightlightDropdown}>
+              time range
+            </a>
+          </small>
         </BuilderCard.Empty>
       )
     }
@@ -258,7 +265,13 @@ const TagSelectorValues = (props: Props & {onLoadMoreValues: () => void}) => {
     if (!values.length) {
       return (
         <BuilderCard.Empty>
-          No values found <small>in the current time range</small>
+          No values found{' '}
+          <small>
+            in the current{' '}
+            <a href="#" onClick={hightlightDropdown}>
+              time range
+            </a>
+          </small>
         </BuilderCard.Empty>
       )
     }

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -20,8 +20,9 @@ export function hightlightDropdown(e) {
   }
   const el1 = document.getElementsByClassName('time-range-dropdown')[0]
   if (el1) {
-    el1.classList.add('highlight')
-    if (timeoutHandle) {
+    if (!timeoutHandle) {
+      el1.classList.add('highlight')
+    } else {
       clearTimeout(timeoutHandle)
     }
     timeoutHandle = setTimeout(() => {

--- a/ui/src/shared/components/TimeRangeDropdown.js
+++ b/ui/src/shared/components/TimeRangeDropdown.js
@@ -13,6 +13,27 @@ import {ErrorHandling} from 'src/shared/decorators/errors'
 import TimeRangeLabel from './TimeRangeLabel'
 const emptyTime = {lower: '', upper: ''}
 
+let timeoutHandle
+export function hightlightDropdown(e) {
+  if (e && e.preventDefault) {
+    e.preventDefault()
+  }
+  const el1 = document.getElementsByClassName('time-range-dropdown')[0]
+  if (el1) {
+    el1.classList.add('highlight')
+    if (timeoutHandle) {
+      clearTimeout(timeoutHandle)
+    }
+    timeoutHandle = setTimeout(() => {
+      const el2 = document.getElementsByClassName('time-range-dropdown')[0]
+      if (el2) {
+        el2.classList.remove('highlight')
+      }
+      timeoutHandle = undefined
+    }, 1000)
+  }
+}
+
 class TimeRangeDropdown extends Component {
   constructor(props) {
     super(props)

--- a/ui/src/shared/components/TimeRangeLabel.tsx
+++ b/ui/src/shared/components/TimeRangeLabel.tsx
@@ -19,7 +19,10 @@ interface PassedProps {
 }
 type Props = PassedProps & ReturnType<typeof mstp>
 
-const TimeRangeLabel = ({timeRange: {upper, lower}, timeZone}: Props) => {
+export function timeRangeLabel({
+  timeRange: {upper, lower},
+  timeZone,
+}: Props): string {
   if (upper && lower) {
     if (upper === 'now()') {
       return `${format(lower, timeZone)} - Now`
@@ -30,8 +33,13 @@ const TimeRangeLabel = ({timeRange: {upper, lower}, timeZone}: Props) => {
   const selected = timeRanges.find(range => range.lower === lower)
   return selected ? selected.inputValue : 'Custom'
 }
+const TimeRangeLabel = (props: Props) => {
+  return timeRangeLabel(props)
+}
 
 const mstp = (state: any) => ({
-  timeZone: _.get(state, ['app', 'persisted', 'timeZone']) as TimeZones,
+  timeZone: _.get(state, ['app', 'persisted', 'timeZone']) as
+    | TimeZones
+    | undefined,
 })
 export default connect(mstp)(TimeRangeLabel)

--- a/ui/src/style/components/custom-time-range.scss
+++ b/ui/src/style/components/custom-time-range.scss
@@ -297,20 +297,16 @@ $rd-cell-size: 30px;
   }
 }
 @keyframes TimeRangeHighlight {
-  0% {
-    padding-left: 0px;
-    padding-right: 0px;
-    border-width: 0px 9px;
-    border-color: red;
-    border-style: solid;
+  25% {
+    transform: scale(1.2);
+  }
+  50% {
+    transform: scale(0.9);
+  }
+  75% {
+    transform: scale(1.2);
   }
   100% {
-    padding-left: 9px;
-    padding-right: 9px;
-    border-width: 0px 0px;
-    border-color: red;
-    border-style: solid;
-    transform: scale(1.2);
   }
 }
 .time-range-dropdown {
@@ -319,7 +315,12 @@ $rd-cell-size: 30px;
 
   &.highlight .dropdown-toggle {
     pointer-events: none;
-    animation: TimeRangeHighlight 1s ease-out infinite;
+    padding-left: 6px;
+    padding-right: 6px;
+    border-width: 3px;
+    border-color: $c-banana;
+    border-style: solid;
+    animation: TimeRangeHighlight 1s linear 1;
   }
 }
 

--- a/ui/src/style/components/custom-time-range.scss
+++ b/ui/src/style/components/custom-time-range.scss
@@ -75,9 +75,7 @@
 .custom-time--shortcut {
   white-space: nowrap;
   padding: 6px 16px;
-  transition:
-    color 0.25s ease,
-    background-color 0.25s ease;
+  transition: color 0.25s ease, background-color 0.25s ease;
   color: $g11-sidewalk;
   font-weight: 500;
 
@@ -138,14 +136,14 @@ $rd-cell-size: 30px;
   left: 0;
   &:after {
     left: calc(50% - 1px);
-    content: "\e901";
+    content: '\e901';
   }
 }
 .rd-next {
   left: calc(100% - #{$custom-time-arrow});
   &:after {
     left: calc(50% + 1px);
-    content: "\e903";
+    content: '\e903';
   }
 }
 .rd-month-label {
@@ -298,10 +296,33 @@ $rd-cell-size: 30px;
     background-color: $g6-smoke;
   }
 }
-/* Custom positioning for dashboard use */
-.time-range-dropdown {
-  position: relative;
+@keyframes TimeRangeHighlight {
+  0% {
+    padding-left: 0px;
+    padding-right: 0px;
+    border-width: 0px 9px;
+    border-color: red;
+    border-style: solid;
+  }
+  100% {
+    padding-left: 9px;
+    padding-right: 9px;
+    border-width: 0px 0px;
+    border-color: red;
+    border-style: solid;
+    transform: scale(1.2);
+  }
 }
+.time-range-dropdown {
+  /* Custom positioning for dashboard use */
+  position: relative;
+
+  &.highlight .dropdown-toggle {
+    pointer-events: none;
+    animation: TimeRangeHighlight 1s ease-out infinite;
+  }
+}
+
 .custom-time--overlay {
   position: absolute;
   top: 0;


### PR DESCRIPTION
Closes #5880

- non-empty Tag Selector lists are accompanied with the last entry showing `keys/values depend on time range`, empty lists already contain a message `No tag keys (values) found in the selected time range`
- every text that references the time range visualizes Time Range dropdown on click and has a title showing the actual time range

![FluxQueryBuilderTimeRangeVisualization](https://user-images.githubusercontent.com/16321466/158005780-7fa48d10-b013-4c3f-bd89-992ddc0e30f4.gif)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
