### PR TITLE
feat(ui/admin): remember state of influxdb users/roles filters

### DIFF
--- a/ui/cypress/integration/admin_influxdb.test.ts
+++ b/ui/cypress/integration/admin_influxdb.test.ts
@@ -289,10 +289,14 @@ describe('InfluxDB', () => {
         cy.get('th').contains('Users').should('exist')
       })
 
-      cy.getByTestID('hide-users--toggle').click()
+      cy.getByTestID('show-users--toggle').click()
       cy.getByTestID('admin-table--head').within(() => {
         cy.get('th').contains('Users').should('not.exist')
       })
+      cy.getByTestID('show-users--toggle').click()
+      cy.getByTestID('admin-table--head').within(() => {
+        cy.get('th').contains('Users').should('exist')
+      })      
     })
   })
 })

--- a/ui/src/admin/actions/influxdb.js
+++ b/ui/src/admin/actions/influxdb.js
@@ -484,3 +484,7 @@ export const changeSelectedDBs = (selectedDBs /* : string[] */) => ({
 export const changeShowUsers = () => ({
   type: 'INFLUXDB_CHANGE_SHOW_USERS',
 })
+
+export const changeShowRoles = () => ({
+  type: 'INFLUXDB_CHANGE_SHOW_ROLES',
+})

--- a/ui/src/admin/actions/influxdb.js
+++ b/ui/src/admin/actions/influxdb.js
@@ -473,3 +473,10 @@ export const updateUserPasswordAsync = (user, password) => async dispatch => {
     )
   }
 }
+
+export const changeSelectedDBs = (selectedDBs /* : string[] */) => ({
+  type: 'INFLUXDB_CHANGE_SELECTED_DBS',
+  payload: {
+    selectedDBs,
+  },
+})

--- a/ui/src/admin/actions/influxdb.js
+++ b/ui/src/admin/actions/influxdb.js
@@ -480,3 +480,7 @@ export const changeSelectedDBs = (selectedDBs /* : string[] */) => ({
     selectedDBs,
   },
 })
+
+export const changeShowUsers = () => ({
+  type: 'INFLUXDB_CHANGE_SHOW_USERS',
+})

--- a/ui/src/admin/components/influxdb/MultiDBSelector.tsx
+++ b/ui/src/admin/components/influxdb/MultiDBSelector.tsx
@@ -1,0 +1,52 @@
+import React, {useCallback} from 'react'
+import allOrParticularSelection from 'src/admin/util/allOrParticularSelection'
+import {MultiSelectDropdown} from 'src/reusable_ui'
+import {Database} from 'src/types/influxAdmin'
+
+interface Props {
+  databases: Database[]
+  selectedDBs: string[]
+  setSelectedDBs: (changeFn: (oldDBs: string[]) => string[]) => void
+}
+const MultiDBSelector = ({databases, selectedDBs, setSelectedDBs}: Props) => {
+  const changeSelectedDBs = useCallback(
+    (newDBs: string[]) =>
+      setSelectedDBs((oldDBs: string[]) => {
+        return allOrParticularSelection(oldDBs, newDBs)
+      }),
+    [setSelectedDBs]
+  )
+
+  return (
+    <div className="db-selector">
+      <MultiSelectDropdown
+        onChange={changeSelectedDBs}
+        selectedIDs={selectedDBs}
+        emptyText="<no database>"
+      >
+        {databases.reduce(
+          (acc, db) => {
+            acc.push(
+              <MultiSelectDropdown.Item
+                key={db.name}
+                id={db.name}
+                value={{id: db.name}}
+              >
+                {db.name}
+              </MultiSelectDropdown.Item>
+            )
+            return acc
+          },
+          [
+            <MultiSelectDropdown.Item id="*" key="*" value={{id: '*'}}>
+              All Databases
+            </MultiSelectDropdown.Item>,
+            <MultiSelectDropdown.Divider id="" key="" />,
+          ]
+        )}
+      </MultiSelectDropdown>
+    </div>
+  )
+}
+
+export default MultiDBSelector

--- a/ui/src/admin/components/influxdb/MultiDBSelector.tsx
+++ b/ui/src/admin/components/influxdb/MultiDBSelector.tsx
@@ -1,26 +1,27 @@
-import React, {useCallback} from 'react'
-import allOrParticularSelection from 'src/admin/util/allOrParticularSelection'
+import React from 'react'
+import {connect, ResolveThunks} from 'react-redux'
+import {changeSelectedDBs} from 'src/admin/actions/influxdb'
 import {MultiSelectDropdown} from 'src/reusable_ui'
 import {Database} from 'src/types/influxAdmin'
 
