### PR TITLE
fix(ui): detect unsupported value properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [#5913](https://github.com/influxdata/chronograf/pull/5913): Improve InfluxDB Enterprise detection. 
 1. [#5917](https://github.com/influxdata/chronograf/pull/5917): Improve InfluxDB Enterprise user creation process. 
 1. [#5917](https://github.com/influxdata/chronograf/pull/5917): Avoid stale reads in communication with InfluxDB Enterprise meta nodes. 
+1. [#5938](https://github.com/influxdata/chronograf/pull/5938): Properly detect unsupported values in Alert Rule builder.
 
 ### Other
 

--- a/ui/src/kapacitor/components/RuleGraphDygraph.tsx
+++ b/ui/src/kapacitor/components/RuleGraphDygraph.tsx
@@ -64,7 +64,7 @@ class RuleGraphDygraph extends Component<Props, State> {
     if (!timeSeriesToDygraphResult) {
       return null
     }
-    if (timeSeriesToDygraphResult.unsupportedValue) {
+    if (timeSeriesToDygraphResult.unsupportedValue !== undefined) {
       console.error(
         'Unsupported y-axis value, cannot display data',
         timeSeriesToDygraphResult


### PR DESCRIPTION
Closes #5935

_Briefly describe your proposed changes:_
Repairs detection of unsupported values for Dygraph visualization.
_What was the problem?_
The detection treated `false` unsupported value as a supported value
_What was the solution?_
Alert rule builder works only with number values, so it now strictly requires that there is no (`undefined`) unsupported value in the query, in such a case the UI (already) shows:
![image](https://user-images.githubusercontent.com/16321466/173537632-70891401-e00f-4616-ac1b-b47bc0f5aa6b.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
