### PR TITLE
chore: strip 'v' prefix from InfluxDB version

### DIFF
--- a/influx/influx.go
+++ b/influx/influx.go
@@ -340,7 +340,8 @@ func (c *Client) ping(u *url.URL) (string, string, error) {
 	} else if strings.Contains(version, "relay") {
 		return version, chronograf.InfluxRelay, nil
 	}
-	// older InfluxDB instances might have version 'v1.x.x'
+	// Strip v prefix from version, some older '1.x' versions and also
+	// InfluxDB 2.2.0 return version in format vx.x.x
 	if strings.HasPrefix(version, "v") {
 		version = version[1:]
 	}


### PR DESCRIPTION
InfluxDB 2.2.0 reports its version as  `v2.2.0`, but some tools expected the version to look like `2.2.0`. Chronograf fortunately handles both version formats properly, the code that makes it happen was commented in this PR to know that also the newest InfluxDB requires extra care in version processing.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
