### PR TITLE
feat(ui): change layout of InfluxDB administration pages to occupy full page width

### DIFF
--- a/ui/src/admin/components/DatabaseManager.js
+++ b/ui/src/admin/components/DatabaseManager.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import DatabaseTable from 'src/admin/components/DatabaseTable'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
 const DatabaseManager = ({
   databases,
@@ -25,7 +26,7 @@ const DatabaseManager = ({
   onDeleteRetentionPolicy,
 }) => {
   return (
-    <div className="panel panel-solid">
+    <div className="panel panel-solid influxdb-admin">
       <div className="panel-heading">
         <h2 className="panel-title">
           {databases.length === 1
@@ -40,29 +41,33 @@ const DatabaseManager = ({
           <span className="icon plus" /> Create Database
         </button>
       </div>
-      <div className="panel-body">
-        {databases.map(db => (
-          <DatabaseTable
-            key={db.links.self}
-            database={db}
-            isRFDisplayed={isRFDisplayed}
-            onEditDatabase={onEditDatabase}
-            onKeyDownDatabase={onKeyDownDatabase}
-            onCancelDatabase={onCancelDatabase}
-            onConfirmDatabase={onConfirmDatabase}
-            onRemoveDeleteCode={onRemoveDeleteCode}
-            onDeleteDatabase={onDeleteDatabase}
-            onStartDeleteDatabase={onStartDeleteDatabase}
-            onDatabaseDeleteConfirm={onDatabaseDeleteConfirm}
-            onAddRetentionPolicy={onAddRetentionPolicy}
-            onStopEditRetentionPolicy={onStopEditRetentionPolicy}
-            onCancelRetentionPolicy={onCancelRetentionPolicy}
-            onCreateRetentionPolicy={onCreateRetentionPolicy}
-            onUpdateRetentionPolicy={onUpdateRetentionPolicy}
-            onRemoveRetentionPolicy={onRemoveRetentionPolicy}
-            onDeleteRetentionPolicy={onDeleteRetentionPolicy}
-          />
-        ))}
+      <div className="panel-body" style={{paddingRight: 20}}>
+        <FancyScrollbar>
+          <div style={{paddingRight: 10}}>
+            {databases.map(db => (
+              <DatabaseTable
+                key={db.links.self}
+                database={db}
+                isRFDisplayed={isRFDisplayed}
+                onEditDatabase={onEditDatabase}
+                onKeyDownDatabase={onKeyDownDatabase}
+                onCancelDatabase={onCancelDatabase}
+                onConfirmDatabase={onConfirmDatabase}
+                onRemoveDeleteCode={onRemoveDeleteCode}
+                onDeleteDatabase={onDeleteDatabase}
+                onStartDeleteDatabase={onStartDeleteDatabase}
+                onDatabaseDeleteConfirm={onDatabaseDeleteConfirm}
+                onAddRetentionPolicy={onAddRetentionPolicy}
+                onStopEditRetentionPolicy={onStopEditRetentionPolicy}
+                onCancelRetentionPolicy={onCancelRetentionPolicy}
+                onCreateRetentionPolicy={onCreateRetentionPolicy}
+                onUpdateRetentionPolicy={onUpdateRetentionPolicy}
+                onRemoveRetentionPolicy={onRemoveRetentionPolicy}
+                onDeleteRetentionPolicy={onDeleteRetentionPolicy}
+              />
+            ))}
+          </div>
+        </FancyScrollbar>
       </div>
     </div>
   )

--- a/ui/src/admin/components/RolesTable.js
+++ b/ui/src/admin/components/RolesTable.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import RoleRow from 'src/admin/components/RoleRow'
 import EmptyRow from 'src/admin/components/EmptyRow'
 import FilterBar from 'src/admin/components/FilterBar'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
 const RolesTable = ({
   roles,
@@ -18,7 +19,7 @@ const RolesTable = ({
   onUpdateRoleUsers,
   onUpdateRolePermissions,
 }) => (
-  <div className="panel panel-solid">
+  <div className="panel panel-solid influxdb-admin">
     <FilterBar
       type="roles"
       onFilter={onFilter}
@@ -26,40 +27,42 @@ const RolesTable = ({
       onClickCreate={onClickCreate}
     />
     <div className="panel-body">
-      <table className="table v-center admin-table table-highlight">
-        <thead>
-          <tr>
-            <th>Name</th>
-            <th className="admin-table--left-offset">Permissions</th>
-            <th className="admin-table--left-offset">Users</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {roles.length ? (
-            roles
-              .filter(r => !r.hidden)
-              .map(role => (
-                <RoleRow
-                  key={role.links.self}
-                  allUsers={allUsers}
-                  allPermissions={permissions}
-                  role={role}
-                  onEdit={onEdit}
-                  onSave={onSave}
-                  onCancel={onCancel}
-                  onDelete={onDelete}
-                  onUpdateRoleUsers={onUpdateRoleUsers}
-                  onUpdateRolePermissions={onUpdateRolePermissions}
-                  isEditing={role.isEditing}
-                  isNew={role.isNew}
-                />
-              ))
-          ) : (
-            <EmptyRow tableName={'Roles'} />
-          )}
-        </tbody>
-      </table>
+      <FancyScrollbar>
+        <table className="table v-center admin-table table-highlight">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th className="admin-table--left-offset">Permissions</th>
+              <th className="admin-table--left-offset">Users</th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {roles.length ? (
+              roles
+                .filter(r => !r.hidden)
+                .map(role => (
+                  <RoleRow
+                    key={role.links.self}
+                    allUsers={allUsers}
+                    allPermissions={permissions}
+                    role={role}
+                    onEdit={onEdit}
+                    onSave={onSave}
+                    onCancel={onCancel}
+                    onDelete={onDelete}
+                    onUpdateRoleUsers={onUpdateRoleUsers}
+                    onUpdateRolePermissions={onUpdateRolePermissions}
+                    isEditing={role.isEditing}
+                    isNew={role.isNew}
+                  />
+                ))
+            ) : (
+              <EmptyRow tableName={'Roles'} />
+            )}
+          </tbody>
+        </table>
+      </FancyScrollbar>
     </div>
   </div>
 )

--- a/ui/src/admin/components/UsersTable.js
+++ b/ui/src/admin/components/UsersTable.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import UserRow from 'src/admin/components/UserRow'
 import EmptyRow from 'src/admin/components/EmptyRow'
 import FilterBar from 'src/admin/components/FilterBar'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
 const UsersTable = ({
   users,
@@ -21,7 +22,7 @@ const UsersTable = ({
   onUpdateRoles,
   onUpdatePassword,
 }) => (
-  <div className="panel panel-solid">
+  <div className="panel panel-solid influxdb-admin">
     <FilterBar
       type="users"
       onFilter={onFilter}
@@ -29,45 +30,47 @@ const UsersTable = ({
       onClickCreate={onClickCreate}
     />
     <div className="panel-body">
-      <table className="table v-center admin-table table-highlight">
-        <thead>
-          <tr>
-            <th>User</th>
-            <th>Password</th>
-            {hasRoles && <th className="admin-table--left-offset">Roles</th>}
-            <th className="admin-table--left-offset">
-              {hasRoles ? 'Permissions' : 'Administrator'}
-            </th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {users.length ? (
-            users
-              .filter(u => !u.hidden)
-              .map(user => (
-                <UserRow
-                  key={user.links.self}
-                  user={user}
-                  onEdit={onEdit}
-                  onSave={onSave}
-                  onCancel={onCancel}
-                  onDelete={onDelete}
-                  isEditing={user.isEditing}
-                  isNew={user.isNew}
-                  allRoles={allRoles}
-                  hasRoles={hasRoles}
-                  allPermissions={permissions}
-                  onUpdatePermissions={onUpdatePermissions}
-                  onUpdateRoles={onUpdateRoles}
-                  onUpdatePassword={onUpdatePassword}
-                />
-              ))
-          ) : (
-            <EmptyRow tableName={'Users'} />
-          )}
-        </tbody>
-      </table>
+      <FancyScrollbar>
+        <table className="table v-center admin-table table-highlight">
+          <thead>
+            <tr>
+              <th>User</th>
+              <th>Password</th>
+              {hasRoles && <th className="admin-table--left-offset">Roles</th>}
+              <th className="admin-table--left-offset">
+                {hasRoles ? 'Permissions' : 'Administrator'}
+              </th>
+              <th />
+            </tr>
+          </thead>
+          <tbody>
+            {users.length ? (
+              users
+                .filter(u => !u.hidden)
+                .map(user => (
+                  <UserRow
+                    key={user.links.self}
+                    user={user}
+                    onEdit={onEdit}
+                    onSave={onSave}
+                    onCancel={onCancel}
+                    onDelete={onDelete}
+                    isEditing={user.isEditing}
+                    isNew={user.isNew}
+                    allRoles={allRoles}
+                    hasRoles={hasRoles}
+                    allPermissions={permissions}
+                    onUpdatePermissions={onUpdatePermissions}
+                    onUpdateRoles={onUpdateRoles}
+                    onUpdatePassword={onUpdatePassword}
+                  />
+                ))
+            ) : (
+              <EmptyRow tableName={'Users'} />
+            )}
+          </tbody>
+        </table>
+      </FancyScrollbar>
     </div>
   </div>
 )

--- a/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
@@ -92,24 +92,22 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
   public render() {
     return (
       <Page>
-        <div className="deceo--page">
-          <div className="deceo">
-            <Page.Header fullWidth={true}>
-              <Page.Header.Left>
-                <Page.Title title="InfluxDB Admin" />
-              </Page.Header.Left>
-              <Page.Header.Right showSourceIndicator={true}>
-                {this.state.loading !== RemoteDataState.Loading && (
-                  <span
-                    className="icon refresh"
-                    title="Refresh"
-                    onClick={this.refresh}
-                  />
-                )}
-              </Page.Header.Right>
-            </Page.Header>
-            <div style={{height: 'calc(100% - 60px)'}}>{this.admin}</div>
-          </div>
+        <div className="deceo">
+          <Page.Header fullWidth={true}>
+            <Page.Header.Left>
+              <Page.Title title="InfluxDB Admin" />
+            </Page.Header.Left>
+            <Page.Header.Right showSourceIndicator={true}>
+              {this.state.loading !== RemoteDataState.Loading && (
+                <span
+                  className="icon refresh"
+                  title="Refresh"
+                  onClick={this.refresh}
+                />
+              )}
+            </Page.Header.Right>
+          </Page.Header>
+          <div style={{height: 'calc(100% - 60px)'}}>{this.admin}</div>
         </div>
       </Page>
     )

--- a/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
@@ -92,21 +92,25 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
   public render() {
     return (
       <Page>
-        <Page.Header>
-          <Page.Header.Left>
-            <Page.Title title="InfluxDB Admin" />
-          </Page.Header.Left>
-          <Page.Header.Right showSourceIndicator={true}>
-            {this.state.loading !== RemoteDataState.Loading && (
-              <span
-                className="icon refresh"
-                title="Refresh"
-                onClick={this.refresh}
-              />
-            )}
-          </Page.Header.Right>
-        </Page.Header>
-        <Page.Contents fullWidth={true}>{this.admin}</Page.Contents>
+        <div className="deceo--page">
+          <div className="deceo">
+            <Page.Header fullWidth={true}>
+              <Page.Header.Left>
+                <Page.Title title="InfluxDB Admin" />
+              </Page.Header.Left>
+              <Page.Header.Right showSourceIndicator={true}>
+                {this.state.loading !== RemoteDataState.Loading && (
+                  <span
+                    className="icon refresh"
+                    title="Refresh"
+                    onClick={this.refresh}
+                  />
+                )}
+              </Page.Header.Right>
+            </Page.Header>
+            <div style={{height: 'calc(100% - 60px)'}}>{this.admin}</div>
+          </div>
+        </div>
       </Page>
     )
   }
@@ -137,7 +141,7 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
         </div>
       )
     }
-    return <div className="container-fluid">{children}</div>
+    return <div>{children}</div>
   }
 }
 

--- a/ui/src/admin/containers/influxdb/AdminInfluxDBTab.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBTab.tsx
@@ -1,4 +1,4 @@
-import React, {ReactNode} from 'react'
+import React from 'react'
 import {useMemo} from 'react'
 import SubSections from 'src/shared/components/SubSections'
 import {Source, SourceAuthenticationMethod} from 'src/types'
@@ -6,7 +6,7 @@ import {Source, SourceAuthenticationMethod} from 'src/types'
 interface Props {
   source: Source
   activeTab: 'databases' | 'users' | 'roles' | 'queries'
-  children: ReactNode
+  children: JSX.Element
 }
 export function hasRoleManagement(source: Source) {
   return !!source?.links?.roles
@@ -48,6 +48,7 @@ const AdminInfluxDBTab = ({source, activeTab, children}: Props) => {
       sourceID={source.id}
       activeSection={activeTab}
       sections={sections}
+      position="top"
     >
       {children}
     </SubSections>

--- a/ui/src/admin/containers/influxdb/QueriesPage.tsx
+++ b/ui/src/admin/containers/influxdb/QueriesPage.tsx
@@ -29,6 +29,7 @@ import FormElementError from 'src/reusable_ui/components/form_layout/FormElement
 import {Source} from 'src/types'
 import {QueryStat} from 'src/types/influxAdmin'
 import AdminInfluxDBTab from './AdminInfluxDBTab'
+import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 
 interface Props {
   source: Source
@@ -81,7 +82,7 @@ class QueriesPage extends Component<Props, State> {
 
     return (
       <AdminInfluxDBTab activeTab="queries" source={source}>
-        <div className="panel panel-solid">
+        <div className="panel panel-solid influxdb-admin">
           <div className="panel-heading">
             <h2 className="panel-title">{title}</h2>
             <div style={{float: 'right', display: 'flex'}}>
@@ -105,23 +106,25 @@ class QueriesPage extends Component<Props, State> {
             </div>
           </div>
           <div className="panel-body">
-            {queries && queries.length ? (
-              <QueriesTable
-                queries={queries}
-                queriesSort={queriesSort}
-                changeSort={changeSort}
-                onKillQuery={this.handleKillQuery}
-              />
-            ) : null}
-            {errors.length ? (
-              <div style={{marginTop: '5px'}}>
-                {errors.map((e, i) => (
-                  <div key={`error${i}`}>
-                    <FormElementError message={e} />
-                  </div>
-                ))}
-              </div>
-            ) : null}
+            <FancyScrollbar>
+              {queries && queries.length ? (
+                <QueriesTable
+                  queries={queries}
+                  queriesSort={queriesSort}
+                  changeSort={changeSort}
+                  onKillQuery={this.handleKillQuery}
+                />
+              ) : null}
+              {errors.length ? (
+                <div style={{marginTop: '5px'}}>
+                  {errors.map((e, i) => (
+                    <div key={`error${i}`}>
+                      <FormElementError message={e} />
+                    </div>
+                  ))}
+                </div>
+              ) : null}
+            </FancyScrollbar>
           </div>
         </div>
       </AdminInfluxDBTab>

--- a/ui/src/shared/components/SubSections.tsx
+++ b/ui/src/shared/components/SubSections.tsx
@@ -1,34 +1,55 @@
 import React, {Component, ReactNode} from 'react'
 import uuid from 'uuid'
-import {withRouter, InjectedRouter} from 'react-router'
+import {withRouter, WithRouterProps} from 'react-router'
 
 import SubSectionsTab from 'src/shared/components/SubSectionsTab'
 import {ErrorHandling} from 'src/shared/decorators/errors'
 import {PageSection} from 'src/types/shared'
 import NotFound from './NotFound'
 
-interface Props {
+interface ClassNames {
+  top: string
+  nav: string
+  tabs: string
+  content: string
+}
+
+const TOP: ClassNames = {
+  top: 'subsection',
+  nav: 'subsection--nav',
+  tabs: 'subsection__tabs subsection__tabs--row',
+  content: 'subsection--content',
+}
+
+const LEFT: ClassNames = {
+  top: 'row subsection',
+  nav: 'col-md-2 subsection--nav',
+  tabs: 'subsection__tabs',
+  content: 'col-md-10 subsection--content',
+}
+interface Props extends WithRouterProps {
   sections: PageSection[]
   activeSection: string
   sourceID: string
-  router: InjectedRouter
   parentUrl: string
   children?: ReactNode
+  position?: 'left' | 'top'
 }
 
 @ErrorHandling
 class SubSections extends Component<Props> {
-  constructor(props) {
+  constructor(props: Props) {
     super(props)
   }
 
   public render() {
-    const {sections, activeSection} = this.props
+    const {sections, activeSection, position} = this.props
+    const classes = position === 'top' ? TOP : LEFT
 
     return (
-      <div className="row subsection">
-        <div className="col-md-2 subsection--nav" data-test="subsectionNav">
-          <div className="subsection--tabs">
+      <div className={classes.top}>
+        <div className={classes.nav} data-test="subsectionNav">
+          <div className={classes.tabs}>
             {sections.map(
               section =>
                 section.enabled && (
@@ -42,10 +63,7 @@ class SubSections extends Component<Props> {
             )}
           </div>
         </div>
-        <div
-          className="col-md-10 subsection--content"
-          data-test="subsectionContent"
-        >
+        <div className={classes.content} data-test="subsectionContent">
           {this.activeSectionComponent}
         </div>
       </div>

--- a/ui/src/style/layout/page-subsections.scss
+++ b/ui/src/style/layout/page-subsections.scss
@@ -20,10 +20,22 @@ $subsection-font: 17px;
     }
 }
 
-.subsection--tabs {
+.subsection__tabs {
     display: flex;
     flex-direction: column;
     align-items: stretch;
+    &.subsection__tabs--row {
+        flex-direction: row;
+        .subsection--tab {
+            height: ($chronograf-page-header-height / 2);
+            line-height: ($chronograf-page-header-height / 2);
+            border-radius: $radius $radius 0 0;
+            padding: 0 8px 0 10px;
+            &:nth-child(1) {
+                margin: 0 0 0 20px;
+            }
+        }
+    }
 }
 
 .subsection--tab {
@@ -44,6 +56,9 @@ $subsection-font: 17px;
         cursor: pointer;
         color: $g18-cloud;
         background-color: $g3-castle;
+    }
+    & .subsection__tabs--row {
+        padding: 0 8px 0 8px;
     }
 }
 

--- a/ui/src/style/pages/admin.scss
+++ b/ui/src/style/pages/admin.scss
@@ -106,6 +106,17 @@ pre.admin-table--query {
   }
 }
 
+.influxdb-admin.panel.panel-solid {
+  border-radius: 0px;
+  .panel-heading {
+    height: 90px;
+  }
+  .panel-body {
+    border-radius: 0px;
+    height: calc(100vh - 180px);
+    min-height: 10px;
+  }
+}
 /*
     Database Manager
     ----------------------------------------------------------------------------

--- a/ui/src/types/shared.ts
+++ b/ui/src/types/shared.ts
@@ -13,6 +13,6 @@ export interface DropdownAction {
 export interface PageSection {
   url: string
   name: string
-  component: ReactNode
+  component?: ReactNode
   enabled: boolean
 }


### PR DESCRIPTION
This PR reorganizes InfluxDB administration pages to occupy full page width, so there is more space for longer texts (such as queries) and a table-style role/permission management (as requested by https://github.com/influxdata/chronograf/issues/5834). InfluxDB administration tabs are newly organized at the top of the page.

**BEFORE THIS PR**:
![image](https://user-images.githubusercontent.com/16321466/168867605-57bafa91-299f-41a6-93eb-ba6665c0d65a.png)

**THIS PR**:
![image](https://user-images.githubusercontent.com/16321466/168868090-e392ae82-99bc-4339-bab3-d5a2ee86693b.png)


  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
