### PR TITLE
fix(ui): show unsupported administration against 2.x InfluxDB

### DIFF
--- a/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
+++ b/ui/src/admin/containers/influxdb/AdminInfluxDBScopedPage.tsx
@@ -139,6 +139,18 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
   }
   public content() {
     const {source, children} = this.props
+
+    if (!source.version || source.version.startsWith('2')) {
+      return (
+        <WrapToPage hideRefresh={true}>
+          <div className="container-fluid">
+            These functions are not available for the currently selected
+            InfluxDB Connection.
+          </div>
+        </WrapToPage>
+      )
+    }
+
     const {loading, error, errorMessage} = this.state
     if (
       loading === RemoteDataState.Loading ||
@@ -164,16 +176,6 @@ export class AdminInfluxDBScopedPage extends PureComponent<Props, State> {
       )
     }
 
-    if (!source.version || source.version.startsWith('2')) {
-      return (
-        <WrapToPage hideRefresh={true}>
-          <div className="container-fluid">
-            These functions are not available for the currently selected
-            InfluxDB Connection.
-          </div>
-        </WrapToPage>
-      )
-    }
     return children
   }
 }


### PR DESCRIPTION
Closes #5951 

_Briefly describe your proposed changes:_
![image](https://user-images.githubusercontent.com/16321466/175214571-2b309e6c-78cb-4993-b9b6-96078490b6b8.png)

_What was the problem?_
Detection of unsupported administration was not applied.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
