### PR TITLE
feat: add reader role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+1. [#5904](https://github.com/influxdata/chronograf/pull/5904): Add reader role.
+
 ### Bug Fixes
 
 ### Other

--- a/kv/organizations_test.go
+++ b/kv/organizations_test.go
@@ -273,7 +273,7 @@ func TestOrganizationsStore_Update(t *testing.T) {
 			addFirst: true,
 		},
 		{
-			name:   "Update organization default role",
+			name:   "Update organization default role to viewer",
 			fields: fields{},
 			args: args{
 				ctx: context.Background(),
@@ -291,7 +291,25 @@ func TestOrganizationsStore_Update(t *testing.T) {
 			addFirst: true,
 		},
 		{
-			name:   "Update organization name and default role",
+			name:   "Update organization default role to reader",
+			fields: fields{},
+			args: args{
+				ctx: context.Background(),
+				initial: &chronograf.Organization{
+					Name: "The Good Place",
+				},
+				updates: &chronograf.Organization{
+					DefaultRole: roles.ReaderRoleName,
+				},
+			},
+			want: &chronograf.Organization{
+				Name:        "The Good Place",
+				DefaultRole: roles.ReaderRoleName,
+			},
+			addFirst: true,
+		},
+		{
+			name:   "Update organization name and default role to viewer",
 			fields: fields{},
 			args: args{
 				ctx: context.Background(),
@@ -307,6 +325,26 @@ func TestOrganizationsStore_Update(t *testing.T) {
 			want: &chronograf.Organization{
 				Name:        "The Bad Place",
 				DefaultRole: roles.ViewerRoleName,
+			},
+			addFirst: true,
+		},
+		{
+			name:   "Update organization name and default role to reader",
+			fields: fields{},
+			args: args{
+				ctx: context.Background(),
+				initial: &chronograf.Organization{
+					Name:        "The Good Place",
+					DefaultRole: roles.AdminRoleName,
+				},
+				updates: &chronograf.Organization{
+					Name:        "The Bad Place",
+					DefaultRole: roles.ReaderRoleName,
+				},
+			},
+			want: &chronograf.Organization{
+				Name:        "The Bad Place",
+				DefaultRole: roles.ReaderRoleName,
 			},
 			addFirst: true,
 		},
@@ -405,7 +443,7 @@ func TestOrganizationsStore_Update(t *testing.T) {
 		}
 
 		if tt.addFirst {
-			tt.args.initial, err = s.Add(tt.args.ctx, tt.args.initial)
+			tt.args.initial, _ = s.Add(tt.args.ctx, tt.args.initial)
 		}
 
 		if tt.args.updates.Name != "" {

--- a/roles/roles.go
+++ b/roles/roles.go
@@ -9,6 +9,7 @@ const ContextKey = contextKey("role")
 // Chronograf User Roles
 const (
 	MemberRoleName   = "member"
+	ReaderRoleName   = "reader"
 	ViewerRoleName   = "viewer"
 	EditorRoleName   = "editor"
 	AdminRoleName    = "admin"

--- a/server/auth.go
+++ b/server/auth.go
@@ -63,7 +63,6 @@ func AuthorizedToken(auth oauth2.Authenticator, logger chronograf.Logger, next h
 		// Send the principal to the next handler
 		ctx = context.WithValue(ctx, oauth2.PrincipalKey, principal)
 		next.ServeHTTP(w, r.WithContext(ctx))
-		return
 	})
 }
 

--- a/server/auth.go
+++ b/server/auth.go
@@ -293,7 +293,6 @@ func AuthorizedUser(
 		}
 
 		Error(w, http.StatusForbidden, "User is not authorized", logger)
-		return
 	})
 }
 
@@ -306,7 +305,14 @@ func hasAuthorizedRole(u *chronograf.User, role string) bool {
 	case roles.MemberRoleName:
 		for _, r := range u.Roles {
 			switch r.Name {
-			case roles.MemberRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
+			case roles.MemberRoleName, roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
+				return true
+			}
+		}
+	case roles.ReaderRoleName:
+		for _, r := range u.Roles {
+			switch r.Name {
+			case roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
 				return true
 			}
 		}

--- a/server/mux.go
+++ b/server/mux.go
@@ -92,6 +92,15 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 		)
 	}
 	_ = EnsureMember
+	EnsureReader := func(next http.HandlerFunc) http.HandlerFunc {
+		return AuthorizedUser(
+			service.Store,
+			opts.UseAuth,
+			roles.ReaderRoleName,
+			opts.Logger,
+			next,
+		)
+	}
 	EnsureViewer := func(next http.HandlerFunc) http.HandlerFunc {
 		return AuthorizedUser(
 			service.Store,
@@ -174,27 +183,27 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.DELETE("/chronograf/v1/mappings/:id", EnsureSuperAdmin(service.RemoveMapping))
 
 	// Sources
-	router.GET("/chronograf/v1/sources", EnsureViewer(service.Sources))
+	router.GET("/chronograf/v1/sources", EnsureReader(service.Sources))
 	router.POST("/chronograf/v1/sources", EnsureEditor(service.NewSource))
 
-	router.GET("/chronograf/v1/sources/:id", EnsureViewer(service.SourcesID))
+	router.GET("/chronograf/v1/sources/:id", EnsureReader(service.SourcesID))
 	router.PATCH("/chronograf/v1/sources/:id", EnsureEditor(service.UpdateSource))
 	router.DELETE("/chronograf/v1/sources/:id", EnsureEditor(service.RemoveSource))
-	router.GET("/chronograf/v1/sources/:id/health", EnsureViewer(service.SourceHealth))
+	router.GET("/chronograf/v1/sources/:id/health", EnsureReader(service.SourceHealth))
 
 	// Flux
-	router.GET("/chronograf/v1/flux", EnsureViewer(service.Flux))
-	router.POST("/chronograf/v1/flux/ast", EnsureViewer(service.FluxAST))
+	router.GET("/chronograf/v1/flux", EnsureReader(service.Flux))
+	router.POST("/chronograf/v1/flux/ast", EnsureReader(service.FluxAST))
 	router.GET("/chronograf/v1/flux/suggestions", EnsureViewer(service.FluxSuggestions))
 	router.GET("/chronograf/v1/flux/suggestions/:name", EnsureViewer(service.FluxSuggestion))
 
 	// Source Proxy to Influx; Has gzip compression around the handler
-	influx := gziphandler.GzipHandler(http.HandlerFunc(EnsureViewer(service.Influx)))
+	influx := gziphandler.GzipHandler(http.HandlerFunc(EnsureReader(service.Influx)))
 	router.Handler("POST", "/chronograf/v1/sources/:id/proxy", influx)
 
 	// Source Proxy to Influx's flux endpoint; compression because the responses from
 	// flux could be large.
-	router.Handler("POST", "/chronograf/v1/sources/:id/proxy/flux", EnsureViewer(service.ProxyFlux))
+	router.Handler("POST", "/chronograf/v1/sources/:id/proxy/flux", EnsureReader(service.ProxyFlux))
 
 	// Write proxies line protocol write requests to InfluxDB
 	router.POST("/chronograf/v1/sources/:id/write", EnsureViewer(service.Write))
@@ -205,12 +214,12 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	//
 	// Admins should ensure that the InfluxDB source as the proper permissions
 	// intended for Chronograf Users with the Viewer Role type.
-	router.POST("/chronograf/v1/sources/:id/queries", EnsureViewer(service.Queries))
+	router.POST("/chronograf/v1/sources/:id/queries", EnsureReader(service.Queries))
 
 	// Annotations are user-defined events associated with this source
-	router.GET("/chronograf/v1/sources/:id/annotations", EnsureViewer(service.Annotations))
+	router.GET("/chronograf/v1/sources/:id/annotations", EnsureReader(service.Annotations))
 	router.POST("/chronograf/v1/sources/:id/annotations", EnsureEditor(service.NewAnnotation))
-	router.GET("/chronograf/v1/sources/:id/annotations/:aid", EnsureViewer(service.Annotation))
+	router.GET("/chronograf/v1/sources/:id/annotations/:aid", EnsureReader(service.Annotation))
 	router.DELETE("/chronograf/v1/sources/:id/annotations/:aid", EnsureEditor(service.RemoveAnnotation))
 	router.PATCH("/chronograf/v1/sources/:id/annotations/:aid", EnsureEditor(service.UpdateAnnotation))
 
@@ -299,18 +308,18 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.PATCH("/chronograf/v1/users/:id", EnsureSuperAdmin(rawStoreAccess(service.UpdateUser)))
 
 	// Dashboards
-	router.GET("/chronograf/v1/dashboards", EnsureViewer(service.Dashboards))
+	router.GET("/chronograf/v1/dashboards", EnsureReader(service.Dashboards))
 	router.POST("/chronograf/v1/dashboards", EnsureEditor(service.NewDashboard))
 
-	router.GET("/chronograf/v1/dashboards/:id", EnsureViewer(service.DashboardID))
+	router.GET("/chronograf/v1/dashboards/:id", EnsureReader(service.DashboardID))
 	router.DELETE("/chronograf/v1/dashboards/:id", EnsureEditor(service.RemoveDashboard))
 	router.PUT("/chronograf/v1/dashboards/:id", EnsureEditor(service.ReplaceDashboard))
 	router.PATCH("/chronograf/v1/dashboards/:id", EnsureEditor(service.UpdateDashboard))
 	// Dashboard Cells
-	router.GET("/chronograf/v1/dashboards/:id/cells", EnsureViewer(service.DashboardCells))
+	router.GET("/chronograf/v1/dashboards/:id/cells", EnsureReader(service.DashboardCells))
 	router.POST("/chronograf/v1/dashboards/:id/cells", EnsureEditor(service.NewDashboardCell))
 
-	router.GET("/chronograf/v1/dashboards/:id/cells/:cid", EnsureViewer(service.DashboardCellID))
+	router.GET("/chronograf/v1/dashboards/:id/cells/:cid", EnsureReader(service.DashboardCellID))
 	router.DELETE("/chronograf/v1/dashboards/:id/cells/:cid", EnsureEditor(service.RemoveDashboardCell))
 	router.PUT("/chronograf/v1/dashboards/:id/cells/:cid", EnsureEditor(service.ReplaceDashboardCell))
 
@@ -348,7 +357,7 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.GET("/chronograf/v1/org_config/logviewer", EnsureViewer(service.OrganizationLogViewerConfig))
 	router.PUT("/chronograf/v1/org_config/logviewer", EnsureEditor(service.ReplaceOrganizationLogViewerConfig))
 
-	router.GET("/chronograf/v1/env", EnsureViewer(service.Environment))
+	router.GET("/chronograf/v1/env", EnsureReader(service.Environment))
 
 	// Validates go templates for the js client
 	router.POST("/chronograf/v1/validate_text_templates", EnsureViewer(service.ValidateTextTemplate))

--- a/server/mux.go
+++ b/server/mux.go
@@ -357,7 +357,7 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	router.GET("/chronograf/v1/org_config/logviewer", EnsureViewer(service.OrganizationLogViewerConfig))
 	router.PUT("/chronograf/v1/org_config/logviewer", EnsureEditor(service.ReplaceOrganizationLogViewerConfig))
 
-	router.GET("/chronograf/v1/env", EnsureReader(service.Environment))
+	router.GET("/chronograf/v1/env", EnsureMember(service.Environment))
 
 	// Validates go templates for the js client
 	router.POST("/chronograf/v1/validate_text_templates", EnsureViewer(service.ValidateTextTemplate))

--- a/server/organizations.go
+++ b/server/organizations.go
@@ -27,7 +27,7 @@ func (r *organizationRequest) ValidCreate() error {
 
 func (r *organizationRequest) ValidUpdate() error {
 	if r.Name == "" && r.DefaultRole == "" {
-		return fmt.Errorf("No fields to update")
+		return fmt.Errorf("no fields to update")
 	}
 
 	if r.DefaultRole != "" {

--- a/server/organizations.go
+++ b/server/organizations.go
@@ -43,10 +43,10 @@ func (r *organizationRequest) ValidDefaultRole() error {
 	}
 
 	switch r.DefaultRole {
-	case roles.MemberRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
+	case roles.MemberRoleName, roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
 		return nil
 	default:
-		return fmt.Errorf("default role must be member, viewer, editor, or admin")
+		return fmt.Errorf("default role must be member, reader, viewer, editor, or admin")
 	}
 }
 

--- a/server/organizations_test.go
+++ b/server/organizations_test.go
@@ -385,7 +385,7 @@ func TestService_UpdateOrganization(t *testing.T) {
 			id:              "1337",
 			wantStatus:      http.StatusUnprocessableEntity,
 			wantContentType: "application/json",
-			wantBody:        `{"code":422,"message":"default role must be member, viewer, editor, or admin"}`,
+			wantBody:        `{"code":422,"message":"default role must be member, reader, viewer, editor, or admin"}`,
 		},
 	}
 

--- a/server/organizations_test.go
+++ b/server/organizations_test.go
@@ -299,7 +299,7 @@ func TestService_UpdateOrganization(t *testing.T) {
 			wantBody:        `{"code":422,"message":"No fields to update"}`,
 		},
 		{
-			name: "Update Organization default role",
+			name: "Update Organization default role to viewer",
 			args: args{
 				w: httptest.NewRecorder(),
 				r: httptest.NewRequest(
@@ -330,6 +330,39 @@ func TestService_UpdateOrganization(t *testing.T) {
 			wantStatus:      http.StatusOK,
 			wantContentType: "application/json",
 			wantBody:        `{"links":{"self":"/chronograf/v1/organizations/1337"},"id":"1337","name":"The Good Place","defaultRole":"viewer"}`,
+		},
+		{
+			name: "Update Organization default role to reader",
+			args: args{
+				w: httptest.NewRecorder(),
+				r: httptest.NewRequest(
+					"GET",
+					"http://any.url", // can be any valid URL as we are bypassing mux
+					nil,
+				),
+				org: &organizationRequest{
+					DefaultRole: roles.ReaderRoleName,
+				},
+			},
+			fields: fields{
+				Logger: log.New(log.DebugLevel),
+				OrganizationsStore: &mocks.OrganizationsStore{
+					UpdateF: func(ctx context.Context, o *chronograf.Organization) error {
+						return nil
+					},
+					GetF: func(ctx context.Context, q chronograf.OrganizationQuery) (*chronograf.Organization, error) {
+						return &chronograf.Organization{
+							ID:          "1337",
+							Name:        "The Good Place",
+							DefaultRole: roles.MemberRoleName,
+						}, nil
+					},
+				},
+			},
+			id:              "1337",
+			wantStatus:      http.StatusOK,
+			wantContentType: "application/json",
+			wantBody:        `{"links":{"self":"/chronograf/v1/organizations/1337"},"id":"1337","name":"The Good Place","defaultRole":"reader"}`,
 		},
 		{
 			name: "Update Organization - invalid update",

--- a/server/organizations_test.go
+++ b/server/organizations_test.go
@@ -220,10 +220,9 @@ func TestService_UpdateOrganization(t *testing.T) {
 		Logger             chronograf.Logger
 	}
 	type args struct {
-		w      *httptest.ResponseRecorder
-		r      *http.Request
-		org    *organizationRequest
-		setPtr bool
+		w   *httptest.ResponseRecorder
+		r   *http.Request
+		org *organizationRequest
 	}
 	tests := []struct {
 		name            string
@@ -296,7 +295,7 @@ func TestService_UpdateOrganization(t *testing.T) {
 			id:              "1337",
 			wantStatus:      http.StatusUnprocessableEntity,
 			wantContentType: "application/json",
-			wantBody:        `{"code":422,"message":"No fields to update"}`,
+			wantBody:        `{"code":422,"message":"no fields to update"}`,
 		},
 		{
 			name: "Update Organization default role to viewer",
@@ -389,7 +388,7 @@ func TestService_UpdateOrganization(t *testing.T) {
 			id:              "1337",
 			wantStatus:      http.StatusUnprocessableEntity,
 			wantContentType: "application/json",
-			wantBody:        `{"code":422,"message":"No fields to update"}`,
+			wantBody:        `{"code":422,"message":"no fields to update"}`,
 		},
 		{
 			name: "Update Organization - invalid role",

--- a/server/stores.go
+++ b/server/stores.go
@@ -40,7 +40,7 @@ func hasRoleContext(ctx context.Context) (string, bool) {
 		return "", false
 	}
 	switch role {
-	case roles.MemberRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
+	case roles.MemberRoleName, roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName:
 		return role, true
 	default:
 		return "", false

--- a/server/users.go
+++ b/server/users.go
@@ -27,10 +27,10 @@ func (r *userRequest) ValidCreate() error {
 		return fmt.Errorf("Name required on Chronograf User request body")
 	}
 	if r.Provider == "" {
-		return fmt.Errorf("Provider required on Chronograf User request body")
+		return fmt.Errorf("provider required on Chronograf User request body")
 	}
 	if r.Scheme == "" {
-		return fmt.Errorf("Scheme required on Chronograf User request body")
+		return fmt.Errorf("scheme required on Chronograf User request body")
 	}
 
 	// TODO: This Scheme value is hard-coded temporarily since we only currently
@@ -42,7 +42,7 @@ func (r *userRequest) ValidCreate() error {
 
 func (r *userRequest) ValidUpdate() error {
 	if r.Roles == nil {
-		return fmt.Errorf("No Roles to update")
+		return fmt.Errorf("no roles to update")
 	}
 	return r.ValidRoles()
 }
@@ -62,7 +62,7 @@ func (r *userRequest) ValidRoles() error {
 			case roles.MemberRoleName, roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName, roles.WildcardRoleName:
 				continue
 			default:
-				return fmt.Errorf("Unknown role %s. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'", r.Name)
+				return fmt.Errorf("unknown role %s, valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'", r.Name)
 			}
 		}
 	}
@@ -277,17 +277,17 @@ func (s *Service) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	// But currently, it is not possible to change name, provider, or
 	// scheme via the API.
 	if req.Name != "" && req.Name != u.Name {
-		err := fmt.Errorf("Cannot update Name")
+		err := fmt.Errorf("cannot update Name")
 		invalidData(w, err, s.Logger)
 		return
 	}
 	if req.Provider != "" && req.Provider != u.Provider {
-		err := fmt.Errorf("Cannot update Provider")
+		err := fmt.Errorf("cannot update Provider")
 		invalidData(w, err, s.Logger)
 		return
 	}
 	if req.Scheme != "" && req.Scheme != u.Scheme {
-		err := fmt.Errorf("Cannot update Scheme")
+		err := fmt.Errorf("cannot update Scheme")
 		invalidData(w, err, s.Logger)
 		return
 	}
@@ -302,7 +302,7 @@ func (s *Service) UpdateUser(w http.ResponseWriter, r *http.Request) {
 	}
 	// If the user being updated is the user making the request and they are
 	// changing their SuperAdmin status, return an unauthorized error
-	if ctxUser.ID == u.ID && u.SuperAdmin == true && req.SuperAdmin == false {
+	if ctxUser.ID == u.ID && u.SuperAdmin && !req.SuperAdmin {
 		Error(w, http.StatusUnauthorized, "user cannot modify their own SuperAdmin status", s.Logger)
 		return
 	}
@@ -357,7 +357,7 @@ func setSuperAdmin(ctx context.Context, req userRequest, user *chronograf.User) 
 	} else if !isSuperAdmin && (user.SuperAdmin != req.SuperAdmin) {
 		// If req.SuperAdmin has been set, and the request was not made with the SuperAdmin
 		// context, return error
-		return fmt.Errorf("User does not have authorization required to set SuperAdmin status. See https://github.com/influxdata/chronograf/issues/2601 for more information.")
+		return fmt.Errorf("user does not have authorization required to set SuperAdmin status, see https://github.com/influxdata/chronograf/issues/2601 for more information")
 	}
 
 	return nil

--- a/server/users.go
+++ b/server/users.go
@@ -59,10 +59,10 @@ func (r *userRequest) ValidRoles() error {
 			}
 			orgs[r.Organization] = true
 			switch r.Name {
-			case roles.MemberRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName, roles.WildcardRoleName:
+			case roles.MemberRoleName, roles.ReaderRoleName, roles.ViewerRoleName, roles.EditorRoleName, roles.AdminRoleName, roles.WildcardRoleName:
 				continue
 			default:
-				return fmt.Errorf("Unknown role %s. Valid roles are 'member', 'viewer', 'editor', 'admin', and '*'", r.Name)
+				return fmt.Errorf("Unknown role %s. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'", r.Name)
 			}
 		}
 	}

--- a/server/users_test.go
+++ b/server/users_test.go
@@ -1702,7 +1702,7 @@ func TestUserRequest_ValidCreate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BilliettaSpecialRole. Valid roles are 'member', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("Unknown role BilliettaSpecialRole. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Invalid roles - missing organization",
@@ -1792,7 +1792,7 @@ func TestUserRequest_ValidUpdate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Valid – roles empty",
@@ -1824,7 +1824,7 @@ func TestUserRequest_ValidUpdate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Invalid - duplicate organization",

--- a/server/users_test.go
+++ b/server/users_test.go
@@ -376,7 +376,7 @@ func TestService_NewUser(t *testing.T) {
 			},
 			wantStatus:      http.StatusUnauthorized,
 			wantContentType: "application/json",
-			wantBody:        `{"code":401,"message":"User does not have authorization required to set SuperAdmin status. See https://github.com/influxdata/chronograf/issues/2601 for more information."}`,
+			wantBody:        `{"code":401,"message":"user does not have authorization required to set SuperAdmin status, see https://github.com/influxdata/chronograf/issues/2601 for more information"}`,
 		},
 		{
 			name: "Create a new SuperAdmin User - as superadmin",
@@ -1361,7 +1361,7 @@ func TestService_UpdateUser(t *testing.T) {
 			id:              "1336",
 			wantStatus:      http.StatusUnauthorized,
 			wantContentType: "application/json",
-			wantBody:        `{"code":401,"message":"User does not have authorization required to set SuperAdmin status. See https://github.com/influxdata/chronograf/issues/2601 for more information."}`,
+			wantBody:        `{"code":401,"message":"user does not have authorization required to set SuperAdmin status, see https://github.com/influxdata/chronograf/issues/2601 for more information"}`,
 		},
 		{
 			name: "Update a Chronograf user to super admin - with super admin context",
@@ -1665,7 +1665,7 @@ func TestUserRequest_ValidCreate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Provider required on Chronograf User request body"),
+			err:     fmt.Errorf("provider required on Chronograf User request body"),
 		},
 		{
 			name: "Invalid – Scheme missing",
@@ -1683,7 +1683,7 @@ func TestUserRequest_ValidCreate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Scheme required on Chronograf User request body"),
+			err:     fmt.Errorf("scheme required on Chronograf User request body"),
 		},
 		{
 			name: "Invalid roles - bad role name",
@@ -1702,7 +1702,7 @@ func TestUserRequest_ValidCreate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BilliettaSpecialRole. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("unknown role BilliettaSpecialRole, valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Invalid roles - missing organization",
@@ -1773,7 +1773,7 @@ func TestUserRequest_ValidUpdate(t *testing.T) {
 				u: &userRequest{},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("No Roles to update"),
+			err:     fmt.Errorf("no roles to update"),
 		},
 		{
 			name: "Invalid - bad role name",
@@ -1792,7 +1792,7 @@ func TestUserRequest_ValidUpdate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("unknown role BillietaSpecialOrg, valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Valid – roles empty",
@@ -1824,7 +1824,7 @@ func TestUserRequest_ValidUpdate(t *testing.T) {
 				},
 			},
 			wantErr: true,
-			err:     fmt.Errorf("Unknown role BillietaSpecialOrg. Valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
+			err:     fmt.Errorf("unknown role BillietaSpecialOrg, valid roles are 'member', 'reader', 'viewer', 'editor', 'admin', and '*'"),
 		},
 		{
 			name: "Invalid - duplicate organization",

--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -9,3 +9,5 @@ log/
 yarn-error.log
 .cache/
 build/
+results/
+screenshots/

--- a/ui/cypress/integration/welcome.test.ts
+++ b/ui/cypress/integration/welcome.test.ts
@@ -10,7 +10,9 @@ describe('Welcome Page', () => {
     cy.get('[id="Connection Name"]').clear().type(Cypress.env('connectionName'))
     cy.get('[id="Username"]').clear().type(Cypress.env('username'))
     cy.get('[id="Password"]').clear().type(Cypress.env('password'))
-    cy.get('.wizard-checkbox--label').contains('Unsafe SSL').click()
+    if (Cypress.env('url').startsWith('https')){
+      cy.get('.wizard-checkbox--label').contains('Unsafe SSL').click()
+    }
 
     cy.get('.wizard-button-bar').within(() => {
       cy.get('button').contains('Add Connection').click()

--- a/ui/dist.go
+++ b/ui/dist.go
@@ -1,12 +1,15 @@
 package ui
 
 import (
+	"crypto/sha1"
 	"embed"
-	"fmt"
+	"encoding/base64"
+	"io"
 	"io/fs"
 	"net/http"
 	"regexp"
 	"strings"
+	"sync"
 )
 
 const (
@@ -19,6 +22,7 @@ const (
 //go:embed build/*
 var embeddedFS embed.FS
 var buildDir fs.FS
+var fileETags sync.Map
 
 //go:embed package.json
 var packageJson string
@@ -59,22 +63,34 @@ func (b *BindataAssets) Handler() http.Handler {
 }
 
 // addCacheHeaders requests an hour of Cache-Control and sets an ETag based on file size and modtime
-func addCacheHeaders(file fs.File, headers http.Header) error {
-	fi, err := file.Stat()
-	if err == nil {
-		headers.Add("Cache-Control", "public, max-age=3600")
+func addCacheHeaders(name string, headers http.Header) error {
+	headers.Set("Cache-Control", "public, max-age=3600")
+	headers.Set("X-Frame-Options", "SAMEORIGIN")
+	headers.Set("X-XSS-Protection", "1; mode=block")
+	headers.Set("X-Content-Type-Options", "nosniff")
+	headers.Set("Content-Security-Policy", "script-src 'self'; object-src 'self'")
 
-		headers.Add("X-Frame-Options", "SAMEORIGIN")
-		headers.Add("X-XSS-Protection", "1; mode=block")
-		headers.Add("X-Content-Type-Options", "nosniff")
-		headers.Add("Content-Security-Policy", "script-src 'self'; object-src 'self'")
+	// go embed does not include real Stat().ModTime to make ETag computation simple
+	// see https://github.com/golang/go/issues/43223
+	// as a workaround, compute ETag from file contents cand cache it
 
-		hour, minute, second := fi.ModTime().Clock()
-		etag := fmt.Sprintf(`"%d%d%d%d%d"`, fi.Size(), fi.ModTime().Day(), hour, minute, second)
-
+	if etag, found := fileETags.Load(name); found {
+		headers.Set("ETag", etag.(string))
+		return nil
+	}
+	// compute and store SHA1 digest of file contents as an ETag
+	hash := sha1.New()
+	if input, err := buildDir.Open(name); err != nil {
+		return err
+	} else {
+		if _, err := io.Copy(hash, input); err != nil {
+			return err
+		}
+		etag := base64.StdEncoding.EncodeToString(hash.Sum(nil))
+		fileETags.Store(name, etag)
 		headers.Set("ETag", etag)
 	}
-	return err
+	return nil
 }
 
 // ServeHTTP wraps http.FileServer by returning a default asset if the asset
@@ -98,13 +114,14 @@ func (b *BindataAssets) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			// Additionally, because we know we are returning the default asset,
 			// we need to set the default asset's content-type.
 			w.Header().Set("Content-Type", DefaultPageContentType)
-			defaultFile, err := buildDir.Open(DefaultPage)
+			name = DefaultPage
+			defaultFile, err := buildDir.Open(name)
 			if err != nil {
 				return nil, err
 			}
 			file = defaultFile
 		}
-		if err := addCacheHeaders(file, w.Header()); err != nil {
+		if err := addCacheHeaders(name, w.Header()); err != nil {
 			return nil, err
 		}
 		// https://github.com/influxdata/chronograf/issues/5565

--- a/ui/src/CheckSources.tsx
+++ b/ui/src/CheckSources.tsx
@@ -14,7 +14,7 @@ import {
   READER_ROLE,
   EDITOR_ROLE,
   ADMIN_ROLE,
-} from 'src/auth/Authorized'
+} from 'src/auth/roles'
 
 import {getSourceHealth} from 'src/sources/apis'
 import {getSourcesAsync} from 'src/shared/actions/sources'

--- a/ui/src/CheckSources.tsx
+++ b/ui/src/CheckSources.tsx
@@ -11,7 +11,7 @@ import PageSpinner from 'src/shared/components/PageSpinner'
 
 import {
   isUserAuthorized,
-  VIEWER_ROLE,
+  READER_ROLE,
   EDITOR_ROLE,
   ADMIN_ROLE,
 } from 'src/auth/Authorized'
@@ -90,7 +90,7 @@ export class CheckSources extends Component<Props, State> {
       router,
       auth: {isUsingAuth, me},
     } = this.props
-    if (!isUsingAuth || isUserAuthorized(me.role, VIEWER_ROLE)) {
+    if (!isUsingAuth || isUserAuthorized(me.role, READER_ROLE)) {
       await this.props.getSources()
       this.setState({isFetching: false})
     } else {
@@ -150,7 +150,7 @@ export class CheckSources extends Component<Props, State> {
       return router.push('/purgatory')
     }
 
-    if (!isFetching && isUsingAuth && !isUserAuthorized(me.role, VIEWER_ROLE)) {
+    if (!isFetching && isUsingAuth && !isUserAuthorized(me.role, READER_ROLE)) {
       // if you're a member, go to purgatory.
       return router.push('/purgatory')
     }
@@ -159,17 +159,25 @@ export class CheckSources extends Component<Props, State> {
     // Do we need to refresh this data more frequently? Does it need to come as frequently as the `me` response?
     if (!isFetching && !source) {
       const rest = location.pathname.match(/\/sources\/\d+?\/(.+)/)
-      const restString = rest === null ? DEFAULT_HOME_PAGE : rest[1]
+      let restString = rest === null ? DEFAULT_HOME_PAGE : rest[1]
 
-      if (isUsingAuth && !isUserAuthorized(me.role, EDITOR_ROLE)) {
-        if (defaultSource) {
-          return router.push(`/sources/${defaultSource.id}/${restString}`)
-        } else if (sources[0]) {
-          return router.push(`/sources/${sources[0].id}/${restString}`)
+      if (isUsingAuth) {
+        if (!isUserAuthorized(me.role, EDITOR_ROLE)) {
+          if (me.role === READER_ROLE) {
+            // reader role can only read dashboards
+            if (!restString.startsWith('dashboards')) {
+              restString = 'dashboards'
+            }
+          }
+          if (defaultSource) {
+            return router.push(`/sources/${defaultSource.id}/${restString}`)
+          } else if (sources[0]) {
+            return router.push(`/sources/${sources[0].id}/${restString}`)
+          }
+          // if you're a viewer and there are no sources, go to purgatory.
+          notify(copy.notifyOrgHasNoSources())
+          return router.push('/purgatory')
         }
-        // if you're a viewer and there are no sources, go to purgatory.
-        notify(copy.notifyOrgHasNoSources())
-        return router.push('/purgatory')
       }
 
       // if you're an editor or not using auth, try for sources or otherwise

--- a/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
+++ b/ui/src/admin/components/chronograf/OrganizationsTableRowNew.js
@@ -5,7 +5,7 @@ import ConfirmOrCancel from 'shared/components/ConfirmOrCancel'
 import Dropdown from 'shared/components/Dropdown'
 
 import {USER_ROLES} from 'src/admin/constants/chronografAdmin'
-import {MEMBER_ROLE} from 'src/auth/Authorized'
+import {MEMBER_ROLE} from 'src/auth/roles'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 class OrganizationsTableRowNew extends Component {

--- a/ui/src/admin/constants/chronografAdmin.js
+++ b/ui/src/admin/constants/chronografAdmin.js
@@ -4,7 +4,7 @@ import {
   EDITOR_ROLE,
   READER_ROLE,
   ADMIN_ROLE,
-} from 'src/auth/Authorized'
+} from 'src/auth/roles'
 
 export const USER_ROLES = [
   {name: MEMBER_ROLE},

--- a/ui/src/admin/constants/chronografAdmin.js
+++ b/ui/src/admin/constants/chronografAdmin.js
@@ -2,11 +2,13 @@ import {
   MEMBER_ROLE,
   VIEWER_ROLE,
   EDITOR_ROLE,
+  READER_ROLE,
   ADMIN_ROLE,
 } from 'src/auth/Authorized'
 
 export const USER_ROLES = [
   {name: MEMBER_ROLE},
+  {name: READER_ROLE},
   {name: VIEWER_ROLE},
   {name: EDITOR_ROLE},
   {name: ADMIN_ROLE},

--- a/ui/src/admin/containers/chronograf/AdminChronografPage.js
+++ b/ui/src/admin/containers/chronograf/AdminChronografPage.js
@@ -10,11 +10,7 @@ import AllUsersPage from 'src/admin/containers/chronograf/AllUsersPage'
 import OrganizationsPage from 'src/admin/containers/chronograf/OrganizationsPage'
 import ProvidersPage from 'src/admin/containers/ProvidersPage'
 
-import {
-  isUserAuthorized,
-  ADMIN_ROLE,
-  SUPERADMIN_ROLE,
-} from 'src/auth/Authorized'
+import {isUserAuthorized, ADMIN_ROLE, SUPERADMIN_ROLE} from 'src/auth/roles'
 
 const sections = me => [
   {

--- a/ui/src/auth/Authorized.js
+++ b/ui/src/auth/Authorized.js
@@ -3,46 +3,16 @@ import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 
-export const MEMBER_ROLE = 'member'
-export const READER_ROLE = 'reader'
-export const VIEWER_ROLE = 'viewer'
-export const EDITOR_ROLE = 'editor'
-export const ADMIN_ROLE = 'admin'
-export const SUPERADMIN_ROLE = 'superadmin'
-
-export const isUserAuthorized = (meRole, requiredRole) => {
-  switch (requiredRole) {
-    case READER_ROLE:
-      return (
-        meRole === READER_ROLE ||
-        meRole === VIEWER_ROLE ||
-        meRole === EDITOR_ROLE ||
-        meRole === ADMIN_ROLE ||
-        meRole === SUPERADMIN_ROLE
-      )
-    case VIEWER_ROLE:
-      return (
-        meRole === VIEWER_ROLE ||
-        meRole === EDITOR_ROLE ||
-        meRole === ADMIN_ROLE ||
-        meRole === SUPERADMIN_ROLE
-      )
-    case EDITOR_ROLE:
-      return (
-        meRole === EDITOR_ROLE ||
-        meRole === ADMIN_ROLE ||
-        meRole === SUPERADMIN_ROLE
-      )
-    case ADMIN_ROLE:
-      return meRole === ADMIN_ROLE || meRole === SUPERADMIN_ROLE
-    case SUPERADMIN_ROLE:
-      return meRole === SUPERADMIN_ROLE
-    // 'member' is the default role and has no authorization for anything currently
-    case MEMBER_ROLE:
-    default:
-      return false
-  }
-}
+import {isUserAuthorized} from './roles'
+export {
+  isUserAuthorized,
+  MEMBER_ROLE,
+  READER_ROLE,
+  VIEWER_ROLE,
+  EDITOR_ROLE,
+  ADMIN_ROLE,
+  SUPERADMIN_ROLE,
+} from './roles'
 
 class Authorized extends Component {
   UNSAFE_componentWillUpdate() {

--- a/ui/src/auth/Authorized.js
+++ b/ui/src/auth/Authorized.js
@@ -4,6 +4,7 @@ import {connect} from 'react-redux'
 import {withRouter} from 'react-router'
 
 export const MEMBER_ROLE = 'member'
+export const READER_ROLE = 'reader'
 export const VIEWER_ROLE = 'viewer'
 export const EDITOR_ROLE = 'editor'
 export const ADMIN_ROLE = 'admin'

--- a/ui/src/auth/Authorized.js
+++ b/ui/src/auth/Authorized.js
@@ -12,6 +12,14 @@ export const SUPERADMIN_ROLE = 'superadmin'
 
 export const isUserAuthorized = (meRole, requiredRole) => {
   switch (requiredRole) {
+    case READER_ROLE:
+      return (
+        meRole === READER_ROLE ||
+        meRole === VIEWER_ROLE ||
+        meRole === EDITOR_ROLE ||
+        meRole === ADMIN_ROLE ||
+        meRole === SUPERADMIN_ROLE
+      )
     case VIEWER_ROLE:
       return (
         meRole === VIEWER_ROLE ||

--- a/ui/src/auth/Landing.tsx
+++ b/ui/src/auth/Landing.tsx
@@ -1,0 +1,9 @@
+import {useRedirectPath} from './Login'
+
+// landing page is used after successful OAuth2 authentication
+const Landing = ({router}) => {
+  const redirectPage = useRedirectPath() || '/'
+  return router.push(redirectPage)
+}
+
+export default Landing

--- a/ui/src/auth/LandingPage.tsx
+++ b/ui/src/auth/LandingPage.tsx
@@ -1,9 +1,9 @@
 import {useRedirectPath} from './Login'
 
 // landing page is used after successful OAuth2 authentication
-const Landing = ({router}) => {
+const LandingPage = ({router}) => {
   const redirectPage = useRedirectPath() || '/'
   return router.push(redirectPage)
 }
 
-export default Landing
+export default LandingPage

--- a/ui/src/auth/LandingPage.tsx
+++ b/ui/src/auth/LandingPage.tsx
@@ -1,9 +1,11 @@
+import {useEffect} from 'react'
 import {useRedirectPath} from './Login'
 
 // landing page is used after successful OAuth2 authentication
 const LandingPage = ({router}) => {
   const redirectPage = useRedirectPath() || '/'
-  return router.push(redirectPage)
+  useEffect(() => router.push(redirectPage), [])
+  return null
 }
 
 export default LandingPage

--- a/ui/src/auth/LandingPage.tsx
+++ b/ui/src/auth/LandingPage.tsx
@@ -3,8 +3,7 @@ import {useRedirectPath} from './Login'
 
 // landing page is used after successful OAuth2 authentication
 const LandingPage = ({router}) => {
-  const redirectPage = useRedirectPath() || '/'
-  useEffect(() => router.push(redirectPage), [])
+  useEffect(() => router.push(useRedirectPath()), [])
   return null
 }
 

--- a/ui/src/auth/Login.js
+++ b/ui/src/auth/Login.js
@@ -21,14 +21,15 @@ function storeRedirectPath() {
 }
 
 export function useRedirectPath() {
+  let retVal
   try {
-    const retVal = window.localStorage.getItem(REDIRECT_KEY)
+    retVal = window.localStorage.getItem(REDIRECT_KEY)
     window.localStorage.removeItem(REDIRECT_KEY)
-    return retVal
   } catch (e) {
-    // return no redirect path if locastorage is not available
-    return ''
+    // localStorage is not available, use default
   }
+  // return redirect to localStorage page or root page
+  return retVal || '/'
 }
 
 const Login = ({auth}) => {

--- a/ui/src/auth/Login.js
+++ b/ui/src/auth/Login.js
@@ -8,6 +8,28 @@ import SplashPage from 'shared/components/SplashPage'
 import {connect} from 'react-redux'
 
 const VERSION = process.env.npm_package_version
+const REDIRECT_KEY = 'chronoRedirect'
+
+function storeRedirectPath() {
+  try {
+    const url = new URL(window.location.href)
+    const redirect = url.searchParams.get('redirect')
+    window.localStorage.setItem(REDIRECT_KEY, redirect || '')
+  } catch (e) {
+    // will perform default redirect if localStorage is not available
+  }
+}
+
+export function useRedirectPath() {
+  try {
+    const retVal = window.localStorage.getItem(REDIRECT_KEY)
+    window.localStorage.removeItem(REDIRECT_KEY)
+    return retVal
+  } catch (e) {
+    // return no redirect path if locastorage is not available
+    return ''
+  }
+}
 
 const Login = ({auth}) => {
   if (
@@ -21,6 +43,7 @@ const Login = ({auth}) => {
   if (auth.isAuthLoading) {
     return <PageSpinner />
   }
+  storeRedirectPath()
 
   return (
     <div>

--- a/ui/src/auth/PurgatoryAuthItem.js
+++ b/ui/src/auth/PurgatoryAuthItem.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import {isUserAuthorized, READER_ROLE} from 'src/auth/Authorized'
+import {isUserAuthorized, READER_ROLE} from 'src/auth/roles'
 
 const PurgatoryAuthItem = ({roleAndOrg, onClickLogin, superAdmin}) => (
   <div

--- a/ui/src/auth/PurgatoryAuthItem.js
+++ b/ui/src/auth/PurgatoryAuthItem.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import {isUserAuthorized, VIEWER_ROLE} from 'src/auth/Authorized'
+import {isUserAuthorized, READER_ROLE} from 'src/auth/Authorized'
 
 const PurgatoryAuthItem = ({roleAndOrg, onClickLogin, superAdmin}) => (
   <div
@@ -15,7 +15,7 @@ const PurgatoryAuthItem = ({roleAndOrg, onClickLogin, superAdmin}) => (
       <div className="auth--list-org">{roleAndOrg.organization.name}</div>
       <div className="auth--list-role">{roleAndOrg.role}</div>
     </div>
-    {superAdmin || isUserAuthorized(roleAndOrg.role, VIEWER_ROLE) ? (
+    {superAdmin || isUserAuthorized(roleAndOrg.role, READER_ROLE) ? (
       <button
         className="btn btn-sm btn-primary"
         onClick={onClickLogin(roleAndOrg.organization)}

--- a/ui/src/auth/roles.js
+++ b/ui/src/auth/roles.js
@@ -1,0 +1,40 @@
+export const MEMBER_ROLE = 'member'
+export const READER_ROLE = 'reader'
+export const VIEWER_ROLE = 'viewer'
+export const EDITOR_ROLE = 'editor'
+export const ADMIN_ROLE = 'admin'
+export const SUPERADMIN_ROLE = 'superadmin'
+
+export const isUserAuthorized = (meRole, requiredRole) => {
+  switch (requiredRole) {
+    case READER_ROLE:
+      return (
+        meRole === READER_ROLE ||
+        meRole === VIEWER_ROLE ||
+        meRole === EDITOR_ROLE ||
+        meRole === ADMIN_ROLE ||
+        meRole === SUPERADMIN_ROLE
+      )
+    case VIEWER_ROLE:
+      return (
+        meRole === VIEWER_ROLE ||
+        meRole === EDITOR_ROLE ||
+        meRole === ADMIN_ROLE ||
+        meRole === SUPERADMIN_ROLE
+      )
+    case EDITOR_ROLE:
+      return (
+        meRole === EDITOR_ROLE ||
+        meRole === ADMIN_ROLE ||
+        meRole === SUPERADMIN_ROLE
+      )
+    case ADMIN_ROLE:
+      return meRole === ADMIN_ROLE || meRole === SUPERADMIN_ROLE
+    case SUPERADMIN_ROLE:
+      return meRole === SUPERADMIN_ROLE
+    // 'member' is the default role and has no authorization for anything currently
+    case MEMBER_ROLE:
+    default:
+      return false
+  }
+}

--- a/ui/src/dashboards/components/DashboardHeader.tsx
+++ b/ui/src/dashboards/components/DashboardHeader.tsx
@@ -54,6 +54,7 @@ interface Props {
   onRenameDashboard: (name: string) => Promise<void>
   dashboardLinks: DashboardsModels.DashboardSwitcherLinks
   isHidden: boolean
+  children?: JSX.Element
 }
 
 @ErrorHandling
@@ -105,6 +106,7 @@ class DashboardHeader extends Component<Props, State> {
       onSetTimeZone,
       onManualRefresh,
       handleChooseAutoRefresh,
+      children,
     } = this.props
     const {selected} = this.state
 
@@ -134,6 +136,7 @@ class DashboardHeader extends Component<Props, State> {
             shape={ButtonShape.Square}
             titleText="Enter Full-Screen Presentation Mode"
           />
+          {children}
         </Page.Header.Right>
       </Page.Header>
     )

--- a/ui/src/dashboards/containers/DashboardPage.tsx
+++ b/ui/src/dashboards/containers/DashboardPage.tsx
@@ -59,10 +59,18 @@ import * as QueriesModels from 'src/types/queries'
 import * as SourcesModels from 'src/types/sources'
 import * as TempVarsModels from 'src/types/tempVars'
 import {NewDefaultCell} from 'src/types/dashboards'
-import {NotificationAction, TimeZones, RefreshRate} from 'src/types'
+import {
+  NotificationAction,
+  TimeZones,
+  RefreshRate,
+  Me,
+  Links as CommonLinks,
+} from 'src/types'
 import {AnnotationsDisplaySetting} from 'src/types/annotations'
 import {Links} from 'src/types/flux'
 import {createTimeRangeTemplates} from 'src/shared/utils/templates'
+import UserNavBlock from 'src/side_nav/components/UserNavBlock'
+import {READER_ROLE} from 'src/auth/Authorized'
 
 interface OwnProps extends ManualRefreshProps, WithRouterProps {
   source: SourcesModels.Source
@@ -119,6 +127,9 @@ type ReduxDispatchProps = ResolveThunks<{
   updateTemplateQueryParams: typeof dashboardActions.updateTemplateQueryParams
   updateQueryParams: typeof dashboardActions.updateQueryParams
   updateTimeRangeQueryParams: typeof dashboardActions.updateTimeRangeQueryParams
+  logoutLink?: string
+  me: Me
+  links: CommonLinks
 }>
 
 type Props = OwnProps & ReduxStateProps & ReduxDispatchProps
@@ -270,6 +281,9 @@ class DashboardPage extends Component<Props, State> {
       showTemplateVariableControlBar,
       handleClickPresentationButton,
       toggleTemplateVariableControlBar,
+      me,
+      logoutLink,
+      links,
     } = this.props
 
     const {dashboardTime, upperDashboardTime} = createTimeRangeTemplates(
@@ -335,7 +349,16 @@ class DashboardPage extends Component<Props, State> {
           onToggleShowTempVarControls={toggleTemplateVariableControlBar}
           onToggleShowAnnotationControls={this.toggleAnnotationControls}
           handleClickPresentationButton={handleClickPresentationButton}
-        />
+        >
+          {isUsingAuth && me.role === READER_ROLE ? (
+            <UserNavBlock
+              logoutLink={logoutLink}
+              links={links}
+              me={me}
+              header={true}
+            />
+          ) : undefined}
+        </DashboardHeader>
         {!inPresentationMode && showTemplateVariableControlBar && (
           <TemplateControlBar
             templates={dashboard && dashboard.templates}
@@ -600,7 +623,7 @@ const mstp = (state: any, {params: {dashboardID}}) => {
     annotations: {displaySetting},
     dashboardUI: {dashboards, cellQueryStatuses, zoomedTimeRange},
     sources,
-    auth: {me, isUsingAuth},
+    auth: {me, isUsingAuth, logoutLink},
     cellEditorOverlay: {timeRange: editorTimeRange},
   } = state
 
@@ -628,7 +651,10 @@ const mstp = (state: any, {params: {dashboardID}}) => {
     editorTimeRange,
     showTemplateVariableControlBar,
     annotationsDisplaySetting: displaySetting,
-  } as ReduxStateProps
+    logoutLink,
+    me,
+    links,
+  }
 }
 
 const mdtp = {

--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -31,9 +31,11 @@ import {
   notifyDashboardExportFailed,
 } from 'src/shared/copy/notifications'
 
-import {Source, Dashboard, RemoteDataState} from 'src/types'
+import {Source, Dashboard, RemoteDataState, Links, Me} from 'src/types'
 import {Notification} from 'src/types/notifications'
 import {DashboardFile, Cell} from 'src/types/dashboards'
+import UserNavBlock from 'src/side_nav/components/UserNavBlock'
+import {READER_ROLE} from 'src/auth/Authorized'
 
 export interface Props extends WithRouterProps {
   source: Source
@@ -48,6 +50,10 @@ export interface Props extends WithRouterProps {
   retainRangesDashTimeV1: (dashboardIDs: number[]) => void
   retainDashRefresh: (dashboardIDs: number[]) => void
   dashboards: Dashboard[]
+  isUsingAuth: boolean
+  logoutLink?: string
+  links?: Links
+  me: Me
 }
 
 interface State {
@@ -81,7 +87,16 @@ export class DashboardsPage extends PureComponent<Props, State> {
   }
 
   public render() {
-    const {dashboards, notify, sources, source} = this.props
+    const {
+      dashboards,
+      notify,
+      sources,
+      source,
+      isUsingAuth,
+      me,
+      logoutLink,
+      links,
+    } = this.props
     const {dashboardsStatus} = this.state
     const dashboardLink = `/sources/${this.props.source.id}`
 
@@ -91,7 +106,17 @@ export class DashboardsPage extends PureComponent<Props, State> {
           <Page.Header.Left>
             <Page.Title title="Dashboards" />
           </Page.Header.Left>
-          <Page.Header.Right showSourceIndicator={true} />
+          <Page.Header.Right showSourceIndicator={true}>
+            {isUsingAuth && me.role === READER_ROLE ? (
+              <UserNavBlock
+                logoutLink={logoutLink}
+                links={links}
+                me={me}
+                sourcePrefix={`/sources/${source?.id}`}
+                header={true}
+              />
+            ) : undefined}
+          </Page.Header.Right>
         </Page.Header>
         <Page.Contents>
           <DashboardsContents
@@ -187,10 +212,16 @@ export class DashboardsPage extends PureComponent<Props, State> {
 const mapStateToProps = ({
   dashboardUI: {dashboards, dashboard},
   sources,
+  auth: {isUsingAuth, logoutLink, me},
+  links,
 }): Partial<Props> => ({
   dashboards,
   dashboard,
   sources,
+  isUsingAuth,
+  logoutLink,
+  me,
+  links,
 })
 
 const mapDispatchToProps = {

--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -112,7 +112,6 @@ export class DashboardsPage extends PureComponent<Props, State> {
                 logoutLink={logoutLink}
                 links={links}
                 me={me}
-                sourcePrefix={`/sources/${source?.id}`}
                 header={true}
               />
             ) : undefined}

--- a/ui/src/dashboards/containers/DashboardsPage.tsx
+++ b/ui/src/dashboards/containers/DashboardsPage.tsx
@@ -35,7 +35,7 @@ import {Source, Dashboard, RemoteDataState, Links, Me} from 'src/types'
 import {Notification} from 'src/types/notifications'
 import {DashboardFile, Cell} from 'src/types/dashboards'
 import UserNavBlock from 'src/side_nav/components/UserNavBlock'
-import {READER_ROLE} from 'src/auth/Authorized'
+import {READER_ROLE} from 'src/auth/roles'
 
 export interface Props extends WithRouterProps {
   source: Source

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -39,6 +39,7 @@ import {
 } from 'src/kapacitor'
 import {AdminChronografPage, AdminInfluxDBPage} from 'src/admin'
 import {ManageSources, OnboardingWizard} from 'src/sources'
+import LandingPage from './auth/LandingPage'
 
 import NotFound from 'src/shared/components/NotFound'
 import PageSpinner from 'src/shared/components/PageSpinner'
@@ -59,7 +60,6 @@ import {HEARTBEAT_INTERVAL} from 'src/shared/constants'
 
 import * as ErrorsModels from 'src/types/errors'
 import {setCustomAutoRefreshOptions} from './shared/components/dropdown_auto_refresh/autoRefreshOptions'
-import Landing from './auth/Landing'
 
 const errorsQueue = []
 
@@ -156,7 +156,10 @@ class Root extends PureComponent<Record<string, never>, State> {
         <TimeMachineContextProvider>
           <Router history={history}>
             <Route path="/" component={UserIsAuthenticated(CheckSources)} />
-            <Route path="/landing" component={UserIsAuthenticated(Landing)} />
+            <Route
+              path="/landing"
+              component={UserIsAuthenticated(LandingPage)}
+            />
             <Route path="/login" component={UserIsNotAuthenticated(Login)} />
             <Route
               path="/purgatory"

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -59,6 +59,7 @@ import {HEARTBEAT_INTERVAL} from 'src/shared/constants'
 
 import * as ErrorsModels from 'src/types/errors'
 import {setCustomAutoRefreshOptions} from './shared/components/dropdown_auto_refresh/autoRefreshOptions'
+import Landing from './auth/Landing'
 
 const errorsQueue = []
 
@@ -155,6 +156,7 @@ class Root extends PureComponent<Record<string, never>, State> {
         <TimeMachineContextProvider>
           <Router history={history}>
             <Route path="/" component={UserIsAuthenticated(CheckSources)} />
+            <Route path="/landing" component={UserIsAuthenticated(Landing)} />
             <Route path="/login" component={UserIsNotAuthenticated(Login)} />
             <Route
               path="/purgatory"

--- a/ui/src/shared/components/AddAnnotationToggle.tsx
+++ b/ui/src/shared/components/AddAnnotationToggle.tsx
@@ -1,5 +1,6 @@
 import React, {FunctionComponent} from 'react'
 import {connect} from 'react-redux'
+import {isUserAuthorized, VIEWER_ROLE} from 'src/auth/roles'
 
 import {Button, ComponentColor, IconFont} from 'src/reusable_ui'
 
@@ -9,9 +10,12 @@ import {
 } from 'src/shared/actions/annotations'
 
 import {ADDING} from 'src/shared/annotations/helpers'
+import {Me} from 'src/types'
 
 interface Props {
   isAddingAnnotation: boolean
+  isUsingAuth: boolean
+  me: Me
   onAddingAnnotation: typeof addingAnnotation
   onDismissAddingAnnotation: typeof dismissAddingAnnotation
 }
@@ -21,7 +25,13 @@ const AddAnnotationToggle: FunctionComponent<Props> = props => {
     isAddingAnnotation,
     onAddingAnnotation,
     onDismissAddingAnnotation,
+    isUsingAuth,
+    me,
   } = props
+
+  if (isUsingAuth && !isUserAuthorized(me.role, VIEWER_ROLE)) {
+    return null
+  }
 
   let onToggle
   let buttonContent = 'Annotate'
@@ -47,8 +57,10 @@ const AddAnnotationToggle: FunctionComponent<Props> = props => {
   )
 }
 
-const mstp = ({annotations: {mode}}) => ({
+const mstp = ({auth: {isUsingAuth, me}, annotations: {mode}}) => ({
   isAddingAnnotation: mode === ADDING,
+  isUsingAuth,
+  me,
 })
 
 const mdtp = {

--- a/ui/src/shared/components/AnnotationTooltip.tsx
+++ b/ui/src/shared/components/AnnotationTooltip.tsx
@@ -63,7 +63,7 @@ const AnnotationTooltip: FunctionComponent<Props> = props => {
         <div className="annotation-tooltip--items">
           <div className="annotation-tooltip-text">
             {annotation.text}
-            {isUsingAuth && isUserAuthorized(me, VIEWER_ROLE) ? (
+            {!isUsingAuth || isUserAuthorized(me, VIEWER_ROLE) ? (
               <span
                 className="annotation-tooltip--edit icon pencil"
                 onClick={setEditing}

--- a/ui/src/shared/components/AnnotationTooltip.tsx
+++ b/ui/src/shared/components/AnnotationTooltip.tsx
@@ -6,7 +6,8 @@ import classnames from 'classnames'
 import AnnotationTagsDropdown from 'src/shared/components/AnnotationTagsDropdown'
 import {setEditingAnnotation} from 'src/shared/actions/annotations'
 
-import {Annotation} from 'src/types'
+import {Annotation, Me} from 'src/types'
+import {isUserAuthorized, VIEWER_ROLE} from 'src/auth/roles'
 
 interface TimeStampProps {
   time: number
@@ -24,6 +25,8 @@ interface AnnotationState {
 }
 
 interface Props {
+  isUsingAuth: boolean
+  me: Me
   annotation: Annotation
   timestamp: number
   onMouseLeave: (e: MouseEvent<HTMLDivElement>) => void
@@ -38,6 +41,8 @@ const AnnotationTooltip: FunctionComponent<Props> = props => {
     timestamp,
     annotationState: {isDragging, isMouseOver},
     onSetEditingAnnotation,
+    isUsingAuth,
+    me,
   } = props
 
   const tooltipClass = classnames('annotation-tooltip', {
@@ -58,10 +63,12 @@ const AnnotationTooltip: FunctionComponent<Props> = props => {
         <div className="annotation-tooltip--items">
           <div className="annotation-tooltip-text">
             {annotation.text}
-            <span
-              className="annotation-tooltip--edit icon pencil"
-              onClick={setEditing}
-            />
+            {isUsingAuth && isUserAuthorized(me, VIEWER_ROLE) ? (
+              <span
+                className="annotation-tooltip--edit icon pencil"
+                onClick={setEditing}
+              />
+            ) : null}
           </div>
           <div className="annotation-tooltip--lower">
             <TimeStamp time={timestamp} />
@@ -75,8 +82,12 @@ const AnnotationTooltip: FunctionComponent<Props> = props => {
   )
 }
 
+const mstp = ({auth: {isUsingAuth, me}}) => ({
+  isUsingAuth,
+  me,
+})
 const mdtp = {
   onSetEditingAnnotation: setEditingAnnotation,
 }
 
-export default connect(null, mdtp)(AnnotationTooltip)
+export default connect(mstp, mdtp)(AnnotationTooltip)

--- a/ui/src/shared/reducers/helpers/auth.ts
+++ b/ui/src/shared/reducers/helpers/auth.ts
@@ -1,6 +1,6 @@
 import _ from 'lodash'
 
-import {SUPERADMIN_ROLE, MEMBER_ROLE} from 'src/auth/Authorized'
+import {SUPERADMIN_ROLE, MEMBER_ROLE} from 'src/auth/roles'
 import {Me} from 'src/types/auth'
 
 export const getMeRole = (me: Me): string => {

--- a/ui/src/side_nav/components/UserNavBlock.tsx
+++ b/ui/src/side_nav/components/UserNavBlock.tsx
@@ -27,22 +27,25 @@ interface Props {
   links: Links
   logoutLink: string
   meChangeOrg: (meLink: string, orgID: OrgID) => Promise<void>
+  header?: boolean
 }
 
 @ErrorHandling
 class UserNavBlock extends PureComponent<Props> {
   public render() {
-    const {logoutLink, me, links, meChangeOrg} = this.props
-
+    const {logoutLink, me, links, meChangeOrg, header} = this.props
+    const extraModifier = header ? 'header' : 'sidenav'
     return (
-      <div className="sidebar--item">
+      <div className={`sidebar--item sidebar--${extraModifier}`}>
         <div className="sidebar--square">
           <div className="sidebar--icon icon user-outline" />
           {this.isSuperAdmin && (
             <span className="sidebar--icon sidebar--icon__superadmin icon crown2" />
           )}
         </div>
-        <div className="sidebar-menu sidebar-menu--user-nav">
+        <div
+          className={`sidebar-menu sidebar-menu--user-nav sidebar-menu--${extraModifier}`}
+        >
           {!!this.customLinks && (
             <div className="sidebar-menu--section sidebar-menu--section__custom-links">
               Custom Links

--- a/ui/src/side_nav/containers/SideNav.tsx
+++ b/ui/src/side_nav/containers/SideNav.tsx
@@ -3,7 +3,11 @@ import React, {PureComponent} from 'react'
 import {withRouter, Link, WithRouterProps} from 'react-router'
 import {connect} from 'react-redux'
 
-import Authorized, {ADMIN_ROLE} from 'src/auth/Authorized'
+import Authorized, {
+  ADMIN_ROLE,
+  isUserAuthorized,
+  VIEWER_ROLE,
+} from 'src/auth/Authorized'
 
 import UserNavBlock from 'src/side_nav/components/UserNavBlock'
 
@@ -53,6 +57,11 @@ class SideNav extends PureComponent<Props> {
 
     const defaultSource = sources.find(s => s.default)
     const id = sourceID || _.get(defaultSource, 'id', 0)
+
+    if (isUsingAuth && !isUserAuthorized(me.role, VIEWER_ROLE)) {
+      // sidenav is available at least for VIEWER_ROLE
+      return null
+    }
 
     const sourcePrefix = `/sources/${id}`
     const dataExplorerLink = `${sourcePrefix}/chronograf/data-explorer`

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -34,7 +34,7 @@ import {
   SOURCE_TYPE_INFLUX_V2,
   SOURCE_TYPE_INFLUX_V1,
 } from 'src/shared/constants'
-import {SUPERADMIN_ROLE} from 'src/auth/Authorized'
+import {SUPERADMIN_ROLE} from 'src/auth/roles'
 
 // Types
 import {Source, Me} from 'src/types'

--- a/ui/src/style/layout/sidebar.scss
+++ b/ui/src/style/layout/sidebar.scss
@@ -4,6 +4,7 @@
 */
 
 $sidebar--width: 60px;
+$sidebar--header-width: 30px;
 
 $sidebar--gradient-start: $g7-graphite;
 $sidebar--gradient-end: $g4-onyx;
@@ -35,7 +36,7 @@ $sidebar-menu--gutter: 18px;
   display: flex;
   flex-direction: column;
   width: $sidebar--width;
-  @include gradient-v($sidebar--gradient-start,$sidebar--gradient-end);
+  @include gradient-v($sidebar--gradient-start, $sidebar--gradient-end);
 }
 .sidebar--bottom {
   position: absolute;
@@ -55,6 +56,10 @@ $sidebar-menu--gutter: 18px;
   width: $sidebar--width;
   height: $sidebar--width;
   position: relative;
+  &.sidebar--header {
+    width: $sidebar--header-width;
+    height: $sidebar--header-width;
+  }
 }
 .sidebar--square {
   display: block;
@@ -69,22 +74,20 @@ $sidebar-menu--gutter: 18px;
   color: $sidebar--icon;
   top: 50%;
   left: 50%;
-  transform: translate(-50%,-50%);
+  transform: translate(-50%, -50%);
   font-size: $sidebar--width * 0.4222;
-  transition:
-    text-shadow 0.4s ease;
+  transition: text-shadow 0.4s ease;
 }
 /*
   Sidebar Item Active State
 */
 .sidebar--item.active {
-  .sidebar--square {background-color: $sidebar--item-bg-active;}
+  .sidebar--square {
+    background-color: $sidebar--item-bg-active;
+  }
   .sidebar--icon {
     color: $sidebar--icon-active;
-    text-shadow:
-      0 0 9px $c-laser,
-      0 0 15px $c-ocean,
-      0 0 20px $c-amethyst;
+    text-shadow: 0 0 9px $c-laser, 0 0 15px $c-ocean, 0 0 20px $c-amethyst;
   }
 }
 
@@ -95,35 +98,39 @@ $sidebar-menu--gutter: 18px;
   cursor: pointer;
   z-index: 5;
 
-  .sidebar--square {background-color: $sidebar--item-bg-hover;}
-  .sidebar--icon {color: $sidebar--icon-hover;}
-  .sidebar-menu {display: flex;}
+  .sidebar--square {
+    background-color: $sidebar--item-bg-hover;
+  }
+  .sidebar--icon {
+    color: $sidebar--icon-hover;
+  }
+  .sidebar-menu {
+    display: flex;
+  }
 }
 .sidebar--item.active:hover .sidebar--icon {
-  text-shadow:
-    0 0 9px $c-yeti,
-    0 0 15px $c-hydrogen,
-    0 0 20px $c-laser;
+  text-shadow: 0 0 9px $c-yeti, 0 0 15px $c-hydrogen, 0 0 20px $c-laser;
 }
 /*
   Sidebar Logo Square
 */
 .sidebar--square.sidebar--logo {
   background-color: $sidebar--logo-bg;
-  .sidebar--icon {color: $sidebar--logo-color;}
+  .sidebar--icon {
+    color: $sidebar--logo-color;
+  }
 }
 .sidebar--item:hover .sidebar--square.sidebar--logo {
   background-color: $sidebar--logo-bg-hover;
-  .sidebar--icon {color: $sidebar--logo-color-hover;}
+  .sidebar--icon {
+    color: $sidebar--logo-color-hover;
+  }
 }
 .sidebar--item.active .sidebar--square.sidebar--logo {
   background-color: $sidebar--logo-bg-hover;
   .sidebar--icon {
     color: $sidebar--logo-color-hover;
-    text-shadow:
-      0 0 9px $c-hydrogen,
-      0 0 15px $c-neutrino,
-      0 0 20px $c-yeti;
+    text-shadow: 0 0 9px $c-hydrogen, 0 0 15px $c-neutrino, 0 0 20px $c-yeti;
   }
 }
 
@@ -136,7 +143,7 @@ $sidebar-menu--gutter: 18px;
   top: 0;
   left: 100%;
   border-radius: 0 $radius $radius 0;
-  @include gradient-h($sidebar-menu--bg,$sidebar-menu--bg-accent);
+  @include gradient-h($sidebar-menu--bg, $sidebar-menu--bg-accent);
   transition: opacity 0.25s ease;
   display: none;
   flex-direction: column;
@@ -168,26 +175,31 @@ $sidebar-menu--gutter: 18px;
   transition: none;
 
   // Rounding bottom outside corner of match container
-  &:nth-last-child(2) {border-bottom-right-radius: $radius;}
+  &:nth-last-child(2) {
+    border-bottom-right-radius: $radius;
+  }
 }
 .sidebar-menu--item.active,
 .sidebar-menu--item.active:link,
 .sidebar-menu--item.active:active,
 .sidebar-menu--item.active:visited {
-  @include gradient-h($sidebar-menu--item-bg,$sidebar-menu--item-bg-accent);
+  @include gradient-h($sidebar-menu--item-bg, $sidebar-menu--item-bg-accent);
   color: $sidebar-menu--item-text-active;
   font-weight: 700;
 }
 .sidebar-menu--item:hover,
 .sidebar-menu--item.active:hover {
-  @include gradient-h($sidebar-menu--item-bg-hover,$sidebar-menu--item-bg-hover-accent);
+  @include gradient-h(
+    $sidebar-menu--item-bg-hover,
+    $sidebar-menu--item-bg-hover-accent
+  );
   color: $sidebar-menu--item-text-hover;
 }
 .sidebar-menu--heading,
 .sidebar-menu--heading:link,
 .sidebar-menu--heading:visited,
 .sidebar-menu--heading:active,
-.sidebar-menu--heading:hover, {
+.sidebar-menu--heading:hover {
   color: $g20-white;
   height: $sidebar--width;
   line-height: $sidebar--width;
@@ -208,7 +220,7 @@ $sidebar-menu--gutter: 18px;
   height: 60px;
   bottom: 12px;
   left: 6px;
-  transform: translate(-50%,-50%) rotate(30deg);
+  transform: translate(-50%, -50%) rotate(30deg);
 }
 
 .sidebar-menu--section {
@@ -229,7 +241,7 @@ $sidebar-menu--gutter: 18px;
     left: 0;
     width: 100%;
     height: 2px;
-    @include gradient-h($c-laser,$c-potassium);
+    @include gradient-h($c-laser, $c-potassium);
   }
 }
 
@@ -245,7 +257,7 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
   @include no-user-select();
 
   > div {
-    @include gradient-h($c-pineapple,$c-tiger);
+    @include gradient-h($c-pineapple, $c-tiger);
     color: $c-sapphire;
   }
   span.icon {
@@ -266,7 +278,7 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
   @include no-user-select();
 
   > div {
-    @include gradient-h($c-rainforest,$c-pool);
+    @include gradient-h($c-rainforest, $c-pool);
     color: $g20-white;
   }
   span.icon {
@@ -289,24 +301,57 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
 }
 
 .fancy-scroll--container.sidebar-menu--scrollbar {
-  .fancy-scroll--thumb-h {display: none !important;}
-  .fancy-scroll--thumb-v { @include gradient-v($g20-white,$c-neutrino); }
+  .fancy-scroll--thumb-h {
+    display: none !important;
+  }
+  .fancy-scroll--thumb-v {
+    @include gradient-v($g20-white, $c-neutrino);
+  }
 }
 
 .sidebar-menu--user-nav {
   top: initial;
   bottom: 0;
 
-  .sidebar-menu--section__custom-links  { order: 0; }
-  .sidebar-menu--item__link-name        { order: 1; }
-  .sidebar-menu--section__switch-orgs   { order: 2; }
-  .sidebar-menu--scrollbar              { order: 3; }
-  .sidebar-menu--section__account       { order: 4; }
-  .sidebar-menu--provider               { order: 5; }
-  .sidebar-menu--item__logout           { order: 6; }
-  .sidebar-menu--heading                { order: 7; }
-  .sidebar-menu--triangle               { order: 8; }
-  
+  .sidebar-menu--section__custom-links {
+    order: 0;
+  }
+  .sidebar-menu--item__link-name {
+    order: 1;
+  }
+  .sidebar-menu--section__switch-orgs {
+    order: 2;
+  }
+  .sidebar-menu--scrollbar {
+    order: 3;
+  }
+  .sidebar-menu--section__account {
+    order: 4;
+  }
+  .sidebar-menu--provider {
+    order: 5;
+  }
+  .sidebar-menu--item__logout {
+    order: 6;
+  }
+  .sidebar-menu--heading {
+    order: 7;
+  }
+  .sidebar-menu--triangle {
+    order: 8;
+  }
+
+  &.sidebar-menu--header {
+    top: 31px;
+    left: auto;
+    right: 0px;
+    bottom: auto;
+    border-radius: $radius 0 0 $radius;
+  }
+  > .sidebar-menu--heading {
+    order: 1;
+  }
+
   .sidebar-menu--section__custom-links:after {
     display: none;
     border-top-right-radius: $radius;
@@ -314,31 +359,49 @@ span.icon.sidebar--icon.sidebar--icon__superadmin {
 }
 
 @media only screen and (min-height: 800px) {
-  .sidebar-menu--user-nav {
+  .sidebar-menu--user-nav.sidebar-menu--sidenav {
     top: 0;
     bottom: initial;
 
-    .sidebar-menu--heading                { order: 0; }
-    .sidebar-menu--section__account       { order: 1; }
-    .sidebar-menu--provider               { order: 2; }
-    .sidebar-menu--item__logout           { order: 3; }
-    .sidebar-menu--section__switch-orgs   { order: 4; }
-    .sidebar-menu--scrollbar              { order: 5; }
-    .sidebar-menu--section__custom-links  { order: 6; }
-    .sidebar-menu--item__link-name        { order: 7; }
-    .sidebar-menu--triangle               { order: 8; }
-  
+    .sidebar-menu--heading {
+      order: 0;
+    }
+    .sidebar-menu--section__account {
+      order: 1;
+    }
+    .sidebar-menu--provider {
+      order: 2;
+    }
+    .sidebar-menu--item__logout {
+      order: 3;
+    }
+    .sidebar-menu--section__switch-orgs {
+      order: 4;
+    }
+    .sidebar-menu--scrollbar {
+      order: 5;
+    }
+    .sidebar-menu--section__custom-links {
+      order: 6;
+    }
+    .sidebar-menu--item__link-name {
+      order: 7;
+    }
+    .sidebar-menu--triangle {
+      order: 8;
+    }
+
     .sidebar-menu--section__custom-links:after {
       display: initial;
       border-top-right-radius: 0;
     }
-  
+
     .sidebar-menu--triangle {
       width: 40px;
       height: 40px;
       top: $sidebar--width;
       left: 0;
-      transform: translate(-50%,-50%) rotate(45deg);
+      transform: translate(-50%, -50%) rotate(45deg);
     }
   }
 }


### PR DESCRIPTION
This PR 
- adds a new reader role, `reader` changes the UI to show just Dashboards in read-only mode
- redirects the user to the original URL (for example a dashboard URL) after authentication takes place; users were always redirected to the main page before this PR

UI for the reader role does not show the sidebar navigation menu, just the header, and content. 
![image](https://user-images.githubusercontent.com/16321466/162208653-9536cd85-a814-4ddc-8731-f69ef330e4ca.png)

The header for the reader role includes the User menu in the page header (of  Dashboards page or a particular Dashboard page) that let the user can use to change organization or logout.

![image](https://user-images.githubusercontent.com/16321466/164724847-2831eff1-334a-4092-be0a-1b6c9eace30d.png)

Administration pages newly contain reader role
  - as a default choice for an organization (<a target="screenshot" href="https://user-images.githubusercontent.com/16321466/164725135-d429c987-eda9-4909-bc65-741f0a33503c.png">screenshot</a>)
  - as an option to assign to a specific user (<a target="screenshot" href="https://user-images.githubusercontent.com/16321466/164725332-08cd2692-82ee-4de1-b5c1-a43530ecc9c5.png">screenshot</a>)

Dashboards can execute arbitrary queries from within the browser, it is important to configure the InfluxDB connection to use a user (or token) that can only query the database.
 
<!-- checkboxes -->

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
