### PR TITLE
fix(ui): fix alignment of buttons on Queries page

### DIFF
--- a/ui/src/admin/containers/influxdb/QueriesPage.tsx
+++ b/ui/src/admin/containers/influxdb/QueriesPage.tsx
@@ -85,7 +85,7 @@ class QueriesPage extends Component<Props, State> {
         <div className="panel panel-solid influxdb-admin">
           <div className="panel-heading">
             <h2 className="panel-title">{title}</h2>
-            <div style={{float: 'right', display: 'flex'}}>
+            <div className="panel-heading--right">
               {queries && queries.length ? (
                 <div style={{marginRight: '5px'}}>
                   <Button


### PR DESCRIPTION
This PR properly aligns header buttons on `Queries` page to the right, it is a side defect of 1.10 new Role/User management.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
