### PR TITLE
feat(ui): manage InfluxDB OSS admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#5904](https://github.com/influxdata/chronograf/pull/5904): Add reader role.
+1. [#5916](https://github.com/influxdata/chronograf/pull/5916): Manage InfluxDB OSS admin users.
 
 ### Bug Fixes
 

--- a/ui/src/admin/components/UserAdminDropdown.tsx
+++ b/ui/src/admin/components/UserAdminDropdown.tsx
@@ -1,0 +1,66 @@
+import React, {PureComponent} from 'react'
+import classnames from 'classnames'
+
+import MultiSelectDropdown from 'src/shared/components/MultiSelectDropdown'
+
+import {USERS_TABLE} from 'src/admin/constants/tableSizing'
+import {User} from 'src/types/influxAdmin'
+import {ErrorHandling} from 'src/shared/decorators/errors'
+
+interface Props {
+  user: User
+  onUpdatePermissions: (user: User, permissions: any[]) => void
+}
+
+const ADMIN_YES_OPTION = 'YES'
+const ALL_PERMISSIONS = [{name: ADMIN_YES_OPTION}]
+
+@ErrorHandling
+class UserAdminDropdown extends PureComponent<Props> {
+  public render() {
+    return (
+      <MultiSelectDropdown
+        buttonSize="btn-xs"
+        buttonColor="btn-primary"
+        resetStateOnReceiveProps={false}
+        items={ALL_PERMISSIONS}
+        label={this.permissionsLabel}
+        customClass={this.permissionsClass}
+        selectedItems={this.selectedPermissions}
+        onApply={this.handleApply}
+      />
+    )
+  }
+
+  private handleApply = (items): void => {
+    const {onUpdatePermissions, user} = this.props
+    let permissions = (user.permissions || []).filter(x => x.scope !== 'all')
+    if (items && items.length) {
+      permissions = [{scope: 'all', allowed: ['ALL']}, ...permissions]
+    }
+    onUpdatePermissions(user, permissions)
+  }
+
+  private get admin() {
+    return (
+      (this.props.user.permissions || []).filter(
+        x => x.scope === 'all' && (x.allowed || []).includes('ALL')
+      ).length > 0
+    )
+  }
+  private get selectedPermissions() {
+    return this.admin ? [{name: ADMIN_YES_OPTION}] : []
+  }
+
+  private get permissionsLabel() {
+    return this.admin ? 'YES' : 'NO'
+  }
+
+  private get permissionsClass() {
+    return classnames(`dropdown-${USERS_TABLE.colPermissions}`, {
+      'admin-table--multi-select-empty': !this.admin,
+    })
+  }
+}
+
+export default UserAdminDropdown

--- a/ui/src/admin/components/UserAdminDropdown.tsx
+++ b/ui/src/admin/components/UserAdminDropdown.tsx
@@ -4,12 +4,12 @@ import classnames from 'classnames'
 import MultiSelectDropdown from 'src/shared/components/MultiSelectDropdown'
 
 import {USERS_TABLE} from 'src/admin/constants/tableSizing'
-import {User} from 'src/types/influxAdmin'
+import {User, UserPermission} from 'src/types/influxAdmin'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   user: User
-  onUpdatePermissions: (user: User, permissions: any[]) => void
+  onUpdatePermissions: (user: User, permissions: UserPermission[]) => void
 }
 
 const ADMIN_YES_OPTION = 'YES'

--- a/ui/src/admin/components/UserPermissionsDropdown.tsx
+++ b/ui/src/admin/components/UserPermissionsDropdown.tsx
@@ -5,13 +5,13 @@ import _ from 'lodash'
 import MultiSelectDropdown from 'src/shared/components/MultiSelectDropdown'
 
 import {USERS_TABLE} from 'src/admin/constants/tableSizing'
-import {User} from 'src/types/influxAdmin'
+import {User, UserPermission} from 'src/types/influxAdmin'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 
 interface Props {
   user: User
   allPermissions: string[]
-  onUpdatePermissions: (user: User, permissions: any[]) => void
+  onUpdatePermissions: (user: User, permissions: UserPermission[]) => void
 }
 
 @ErrorHandling

