### PR TITLE
feat(ui): add refresh button to InfluxDB Users/Roles/Databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 1. [#5925](https://github.com/influxdata/chronograf/pull/5925): Improve InfluxDB user creation.
 1. [#5926](https://github.com/influxdata/chronograf/pull/5926): Improve InfluxDB role creation.
 1. [#5927](https://github.com/influxdata/chronograf/pull/5927): Show effective permissions on Users page.
+1. [#5929](https://github.com/influxdata/chronograf/pull/5926): Add refresh button to InfluxDB Users/Roles/Databases page.
 
 ### Bug Fixes
 

--- a/ui/src/admin/containers/influxdb/AdminInfluxDBTabbedPage.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBTabbedPage.tsx
@@ -44,7 +44,7 @@ const AdminInfluxDBTabbedPage = ({source, activeTab, children}: Props) => {
     ]
   }, [source])
   return (
-    <WrapToPage>
+    <WrapToPage hideRefresh={activeTab === 'queries'}>
       <SubSections
         parentUrl="admin-influxdb"
         sourceID={source.id}


### PR DESCRIPTION
This PR adds a refresh button to InfluxDB pages for users, roles, and databases. It does not add a refresh button to Queries pages, a different reload mechanism is used therein.

![image](https://user-images.githubusercontent.com/16321466/172581003-f353d359-f99c-410e-840a-f9fd03634cdf.png)

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
