### PR TITLE
feat(ui): allow to customize annotation color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 1. [#5929](https://github.com/influxdata/chronograf/pull/5926): Add refresh button to InfluxDB Users/Roles/Databases page.
 1. [#5940](https://github.com/influxdata/chronograf/pull/5940): Support InfluxDB behind proxy under subpath.
 1. [#5956](https://github.com/influxdata/chronograf/pull/5956): Add InfluxDB admin tabs to user/role detail page.
+1. [#5959](https://github.com/influxdata/chronograf/pull/5959): Allow to customize annotation color.
 
 ### Bug Fixes
 

--- a/chronograf.go
+++ b/chronograf.go
@@ -535,6 +535,7 @@ var annotationTagsBlacklist = map[string]bool{
 	"endTime":          true,
 	"modified_time_ns": true,
 	"text":             true,
+	"color":            true,
 	"type":             true,
 	"id":               true,
 }
@@ -566,6 +567,7 @@ type Annotation struct {
 	StartTime time.Time      // StartTime starts the annotation
 	EndTime   time.Time      // EndTime ends the annotation
 	Text      string         // Text is the associated user-facing text describing the annotation
+	Color     string         // Color associated with the annotation
 	Tags      AnnotationTags // Tags is a collection of user defined key/value pairs that contextualize the annotation
 }
 

--- a/influx/annotations.go
+++ b/influx/annotations.go
@@ -162,6 +162,7 @@ func toPoint(anno *chronograf.Annotation, now time.Time) chronograf.Point {
 			"start_time":       anno.StartTime.UnixNano(),
 			"modified_time_ns": int64(now.UnixNano()),
 			"text":             anno.Text,
+			"color":            anno.Color,
 		},
 	}
 }
@@ -301,6 +302,9 @@ func (r *influxResults) Annotations() (res []chronograf.Annotation, err error) {
 				}
 				if anno.ID, err = v.String(i); err != nil {
 					return
+				}
+				if colorIndex, found := columnIndex["color"]; found {
+					anno.Color, _ = v.String(colorIndex)
 				}
 
 				anno.Tags = chronograf.AnnotationTags{}

--- a/influx/annotations_test.go
+++ b/influx/annotations_test.go
@@ -40,6 +40,7 @@ func Test_toPoint(t *testing.T) {
 					"start_time":       time.Time{}.UnixNano(),
 					"modified_time_ns": int64(time.Unix(0, 0).UnixNano()),
 					"text":             "mytext",
+					"color":            "",
 				},
 			},
 		},
@@ -50,6 +51,7 @@ func Test_toPoint(t *testing.T) {
 				Text:      "mytext",
 				StartTime: time.Unix(100, 0),
 				EndTime:   time.Unix(200, 0),
+				Color:     "red",
 			},
 			now: time.Unix(0, 0),
 			want: chronograf.Point{
@@ -65,6 +67,7 @@ func Test_toPoint(t *testing.T) {
 					"start_time":       time.Unix(100, 0).UnixNano(),
 					"modified_time_ns": int64(time.Unix(0, 0).UnixNano()),
 					"text":             "mytext",
+					"color":            "red",
 				},
 			},
 		},

--- a/server/annotations.go
+++ b/server/annotations.go
@@ -28,6 +28,7 @@ type annotationResponse struct {
 	StartTime string                    `json:"startTime"` // StartTime in RFC3339 of the start of the annotation
 	EndTime   string                    `json:"endTime"`   // EndTime in RFC3339 of the end of the annotation
 	Text      string                    `json:"text"`      // Text is the associated user-facing text describing the annotation
+	Color     string                    `json:"color"`     // Optional annotation color
 	Tags      chronograf.AnnotationTags `json:"tags"`      // Tags is a collection of user defined key/value pairs that contextualize the annotation
 	Links     annotationLinks           `json:"links"`
 }
@@ -39,6 +40,7 @@ func newAnnotationResponse(src chronograf.Source, a *chronograf.Annotation) anno
 		StartTime: a.StartTime.UTC().Format(timeMilliFormat),
 		EndTime:   a.EndTime.UTC().Format(timeMilliFormat),
 		Text:      a.Text,
