### PR TITLE
fix(ui): reorder Alerting side menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [#5885](https://github.com/influxdata/chronograf/pull/5885): Repair time zone selector on Host page.
 1. [#5886](https://github.com/influxdata/chronograf/pull/5886): Report correct chronograf version.
 1. [#5888](https://github.com/influxdata/chronograf/pull/5888): Show failure reason on Queries page.
+1. [#5892](https://github.com/influxdata/chronograf/pull/5892): Reorder Alerting side menu.
 
 ### Other
 

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -108,15 +108,15 @@ class SideNav extends PureComponent<Props> {
             'fluxtasks',
           ]}
           icon="alerts"
-          link={`${sourcePrefix}/tickscripts`}
+          link={`${sourcePrefix}/alert-rules`}
           location={location}
         >
           <NavHeader link={`${sourcePrefix}/tickscripts`} title="Alerting" />
-          <NavListItem link={`${sourcePrefix}/tickscripts`}>
-            TICKscripts
-          </NavListItem>
           <NavListItem link={`${sourcePrefix}/alert-rules`}>
             Alert Rules
+          </NavListItem>
+          <NavListItem link={`${sourcePrefix}/tickscripts`}>
+            TICKscripts
           </NavListItem>
           <NavListItem link={`${sourcePrefix}/flux-tasks`}>
             Flux Tasks

--- a/yarn.lock
+++ b/yarn.lock
@@ -2915,9 +2915,9 @@ caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
   integrity sha512-3ZLkHhAfYajg2JCY0VeUmrYxAlmI7cdsFttXNgfwR1fu+m80t9cF7F8oVvuPt8u88X5nl633rRvVs6a/nJdXMg==
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001181:
-  version "1.0.30001259"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001259.tgz"
-  integrity sha512-V7mQTFhjITxuk9zBpI6nYsiTXhcPe05l+364nZjK7MFK/E7ibvYBSAXr4YcA6oPR8j3ZLM/LN+lUqUVAQEUZFg==
+  version "1.0.30001319"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001319.tgz"
+  integrity sha512-xjlIAFHucBRSMUo1kb5D4LYgcN1M45qdKP++lhqowDpwJwGkpIRTt5qQqnhxjj1vHcI7nrJxWhCC1ATrCEBTcw==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Closes #5891

`Alert Rules` is herein the first and the default item of the Alertin side menu, as it was in 1.9.3.

![image](https://user-images.githubusercontent.com/16321466/159132743-5f0c461d-e0cd-45d0-ae94-5a194b9eec8a.png)

Moreover this PR updates `caniuse-lite` that is used during UI build to install required polyfills.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
