### PR TITLE
fix(ci): upgrade github action to use node 16

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14.15.0'
+          node-version: '16.14.2'
       - run: if [ ! -x "$(command -v yarn)" ]; then npm install -g yarn; fi
       - run: yarn node --version
 

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -79,6 +79,7 @@ jobs:
             apt update
             apt install -y build-essential
             yarn install --frozen-lockfile
+            yarn run cypress install
             yarn run cypress run --browser chrome --config baseUrl=http://host.docker.internal:8888 --reporter junit --reporter-options 'mochaFile=cypress/results/results-[hash].xml'
 
       - name: Upload Artifact


### PR DESCRIPTION
This PR fixes github action to use node 16, i.e. the same version that is already used during CI build. Upgrade to node 16 was  already done in https://github.com/influxdata/chronograf/pull/5875, before github actions were introduced. 

This upgrade is required in order to continue with dependency upgrades for the next version of chronograf. Github actions fail on node 14 with
```
Run make
cd ui && yarn --no-progress --no-emoji
yarn install v1.22.17
[1/4] Resolving packages...
[2/4] Fetching packages...
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
error @typescript-eslint/eslint-plugin@5.17.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.17.0 || >=16.0.0". Got "14.15.0"
error Found incompatible module.
make: *** [Makefile:[9](https://github.com/influxdata/chronograf/runs/5766813254?check_suite_focus=true#step:11:9)4: .jsdep] Error 1
Error: Process completed with exit code 2.
```  

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
