### PR TITLE
fix(ui): repair table visualization to keep string data as-is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+1. [#5882](https://github.com/influxdata/chronograf/pull/5882): Repair table visualization of string values.
+
 ### Other
 
 1. [#5875](https://github.com/influxdata/chronograf/pull/5875): Upgrade to node 16 LTS.

--- a/ui/src/dashboards/utils/tableGraph.ts
+++ b/ui/src/dashboards/utils/tableGraph.ts
@@ -304,14 +304,15 @@ export const transformTableData = (
   - `parseFloat('02abc')` is 2
 
 */
-export const isNumerical = <T>(x: T | string): x is string =>
-  !isNaN(Number(x)) && !isNaN(parseFloat(x as string))
+export const isNumerical = (x: number | string): boolean =>
+  typeof x === 'number' || (!isNaN(Number(x)) && !isNaN(parseFloat(x)))
 
 export const formatNumericCell = (
-  cellData: string,
+  cellData: string | number,
   decimalPlaces: DecimalPlaces
 ) => {
-  const cellValue = parseFloat(cellData)
+  const cellValue =
+    typeof cellData === 'number' ? cellData : parseFloat(cellData)
 
   if (isTruncatedNumber(cellValue, decimalPlaces)) {
     return toFixed(cellValue, decimalPlaces)

--- a/ui/src/shared/components/TableGraph.tsx
+++ b/ui/src/shared/components/TableGraph.tsx
@@ -14,7 +14,6 @@ import {fastReduce} from 'src/utils/fast'
 import {ErrorHandlingWith, DefaultError} from 'src/shared/decorators/errors'
 import {
   getDefaultTimeField,
-  isNumerical,
   formatNumericCell,
 } from 'src/dashboards/utils/tableGraph'
 
@@ -480,7 +479,7 @@ class TableGraph extends PureComponent<Props, State> {
       return _.defaultTo(fieldName, '').toString()
     }
 
-    if (isNumerical(cellData)) {
+    if (typeof cellData === 'number') {
       return formatNumericCell(cellData, decimalPlaces)
     }
 
@@ -540,7 +539,7 @@ class TableGraph extends PureComponent<Props, State> {
     const isFieldName = this.isVerticalTimeAxis ? isFirstRow : isFirstCol
     const isFixedCorner = isFirstRow && isFirstCol
 
-    const cellDataIsNumerical = isNumerical(cellData)
+    const cellDataIsNumerical = typeof cellData === 'number'
 
     let cellStyle: React.CSSProperties = style // tslint:disable-line
     if (

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -66,7 +66,9 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
 
   const groupRow = annotationData.find(row => row[0] === '#group')
   const defaultsRow = annotationData.find(row => row[0] === '#default')
-  const dataTypeRow = annotationData.find(row => row[0] === '#datatype')
+  const dataTypeRow: string[] = annotationData.find(
+    row => row[0] === '#datatype'
+  )
 
   // groupRow = ['#group', 'false', 'true', 'true', 'false']
   const groupKeyIndices = groupRow.reduce((acc, value, i) => {
@@ -96,9 +98,22 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
       {}
     )
 
-    if (timeColIndex >= 0) {
-      for (const row of tableData) {
+    const numberColumns = (dataTypeRow || []).reduce((acc, val, i) => {
+      if (val === 'long' || val === 'unsignedLong' || val === 'double') {
+        acc.push(i)
+      }
+      return acc
+    }, [] as number[])
+    for (const row of tableData) {
+      if (timeColIndex >= 0) {
         row[timeColIndex] = new Date(row[timeColIndex]).valueOf()
+      }
+      if (numberColumns.length) {
+        numberColumns.forEach(colIndex => {
+          if (row[colIndex] !== '') {
+            row[colIndex] = parseFloat(row[colIndex] as string)
+          }
+        })
       }
     }
 

--- a/ui/src/shared/parsing/flux/response.ts
+++ b/ui/src/shared/parsing/flux/response.ts
@@ -59,10 +59,6 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
   const tableColIndex = headerRow.findIndex(h => h === 'table')
   const timeColIndex = headerRow.findIndex(h => h === '_time')
 
-  if (!timeColIndex) {
-    throw new Error('Could not find time Column')
-  }
-
   // Group rows by their table id
   const tablesData: Array<Array<Array<string | number>>> = Object.values(
     _.groupBy(nonAnnotationData.slice(1), row => row[tableColIndex])
@@ -100,8 +96,10 @@ export const parseTables = (responseChunk: string): FluxTable[] => {
       {}
     )
 
-    for (const row of tableData) {
-      row[timeColIndex] = new Date(row[timeColIndex]).valueOf()
+    if (timeColIndex >= 0) {
+      for (const row of tableData) {
+        row[timeColIndex] = new Date(row[timeColIndex]).valueOf()
+      }
     }
 
     const data: Array<Array<string | number>> = [headerRow, ...tableData]


### PR DESCRIPTION
Closes #5857

_What was the problem?_
Table visualization always parses string data to detect if they are numbers and display them as numbers even when they were never meant to represent numbers.
_What was the solution?_
1. Flux result parsers were enhanced to produce numbers for columns that are described as numbers (was string before).   InfluxQL results already contain numbers in number columns.
2. Change table visualization to render numbers only when numbers appear.

As a regression, columns that contain number data that were originally written as a string cannot be now visualized as numbers in a table visualization.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
