### PR TITLE
fix(ui/admin): require successful data loading in influxdb admin pages

### DIFF
--- a/ui/src/admin/actions/influxdb.js
+++ b/ui/src/admin/actions/influxdb.js
@@ -252,41 +252,25 @@ export const editRetentionPolicyFailed = (
 
 // async actions
 export const loadUsersAsync = url => async dispatch => {
-  try {
-    const {data} = await getUsersAJAX(url)
-    dispatch(loadUsers(data))
-  } catch (error) {
-    dispatch(errorThrown(error))
-  }
+  const {data} = await getUsersAJAX(url)
+  dispatch(loadUsers(data))
 }
 
 export const loadRolesAsync = url => async dispatch => {
-  try {
-    const {data} = await getRolesAJAX(url)
-    dispatch(loadRoles(data))
-  } catch (error) {
-    dispatch(errorThrown(error))
-  }
+  const {data} = await getRolesAJAX(url)
+  dispatch(loadRoles(data))
 }
 
 export const loadPermissionsAsync = url => async dispatch => {
-  try {
-    const {data} = await getPermissionsAJAX(url)
-    dispatch(loadPermissions(data))
-  } catch (error) {
-    dispatch(errorThrown(error))
-  }
+  const {data} = await getPermissionsAJAX(url)
+  dispatch(loadPermissions(data))
 }
 
 export const loadDBsAndRPsAsync = url => async dispatch => {
-  try {
-    const {
-      data: {databases},
-    } = await getDbsAndRpsAJAX(url)
-    dispatch(loadDatabases(_.sortBy(databases, ({name}) => name.toLowerCase())))
-  } catch (error) {
-    dispatch(errorThrown(error))
-  }
+  const {
+    data: {databases},
+  } = await getDbsAndRpsAJAX(url)
+  dispatch(loadDatabases(_.sortBy(databases, ({name}) => name.toLowerCase())))
 }
 
 export const createUserAsync = (url, user) => async dispatch => {

--- a/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
@@ -111,8 +111,17 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
         }
       }
       this.setState({loading: RemoteDataState.Done})
-    } catch (error) {
-      console.error(error)
+    } catch (e) {
+      console.error(e)
+      // extract error message for the UI
+      let error = e
+      if (error.message) {
+        error = error.message
+      } else if (error.data?.message) {
+        error = error.data?.message
+      } else if (error.statusText) {
+        error = error.statusText
+      }
       this.setState({
         loading: RemoteDataState.Error,
         error,


### PR DESCRIPTION
This PR fixes error handling in InfluxDB administration, no UI functionality is available after loading failure of users, roles, databases, or permissions.

_Briefly describe your proposed changes:_
Data loading exceptions are caught in the code and shown to the user (that can retry the loading with a refresh icon button):
![image](https://user-images.githubusercontent.com/16321466/174011951-2bbf216b-934a-4232-912a-424c94189fba.png)

_What was the problem?_
Errors during data loading were displayed as UI notifications, React rendering then continued with invalid data and errors start to happen on invalid data without a real explanation. 

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