+		Color:     a.Color,
 		Tags:      a.Tags,
 		Links: annotationLinks{
 			Self: fmt.Sprintf("%s/%d/annotations/%s", base, src.ID, a.ID),
@@ -227,7 +229,8 @@ func (s *Service) Annotation(w http.ResponseWriter, r *http.Request) {
 type newAnnotationRequest struct {
 	StartTime time.Time
 	EndTime   time.Time
-	Text      string                    `json:"text,omitempty"` // Text is the associated user-facing text describing the annotation
+	Text      string                    `json:"text,omitempty"`  // Text is the associated user-facing text describing the annotation
+	Color     string                    `json:"color,omitempty"` // Optional annotation color
 	Tags      chronograf.AnnotationTags `json:"tags"`
 }
 
@@ -267,6 +270,7 @@ func (ar *newAnnotationRequest) Annotation() *chronograf.Annotation {
 		StartTime: ar.StartTime,
 		EndTime:   ar.EndTime,
 		Text:      ar.Text,
+		Color:     ar.Color,
 		Tags:      ar.Tags,
 	}
 }
@@ -379,6 +383,7 @@ type updateAnnotationRequest struct {
 	StartTime *time.Time                `json:"startTime,omitempty"` // StartTime is the time in rfc3339 milliseconds
 	EndTime   *time.Time                `json:"endTime,omitempty"`   // EndTime is the time in rfc3339 milliseconds
 	Text      *string                   `json:"text,omitempty"`      // Text is the associated user-facing text describing the annotation
+	Color     *string                   `json:"color,omitempty"`     // Annotation color
 	Tags      chronograf.AnnotationTags `json:"tags"`
 }
 
@@ -478,6 +483,10 @@ func (s *Service) UpdateAnnotation(w http.ResponseWriter, r *http.Request) {
 	}
 	if req.Text != nil {
 		cur.Text = *req.Text
+	}
+
+	if req.Color != nil {
+		cur.Color = *req.Color
 	}
 	if req.Tags != nil {
 		if err = req.Tags.Valid(); err != nil {

--- a/server/swagger.json
+++ b/server/swagger.json
@@ -6699,6 +6699,7 @@
             "startTime": "2018-07-09T18:08:15.933Z",
             "endTime": "2018-07-09T18:08:15.933Z",
             "text": "unknown event",
+            "color": "",
             "tags": {},
             "links": {
               "self": "/chronograf/v1/sources/1/annotations/50ee18e8-8115-4fac-abed-24ce89e96047"
@@ -6709,6 +6710,7 @@
             "startTime": "2018-07-09T17:48:04.23Z",
             "endTime": "2018-07-09T17:48:08.652Z",
             "text": "todo: investigate this spike",
+            "color":  "",
             "tags": {
               "repo": "influxdata/chronograf"
             },
@@ -6750,6 +6752,13 @@
             "text": "my annotation"
           }
         },
+        "color": {
+          "type": "string",
+          "description": "Annotation color",
+          "example": {
+            "text": "red"
+          }
+        },
         "tags": {
           "type": "object",
           "description": "A set of user-defined tags associated with the annotation",
@@ -6773,6 +6782,7 @@
         "startTime": "2018-07-09T17:48:04.23Z",
         "endTime": "2018-07-09T17:48:08.652Z",
         "text": "no name",
+        "color": "red",
         "tags": {
           "repo": "influxdata/chronograf"
         },
@@ -6803,6 +6813,13 @@
           "description": "A user-facing description of the annotation",
           "example": {
             "text": "my annotation"
+          }
+        },
+        "color": {
+          "type": "string",
+          "description": "Annotation color",
+          "example": {
+            "text": "red"
           }
         },
         "tags": {

--- a/ui/src/shared/components/AnnotationPoint.tsx
+++ b/ui/src/shared/components/AnnotationPoint.tsx
@@ -54,7 +54,7 @@ class AnnotationPoint extends Component<Props, State> {
           onMouseEnter={this.handleMouseEnter}
           onMouseLeave={this.handleMouseLeave}
         />
-        <div className={this.flagClass} />
+        <div className={this.flagClass} style={this.flagStyle} />
         <AnnotationTooltip
           timestamp={annotation.startTime}
           annotation={annotation}
@@ -151,9 +151,17 @@ class AnnotationPoint extends Component<Props, State> {
       DYGRAPH_CONTAINER_V_MARGIN * 2
     }px)`
 
+    const backgroundColor = annotation.color || undefined
     return {
       left,
       height,
+      backgroundColor,
+    }
+  }
+
+  private get flagStyle(): CSSProperties {
+    return {
+      backgroundColor: this.props.annotation.color || undefined,
     }
   }
 

--- a/ui/src/shared/components/AnnotationSpan.tsx
+++ b/ui/src/shared/components/AnnotationSpan.tsx
@@ -1,4 +1,4 @@
-import React, {Component, MouseEvent, DragEvent} from 'react'
+import React, {Component, MouseEvent, DragEvent, CSSProperties} from 'react'
 import {connect} from 'react-redux'
 
 import {
@@ -146,6 +146,9 @@ class AnnotationSpan extends Component<Props, State> {
     const flagClass = isDragging
       ? 'annotation-span--left-flag dragging'
       : 'annotation-span--left-flag'
+    const flagStyle: CSSProperties = {
+      borderLeftColor: annotation.color || undefined,
+    }
     const markerClass = isDragging ? 'annotation dragging' : 'annotation'
     const clickClass = isEditing
       ? 'annotation--click-area editing'
@@ -159,6 +162,7 @@ class AnnotationSpan extends Component<Props, State> {
 
     const markerStyles = {
       left: `${dygraph.toDomXCoord(startTime) + DYGRAPH_CONTAINER_H_MARGIN}px`,
+      backgroundColor: annotation.color || undefined,
       height: `calc(100% - ${
         staticLegendHeight +
         DYGRAPH_CONTAINER_XLABEL_MARGIN +
@@ -185,7 +189,7 @@ class AnnotationSpan extends Component<Props, State> {
           onMouseEnter={this.handleMouseEnter('left')}
           onMouseLeave={this.handleMouseLeave}
         />
-        <div className={flagClass} />
+        <div className={flagClass} style={flagStyle} />
       </div>
     )
   }
@@ -201,6 +205,9 @@ class AnnotationSpan extends Component<Props, State> {
     const flagClass = isDragging
       ? 'annotation-span--right-flag dragging'
       : 'annotation-span--right-flag'
+    const flagStyle: CSSProperties = {
+      borderRightColor: annotation.color || undefined,
+    }
     const markerClass = isDragging ? 'annotation dragging' : 'annotation'
     const clickClass = isEditing
       ? 'annotation--click-area editing'
@@ -214,6 +221,7 @@ class AnnotationSpan extends Component<Props, State> {
 
     const markerStyles = {
       left: `${dygraph.toDomXCoord(endTime) + DYGRAPH_CONTAINER_H_MARGIN}px`,
+      backgroundColor: annotation.color || undefined,
       height: `calc(100% - ${
         staticLegendHeight +
         DYGRAPH_CONTAINER_XLABEL_MARGIN +
@@ -240,7 +248,7 @@ class AnnotationSpan extends Component<Props, State> {
           onMouseEnter={this.handleMouseEnter('right')}
           onMouseLeave={this.handleMouseLeave}
         />
-        <div className={flagClass} />
+        <div className={flagClass} style={flagStyle} />
       </div>
     )
   }

--- a/ui/src/shared/components/ColorDropdown.tsx
+++ b/ui/src/shared/components/ColorDropdown.tsx
@@ -8,7 +8,7 @@ import {ColorNumber, ThresholdColor} from 'src/types/colors'
 import {DROPDOWN_MENU_MAX_HEIGHT} from 'src/shared/constants/index'
 
 interface Props {
-  selected: ColorNumber
+  selected: Partial<ColorNumber>
   disabled?: boolean
   stretchToFit?: boolean
   colors: ThresholdColor[]

--- a/ui/src/shared/constants/thresholds.ts
+++ b/ui/src/shared/constants/thresholds.ts
@@ -13,6 +13,10 @@ export const THRESHOLD_TYPE_TEXT = 'text'
 export const THRESHOLD_TYPE_BG = 'background'
 export const THRESHOLD_TYPE_BASE = 'base'
 
+export const THRESHOLD_COLOR_WHITE = {
+  hex: '#ffffff',
+  name: 'white',
+}
 export const THRESHOLD_COLORS = [
   {
     hex: '#BF3D5E',
@@ -82,10 +86,7 @@ export const THRESHOLD_COLORS = [
     hex: '#545667',
     name: 'graphite',
   },
-  {
-    hex: '#ffffff',
-    name: 'white',
-  },
+  THRESHOLD_COLOR_WHITE,
   {
     hex: '#292933',
     name: 'castle',

--- a/ui/src/types/annotations.ts
+++ b/ui/src/types/annotations.ts
@@ -3,6 +3,7 @@ export interface Annotation {
   startTime: number
   endTime: number
   text: string
+  color?: string
   tags?: AnnotationTags
   links: {self: string}
 }


### PR DESCRIPTION
Closes #5605

This PR enhances annotation model, API, and UI so that the user can choose annotation color (which was always white before this PR).

![image](https://user-images.githubusercontent.com/16321466/175496349-6046ab01-5b86-4c2e-81cf-f8ef89aabe8f.png)

![image](https://user-images.githubusercontent.com/16321466/175496695-0033199f-67a9-44bf-bd19-7736d011690d.png)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] swagger.json updated (if modified Go structs or API)
