### PR TITLE
Allow keyboard-only user/role creation

### DIFF
--- a/ui/src/admin/components/influxdb/CreateRoleDialog.tsx
+++ b/ui/src/admin/components/influxdb/CreateRoleDialog.tsx
@@ -25,6 +25,15 @@ const CreateRoleDialog = ({visible, setVisible, create}: Props) => {
     setName('')
     setVisible(false)
   }, [])
+  const onEnterPressed = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && name) {
+        e.stopPropagation()
+        create({name})
+      }
+    },
+    [name, create]
+  )
   return (
     <OverlayTechnology visible={visible}>
       <OverlayContainer maxWidth={650}>
@@ -38,6 +47,7 @@ const CreateRoleDialog = ({visible, setVisible, create}: Props) => {
                   autoFocus={true}
                   autoComplete="off"
                   onChange={e => setName(e.target.value)}
+                  onKeyPress={onEnterPressed}
                   status={
                     validateRoleName(name)
                       ? ComponentStatus.Valid

--- a/ui/src/admin/components/influxdb/CreateUserDialog.tsx
+++ b/ui/src/admin/components/influxdb/CreateUserDialog.tsx
@@ -29,6 +29,15 @@ const CreateUserDialog = ({visible, setVisible, create}: Props) => {
     setPassword('')
     setVisible(false)
   }, [])
+  const onEnterPressed = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && name && password) {
+        e.stopPropagation()
+        create({name, password})
+      }
+    },
+    [name, password, create]
+  )
   return (
     <OverlayTechnology visible={visible}>
       <OverlayContainer maxWidth={650}>
@@ -42,6 +51,7 @@ const CreateUserDialog = ({visible, setVisible, create}: Props) => {
                   onChange={e => setName(e.target.value)}
                   autoFocus={true}
                   autoComplete="off"
+                  onKeyPress={onEnterPressed}
                   status={
                     validateUserName(name)
                       ? ComponentStatus.Valid
@@ -60,6 +70,7 @@ const CreateUserDialog = ({visible, setVisible, create}: Props) => {
                       : ComponentStatus.Default
                   }
                   onChange={e => setPassword(e.target.value)}
+                  onKeyPress={onEnterPressed}
                   autoComplete="off"
                   testId="password--input"
                 />

--- a/ui/src/style/theme/_buttons.scss
+++ b/ui/src/style/theme/_buttons.scss
@@ -146,15 +146,8 @@ a.btn {
   text-shadow: none;
   border-width: 0;
 
-  // Focus State
-  &:focus {
-    background-color: $bg-color;
-    color: $text-color;
-  }
-
   // Hover State
-  &:hover,
-  &:focus:hover {
+  &:hover,&:focus{
     background-color: $bg-color-hover;
     color: $text-color-hover;
     cursor: pointer;


### PR DESCRIPTION
Closes #5952

_Briefly describe your proposed changes:_
- focused buttons are highlighted so that the user knows that they can be pressed
- User/Role creation dialog reacts upon Enter in input fields to trigger user/role creation
 
_What was the problem?_
- It was not visible that a button received focus (after a keyboard TAB navigation) so the user didn't know that a button can be pressed (Enter or Space key).
- Enter key did not confirm the dialog.

<!-- checkboxes -->
  - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