-interface Props {
+interface ConnectedProps {
   databases: Database[]
   selectedDBs: string[]
-  setSelectedDBs: (changeFn: (oldDBs: string[]) => string[]) => void
 }
+const mapStateToProps = ({adminInfluxDB: {databases, selectedDBs}}) => ({
+  databases,
+  selectedDBs,
+})
+const mapDispatchToProps = {
+  setSelectedDBs: changeSelectedDBs,
+}
+type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
+type Props = ConnectedProps & ReduxDispatchProps
 const MultiDBSelector = ({databases, selectedDBs, setSelectedDBs}: Props) => {
-  const changeSelectedDBs = useCallback(
-    (newDBs: string[]) =>
-      setSelectedDBs((oldDBs: string[]) => {
-        return allOrParticularSelection(oldDBs, newDBs)
-      }),
-    [setSelectedDBs]
-  )
-
   return (
     <div className="db-selector">
       <MultiSelectDropdown
-        onChange={changeSelectedDBs}
+        onChange={setSelectedDBs}
         selectedIDs={selectedDBs}
         emptyText="<no database>"
       >
@@ -49,4 +50,4 @@ const MultiDBSelector = ({databases, selectedDBs, setSelectedDBs}: Props) => {
   )
 }
 
-export default MultiDBSelector
+export default connect(mapStateToProps, mapDispatchToProps)(MultiDBSelector)

--- a/ui/src/admin/containers/influxdb/RolePage.tsx
+++ b/ui/src/admin/containers/influxdb/RolePage.tsx
@@ -142,7 +142,7 @@ const RolePage = ({
         )
       )
     },
-    [roleDBPermissions, changedPermissions, setChangedPermissions]
+    [roleDBPermissions, changedPermissions]
   )
   const permissionsChanged = !!Object.keys(changedPermissions).length
   const changePermissions = useMemo(

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -21,14 +21,14 @@ import FancyScrollbar from 'src/shared/components/FancyScrollbar'
 import NoEntities from 'src/admin/components/influxdb/NoEntities'
 import RoleRow from 'src/admin/components/RoleRow'
 import {useCallback} from 'react'
-import allOrParticularSelection from '../../util/allOrParticularSelection'
 import {computeEntitiesDBPermissions} from '../../util/computeEffectiveDBPermissions'
 import useDebounce from 'src/utils/useDebounce'
 import useChangeEffect from 'src/utils/useChangeEffect'
-import {ComponentSize, MultiSelectDropdown, SlideToggle} from 'src/reusable_ui'
+import {ComponentSize, SlideToggle} from 'src/reusable_ui'
 import CreateRoleDialog, {
   validateRoleName,
 } from 'src/admin/components/influxdb/CreateRoleDialog'
+import MultiDBSelector from 'src/admin/components/influxdb/MultiDBSelector'
 
 const validateRole = (
   role: Pick<UserRole, 'name'>,
@@ -88,13 +88,6 @@ const RolesPage = ({
     }
     return selectedDBs
   }, [databases, selectedDBs])
-  const changeSelectedDBs = useCallback(
-    (newDBs: string[]) =>
-      setSelectedDBs((oldDBs: string[]) => {
-        return allOrParticularSelection(oldDBs, newDBs)
-      }),
-    [setSelectedDBs]
-  )
 
   // effective permissions
   const visibleRoles = useMemo(() => roles.filter(x => !x.hidden), [roles])
@@ -159,34 +152,11 @@ const RolesPage = ({
             />
             <span className="icon search" />
           </div>
-          <div className="db-selector">
-            <MultiSelectDropdown
-              onChange={changeSelectedDBs}
-              selectedIDs={selectedDBs}
-              emptyText="<no database>"
-            >
-              {databases.reduce(
-                (acc, db) => {
-                  acc.push(
-                    <MultiSelectDropdown.Item
-                      key={db.name}
-                      id={db.name}
-                      value={{id: db.name}}
-                    >
-                      {db.name}
-                    </MultiSelectDropdown.Item>
-                  )
-                  return acc
-                },
-                [
-                  <MultiSelectDropdown.Item id="*" key="*" value={{id: '*'}}>
-                    All Databases
-                  </MultiSelectDropdown.Item>,
-                  <MultiSelectDropdown.Divider id="" key="" />,
-                ]
-              )}
-            </MultiSelectDropdown>
-          </div>
+          <MultiDBSelector
+            databases={databases}
+            selectedDBs={selectedDBs}
+            setSelectedDBs={setSelectedDBs}
+          />
           <div className="hide-roles-toggle">
             <SlideToggle
               active={showUsers}

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -41,10 +41,13 @@ const validateRole = (
   return true
 }
 
-const mapStateToProps = ({adminInfluxDB: {databases, users, roles}}) => ({
+const mapStateToProps = ({
+  adminInfluxDB: {databases, users, roles, selectedDBs},
+}) => ({
   databases,
   users,
   roles,
+  selectedDBs,
 })
 
 const mapDispatchToProps = {
@@ -60,6 +63,7 @@ interface ConnectedProps {
   databases: Database[]
   users: User[]
   roles: UserRole[]
+  selectedDBs: string[]
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -71,6 +75,7 @@ const RolesPage = ({
   users,
   roles,
   databases,
+  selectedDBs,
   router,
   filterRoles,
   createRole,
@@ -80,8 +85,7 @@ const RolesPage = ({
     () => `/sources/${source.id}/admin-influxdb/roles`,
     [source]
   )
-  // filter databases
-  const [selectedDBs, setSelectedDBs] = useState<string[]>(['*'])
+  // database columns
   const visibleDBNames = useMemo<string[]>(() => {
     if (selectedDBs.includes('*')) {
       return databases.map(db => db.name)
@@ -152,11 +156,7 @@ const RolesPage = ({
             />
             <span className="icon search" />
           </div>
-          <MultiDBSelector
-            databases={databases}
-            selectedDBs={selectedDBs}
-            setSelectedDBs={setSelectedDBs}
-          />
+          <MultiDBSelector />
           <div className="hide-roles-toggle">
             <SlideToggle
               active={showUsers}

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -108,9 +108,7 @@ const RolesPage = ({
 
   // filter users
   const [filterText, setFilterText] = useState('')
-  const changeFilterText = useCallback(e => setFilterText(e.target.value), [
-    setFilterText,
-  ])
+  const changeFilterText = useCallback(e => setFilterText(e.target.value), [])
   const debouncedFilterText = useDebounce(filterText, 200)
   useChangeEffect(() => {
     filterRoles(debouncedFilterText)

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -161,7 +161,7 @@ const RolesPage = ({
               active={showUsers}
               onChange={toggleShowUsers}
               size={ComponentSize.ExtraSmall}
-              entity="users"
+              dataTest="show-users--toggle"
             />
             Show Users
           </div>

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -43,13 +43,14 @@ const validateRole = (
 }
 
 const mapStateToProps = ({
-  adminInfluxDB: {databases, users, roles, selectedDBs, showUsers},
+  adminInfluxDB: {databases, users, roles, selectedDBs, showUsers, rolesFilter},
 }) => ({
   databases,
   users,
   roles,
   selectedDBs,
   showUsers,
+  rolesFilter,
 })
 
 const mapDispatchToProps = {
@@ -68,6 +69,7 @@ interface ConnectedProps {
   roles: UserRole[]
   selectedDBs: string[]
   showUsers: boolean
+  rolesFilter: string
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -81,6 +83,7 @@ const RolesPage = ({
   databases,
   selectedDBs,
   showUsers,
+  rolesFilter,
   router,
   filterRoles,
   createRole,
@@ -106,8 +109,8 @@ const RolesPage = ({
     [visibleDBNames, visibleRoles]
   )
 
-  // filter users
-  const [filterText, setFilterText] = useState('')
+  // filter roles
+  const [filterText, setFilterText] = useState(rolesFilter)
   const changeFilterText = useCallback(e => setFilterText(e.target.value), [])
   const debouncedFilterText = useDebounce(filterText, 200)
   useChangeEffect(() => {

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -6,6 +6,7 @@ import {Source, NotificationAction} from 'src/types'
 import {UserRole, User, Database} from 'src/types/influxAdmin'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {
+  changeShowUsers,
   createRoleAsync,
   filterRoles as filterRolesAction,
 } from 'src/admin/actions/influxdb'
@@ -42,18 +43,20 @@ const validateRole = (
 }
 
 const mapStateToProps = ({
-  adminInfluxDB: {databases, users, roles, selectedDBs},
+  adminInfluxDB: {databases, users, roles, selectedDBs, showUsers},
 }) => ({
   databases,
   users,
   roles,
   selectedDBs,
+  showUsers,
 })
 
 const mapDispatchToProps = {
   filterRoles: filterRolesAction,
   createRole: createRoleAsync,
   notify: notifyAction,
+  toggleShowUsers: changeShowUsers,
 }
 
 interface OwnProps {
@@ -64,6 +67,7 @@ interface ConnectedProps {
   users: User[]
   roles: UserRole[]
   selectedDBs: string[]
+  showUsers: boolean
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -76,9 +80,11 @@ const RolesPage = ({
   roles,
   databases,
   selectedDBs,
+  showUsers,
   router,
   filterRoles,
   createRole,
+  toggleShowUsers,
   notify,
 }: Props) => {
   const rolesPage = useMemo(
@@ -109,13 +115,6 @@ const RolesPage = ({
   useChangeEffect(() => {
     filterRoles(debouncedFilterText)
   }, [debouncedFilterText])
-
-  // hide users
-  const [showUsers, setShowUsers] = useState(true)
-  const changeHideUsers = useCallback(() => setShowUsers(!showUsers), [
-    showUsers,
-    setShowUsers,
-  ])
 
   const [createVisible, setCreateVisible] = useState(false)
   const createNew = useCallback(
@@ -160,7 +159,7 @@ const RolesPage = ({
           <div className="hide-roles-toggle">
             <SlideToggle
               active={showUsers}
-              onChange={changeHideUsers}
+              onChange={toggleShowUsers}
               size={ComponentSize.ExtraSmall}
               entity="users"
             />

--- a/ui/src/admin/containers/influxdb/UserPage.tsx
+++ b/ui/src/admin/containers/influxdb/UserPage.tsx
@@ -173,7 +173,7 @@ const UserPage = ({
         )
       )
     },
-    [userDBPermissions, changedPermissions, setChangedPermissions]
+    [userDBPermissions, changedPermissions]
   )
   const permissionsChanged = !!Object.keys(changedPermissions).length
   const changePermissions = useMemo(

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -46,10 +46,13 @@ const validateUser = (
   return true
 }
 
-const mapStateToProps = ({adminInfluxDB: {databases, users, roles}}) => ({
+const mapStateToProps = ({
+  adminInfluxDB: {databases, users, roles, selectedDBs},
+}) => ({
   databases,
   users,
   roles,
+  selectedDBs,
 })
 
 const mapDispatchToProps = {
@@ -65,6 +68,7 @@ interface ConnectedProps {
   databases: Database[]
   users: User[]
   roles: UserRole[]
+  selectedDBs: string[]
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -76,6 +80,7 @@ const UsersPage = ({
   databases,
   users,
   roles,
+  selectedDBs,
   notify,
   createUser,
   filterUsers,
@@ -87,8 +92,7 @@ const UsersPage = ({
     ],
     [source]
   )
-  // filter databases
-  const [selectedDBs, setSelectedDBs] = useState<string[]>(['*'])
+  // database columns
   const visibleDBNames = useMemo<string[]>(() => {
     if (selectedDBs.includes('*')) {
       return databases.map(db => db.name)
@@ -161,11 +165,7 @@ const UsersPage = ({
             />
             <span className="icon search" />
           </div>
-          <MultiDBSelector
-            databases={databases}
-            selectedDBs={selectedDBs}
-            setSelectedDBs={setSelectedDBs}
-          />
+          <MultiDBSelector />
           {isEnterprise && (
             <div className="hide-roles-toggle">
               <SlideToggle

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -48,13 +48,14 @@ const validateUser = (
 }
 
 const mapStateToProps = ({
-  adminInfluxDB: {databases, users, roles, selectedDBs, showRoles},
+  adminInfluxDB: {databases, users, roles, selectedDBs, showRoles, usersFilter},
 }) => ({
   databases,
   users,
   roles,
   selectedDBs,
   showRoles,
+  usersFilter,
 })
 
 const mapDispatchToProps = {
@@ -73,6 +74,7 @@ interface ConnectedProps {
   roles: UserRole[]
   selectedDBs: string[]
   showRoles: boolean
+  usersFilter: string
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -86,6 +88,7 @@ const UsersPage = ({
   roles,
   selectedDBs,
   showRoles,
+  usersFilter,
   notify,
   createUser,
   filterUsers,
@@ -115,7 +118,7 @@ const UsersPage = ({
   )
 
   // filter users
-  const [filterText, setFilterText] = useState('')
+  const [filterText, setFilterText] = useState(usersFilter)
   const changeFilterText = useCallback(e => setFilterText(e.target.value), [])
   const debouncedFilterText = useDebounce(filterText, 200)
   useChangeEffect(() => {

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -116,9 +116,7 @@ const UsersPage = ({
 
   // filter users
   const [filterText, setFilterText] = useState('')
-  const changeFilterText = useCallback(e => setFilterText(e.target.value), [
-    setFilterText,
-  ])
+  const changeFilterText = useCallback(e => setFilterText(e.target.value), [])
   const debouncedFilterText = useDebounce(filterText, 200)
   useChangeEffect(() => {
     filterUsers(debouncedFilterText)

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -22,15 +22,14 @@ import NoEntities from 'src/admin/components/influxdb/NoEntities'
 import UserRow from 'src/admin/components/UserRow'
 import useDebounce from 'src/utils/useDebounce'
 import useChangeEffect from 'src/utils/useChangeEffect'
-import MultiSelectDropdown from 'src/reusable_ui/components/dropdowns/MultiSelectDropdown'
 import {ComponentSize, SlideToggle} from 'src/reusable_ui'
 import {computeEffectiveUserDBPermissions} from '../../util/computeEffectiveDBPermissions'
-import allOrParticularSelection from '../../util/allOrParticularSelection'
 import CreateUserDialog, {
   validatePassword,
   validateUserName,
 } from '../../components/influxdb/CreateUserDialog'
 import {withRouter, WithRouterProps} from 'react-router'
+import MultiDBSelector from 'src/admin/components/influxdb/MultiDBSelector'
 
 const validateUser = (
   user: Pick<User, 'name' | 'password'>,
@@ -96,13 +95,6 @@ const UsersPage = ({
     }
     return selectedDBs
   }, [databases, selectedDBs])
-  const changeSelectedDBs = useCallback(
-    (newDBs: string[]) =>
-      setSelectedDBs((oldDBs: string[]) => {
-        return allOrParticularSelection(oldDBs, newDBs)
-      }),
-    [setSelectedDBs]
-  )
 
   // effective permissions
   const visibleUsers = useMemo(() => users.filter(x => !x.hidden), [users])
@@ -169,34 +161,11 @@ const UsersPage = ({
             />
             <span className="icon search" />
           </div>
-          <div className="db-selector" data-test="db-selector">
-            <MultiSelectDropdown
-              onChange={changeSelectedDBs}
-              selectedIDs={selectedDBs}
-              emptyText="<no database>"
-            >
-              {databases.reduce(
-                (acc, db) => {
-                  acc.push(
-                    <MultiSelectDropdown.Item
-                      key={db.name}
-                      id={db.name}
-                      value={{id: db.name}}
-                    >
-                      {db.name}
-                    </MultiSelectDropdown.Item>
-                  )
-                  return acc
-                },
-                [
-                  <MultiSelectDropdown.Item id="*" key="*" value={{id: '*'}}>
-                    All Databases
-                  </MultiSelectDropdown.Item>,
-                  <MultiSelectDropdown.Divider id="" key="" />,
-                ]
-              )}
-            </MultiSelectDropdown>
-          </div>
+          <MultiDBSelector
+            databases={databases}
+            selectedDBs={selectedDBs}
+            setSelectedDBs={setSelectedDBs}
+          />
           {isEnterprise && (
             <div className="hide-roles-toggle">
               <SlideToggle

--- a/ui/src/admin/containers/influxdb/UsersPage.tsx
+++ b/ui/src/admin/containers/influxdb/UsersPage.tsx
@@ -5,6 +5,7 @@ import {Source, NotificationAction} from 'src/types'
 import {UserRole, User, Database} from 'src/types/influxAdmin'
 import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {
+  changeShowRoles,
   createUserAsync,
   filterUsers as filterUsersAction,
 } from 'src/admin/actions/influxdb'
@@ -47,17 +48,19 @@ const validateUser = (
 }
 
 const mapStateToProps = ({
-  adminInfluxDB: {databases, users, roles, selectedDBs},
+  adminInfluxDB: {databases, users, roles, selectedDBs, showRoles},
 }) => ({
   databases,
   users,
   roles,
   selectedDBs,
+  showRoles,
 })
 
 const mapDispatchToProps = {
   filterUsers: filterUsersAction,
   createUser: createUserAsync,
+  toggleShowRoles: changeShowRoles,
   notify: notifyAction,
 }
 
@@ -69,6 +72,7 @@ interface ConnectedProps {
   users: User[]
   roles: UserRole[]
   selectedDBs: string[]
+  showRoles: boolean
 }
 
 type ReduxDispatchProps = ResolveThunks<typeof mapDispatchToProps>
@@ -81,9 +85,11 @@ const UsersPage = ({
   users,
   roles,
   selectedDBs,
+  showRoles,
   notify,
   createUser,
   filterUsers,
+  toggleShowRoles,
 }: Props) => {
   const [isEnterprise, usersPage] = useMemo(
     () => [
@@ -117,13 +123,6 @@ const UsersPage = ({
   useChangeEffect(() => {
     filterUsers(debouncedFilterText)
   }, [debouncedFilterText])
-
-  // hide role
-  const [showRoles, setShowRoles] = useState(true)
-  const changeHideRoles = useCallback(() => setShowRoles(!showRoles), [
-    showRoles,
-    setShowRoles,
-  ])
 
   const [createVisible, setCreateVisible] = useState(false)
   const createNew = useCallback(
@@ -170,7 +169,7 @@ const UsersPage = ({
             <div className="hide-roles-toggle">
               <SlideToggle
                 active={showRoles}
-                onChange={changeHideRoles}
+                onChange={toggleShowRoles}
                 size={ComponentSize.ExtraSmall}
               />
               Show Roles

--- a/ui/src/admin/reducers/influxdb.js
+++ b/ui/src/admin/reducers/influxdb.js
@@ -49,16 +49,18 @@ export const initialState = {
   selectedDBs: ['*'],
   showUsers: true,
   showRoles: true,
+  usersFilter: '',
+  rolesFilter: '',
 }
 
 const adminInfluxDB = (state = initialState, action) => {
   switch (action.type) {
     case 'INFLUXDB_LOAD_USERS': {
-      return {...state, ...action.payload}
+      return {...state, ...action.payload, usersFilter: ''}
     }
 
     case 'INFLUXDB_LOAD_ROLES': {
-      return {...state, ...action.payload}
+      return {...state, ...action.payload, rolesFilter: ''}
     }
 
     case 'INFLUXDB_LOAD_PERMISSIONS': {
@@ -338,7 +340,7 @@ const adminInfluxDB = (state = initialState, action) => {
           return u
         }),
       }
-      return {...state, ...newState}
+      return {...state, ...newState, usersFilter: text}
     }
 
     case 'INFLUXDB_FILTER_ROLES': {
@@ -349,7 +351,7 @@ const adminInfluxDB = (state = initialState, action) => {
           return r
         }),
       }
-      return {...state, ...newState}
+      return {...state, ...newState, rolesFilter: text}
     }
 
     case 'INFLUXDB_KILL_QUERY': {

--- a/ui/src/admin/reducers/influxdb.js
+++ b/ui/src/admin/reducers/influxdb.js
@@ -38,7 +38,7 @@ const identity = x => x
 function sortQueries(queries, queriesSort) {
   return (querySorters[queriesSort] || identity)(queries)
 }
-const initialState = {
+export const initialState = {
   users: [],
   roles: [],
   permissions: [],

--- a/ui/src/admin/reducers/influxdb.js
+++ b/ui/src/admin/reducers/influxdb.js
@@ -6,6 +6,7 @@ import {
   changeNamedCollection,
   computeNamedChanges,
 } from '../util/changeNamedCollection'
+import allOrParticularSelection from '../util/allOrParticularSelection'
 
 const querySorters = {
   '+time'(queries) {
@@ -37,7 +38,6 @@ const identity = x => x
 function sortQueries(queries, queriesSort) {
   return (querySorters[queriesSort] || identity)(queries)
 }
-
 const initialState = {
   users: [],
   roles: [],
@@ -46,6 +46,7 @@ const initialState = {
   queriesSort: '-time',
   queryIDToKill: null,
   databases: [],
+  selectedDBs: ['*'],
 }
 
 const adminInfluxDB = (state = initialState, action) => {
@@ -63,7 +64,9 @@ const adminInfluxDB = (state = initialState, action) => {
     }
 
     case 'INFLUXDB_LOAD_DATABASES': {
-      return {...state, ...action.payload}
+      const databases = action.payload.databases
+      const selectedDBs = initialState.selectedDBs
+      return {...state, databases, selectedDBs}
     }
 
     case 'INFLUXDB_ADD_DATABASE': {
@@ -358,6 +361,12 @@ const adminInfluxDB = (state = initialState, action) => {
 
     case 'INFLUXDB_SET_QUERY_TO_KILL': {
       return {...state, ...action.payload}
+    }
+    case 'INFLUXDB_CHANGE_SELECTED_DBS': {
+      const newDBs = action.payload.selectedDBs
+      const oldDBs = state.selectedDBs || ['*']
+      const selectedDBs = allOrParticularSelection(oldDBs, newDBs)
+      return {...state, selectedDBs}
     }
   }
 

--- a/ui/src/admin/reducers/influxdb.js
+++ b/ui/src/admin/reducers/influxdb.js
@@ -48,6 +48,7 @@ const initialState = {
   databases: [],
   selectedDBs: ['*'],
   showUsers: true,
+  showRoles: true,
 }
 
 const adminInfluxDB = (state = initialState, action) => {
@@ -371,6 +372,9 @@ const adminInfluxDB = (state = initialState, action) => {
     }
     case 'INFLUXDB_CHANGE_SHOW_USERS': {
       return {...state, showUsers: !state.showUsers}
+    }
+    case 'INFLUXDB_CHANGE_SHOW_ROLES': {
+      return {...state, showRoles: !state.showRoles}
     }
   }
 

--- a/ui/src/admin/reducers/influxdb.js
+++ b/ui/src/admin/reducers/influxdb.js
@@ -47,6 +47,7 @@ const initialState = {
   queryIDToKill: null,
   databases: [],
   selectedDBs: ['*'],
+  showUsers: true,
 }
 
 const adminInfluxDB = (state = initialState, action) => {
@@ -367,6 +368,9 @@ const adminInfluxDB = (state = initialState, action) => {
       const oldDBs = state.selectedDBs || ['*']
       const selectedDBs = allOrParticularSelection(oldDBs, newDBs)
       return {...state, selectedDBs}
+    }
+    case 'INFLUXDB_CHANGE_SHOW_USERS': {
+      return {...state, showUsers: !state.showUsers}
     }
   }
 

--- a/ui/src/localStorage.ts
+++ b/ui/src/localStorage.ts
@@ -10,6 +10,7 @@ import {defaultTableData} from 'src/logs/constants'
 import {VERSION, GIT_SHA} from 'src/shared/constants'
 
 import {LocalStorage} from 'src/types/localStorage'
+import {initialState as adminInfluxDBInitialState} from './admin/reducers/influxdb'
 
 export const loadLocalStorage = (
   errorsQueue: any[]
@@ -39,7 +40,7 @@ export const loadLocalStorage = (
 
     delete state.VERSION
     delete state.GIT_SHA
-
+    state.adminInfluxDB = {...adminInfluxDBInitialState, ...state.adminInfluxDB}
     return state
   } catch (error) {
     console.error(notifyLoadLocalSettingsFailed(error).message)
@@ -55,6 +56,7 @@ export const saveToLocalStorage = ({
   dashTimeV1: {ranges, refreshes},
   logs,
   script,
+  adminInfluxDB: {showUsers, showRoles},
 }: LocalStorage): void => {
   try {
     const dashTimeV1 = {
@@ -104,6 +106,7 @@ export const saveToLocalStorage = ({
           },
           tableTime: minimalLogs.tableTime || {},
         },
+        adminInfluxDB: {showRoles, showUsers},
       })
     )
   } catch (err) {

--- a/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
+++ b/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
@@ -14,7 +14,7 @@ interface Props {
   color?: ComponentColor
   disabled?: boolean
   tooltipText?: string
-  entity?: string
+  dataTest?: string
 }
 
 @ErrorHandling
@@ -27,14 +27,14 @@ class SlideToggle extends Component<Props> {
   }
 
   public render() {
-    const {tooltipText} = this.props
+    const {tooltipText, dataTest} = this.props
 
     return (
       <div
         className={this.className}
         onClick={this.handleClick}
         title={tooltipText}
-        data-test={this.dataTest}
+        data-test={dataTest}
       >
         <div className="slide-toggle--knob" />
       </div>
@@ -58,12 +58,6 @@ class SlideToggle extends Component<Props> {
       `slide-toggle slide-toggle-${size} slide-toggle-${color}`,
       {active, disabled}
     )
-  }
-
-  private get dataTest(): string {
-    const {active, entity} = this.props
-
-    return active ? `hide-${entity}--toggle` : `show-${entity}--toggle`
   }
 }
 

--- a/ui/src/types/localStorage.ts
+++ b/ui/src/types/localStorage.ts
@@ -10,6 +10,10 @@ export interface LocalStorage {
   logs: LogsState
   telegrafSystemInterval: string
   hostPageDisabled: boolean
+  adminInfluxDB: {
+    showUsers: boolean
+    showRoles: boolean
+  }
 }
 
 export type VERSION = string

--- a/ui/test/admin/reducers/influxdb.test.js
+++ b/ui/test/admin/reducers/influxdb.test.js
@@ -21,6 +21,7 @@ import {
   setQueriesSort,
   loadDatabases,
   changeSelectedDBs,
+  changeShowUsers,
 } from 'src/admin/actions/influxdb'
 
 import {NEW_DEFAULT_DATABASE, NEW_EMPTY_RP} from 'src/admin/constants'
@@ -536,6 +537,13 @@ describe('Admin.InfluxDB.Reducers', () => {
           changeSelectedDBs(change)
         )
         expect(selectedDBs).toEqual(next)
+      })
+    })
+    it('can change showUsers flag', () => {
+      const vals = [undefined, true, false]
+      vals.forEach(prev => {
+        const {showUsers} = reducer({showUsers: prev}, changeShowUsers())
+        expect(showUsers).toEqual(!prev)
       })
     })
   })

--- a/ui/test/admin/reducers/influxdb.test.js
+++ b/ui/test/admin/reducers/influxdb.test.js
@@ -19,6 +19,8 @@ import {
   removeDatabaseDeleteCode,
   loadQueries,
   setQueriesSort,
+  loadDatabases,
+  changeSelectedDBs,
 } from 'src/admin/actions/influxdb'
 
 import {NEW_DEFAULT_DATABASE, NEW_EMPTY_RP} from 'src/admin/constants'
@@ -135,6 +137,17 @@ describe('Admin.InfluxDB.Reducers', () => {
   describe('Databases', () => {
     beforeEach(() => {
       state = {databases: [db1, db2]}
+    })
+
+    it('can load databases', () => {
+      const {databases, selectedDBs} = reducer(
+        undefined,
+        loadDatabases([{name: 'db1'}])
+      )
+      expect({databases, selectedDBs}).toEqual({
+        databases: [{name: 'db1'}],
+        selectedDBs: ['*'],
+      })
     })
 
     it('can add a database', () => {
@@ -486,6 +499,44 @@ describe('Admin.InfluxDB.Reducers', () => {
       expect(actual.queries[0].id).toEqual(3)
       expect(actual.queries[1].id).toEqual(2)
       expect(actual.queries[2].id).toEqual(1)
+    })
+  })
+  describe('filters', () => {
+    it('can change selected DBS', () => {
+      const testPairs = [
+        {
+          prev: undefined,
+          change: ['db1'],
+          next: ['db1'],
+        },
+        {
+          prev: [],
+          change: ['db1'],
+          next: ['db1'],
+        },
+        {
+          prev: ['db1'],
+          change: ['db1', '*'],
+          next: ['*'],
+        },
+        {
+          prev: ['*'],
+          change: ['db1', '*'],
+          next: ['db1'],
+        },
+        {
+          prev: ['db1'],
+          change: [],
+          next: [],
+        },
+      ]
+      testPairs.forEach(({prev, change, next}) => {
+        const {selectedDBs} = reducer(
+          {selectedDBs: prev},
+          changeSelectedDBs(change)
+        )
+        expect(selectedDBs).toEqual(next)
+      })
     })
   })
 })

--- a/ui/test/admin/reducers/influxdb.test.js
+++ b/ui/test/admin/reducers/influxdb.test.js
@@ -22,6 +22,7 @@ import {
   loadDatabases,
   changeSelectedDBs,
   changeShowUsers,
+  changeShowRoles,
 } from 'src/admin/actions/influxdb'
 
 import {NEW_DEFAULT_DATABASE, NEW_EMPTY_RP} from 'src/admin/constants'
@@ -544,6 +545,13 @@ describe('Admin.InfluxDB.Reducers', () => {
       vals.forEach(prev => {
         const {showUsers} = reducer({showUsers: prev}, changeShowUsers())
         expect(showUsers).toEqual(!prev)
+      })
+    })
+    it('can change showRoles flag', () => {
+      const vals = [undefined, true, false]
+      vals.forEach(prev => {
+        const {showRoles} = reducer({showRoles: prev}, changeShowRoles())
+        expect(showRoles).toEqual(!prev)
       })
     })
   })

--- a/ui/test/admin/reducers/influxdb.test.js
+++ b/ui/test/admin/reducers/influxdb.test.js
@@ -7,6 +7,7 @@ import {
   syncRole,
   editDatabase,
   editRetentionPolicyRequested,
+  loadUsers,
   loadRoles,
   loadPermissions,
   deleteRole,
@@ -224,7 +225,15 @@ describe('Admin.InfluxDB.Reducers', () => {
       expect(actual.databases).toEqual(expected)
     })
   })
+  it('it can load users', () => {
+    const {users: d, usersFilter} = reducer(state, loadUsers({users}))
+    const expected = {
+      users,
+      usersFilter: '',
+    }
 
+    expect({users: d, usersFilter}).toEqual(expected)
+  })
   it('it can sync a stale user', () => {
     const staleUser = {...u1, roles: []}
     state = {users: [u2, staleUser], roles: []}
@@ -330,13 +339,14 @@ describe('Admin.InfluxDB.Reducers', () => {
     expect(actual.users).toEqual(expected.users)
   })
 
-  it('it can load the roles', () => {
-    const actual = reducer(state, loadRoles({roles}))
+  it('it can load roles', () => {
+    const {roles: d, rolesFilter} = reducer(state, loadRoles({roles}))
     const expected = {
       roles,
+      rolesFilter: '',
     }
 
-    expect(actual.roles).toEqual(expected.roles)
+    expect({roles: d, rolesFilter}).toEqual(expected)
   })
 
   it('it can delete a non-existing role', () => {
@@ -397,15 +407,16 @@ describe('Admin.InfluxDB.Reducers', () => {
 
     const text = 'x'
 
-    const actual = reducer(state, filterRoles(text))
+    const {roles: d, rolesFilter} = reducer(state, filterRoles(text))
     const expected = {
       roles: [
         {...r1, hidden: false},
         {...r2, hidden: true},
       ],
+      rolesFilter: text,
     }
 
-    expect(actual.roles).toEqual(expected.roles)
+    expect({roles: d, rolesFilter}).toEqual(expected)
   })
 
   it('can filter users w/ "zero" text', () => {
@@ -415,15 +426,16 @@ describe('Admin.InfluxDB.Reducers', () => {
 
     const text = 'zero'
 
-    const actual = reducer(state, filterUsers(text))
+    const {users: d, usersFilter} = reducer(state, filterUsers(text))
     const expected = {
       users: [
         {...u1, hidden: true},
         {...u2, hidden: false},
       ],
+      usersFilter: text,
     }
 
-    expect(actual.users).toEqual(expected.users)
+    expect({users: d, usersFilter}).toEqual(expected)
   })
 
   // Permissions


### PR DESCRIPTION
Closes #5942

This PR improves/fixes filters on Admin / InfluxDB Users/Roles page so that:
- the state of `Show Users` / `Show Roles` slide toggles is remembered in the browser local storage (survives browser restart)
- the state of users/roles filter text and selected databases is remembered across InfluxDB admin pages, it is reset every time the admin data is loaded (whenever visiting InfluxDB admin pages from non-admin pages, or after clicking the refresh button)

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
