### PR TITLE
feat(server): support InfluxDB behind proxy under subpath

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 1. [#5926](https://github.com/influxdata/chronograf/pull/5926): Improve InfluxDB role creation.
 1. [#5927](https://github.com/influxdata/chronograf/pull/5927): Show effective permissions on Users page.
 1. [#5929](https://github.com/influxdata/chronograf/pull/5926): Add refresh button to InfluxDB Users/Roles/Databases page.
+1. [#5940](https://github.com/influxdata/chronograf/pull/5940): Support InfluxDB behind proxy under subpath.
 
 ### Bug Fixes
 

--- a/flux/client.go
+++ b/flux/client.go
@@ -1,15 +1,11 @@
 package flux
 
 import (
-	"context"
-	"errors"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 
-	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/util"
 )
 
@@ -24,32 +20,6 @@ type Client struct {
 	URL                *url.URL
 	InsecureSkipVerify bool
 	Timeout            time.Duration
-}
-
-// Ping checks the connection of a Flux.
-func (c *Client) Ping(ctx context.Context) error {
-	t := 2 * time.Second
-	if c.Timeout > 0 {
-		t = c.Timeout
-	}
-	ctx, cancel := context.WithTimeout(ctx, t)
-	defer cancel()
-	err := c.pingTimeout(ctx)
-	return err
-}
-
-func (c *Client) pingTimeout(ctx context.Context) error {
-	resps := make(chan (error))
-	go func() {
-		resps <- c.ping(c.URL)
-	}()
-
-	select {
-	case resp := <-resps:
-		return resp
-	case <-ctx.Done():
-		return chronograf.ErrUpstreamTimeout
-	}
 }
 
 // FluxEnabled returns true if the server has flux querying enabled.
@@ -82,37 +52,4 @@ func (c *Client) FluxEnabled() (bool, error) {
 	// 2.x: Flux is always enabled, the 401 response with 'application/json; charset=utf-8' content type and body
 	// {"code":"unauthorized","message":"unauthorized access"} is received
 	return strings.HasPrefix(contentType, "application/json"), nil
-}
-
-func (c *Client) ping(u *url.URL) error {
-	u = util.AppendPath(u, "/ping")
-
-	req, err := http.NewRequest("GET", u.String(), nil)
-	if err != nil {
-		return err
-	}
-
-	hc := &http.Client{}
-	if c.InsecureSkipVerify {
-		hc.Transport = skipVerifyTransport
-	} else {
-		hc.Transport = defaultTransport
-	}
-
-	resp, err := hc.Do(req)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode != http.StatusNoContent {
-		return errors.New(string(body))
-	}
-
-	return nil
 }

--- a/flux/client.go
+++ b/flux/client.go
@@ -54,8 +54,7 @@ func (c *Client) pingTimeout(ctx context.Context) error {
 
 // FluxEnabled returns true if the server has flux querying enabled.
 func (c *Client) FluxEnabled() (bool, error) {
-	url := c.URL
-	url.Path = "/api/v2/query"
+	url := util.AppendPath(c.URL, "/api/v2/query")
 
 	req, err := http.NewRequest("POST", url.String(), nil)
 	if err != nil {
@@ -86,7 +85,7 @@ func (c *Client) FluxEnabled() (bool, error) {
 }
 
 func (c *Client) ping(u *url.URL) error {
-	u.Path = "ping"
+	u = util.AppendPath(u, "/ping")
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {

--- a/flux/client_test.go
+++ b/flux/client_test.go
@@ -1,0 +1,56 @@
+package flux_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/chronograf/flux"
+)
+
+// NewClient initializes an HTTP Client for InfluxDB.
+func NewClient(urlStr string) *flux.Client {
+	u, _ := url.Parse(urlStr)
+	return &flux.Client{
+		URL:     u,
+		Timeout: 500 * time.Millisecond,
+	}
+}
+
+func Test_FluxEnabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		path := r.URL.Path
+		if !strings.HasSuffix(path, "/api/v2/query") {
+			t.Error("Expected the path to contain `/api/v2/query` but was", path)
+		}
+		if strings.HasPrefix(path, "/enabled_v1") {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusBadRequest)
+			rw.Write([]byte(`{}`))
+			return
+		}
+		if strings.HasPrefix(path, "/enabled_v2") {
+			rw.Header().Add("Content-Type", "application/json")
+			rw.WriteHeader(http.StatusUnauthorized)
+			rw.Write([]byte(`{"code":"unauthorized","message":"unauthorized access"}`))
+			return
+		}
+		rw.Header().Add("Content-Type", "text/plain")
+		rw.WriteHeader(http.StatusForbidden)
+		rw.Write([]byte(`Flux query service disabled.`))
+	}))
+	defer ts.Close()
+
+	if enabled, _ := NewClient(ts.URL).FluxEnabled(); enabled {
+		t.Errorf("Client.FluxEnabled() expected false value")
+	}
+	if enabled, _ := NewClient(ts.URL + "/enabled_v1").FluxEnabled(); !enabled {
+		t.Errorf("Client.FluxEnabled() expected true value")
+	}
+	if enabled, _ := NewClient(ts.URL + "/enabled_v2").FluxEnabled(); !enabled {
+		t.Errorf("Client.FluxEnabled() expected true value")
+	}
+}

--- a/influx/influx.go
+++ b/influx/influx.go
@@ -65,7 +65,8 @@ func (r *responseType) Error() string {
 }
 
 func (c *Client) query(u *url.URL, q chronograf.Query) (chronograf.Response, error) {
-	u.Path = "query"
+	u = util.AppendPath(u, "/query")
+
 	req, err := http.NewRequest("POST", u.String(), nil)
 	if err != nil {
 		return nil, err
@@ -183,7 +184,7 @@ func (c *Client) validateAuthFlux(ctx context.Context, src *chronograf.Source) e
 	if err != nil {
 		return err
 	}
-	u.Path = "api/v2/query"
+	u = util.AppendPath(u, "/api/v2/query")
 	command := "buckets()"
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(command))
 	if err != nil {
@@ -297,7 +298,7 @@ type pingResult struct {
 }
 
 func (c *Client) ping(u *url.URL) (string, string, error) {
-	u.Path = "ping"
+	u = util.AppendPath(u, "/ping")
 
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
@@ -392,7 +393,7 @@ func (c *Client) writePoint(ctx context.Context, point *chronograf.Point) error 
 }
 
 func (c *Client) write(ctx context.Context, u *url.URL, db, rp, lp string) error {
-	u.Path = "write"
+	u = util.AppendPath(u, "/write")
 	req, err := http.NewRequest("POST", u.String(), strings.NewReader(lp))
 	if err != nil {
 		return err

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -539,14 +539,11 @@ func TestClient_write(t *testing.T) {
 
 func Test_Influx_ValidateAuth_V1(t *testing.T) {
 	t.Parallel()
-	called := false
+	calledPath := ""
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
 		rw.Write([]byte(`{"error":"v1authfailed"}`))
-		called = true
-		if path := r.URL.Path; path != "/query" {
-			t.Error("Expected the path to contain `/query` but was: ", path)
-		}
+		calledPath = r.URL.Path
 		expectedAuth := "Basic " + base64.StdEncoding.EncodeToString(([]byte)("my-user:my-pwd"))
 		if auth := r.Header.Get("Authorization"); auth != expectedAuth {
 			t.Errorf("Expected Authorization '%v' but was: %v", expectedAuth, auth)
@@ -554,66 +551,69 @@ func Test_Influx_ValidateAuth_V1(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	client, err := NewClient(ts.URL, log.New(log.DebugLevel))
-	if err != nil {
-		t.Fatal("Unexpected error initializing client: err:", err)
-	}
+	for _, urlContext := range []string{"", "/ctx"} {
+		client, err := NewClient(ts.URL+urlContext, log.New(log.DebugLevel))
+		if err != nil {
+			t.Fatal("Unexpected error initializing client: err:", err)
+		}
+		source := &chronograf.Source{
+			URL:      ts.URL + urlContext,
+			Username: "my-user",
+			Password: "my-pwd",
+		}
 
-	source := &chronograf.Source{
-		URL:      ts.URL,
-		Username: "my-user",
-		Password: "my-pwd",
-	}
-
-	client.Connect(context.Background(), source)
-	err = client.ValidateAuth(context.Background(), &chronograf.Source{})
-	if err == nil {
-		t.Fatal("Expected error but nil")
-	}
-	if !strings.Contains(err.Error(), "v1authfailed") {
-		t.Errorf("Expected client error '%v' to contain server-sent error message", err)
-	}
-	if called == false {
-		t.Error("Expected http request to InfluxDB but there was none")
+		client.Connect(context.Background(), source)
+		err = client.ValidateAuth(context.Background(), &chronograf.Source{})
+		if err == nil {
+			t.Fatal("Expected error but nil")
+		}
+		if !strings.Contains(err.Error(), "v1authfailed") {
+			t.Errorf("Expected client error '%v' to contain server-sent error message", err)
+		}
+		if calledPath != urlContext+"/query" {
+			t.Errorf("Path received: %v, want: %v ", calledPath, urlContext+"/query")
+		}
 	}
 }
 
 func Test_Influx_ValidateAuth_V2(t *testing.T) {
 	t.Parallel()
-	called := false
+	calledPath := ""
 	ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.WriteHeader(http.StatusUnauthorized)
 		rw.Write([]byte(`{"message":"v2authfailed"}`))
-		called = true
+		calledPath = r.URL.Path
 		if auth := r.Header.Get("Authorization"); auth != "Token my-token" {
 			t.Error("Expected Authorization 'Token my-token' but was: ", auth)
 		}
-		if path := r.URL.Path; path != "/api/v2/query" {
+		if path := r.URL.Path; !strings.HasSuffix(path, "/api/v2/query") {
 			t.Error("Expected the path to contain `api/v2/query` but was: ", path)
 		}
 	}))
 	defer ts.Close()
+	for _, urlContext := range []string{"", "/ctx"} {
+		calledPath = ""
+		client, err := NewClient(ts.URL+urlContext, log.New(log.DebugLevel))
+		if err != nil {
+			t.Fatal("Unexpected error initializing client: err:", err)
+		}
+		source := &chronograf.Source{
+			URL:      ts.URL + urlContext,
+			Type:     chronograf.InfluxDBv2,
+			Username: "my-org",
+			Password: "my-token",
+		}
 
-	client, err := NewClient(ts.URL, log.New(log.DebugLevel))
-	if err != nil {
-		t.Fatal("Unexpected error initializing client: err:", err)
-	}
-	source := &chronograf.Source{
-		URL:      ts.URL,
-		Type:     chronograf.InfluxDBv2,
-		Username: "my-org",
-		Password: "my-token",
-	}
-
-	client.Connect(context.Background(), source)
-	err = client.ValidateAuth(context.Background(), source)
-	if err == nil {
-		t.Fatal("Expected error but nil")
-	}
-	if !strings.Contains(err.Error(), "v2authfailed") {
-		t.Errorf("Expected client error '%v' to contain server-sent error message", err)
-	}
-	if called == false {
-		t.Error("Expected http request to InfluxDB but there was none")
+		client.Connect(context.Background(), source)
+		err = client.ValidateAuth(context.Background(), source)
+		if err == nil {
+			t.Fatal("Expected error but nil")
+		}
+		if !strings.Contains(err.Error(), "v2authfailed") {
+			t.Errorf("Expected client error '%v' to contain server-sent error message", err)
+		}
+		if calledPath != urlContext+"/api/v2/query" {
+			t.Errorf("Path received: %v, want: %v ", calledPath, urlContext+"/api/v2/query")
+		}
 	}
 }

--- a/server/influx.go
+++ b/server/influx.go
@@ -16,6 +16,7 @@ import (
 	"github.com/influxdata/chronograf"
 	uuid "github.com/influxdata/chronograf/id"
 	"github.com/influxdata/chronograf/influx"
+	"github.com/influxdata/chronograf/util"
 )
 
 // ValidInfluxRequest checks if queries specify a command.
@@ -124,13 +125,13 @@ func (s *Service) Write(w http.ResponseWriter, r *http.Request) {
 	version := query.Get("v")
 	query.Del("v")
 	if strings.HasPrefix(version, "2") {
-		u.Path = "/api/v2/write"
+		u = util.AppendPath(u, "/api/v2/write")
 		// v2 organization name is stored in username (org does not matter against v1)
 		query.Set("org", src.Username)
 		query.Set("bucket", query.Get("db"))
 		query.Del("db")
 	} else {
-		u.Path = "/write"
+		u = util.AppendPath(u, "/write")
 	}
 	u.RawQuery = query.Encode()
 

--- a/util/path.go
+++ b/util/path.go
@@ -1,0 +1,21 @@
+package util
+
+import (
+	"net/url"
+)
+
+// AppendPath appends path to the supplied URL and returns a new URL instance.
+func AppendPath(url *url.URL, path string) *url.URL {
+	retVal := *url
+	if len(path) == 0 {
+		return &retVal
+	}
+	if path[0] != '/' {
+		path = "/" + path
+	}
+	if len(retVal.Path) > 0 && retVal.Path[len(retVal.Path)-1] == '/' {
+		retVal.Path = retVal.Path[0 : len(retVal.Path)-1]
+	}
+	retVal.Path += path
+	return &retVal
+}

--- a/util/path_test.go
+++ b/util/path_test.go
@@ -1,0 +1,69 @@
+package util_test
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/influxdata/chronograf/util"
+)
+
+func Test_AppendPath(t *testing.T) {
+	tests := []struct {
+		url      string
+		path     string
+		expected string
+	}{
+		{
+			url:      "http://localhost:8086?t=1#asdf",
+			path:     "",
+			expected: "http://localhost:8086?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086?t=1#asdf",
+			path:     "a",
+			expected: "http://localhost:8086/a?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/?t=1#asdf",
+			path:     "",
+			expected: "http://localhost:8086/?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/a?t=1#asdf",
+			path:     "",
+			expected: "http://localhost:8086/a?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/a?t=1#asdf",
+			path:     "b",
+			expected: "http://localhost:8086/a/b?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/a?t=1#asdf",
+			path:     "/b",
+			expected: "http://localhost:8086/a/b?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/a/?t=1#asdf",
+			path:     "b",
+			expected: "http://localhost:8086/a/b?t=1#asdf",
+		},
+		{
+			url:      "http://localhost:8086/a/?t=1#asdf",
+			path:     "/b",
+			expected: "http://localhost:8086/a/b?t=1#asdf",
+		},
+	}
+
+	for _, test := range tests {
+		inURL, _ := url.Parse(test.url)
+		outURL := util.AppendPath(inURL, test.path)
+		if inURL == outURL {
+			t.Errorf("AppendPath(\"%v\",\"%v\") does not return a new URL instance", inURL, test.path)
+		}
+		out := outURL.String()
+		if out != test.expected {
+			t.Errorf("AppendPath(\"%v\",\"%v\") != \"%v\"", inURL, test.path, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5096 

_Briefly describe your proposed changes:_
This PR changes the communication with InfluxDB so that a configured InfluxDB connection URL path is preserved as a context path when calling InfluxDB APIs. It works fine with InfluxDB OSS. InfluxDB Enterprise connections still must be configured without a context path (a proxy path), the cluster design requires doing so.

_What was the problem?_
InfluxDB Connection URL context path was ignored, and paths of InfluxDB APIs were directly used.

_What was the solution?_
API paths are appended to the configured InfluxDB connection path.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