--- a/ui/src/admin/components/UserRow.tsx
+++ b/ui/src/admin/components/UserRow.tsx
@@ -9,6 +9,7 @@ import {USERS_TABLE} from 'src/admin/constants/tableSizing'
 import UserRowEdit from 'src/admin/components/UserRowEdit'
 import {User} from 'src/types/influxAdmin'
 import {ErrorHandling} from 'src/shared/decorators/errors'
+import UserAdminDropdown from './UserAdminDropdown'
 
 interface UserRowProps {
   user: User
@@ -77,10 +78,15 @@ class UserRow extends PureComponent<UserRowProps> {
           </td>
         )}
         <td>
-          {this.hasPermissions && (
+          {this.hasPermissions ? (
             <UserPermissionsDropdown
               user={user}
               allPermissions={allPermissions}
+              onUpdatePermissions={onUpdatePermissions}
+            />
+          ) : (
+            <UserAdminDropdown
+              user={user}
               onUpdatePermissions={onUpdatePermissions}
             />
           )}
@@ -114,8 +120,8 @@ class UserRow extends PureComponent<UserRowProps> {
   }
 
   private get hasPermissions() {
-    const {allPermissions} = this.props
-    return allPermissions && !!allPermissions.length
+    const {allPermissions, hasRoles} = this.props
+    return hasRoles && allPermissions && !!allPermissions.length
   }
 }
 

--- a/ui/src/admin/components/UserRow.tsx
+++ b/ui/src/admin/components/UserRow.tsx
@@ -7,7 +7,7 @@ import ConfirmButton from 'src/shared/components/ConfirmButton'
 import {USERS_TABLE} from 'src/admin/constants/tableSizing'
 
 import UserRowEdit from 'src/admin/components/UserRowEdit'
-import {User} from 'src/types/influxAdmin'
+import {User, UserPermission} from 'src/types/influxAdmin'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import UserAdminDropdown from './UserAdminDropdown'
 
@@ -22,7 +22,7 @@ interface UserRowProps {
   onEdit: () => void
   onSave: () => void
   onDelete: (user: User) => void
-  onUpdatePermissions: (user: User, permissions: any[]) => void
+  onUpdatePermissions: (user: User, permissions: UserPermission[]) => void
   onUpdateRoles: (user: User, roles: any[]) => void
   onUpdatePassword: (user: User, password: string) => void
 }

--- a/ui/src/admin/components/UsersTable.js
+++ b/ui/src/admin/components/UsersTable.js
@@ -35,7 +35,9 @@ const UsersTable = ({
             <th>User</th>
             <th>Password</th>
             {hasRoles && <th className="admin-table--left-offset">Roles</th>}
-            <th className="admin-table--left-offset">Permissions</th>
+            <th className="admin-table--left-offset">
+              {hasRoles ? 'Permissions' : 'Administrator'}
+            </th>
             <th />
           </tr>
         </thead>

--- a/ui/src/types/auth.ts
+++ b/ui/src/types/auth.ts
@@ -48,6 +48,7 @@ export enum InfluxDBPermissionScope {
 
 export interface Permission {
   scope: string
+  name?: string
   allowed: InfluxDBPermissions[]
 }
 

--- a/ui/src/types/influxAdmin.ts
+++ b/ui/src/types/influxAdmin.ts
@@ -2,8 +2,10 @@ export interface UserRole {
   name: string
 }
 
-interface UserPermission {
-  name: string
+export interface UserPermission {
+  scope: string
+  name?: string
+  allowed: string[]
 }
 
 export interface User {


### PR DESCRIPTION
This PR is a part of a solution to #5834. It fixes the way how OSS admin users are assigned, making a user an administrator previously reset all other database-level grants, it does not after this PR. Moreover, the Users UI changed to make clear that an administrator status is managed (it was ALL permission before this PR).

![image](https://user-images.githubusercontent.com/16321466/167558517-4236c61f-aa8b-463e-bf38-98634bb9f733.png)

The concept of user controls that let change the administrator status remain the same (as the previous change of permissions). The user has to select/deselect YES checkbox and then clieck `Apply`:
![image](https://user-images.githubusercontent.com/16321466/167558920-eb6146a5-6a7d-45cc-aed4-7de588533334.png)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
