### PR TITLE
fix(ci): expose InfluxDB enterprise meta service in tests 

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -53,8 +53,12 @@ jobs:
               --set installCRDs=true
           kubectl apply -f .github/workflows/resources/test-resources.yaml
           kubectl create secret generic influxdb-license --from-literal=INFLUXDB_ENTERPRISE_LICENSE_KEY=${INFLUXDB_ENTERPRISE_LICENSE_KEY}
-          helm upgrade --install influxdb influxdata/influxdb-enterprise --namespace default --set-string envFromSecret=influxdb-license --set-string data.service.type=NodePort
-          kubectl patch svc influxdb-influxdb-enterprise-data --type=json -p '[{"op":"replace","path":"/spec/ports/0/nodePort","value":30086}]'
+          helm upgrade --install influxdb influxdata/influxdb-enterprise --namespace default \
+              --set-string envFromSecret=influxdb-license \
+              --set-string data.service.type=NodePort \
+              --set-string meta.service.type=NodePort \
+              --set data.service.nodePort=30086 \
+              --set meta.service.nodePort=30091
         env:
           INFLUXDB_ENTERPRISE_LICENSE_KEY: "${{ secrets.INFLUXDB_ENTERPRISE_LICENSE_KEY }}"
 

--- a/.github/workflows/resources/kind-config.yaml
+++ b/.github/workflows/resources/kind-config.yaml
@@ -3,9 +3,11 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6
     extraPortMappings:
       - containerPort: 30086
         hostPort: 8086
+        listenAddress: "0.0.0.0"
+      - containerPort: 30091
+        hostPort: 8091
         listenAddress: "0.0.0.0"
 ---

--- a/ui/cypress/local-chronograf-influxdb-enterprise.sh
+++ b/ui/cypress/local-chronograf-influxdb-enterprise.sh
@@ -58,8 +58,12 @@ deploy_influxdb_ent() {
         --set installCRDs=true
     kubectl apply -f "${RWD}/.github/workflows/resources/test-resources.yaml"
     kubectl create secret generic influxdb-license --from-literal=INFLUXDB_ENTERPRISE_LICENSE_KEY="${LICENSE_KEY}"
-    helm upgrade --wait --install influxdb influxdata/influxdb-enterprise --namespace default --set-string envFromSecret=influxdb-license --set-string data.service.type=NodePort
-    kubectl patch svc influxdb-influxdb-enterprise-data --type=json -p '[{"op":"replace","path":"/spec/ports/0/nodePort","value":30086}]'
+    helm upgrade --wait --install influxdb influxdata/influxdb-enterprise --namespace default \
+        --set-string envFromSecret=influxdb-license \
+        --set-string data.service.type=NodePort \
+        --set-string meta.service.type=NodePort \
+        --set data.service.nodePort=30086 \
+        --set meta.service.nodePort=30091
     sleep 5
     echo -e "InfluxDB data node status: $(curl -Isk "https://localhost:8086/ping" | head -n 1)"
 }


### PR DESCRIPTION
This PR makes sure that a started InfluxDB enterprise has both meta and data services accessible.

_Briefly describe your proposed changes:_
This PR utilizes the newest influxdb-enterprise helm chart to expose meta and data services as node-ports and then map these ports to `kind control plane` so that these services are accessible to tests.  
_What was the problem?_
InfluxDB meta service was not accessible, so it was not possible to use/test chronograf administration of InfluxDB users, permissions, and roles.
_What was the solution?_
1. influxdata/helm-charts#468 allows customizing the way how meta service is exposed
2. install influxdb-enteprise helm chart  with node port k8s services at predefined ports
3. expose node ports to test environment via kind cluster configuration 

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
