### PR TITLE
feat(ui/flux): autocomplete builtin 'v' object in Flux editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 1. [#5856](https://github.com/influxdata/chronograf/pull/5856): Add alert rule options to not send alert on state recovery and send regardless of state change.
 1. [#5893](https://github.com/influxdata/chronograf/pull/5893): Make aggregation function selection optional.
+1. [#5894](https://github.com/influxdata/chronograf/pull/5894): Autocomplete builtin `v` object in Flux editor.
 
 ### Bug Fixes
 

--- a/ui/src/flux/helpers/autoComplete.ts
+++ b/ui/src/flux/helpers/autoComplete.ts
@@ -64,6 +64,21 @@ export const EXCLUDED_KEYS = new Set([
   ' ',
 ])
 
+const V_OBJECT_SUGGESTIONS = [
+  {
+    text: 'timeRangeStart',
+    displayText: 'timeRangeStart',
+  },
+  {
+    text: 'timeRangeStop',
+    displayText: 'timeRangeStop',
+  },
+  {
+    text: 'windowPeriod',
+    displayText: 'windowPeriod',
+  },
+]
+
 export const getSuggestions = (
   editor: CMEditor,
   allSuggestions: Suggestion[]
@@ -101,6 +116,13 @@ export const getSuggestionsHelper = (
       cursorPosition,
       allSuggestions
     )
+  }
+  if (shouldCompleteVObject(currentLineText, cursorPosition)) {
+    return {
+      start: cursorPosition,
+      end: cursorPosition,
+      suggestions: V_OBJECT_SUGGESTIONS,
+    }
   }
 
   return {
@@ -167,6 +189,16 @@ const shouldCompleteParam = (currentLineText, cursorPosition) => {
   }
 
   return false
+}
+
+const shouldCompleteVObject = (currentLineText, cursorPosition) => {
+  // check whether "[ :]v." preceeds current position
+  const char1 = currentLineText[cursorPosition - 3]
+  return (
+    (char1 === ' ' || char1 === ':') &&
+    currentLineText[cursorPosition - 2] === 'v' &&
+    currentLineText[cursorPosition - 1] === '.'
+  )
 }
 
 export const getParamSuggestions = (

--- a/ui/src/style/components/code-mirror/_time-machine.scss
+++ b/ui/src/style/components/code-mirror/_time-machine.scss
@@ -20,7 +20,7 @@
   .cm-arrow-function,
   .cm-function-arg,
   .cm-function-arg-ref {
-    color: #ff4d96;
+    color: $c-pool; //#ff4d96;
   }
   .cm-operator {
     color: $g15-platinum;


### PR DESCRIPTION
This PR enhances the Flux editor to show suggestions of the built-in `v` object properties:

![autoCompleteVObject](https://user-images.githubusercontent.com/16321466/159134515-a9cefa9f-973a-4bc5-9faf-3e35b905f4fb.gif)

The color of all object references (including 'v') also changed, is not red anymore.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
