### PR TITLE
feat(ui): make aggregation function optional in Flux Query Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5881](https://github.com/influxdata/chronograf/pull/5881): Highlight that Script Builder keys/values depend on the selected time range.
 
 1. [#5856](https://github.com/influxdata/chronograf/pull/5856): Add alert rule options to not send alert on state recovery and send regardless of state change.
+1. [#5893](https://github.com/influxdata/chronograf/pull/5893): Make aggregation function selection optional.
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/TimeMachine/fluxQueryBuilder/AggregationSelector.tsx
+++ b/ui/src/shared/components/TimeMachine/fluxQueryBuilder/AggregationSelector.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 
 import {connect} from 'react-redux'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
-import {fluxWizardError} from 'src/shared/copy/notifications'
 
 import {ComponentSize, SlideToggle} from 'src/reusable_ui'
 import ReactTooltip from 'react-tooltip'
@@ -122,16 +121,7 @@ const AggregationSelector = (props: Props & {children?: JSX.Element}) => {
               const newSelected = active
                 ? selectedFunctions.filter(x => x !== fn)
                 : [fn, ...selectedFunctions]
-              // at least one function must be selected
-              if (newSelected.length) {
-                setSelectedFunctions(newSelected)
-              } else {
-                props.notify(
-                  fluxWizardError(
-                    'You must have at least one aggregation function selected'
-                  )
-                )
-              }
+              setSelectedFunctions(newSelected)
             }
 
             const id = `flx-agrselect${fn}`


### PR DESCRIPTION
Closes #5889

This PR changes the Flux Script Builder so that the aggregation function is optional.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
