### PR TITLE
feat(ui): show effective user permissions on Users page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 1. [#5923](https://github.com/influxdata/chronograf/pull/5923): Manage InfluxDB roles including their database permissions.
 1. [#5925](https://github.com/influxdata/chronograf/pull/5925): Improve InfluxDB user creation.
 1. [#5926](https://github.com/influxdata/chronograf/pull/5926): Improve InfluxDB role creation.
+1. [#5927](https://github.com/influxdata/chronograf/pull/5927): Show effective permissions on Users page.
 
 ### Bug Fixes
 

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -22,7 +22,7 @@ import EmptyRow from 'src/admin/components/EmptyRow'
 import RoleRow from 'src/admin/components/RoleRow'
 import {useCallback} from 'react'
 import allOrParticularSelection from './util/allOrParticularSelection'
-import computeEffectiveDBPermissions from './util/computeEffectiveDBPermissions'
+import {computeEntitiesDBPermissions} from './util/computeEffectiveDBPermissions'
 import useDebounce from 'src/utils/useDebounce'
 import useChangeEffect from 'src/utils/useChangeEffect'
 import {ComponentSize, MultiSelectDropdown, SlideToggle} from 'src/reusable_ui'
@@ -99,7 +99,7 @@ const RolesPage = ({
   // effective permissions
   const visibleRoles = useMemo(() => roles.filter(x => !x.hidden), [roles])
   const perDBPermissions = useMemo(
-    () => computeEffectiveDBPermissions(visibleRoles, visibleDBNames),
+    () => computeEntitiesDBPermissions(visibleRoles, visibleDBNames),
     [visibleDBNames, visibleRoles]
   )
 

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -218,7 +218,7 @@ const RolesPage = ({
                     ? visibleDBNames.map(name => (
                         <th
                           className="admin-table__dbheader"
-                          title={`user's effective permissions for db: ${name}`}
+                          title={`effective permissions for db: ${name}`}
                           key={name}
                         >
                           {name}

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -24,7 +24,7 @@ import useDebounce from 'src/utils/useDebounce'
 import useChangeEffect from 'src/utils/useChangeEffect'
 import MultiSelectDropdown from 'src/reusable_ui/components/dropdowns/MultiSelectDropdown'
 import {ComponentSize, SlideToggle} from 'src/reusable_ui'
-import {computeEntitiesDBPermissions} from './util/computeEffectiveDBPermissions'
+import {computeEffectiveUserDBPermissions} from './util/computeEffectiveDBPermissions'
 import allOrParticularSelection from './util/allOrParticularSelection'
 import CreateUserDialog, {
   validatePassword,
@@ -107,8 +107,9 @@ const UsersPage = ({
   // effective permissions
   const visibleUsers = useMemo(() => users.filter(x => !x.hidden), [users])
   const userDBPermissions = useMemo(
-    () => computeEntitiesDBPermissions(visibleUsers, visibleDBNames),
-    [visibleDBNames, visibleUsers]
+    () =>
+      computeEffectiveUserDBPermissions(visibleUsers, roles, visibleDBNames),
+    [visibleDBNames, visibleUsers, roles]
   )
 
   // filter users
@@ -231,7 +232,7 @@ const UsersPage = ({
                     ? visibleDBNames.map(name => (
                         <th
                           className="admin-table__dbheader"
-                          title={`role's effective permissions for db: ${name}`}
+                          title={`effective permissions for db: ${name}`}
                           key={name}
                         >
                           {name}

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -24,7 +24,7 @@ import useDebounce from 'src/utils/useDebounce'
 import useChangeEffect from 'src/utils/useChangeEffect'
 import MultiSelectDropdown from 'src/reusable_ui/components/dropdowns/MultiSelectDropdown'
 import {ComponentSize, SlideToggle} from 'src/reusable_ui'
-import computeEffectiveDBPermissions from './util/computeEffectiveDBPermissions'
+import {computeEntitiesDBPermissions} from './util/computeEffectiveDBPermissions'
 import allOrParticularSelection from './util/allOrParticularSelection'
 import CreateUserDialog, {
   validatePassword,
@@ -107,7 +107,7 @@ const UsersPage = ({
   // effective permissions
   const visibleUsers = useMemo(() => users.filter(x => !x.hidden), [users])
   const userDBPermissions = useMemo(
-    () => computeEffectiveDBPermissions(visibleUsers, visibleDBNames),
+    () => computeEntitiesDBPermissions(visibleUsers, visibleDBNames),
     [visibleDBNames, visibleUsers]
   )
 

--- a/ui/src/admin/containers/influxdb/util/computeEffectiveDBPermissions.ts
+++ b/ui/src/admin/containers/influxdb/util/computeEffectiveDBPermissions.ts
@@ -1,40 +1,63 @@
 import {User, UserPermission, UserRole} from 'src/types/influxAdmin'
 
-/** Array of users with Arrays of databases containing granted permission records */
+/** Array of corresponding users/roles with Arrays of corresponding databases containing granted permission records */
 type EntitiesDBPermissions = Array<Array<Record<string, boolean>>>
+/** record with database names and their permissions */
+type DBPermRecords = Record<string, Record<string, boolean>>
+
 /**
- * Creates effective user permissions as a record
- * that contains permission names as keys and `true` values
- * for every assigned permission.
+ * ComputeDBPermRecords computes EntitiesDBPermissions for
+ * a suplied user/role and database names.
  */
-export default function computeEffectiveDBPermissions(
-  users: User[] | UserRole[],
+export function computeDBPermRecords(
+  u: User | UserRole,
+  dbNames: string[]
+): DBPermRecords {
+  return u.permissions.reduce((acc: DBPermRecords, perm: UserPermission) => {
+    if (perm.scope === 'all') {
+      const allowed = perm.allowed.includes('ALL')
+        ? {READ: true, WRITE: true}
+        : perm.allowed.reduce((obj, x) => {
+            obj[x] = true
+            return obj
+          }, {})
+      dbNames.forEach(name => (acc[name] = {...allowed, ...acc[name]}))
+    } else if (perm.scope === 'database') {
+      acc[perm.name] = perm.allowed.reduce<Record<string, boolean>>(
+        (obj, permValue) => {
+          obj[permValue] = true
+          return obj
+        },
+        acc[perm.name] || {}
+      )
+    }
+    return acc
+  }, {} as DBPermRecords)
+}
+
+/**
+ * MergeDBPermRecords merges supplied DBPermRecords in to a new DBPermRecords instance.
+ */
+export function mergeDBPermRecords(...records: DBPermRecords[]): DBPermRecords {
+  return records.reduce((acc: DBPermRecords, record: DBPermRecords) => {
+    Object.entries(record).forEach(([db, perms]) => {
+      const dbPerms = acc[db] || (acc[db] = {})
+      Object.entries(perms).forEach(([perm, val]) => (dbPerms[perm] = val))
+    })
+    return acc
+  }, {} as DBPermRecords)
+}
+
+/**
+ * ComputeEntitiesDBPermissions computes EntitiesDBPermissions for
+ * suplied users/roles and database names.
+ */
+export function computeEntitiesDBPermissions(
+  entities: User[] | UserRole[],
   dbNames: string[]
 ): EntitiesDBPermissions {
-  return users.map((u: User | UserRole) => {
-    const permRecord = u.permissions.reduce(
-      (acc: EntitiesDBPermissions, perm: UserPermission) => {
-        if (perm.scope === 'all') {
-          const allowed = perm.allowed.includes('ALL')
-            ? {READ: true, WRITE: true}
-            : perm.allowed.reduce((obj, x) => {
-                obj[x] = true
-                return obj
-              }, {})
-          dbNames.forEach(name => (acc[name] = {...allowed, ...acc[name]}))
-        } else if (perm.scope === 'database') {
-          acc[perm.name] = perm.allowed.reduce<Record<string, boolean>>(
-            (obj, permValue) => {
-              obj[permValue] = true
-              return obj
-            },
-            acc[perm.name] || {}
-          )
-        }
-        return acc
-      },
-      {} as EntitiesDBPermissions
-    )
-    return dbNames.map(name => permRecord[name] || {})
+  return entities.map((u: User | UserRole) => {
+    const dbPermRecords = computeDBPermRecords(u, dbNames)
+    return dbNames.map(dbName => dbPermRecords[dbName] || {})
   })
 }

--- a/ui/test/admin/containers/influxdb/util/computeEffectiveDBPermissions.test.ts
+++ b/ui/test/admin/containers/influxdb/util/computeEffectiveDBPermissions.test.ts
@@ -1,4 +1,4 @@
-import subject from 'src/admin/containers/influxdb/util/computeEffectiveDBPermissions'
+import {computeEntitiesDBPermissions} from 'src/admin/containers/influxdb/util/computeEffectiveDBPermissions'
 import {User} from 'src/types/influxAdmin'
 const redundantUserProperties: Pick<User, 'roles' | 'links'> = {
   roles: [],
@@ -6,91 +6,94 @@ const redundantUserProperties: Pick<User, 'roles' | 'links'> = {
 }
 
 describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
-  it('creates values for empty users', () => {
-    expect(subject([], ['whateverdb'])).toEqual([])
-  })
-  it('creates values for no databases', () => {
-    expect(
-      subject([{name: 'a', permissions: [], ...redundantUserProperties}], [])
-    ).toEqual([[]])
-  })
-  it('computes db-specific permissions', () => {
-    expect(
-      subject(
+  describe('computeEntitiesDBPermissions', () => {
+    const subject = computeEntitiesDBPermissions
+    it('creates values for empty users', () => {
+      expect(subject([], ['whateverdb'])).toEqual([])
+    })
+    it('creates values for no databases', () => {
+      expect(
+        subject([{name: 'a', permissions: [], ...redundantUserProperties}], [])
+      ).toEqual([[]])
+    })
+    it('computes db-specific permissions', () => {
+      expect(
+        subject(
+          [
+            {
+              name: 'a',
+              permissions: [
+                {scope: 'database', name: 'db1', allowed: ['A']},
+                {scope: 'database', name: 'db3', allowed: ['B', 'C']},
+              ],
+              ...redundantUserProperties,
+            },
+          ],
+          ['db1', 'db2', 'db3']
+        )
+      ).toEqual([[{A: true}, {}, {B: true, C: true}]])
+    })
+    it('maps all-scoped ALL permission to READ, WRITE', () => {
+      expect(
+        subject(
+          [
+            {
+              name: 'a',
+              permissions: [{scope: 'all', allowed: ['ALL']}],
+              ...redundantUserProperties,
+            },
+          ],
+          ['db1', 'db2']
+        )
+      ).toEqual([
         [
-          {
-            name: 'a',
-            permissions: [
-              {scope: 'database', name: 'db1', allowed: ['A']},
-              {scope: 'database', name: 'db3', allowed: ['B', 'C']},
-            ],
-            ...redundantUserProperties,
-          },
+          {READ: true, WRITE: true},
+          {READ: true, WRITE: true},
         ],
-        ['db1', 'db2', 'db3']
-      )
-    ).toEqual([[{A: true}, {}, {B: true, C: true}]])
-  })
-  it('maps all-scoped ALL permission to READ, WRITE', () => {
-    expect(
-      subject(
+      ])
+    })
+    it('inherits all permissions', () => {
+      expect(
+        subject(
+          [
+            {
+              name: 'a',
+              permissions: [
+                {scope: 'all', allowed: ['Read']},
+                {scope: 'database', name: 'db1', allowed: ['Write']},
+                {scope: 'database', name: 'db2', allowed: ['Other']},
+              ],
+              ...redundantUserProperties,
+            },
+          ],
+          ['db1', 'db2']
+        )
+      ).toEqual([
         [
-          {
-            name: 'a',
-            permissions: [{scope: 'all', allowed: ['ALL']}],
-            ...redundantUserProperties,
-          },
+          {Read: true, Write: true},
+          {Read: true, Other: true},
         ],
-        ['db1', 'db2']
-      )
-    ).toEqual([
-      [
-        {READ: true, WRITE: true},
-        {READ: true, WRITE: true},
-      ],
-    ])
-  })
-  it('inherits all permissions', () => {
-    expect(
-      subject(
-        [
-          {
-            name: 'a',
-            permissions: [
-              {scope: 'all', allowed: ['Read']},
-              {scope: 'database', name: 'db1', allowed: ['Write']},
-              {scope: 'database', name: 'db2', allowed: ['Other']},
-            ],
-            ...redundantUserProperties,
-          },
-        ],
-        ['db1', 'db2']
-      )
-    ).toEqual([
-      [
-        {Read: true, Write: true},
-        {Read: true, Other: true},
-      ],
-    ])
-  })
-  it('inherits independently on order', () => {
-    expect(
-      subject(
-        [
-          {
-            name: 'a',
-            permissions: [
-              {scope: 'database', name: 'db2', allowed: ['Other']},
-              {scope: 'database', name: 'db1', allowed: ['Write']},
-              {scope: 'all', allowed: ['Read']},
-            ],
-            ...redundantUserProperties,
-          },
-        ],
-        ['db1', 'db2', 'db3']
-      )
-    ).toEqual([
-      [{Read: true, Write: true}, {Read: true, Other: true}, {Read: true}],
-    ])
+      ])
+    })
+    it('inherits independently on order', () => {
+      expect(
+        subject(
+          [
+            {
+              name: 'a',
+              permissions: [
+                {scope: 'database', name: 'db2', allowed: ['Other']},
+                {scope: 'database', name: 'db1', allowed: ['Write']},
+                {scope: 'all', allowed: ['Read']},
+              ],
+              ...redundantUserProperties,
+            },
+          ],
+          ['db1', 'db2', 'db3']
+        )
+      ).toEqual([
+        [{Read: true, Write: true}, {Read: true, Other: true}, {Read: true}],
+      ])
+    })
   })
 })

--- a/ui/test/admin/containers/influxdb/util/computeEffectiveDBPermissions.test.ts
+++ b/ui/test/admin/containers/influxdb/util/computeEffectiveDBPermissions.test.ts
@@ -1,11 +1,146 @@
-import {computeEntitiesDBPermissions} from 'src/admin/containers/influxdb/util/computeEffectiveDBPermissions'
-import {User} from 'src/types/influxAdmin'
-const redundantUserProperties: Pick<User, 'roles' | 'links'> = {
+import {
+  computeDBPermRecords,
+  computeEffectiveUserDBPermissions,
+  computeEntitiesDBPermissions,
+  mergeDBPermRecords,
+} from 'src/admin/containers/influxdb/util/computeEffectiveDBPermissions'
+import {User, UserRole} from 'src/types/influxAdmin'
+const emptyUserProperties: Pick<User, 'roles' | 'links'> = {
   roles: [],
+  links: {self: ''},
+}
+const emptyRoleProperties: Pick<UserRole, 'users' | 'links'> = {
+  users: [],
   links: {self: ''},
 }
 
 describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
+  describe('computeDBPermRecords', () => {
+    const subject = computeDBPermRecords
+    it('creates value for no databases', () => {
+      expect(
+        subject({name: 'a', permissions: [], ...emptyUserProperties}, [])
+      ).toEqual({})
+      expect(
+        subject({name: 'a', permissions: [], ...emptyUserProperties}, [], {
+          db1: {},
+        })
+      ).toEqual({db1: {}})
+    })
+    it('computes db-specific permissions', () => {
+      expect(
+        subject(
+          {
+            name: 'a',
+            permissions: [
+              {scope: 'database', name: 'db1', allowed: ['A']},
+              {scope: 'database', name: 'db3', allowed: ['B', 'C']},
+            ],
+            ...emptyUserProperties,
+          },
+          ['db1', 'db2', 'db3']
+        )
+      ).toEqual({db1: {A: true}, db3: {B: true, C: true}})
+    })
+    it('maps all-scoped ALL permission to READ, WRITE', () => {
+      expect(
+        subject(
+          {
+            name: 'a',
+            permissions: [{scope: 'all', allowed: ['ALL']}],
+            ...emptyUserProperties,
+          },
+          ['db1', 'db2']
+        )
+      ).toEqual({
+        db1: {READ: true, WRITE: true},
+        db2: {READ: true, WRITE: true},
+      })
+    })
+    it('inherits all permissions', () => {
+      expect(
+        subject(
+          {
+            name: 'a',
+            permissions: [
+              {scope: 'all', allowed: ['Read']},
+              {scope: 'database', name: 'db1', allowed: ['Write']},
+              {scope: 'database', name: 'db2', allowed: ['Other']},
+            ],
+            ...emptyUserProperties,
+          },
+          ['db1', 'db2']
+        )
+      ).toEqual({
+        db1: {Read: true, Write: true},
+        db2: {Read: true, Other: true},
+      })
+    })
+    it('inherits independently on order', () => {
+      expect(
+        subject(
+          {
+            name: 'a',
+            permissions: [
+              {scope: 'database', name: 'db2', allowed: ['Other']},
+              {scope: 'database', name: 'db1', allowed: ['Write']},
+              {scope: 'all', allowed: ['Read']},
+            ],
+            ...emptyUserProperties,
+          },
+          ['db1', 'db2', 'db3']
+        )
+      ).toEqual({
+        db1: {Read: true, Write: true},
+        db2: {Read: true, Other: true},
+        db3: {Read: true},
+      })
+    })
+    it('uses custom initial DB perms', () => {
+      expect(
+        subject(
+          {
+            name: 'a',
+            permissions: [
+              {scope: 'database', name: 'db2', allowed: ['Other']},
+              {scope: 'database', name: 'db1', allowed: ['Write']},
+              {scope: 'all', allowed: ['Read']},
+            ],
+            ...emptyUserProperties,
+          },
+          ['db1', 'db2', 'db3'],
+          {a: {Other: true}, db3: {Write: true}}
+        )
+      ).toEqual({
+        a: {Other: true},
+        db1: {Read: true, Write: true},
+        db2: {Read: true, Other: true},
+        db3: {Read: true, Write: true},
+      })
+    })
+  })
+  describe('mergeDBPermRecords', () => {
+    const subject = mergeDBPermRecords
+    it('can merge no records', () => {
+      expect(subject()).toEqual({})
+    })
+    it('can merge empty records', () => {
+      expect(subject({}, {}, {})).toEqual({})
+    })
+    it('can merge perm non-empty records', () => {
+      expect(
+        subject(
+          {db1: {R: true}},
+          {db2: {W: true}},
+          {db1: {W: true}, db2: {R: true}, db3: {O: true, C: true}}
+        )
+      ).toEqual({
+        db1: {R: true, W: true},
+        db2: {R: true, W: true},
+        db3: {O: true, C: true},
+      })
+    })
+  })
   describe('computeEntitiesDBPermissions', () => {
     const subject = computeEntitiesDBPermissions
     it('creates values for empty users', () => {
@@ -13,7 +148,7 @@ describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
     })
     it('creates values for no databases', () => {
       expect(
-        subject([{name: 'a', permissions: [], ...redundantUserProperties}], [])
+        subject([{name: 'a', permissions: [], ...emptyUserProperties}], [])
       ).toEqual([[]])
     })
     it('computes db-specific permissions', () => {
@@ -26,7 +161,7 @@ describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
                 {scope: 'database', name: 'db1', allowed: ['A']},
                 {scope: 'database', name: 'db3', allowed: ['B', 'C']},
               ],
-              ...redundantUserProperties,
+              ...emptyUserProperties,
             },
           ],
           ['db1', 'db2', 'db3']
@@ -40,7 +175,7 @@ describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
             {
               name: 'a',
               permissions: [{scope: 'all', allowed: ['ALL']}],
-              ...redundantUserProperties,
+              ...emptyUserProperties,
             },
           ],
           ['db1', 'db2']
@@ -63,7 +198,7 @@ describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
                 {scope: 'database', name: 'db1', allowed: ['Write']},
                 {scope: 'database', name: 'db2', allowed: ['Other']},
               ],
-              ...redundantUserProperties,
+              ...emptyUserProperties,
             },
           ],
           ['db1', 'db2']
@@ -86,13 +221,112 @@ describe('admin/containers/influxdb/util/computeEffectiveDBPermissions', () => {
                 {scope: 'database', name: 'db1', allowed: ['Write']},
                 {scope: 'all', allowed: ['Read']},
               ],
-              ...redundantUserProperties,
+              ...emptyUserProperties,
             },
           ],
           ['db1', 'db2', 'db3']
         )
       ).toEqual([
         [{Read: true, Write: true}, {Read: true, Other: true}, {Read: true}],
+      ])
+    })
+  })
+  describe('computeEffectiveUserDBPermissions', () => {
+    const subject = computeEffectiveUserDBPermissions
+    it('creates values for empty users', () => {
+      expect(subject([], [], ['whateverdb'])).toEqual([])
+    })
+    it('creates values for no databases', () => {
+      expect(
+        subject([{...emptyUserProperties, name: 'a', permissions: []}], [], [])
+      ).toEqual([[]])
+    })
+    it('computes effective permissions', () => {
+      expect(
+        subject(
+          [
+            {
+              ...emptyUserProperties,
+              name: 'a',
+              permissions: [
+                {scope: 'database', name: 'db1', allowed: ['A']},
+                {scope: 'database', name: 'db3', allowed: ['B', 'C']},
+              ],
+              roles: [
+                {
+                  ...emptyRoleProperties,
+                  name: 'ra',
+                  permissions: [],
+                },
+                {
+                  ...emptyRoleProperties,
+                  name: 'rb',
+                  permissions: [],
+                },
+              ],
+            },
+          ],
+          [
+            {
+              ...emptyRoleProperties,
+              name: 'ra',
+              permissions: [{scope: 'database', name: 'db1', allowed: ['B']}],
+            },
+            {
+              ...emptyRoleProperties,
+              name: 'rb',
+              permissions: [{scope: 'database', name: 'db2', allowed: ['B']}],
+            },
+          ],
+          ['db1', 'db2', 'db3']
+        )
+      ).toEqual([[{A: true, B: true}, {B: true}, {B: true, C: true}]])
+    })
+    it('inherits all permissions from role', () => {
+      expect(
+        subject(
+          [
+            {
+              ...emptyUserProperties,
+              name: 'a',
+              permissions: [
+                {scope: 'database', name: 'db1', allowed: ['W']},
+                {scope: 'all', allowed: ['R']},
+                {scope: 'database', name: 'db2', allowed: ['O']},
+              ],
+              roles: [
+                {
+                  ...emptyRoleProperties,
+                  name: 'ra',
+                  permissions: [],
+                },
+                {
+                  ...emptyRoleProperties,
+                  name: 'rb',
+                  permissions: [],
+                },
+              ],
+            },
+          ],
+          [
+            {
+              ...emptyRoleProperties,
+              name: 'ra',
+              permissions: [{scope: 'database', name: 'db1', allowed: ['B']}],
+            },
+            {
+              ...emptyRoleProperties,
+              name: 'rb',
+              permissions: [{scope: 'all', allowed: ['C']}],
+            },
+          ],
+          ['db1', 'db2']
+        )
+      ).toEqual([
+        [
+          {R: true, W: true, B: true, C: true},
+          {R: true, O: true, C: true},
+        ],
       ])
     })
   })


### PR DESCRIPTION
This PR ensures that effective user permissions (including permissions from user roles) are shown on the Users Page.

![image](https://user-images.githubusercontent.com/16321466/172403477-d8339183-ce07-4746-8234-543e386c9175.png)

The example above demonstrates effective permissions in action:
- `test1` role grants Write on [_internal,a,b] databases, user `lojza` has only this role and no extra granted permissions
- `test2` role grants Read on [a,b] databases, user `pavel` has only this role and no extra granted permissions
-  effective permissions for user `pepa` are shown, they represent user granted permissions (Write on x3 database) and all permissions granted by assigned roles (test1, test2)

It is a part of the solution to https://github.com/influxdata/chronograf/issues/5834

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
