### PR TITLE
fix(server): report correct chronograf version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 1. [#5874](https://github.com/influxdata/chronograf/pull/5874): Propagate InfluxQL errors to UI.
 1. [#5878](https://github.com/influxdata/chronograf/pull/5878): Rename Flux Query to Flux Script.
 1. [#5885](https://github.com/influxdata/chronograf/pull/5885): Repair time zone selector on Host page.
-
+1. [#5886](https://github.com/influxdata/chronograf/pull/5886): Report correct chronograf version.
 
 ### Other
 

--- a/cmd/chronograf/main.go
+++ b/cmd/chronograf/main.go
@@ -6,15 +6,28 @@ import (
 	"os"
 
 	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/dist"
 	"github.com/influxdata/chronograf/server"
 	flags "github.com/jessevdk/go-flags"
 )
 
 // Build flags
 var (
-	version = "1.8.0"
-	commit  = ""
+	version     = ""
+	commit      = ""
+	fullVersion = ""
 )
+
+func init() {
+	if version == "" {
+		// read version from bindata files
+		version = dist.GetVersion()
+	}
+	fullVersion = version
+	if commit != "" {
+		fullVersion = fmt.Sprintf("%s (git: %s)", version, commit)
+	}
+}
 
 func main() {
 	srv := server.Server{
@@ -39,7 +52,7 @@ func main() {
 	}
 
 	if srv.ShowVersion {
-		fmt.Printf("Chronograf %s (git: %s)\n", version, commit)
+		fmt.Printf("Chronograf %s\n", fullVersion)
 		os.Exit(0)
 	}
 

--- a/dist/dist.go
+++ b/dist/dist.go
@@ -102,7 +102,7 @@ func (b *BindataAssets) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 var re = regexp.MustCompile(`"version"\s*:\s*"(.*)"`)
 
-// GetVersion returns version of the assets
+// GetVersion returns version of the packed assets
 func GetVersion() string {
 	if data, err := Asset("../ui/package.json"); err == nil {
 		if matches := re.FindStringSubmatch(string(data)); matches != nil {

--- a/dist/dist.go
+++ b/dist/dist.go
@@ -1,10 +1,11 @@
 package dist
 
-//go:generate go-bindata -o dist_gen.go -ignore 'map|go' -pkg dist ../ui/build/...
+//go:generate go-bindata -o dist_gen.go -ignore 'map|go' -pkg dist ../ui/build/... ../ui/package.json
 
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 
 	assetfs "github.com/elazarl/go-bindata-assetfs"
@@ -97,4 +98,16 @@ func (b *BindataAssets) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Prefix:    b.Prefix,
 	}
 	http.FileServer(dir).ServeHTTP(w, r)
+}
+
+var re = regexp.MustCompile(`"version"\s*:\s*"(.*)"`)
+
+// GetVersion returns version of the assets
+func GetVersion() string {
+	if data, err := Asset("../ui/package.json"); err == nil {
+		if matches := re.FindStringSubmatch(string(data)); matches != nil {
+			return matches[1]
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
Closes #5884

This PR makes sure that `chronograf --version` reports the correct version even if it is not built from a git repository or a CI process, both of them supply the version with extra flags to `go build`. The default chronograf version is now taken from `ui/package.json` that is newly packed into the binary.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
