### PR TITLE
chore(server): test non-empty dist version

### DIFF
--- a/dist/dist_test.go
+++ b/dist/dist_test.go
@@ -1,0 +1,14 @@
+package dist_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/chronograf/dist"
+)
+
+func TestGetVersion(t *testing.T) {
+	version := dist.GetVersion()
+	if version == "" {
+		t.Error("No version information is available!")
+	}
+}


### PR DESCRIPTION
This PR makes sure that chronograf can read its version from packed bindata.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
