### PR TITLE
5840/create user error

### DIFF
--- a/enterprise/meta.go
+++ b/enterprise/meta.go
@@ -206,6 +206,18 @@ func (m *MetaClient) RemoveUserPerms(ctx context.Context, name string, perms Per
 	return m.Post(ctx, "/user", a, nil)
 }
 
+// RemoveUserPerms revokes permissions for a user in Influx Enterprise
+func (m *MetaClient) AddUserPerms(ctx context.Context, name string, perms Permissions) error {
+	a := &UserAction{
+		Action: "add-permissions",
+		User: &User{
+			Name:        name,
+			Permissions: perms,
+		},
+	}
+	return m.Post(ctx, "/user", a, nil)
+}
+
 // SetUserPerms removes permissions not in set and then adds the requested perms
 func (m *MetaClient) SetUserPerms(ctx context.Context, name string, perms Permissions) error {
 	user, err := m.User(ctx, name)
@@ -226,14 +238,7 @@ func (m *MetaClient) SetUserPerms(ctx context.Context, name string, perms Permis
 
 	// ... next, add any permissions the user should have
 	if len(add) > 0 {
-		a := &UserAction{
-			Action: "add-permissions",
-			User: &User{
-				Name:        name,
-				Permissions: add,
-			},
-		}
-		return m.Post(ctx, "/user", a, nil)
+		return m.AddUserPerms(ctx, name, add)
 	}
 	return nil
 }

--- a/enterprise/users.go
+++ b/enterprise/users.go
@@ -20,8 +20,10 @@ func (c *UserStore) Add(ctx context.Context, u *chronograf.User) (*chronograf.Us
 	}
 	perms := ToEnterprise(u.Permissions)
 
-	if err := c.Ctrl.SetUserPerms(ctx, u.Name, perms); err != nil {
-		return nil, err
+	if len(perms) > 0 {
+		if err := c.Ctrl.SetUserPerms(ctx, u.Name, perms); err != nil {
+			return nil, err
+		}
 	}
 	for _, role := range u.Roles {
 		if err := c.Ctrl.AddRoleUsers(ctx, role.Name, []string{u.Name}); err != nil {

--- a/server/sources.go
+++ b/server/sources.go
@@ -544,11 +544,6 @@ func (s *Service) NewSourceUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err != nil {
-		Error(w, http.StatusBadRequest, err.Error(), s.Logger)
-		return
-	}
-
 	su := newSourceUserResponse(srcID, res.Name).WithPermissions(res.Permissions)
 	if _, hasRoles := s.hasRoles(ctx, ts); hasRoles {
 		su.WithRoles(srcID, res.Roles)


### PR DESCRIPTION
Closes #5840

_What was the problem?_
Sometimes, when a multi-meta-node enterprise cluster has many users, the chronograf user creation process fails on `user not found`, the user is however created ... it may take a while. This defect most likely happens because of an eventual consistency of the cluster.
_What was the solution?_
Wait for the user to be created (at most for 2 seconds) with 50ms retries.


  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
