### PR TITLE
fix(ui): skip TLS server verification during dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Bug Fixes
 
 1. [#5882](https://github.com/influxdata/chronograf/pull/5882): Repair table visualization of string values.
+1. [#5913](https://github.com/influxdata/chronograf/pull/5913): Improve InfluxDB Enterprise detection. 
 
 ### Other
 
@@ -16,7 +17,7 @@
 1. [#5898](https://github.com/influxdata/chronograf/pull/5898): Upgrade javascript dependencies.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Upgrade golang to 1.18.
 1. [#5915](https://github.com/influxdata/chronograf/pull/5915): Upgrade github.com/lestrrat-go/jwx to v2
-1. [#5913](https://github.com/influxdata/chronograf/pull/5913): Improve InfluxDB Enterprise detection. 
+
 ## v1.9.4 [2022-03-22]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [#5898](https://github.com/influxdata/chronograf/pull/5898): Upgrade javascript dependencies.
 1. [#5754](https://github.com/influxdata/chronograf/pull/5754): Upgrade golang to 1.18.
 1. [#5915](https://github.com/influxdata/chronograf/pull/5915): Upgrade github.com/lestrrat-go/jwx to v2
+1. [#5913](https://github.com/influxdata/chronograf/pull/5913): Improve InfluxDB Enterprise detection. 
 ## v1.9.4 [2022-03-22]
 
 ### Features

--- a/ui/src/sources/components/SourceStep.tsx
+++ b/ui/src/sources/components/SourceStep.tsx
@@ -250,7 +250,11 @@ class SourceStep extends PureComponent<Props, State> {
     this.detectServerType({password})
 
   private detectServerType = async (changedField: Partial<Source>) => {
-    const source = {...this.state.source, ...changedField}
+    const source = {
+      ...this.state.source,
+      ...changedField,
+      insecureSkipVerify: true, // detect InfluxDB type with TLS server verification off
+    }
     const metaserviceURL = new URL(source.metaUrl || DEFAULT_SOURCE.metaUrl)
     const sourceURL = new URL(source.url || DEFAULT_SOURCE.url)
 


### PR DESCRIPTION
Closes #5912

_Briefly describe your proposed changes:_
TLS server certificate/hostname verification is tuned off during detection of InfluxDB server type, it is just to know whether to show `Meta Service URL` input filed.
_What was the problem?_
`Meta Service URL` was not shown when connecting to InfluxDB Enterprise with chronograf untrusted certificate. 
_What was the solution?_
Turn off server certification verification during InfluxDB type detection in the 'Add Source' wizard, ... and only for the detection.  

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
