### PR TITLE
chore: replace gh workflow cron by push

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -2,8 +2,9 @@ name: "chronograf/cypress"
 
 on:
   pull_request:
-  schedule:
-    - cron: '30 5 * * 1-5'
+  push:
+    branches:
+      - master
 
 jobs:
   e2e:


### PR DESCRIPTION
This PR `cron` to trigger github workflow execution, `push to master` is the trigger herein.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
