### PR TITLE
chore(server): use single JWT library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/NYTimes/gziphandler v1.1.1
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/bouk/httprouter v0.0.0-20160817010721-ee8b3818a7f5
-	github.com/golang-jwt/jwt/v4 v4.0.0
 	github.com/google/go-cmp v0.5.5
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,6 @@ github.com/gogo/protobuf v1.2.2-0.20190730201129-28a6bbf47e48/go.mod h1:SlYgWuQ5
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/golang-jwt/jwt/v4 v4.0.0 h1:RAqyYixv1p7uEnocuy8P1nru5wprCh/MH2BIlW5z5/o=
-github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang/gddo v0.0.0-20181116215533-9bd4a3295021/go.mod h1:xEhNfoBDX1hzLm2Nf80qUvZ2sVwoMZ8d6IE2SrsQfh4=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec h1:lJwO/92dFXWeXOZdoGXgptLmNLwynMSHUmU6besqtiw=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=

--- a/influx/authorization_test.go
+++ b/influx/authorization_test.go
@@ -28,6 +28,17 @@ func TestJWT(t *testing.T) {
 			},
 			want: "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjYwLCJ1c2VybmFtZSI6IkF6dXJlRGlhbW9uZCJ9.kUWGwcpCPwV7MEk7luO1rt8036LyvG4bRL_CfseQGmz4b0S34gATx30g4xvqVAV6bwwYE0YU3P8FjG8ij4kc5g",
 		},
+		{
+			name: "",
+			args: args{
+				username:     "Pepa",
+				sharedSecret: "hunter2",
+				now: func() time.Time {
+					return time.Date(2022, time.July, 1, 20, 0, 0, 0, time.UTC)
+				},
+			},
+			want: "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTY3MDU2NjAsInVzZXJuYW1lIjoiUGVwYSJ9.zrY8LHP4jjZ-MaNOLEeN5dPC8SdA132DjhHv83dHF48lHV25u6OfFKEW11hZlVdI7f6z_bGxTMMezKHnf04jYQ",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/influx/influx_test.go
+++ b/influx/influx_test.go
@@ -12,11 +12,12 @@ import (
 	"testing"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
 	"github.com/influxdata/chronograf/influx"
 	"github.com/influxdata/chronograf/log"
 	"github.com/influxdata/chronograf/mocks"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 // NewClient initializes an HTTP Client for InfluxDB.
@@ -80,25 +81,17 @@ func Test_Influx_AuthorizationBearer(t *testing.T) {
 		rw.Write([]byte(`{}`))
 		auth := r.Header.Get("Authorization")
 		tokenString := strings.Split(auth, " ")[1]
-		token, err := gojwt.Parse(tokenString, func(token *gojwt.Token) (interface{}, error) {
-			if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
-			}
-			return []byte("42"), nil
-		})
+		token, err := jwt.Parse([]byte(tokenString), jwt.WithKey(jwa.HS512, []byte("42")))
 		if err != nil {
 			t.Errorf("Invalid token %v", err)
-		}
-
-		if claims, ok := token.Claims.(gojwt.MapClaims); ok && token.Valid {
-			got := claims["username"]
-			want := "AzureDiamond"
-			if got != want {
-				t.Errorf("Test_Influx_AuthorizationBearer got %s want %s", got, want)
-			}
 			return
 		}
-		t.Errorf("Invalid token %v", token)
+
+		got, _ := token.Get(`username`)
+		want := "AzureDiamond"
+		if got != want {
+			t.Errorf("Test_Influx_AuthorizationBearer got %s want %s", got, want)
+		}
 	}))
 	defer ts.Close()
 
@@ -132,24 +125,12 @@ func Test_Influx_AuthorizationBearerCtx(t *testing.T) {
 		}
 		incomingToken := strings.Split(got, " ")[1]
 
-		alg := func(token *gojwt.Token) (interface{}, error) {
-			if _, ok := token.Method.(*gojwt.SigningMethodHMAC); !ok {
-				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-			}
-			return []byte("hunter2"), nil
-		}
-		claims := &gojwt.MapClaims{}
-		token, err := gojwt.ParseWithClaims(string(incomingToken), claims, alg)
+		token, err := jwt.Parse([]byte(incomingToken), jwt.WithKey(jwa.HS512, []byte("hunter2")))
 		if err != nil {
 			t.Errorf("Test_Influx_AuthorizationBearerCtx unexpected claims error %v", err)
+			return
 		}
-		if !token.Valid {
-			t.Error("Test_Influx_AuthorizationBearerCtx unexpected valid claim")
-		}
-		if err := claims.Valid(); err != nil {
-			t.Errorf("Test_Influx_AuthorizationBearerCtx not expires already %v", err)
-		}
-		user := (*claims)["username"].(string)
+		user, _ := token.Get(`username`)
 		if user != "AzureDiamond" {
 			t.Errorf("Test_Influx_AuthorizationBearerCtx expected username AzureDiamond but got %s", user)
 		}

--- a/oauth2/cookies_test.go
+++ b/oauth2/cookies_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 type MockTokenizer struct {
@@ -38,8 +38,8 @@ func (m *MockTokenizer) ExtendedPrincipal(ctx context.Context, principal Princip
 	return principal, m.ExtendErr
 }
 
-func (m *MockTokenizer) GetClaims(tokenString string) (gojwt.MapClaims, error) {
-	return gojwt.MapClaims{}, nil
+func (m *MockTokenizer) GetClaims(tokenString string) (jwt.Token, error) {
+	return jwt.New(), nil
 }
 
 func TestCookieAuthorize(t *testing.T) {

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -163,11 +163,7 @@ func (j *JWT) FetchKeys(_ context.Context, sink jws.KeySink, sig *jws.Signature,
 			return fmt.Errorf("no JWK found with kid %s", kid)
 		}
 
-		var rawkey interface{}
-		if err := key.Raw(&rawkey); err != nil {
-			return fmt.Errorf("failed to read JWK public key: %s", err)
-		}
-		sink.Key(jwa.RS256, rawkey)
+		sink.Key(jwa.RS256, key)
 	default:
 		return fmt.Errorf("unexpected signing method: %v", sig.ProtectedHeaders().Algorithm())
 	}

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -48,7 +48,6 @@ func parseToken(src string, options ...jwt.ParseOption) (jwt.Token, error) {
 		// Hack to make the rror messages compatible with previous incarnation
 		switch {
 		case errors.Is(err, jwt.ErrInvalidIssuedAt()):
-			// Note: error message is not technically true
 			return nil, fmt.Errorf(`Token used before issued`)
 		case errors.Is(err, jwt.ErrTokenExpired()):
 			return nil, fmt.Errorf(`Token is expired`)

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -2,11 +2,15 @@ package oauth2
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"sync"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jws"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 // Ensure JWT conforms to the Tokenizer interface
@@ -17,6 +21,14 @@ type JWT struct {
 	Secret  string
 	Jwksurl string
 	Now     func() time.Time
+	Cache   *jwk.Cache
+	// Because oauth.JWT is an open struct where anybody can bypass
+	// the constructor call to NewJWT(), there is no way to guarantee
+	// initialization of the (oauth.JWT).Cache field. To overcome
+	// this without chaing the design, we add a sync.Once variable
+	// here such that the code to initialize (oauth.JWT).Cache is
+	// definitely run, but only run once.
+	initCacheOnce sync.Once
 }
 
 // NewJWT creates a new JWT using time.Now
@@ -30,56 +42,136 @@ func NewJWT(secret string, jwksurl string) *JWT {
 	}
 }
 
-// Ensure Claims implements the jwt.Claims interface
-var _ gojwt.Claims = &Claims{}
-
-// Claims extends jwt.StandardClaims' Valid to make sure claims has a subject.
-type Claims struct {
-	gojwt.StandardClaims
-	// We were unable to find a standard claim at https://www.iana.org/assignments/jwt/jwt.xhtml
-	// that felt appropriate for Organization. As a result, we added a custom `org` field.
-	Organization string `json:"org,omitempty"`
-	// We were unable to find a standard claim at https://www.iana.org/assignments/jwt/jwt.xhtml
-	// that felt appropriate for a users Group(s). As a result we added a custom `grp` field.
-	// Multiple groups may be specified by comma delimiting the various group.
-	//
-	// The singlular `grp` was chosen over the `grps` to keep consistent with the JWT naming
-	// convention (it is common for singlularly named values to actually be arrays, see `given_name`,
-	// `family_name`, and `middle_name` in the iana link provided above). I should add the discalimer
-	// I'm currently sick, so this thought process might be off.
-	Group string `json:"grp,omitempty"`
-}
-
-// Valid adds an empty subject test to the StandardClaims checks.
-func (c *Claims) Valid() error {
-	if err := c.StandardClaims.Valid(); err != nil {
-		return err
-	} else if c.StandardClaims.Subject == "" {
-		return fmt.Errorf("claim has no subject")
+func parseToken(src string, options ...jwt.ParseOption) (jwt.Token, error) {
+	token, err := jwt.Parse([]byte(src), options...)
+	if err != nil {
+		// Hack to make the rror messages compatible with previous incarnation
+		switch {
+		case errors.Is(err, jwt.ErrInvalidIssuedAt()):
+			// Note: error message is not technically true
+			return nil, fmt.Errorf(`Token used before issued`)
+		case errors.Is(err, jwt.ErrTokenExpired()):
+			return nil, fmt.Errorf(`Token is expired`)
+		default:
+		}
+		return nil, err
 	}
-
-	return nil
+	return token, nil
 }
 
 // ValidPrincipal checks if the jwtToken is signed correctly and validates with Claims.  lifespan is the
 // maximum valid lifetime of a token.  If the lifespan is 0 then the auth lifespan duration is not checked.
 func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, lifespan time.Duration) (Principal, error) {
-	gojwt.TimeFunc = j.Now
 
-	// Check for expected signing method.
-	alg := j.KeyFunc
+	var options = []jwt.ParseOption{
+		jwt.WithKeyProvider(j),
+		jwt.WithRequiredClaim(jwt.SubjectKey),
+		jwt.WithClock(jwt.ClockFunc(j.Now)),
+	}
 
-	return j.ValidClaims(jwtToken, lifespan, alg)
+	// If the duration of the claim is longer than the auth lifespan then this is
+	// an invalid claim because server assumes that lifespan is the maximum possible
+	// duration.  However, a lifespan of zero means that the duration comparison
+	// against the auth duration is not needed.
+	if lifespan > 0 {
+		options = append(options, jwt.WithValidator(jwt.ValidatorFunc(func(_ context.Context, tok jwt.Token) jwt.ValidationError {
+			exp := tok.Expiration().Round(time.Second)
+			iat := tok.IssuedAt().Round(time.Second)
+
+			// If the duration of the claim is longer than the auth lifespan then this is
+			// an invalid claim because server assumes that lifespan is the maximum possible
+			// duration.  However, a lifespan of zero means that the duration comparison
+			// against the auth duration is not needed.
+			if lifespan > 0 && exp.Sub(iat) > lifespan {
+				return jwt.NewValidationError(fmt.Errorf("claims duration is different from auth lifespan"))
+			}
+			return nil
+		})))
+	}
+
+	token, err := parseToken(string(jwtToken), options...)
+	if err != nil {
+		return Principal{}, err
+	}
+
+	var org, grp string
+	if v, ok := token.Get(`org`); ok {
+		if s, ok := v.(string); ok {
+			org = s
+		}
+	}
+	if v, ok := token.Get(`grp`); ok {
+		if s, ok := v.(string); ok {
+			grp = s
+		}
+	}
+
+	return Principal{
+		Subject:      token.Subject(),
+		Issuer:       token.Issuer(),
+		Organization: org,
+		Group:        grp,
+		// previous incarnation operated in local timezone
+		// semantics, whereas github.com/lestrrat-go/jwx
+		// works in UTC
+		ExpiresAt: token.Expiration().Local(),
+		IssuedAt:  token.IssuedAt().Local(),
+	}, nil
 }
 
-// KeyFunc verifies HMAC or RSA/RS256 signatures
-func (j *JWT) KeyFunc(token *gojwt.Token) (interface{}, error) {
-	if _, ok := token.Method.(*gojwt.SigningMethodHMAC); ok {
-		return []byte(j.Secret), nil
-	} else if _, ok := token.Method.(*gojwt.SigningMethodRSA); ok {
-		return j.KeyFuncRS256(token)
+func (j *JWT) initCache() {
+	// ideally this should be controlled from whatever "main"
+	// module using this component, but we are punting it by
+	// using context.TODO() here.
+	//
+	// Also, we could be using jwk.CachedSet here, but since
+	// one of the tests explicitly asked to check for invalid
+	// JWKS urls during verification time, we are simply using
+	// jwk.Cache instead
+	cache := jwk.NewCache(context.TODO())
+
+	// Note: by default updates are checked every 15 minutes
+	cache.Register(j.Jwksurl)
+	j.Cache = cache
+}
+
+// FetchKeys implements jws.KeyProvider, and dynamically returns the
+// appropriate key to verify the token
+func (j *JWT) FetchKeys(_ context.Context, sink jws.KeySink, sig *jws.Signature, msg *jws.Message) error {
+	switch sig.ProtectedHeaders().Algorithm() {
+	case jwa.HS256:
+		sink.Key(jwa.HS256, []byte(j.Secret))
+	case jwa.RS256:
+		if j.Jwksurl == "" {
+			return fmt.Errorf("JWKSURL not specified, cannot validate RS256 signature")
+		}
+
+		j.initCacheOnce.Do(j.initCache)
+
+		set, err := j.Cache.Get(context.TODO(), j.Jwksurl)
+		if err != nil {
+			return err
+		}
+
+		kid := sig.ProtectedHeaders().KeyID()
+		if kid == "" {
+			return fmt.Errorf("could not convert JWT header kid to string")
+		}
+
+		key, ok := set.LookupKeyID(kid)
+		if !ok {
+			return fmt.Errorf("no JWK found with kid %s", kid)
+		}
+
+		var rawkey interface{}
+		if err := key.Raw(&rawkey); err != nil {
+			return fmt.Errorf("failed to read JWK public key: %s", err)
+		}
+		sink.Key(jwa.RS256, rawkey)
+	default:
+		return fmt.Errorf("unexpected signing method: %v", sig.ProtectedHeaders().Algorithm())
 	}
-	return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+	return nil
 }
 
 // For the id_token, the recommended signature algorithm is RS256, which
@@ -108,128 +200,50 @@ type JWKS struct {
 	Keys []JWK `json:"keys"`
 }
 
-// KeyFuncRS256 verifies RS256 signed JWT tokens, it looks up the signing key in the key discovery service
-func (j *JWT) KeyFuncRS256(token *gojwt.Token) (interface{}, error) {
-	// Don't forget to validate the alg is what you expect:
-	if _, ok := token.Method.(*gojwt.SigningMethodRSA); !ok {
-		return nil, fmt.Errorf("Unsupported signing method: %v", token.Header["alg"])
-	}
-
-	// read JWKS document from key discovery service
-	if j.Jwksurl == "" {
-		return nil, fmt.Errorf("JWKSURL not specified, cannot validate RS256 signature")
-	}
-
-	set, err := jwk.Fetch(context.TODO(), j.Jwksurl)
-	if err != nil {
-		return nil, err
-	}
-
-	kid, ok := token.Header["kid"].(string)
-	if !ok {
-		return nil, fmt.Errorf("could not convert JWT header kid to string")
-	}
-
-	key, ok := set.LookupKeyID(kid)
-	if !ok {
-		return nil, fmt.Errorf("no JWK found with kid %s", kid)
-	}
-
-	var rawkey interface{}
-	if err := key.Raw(&rawkey); err != nil {
-		return nil, fmt.Errorf("failed to read JWK public key: %s", err)
-	}
-
-	return rawkey, nil
-}
-
-// ValidClaims validates a token with StandardClaims
-func (j *JWT) ValidClaims(jwtToken Token, lifespan time.Duration, alg gojwt.Keyfunc) (Principal, error) {
-	// 1. Checks for expired tokens
-	// 2. Checks if time is after the issued at
-	// 3. Check if time is after not before (nbf)
-	// 4. Check if subject is not empty
-	// 5. Check if duration less than auth lifespan
-	token, err := gojwt.ParseWithClaims(string(jwtToken), &Claims{}, alg)
-	if err != nil {
-		return Principal{}, err
-		// at time of this writing and researching the docs, token.Valid seems to be always true
-	} else if !token.Valid {
-		return Principal{}, err
-	}
-
-	// at time of this writing and researching the docs, there will always be claims
-	claims, ok := token.Claims.(*Claims)
-	if !ok {
-		return Principal{}, fmt.Errorf("unable to convert claims to standard claims")
-	}
-
-	exp := time.Unix(claims.ExpiresAt, 0)
-	iat := time.Unix(claims.IssuedAt, 0)
-
-	// If the duration of the claim is longer than the auth lifespan then this is
-	// an invalid claim because server assumes that lifespan is the maximum possible
-	// duration.  However, a lifespan of zero means that the duration comparison
-	// against the auth duration is not needed.
-	if lifespan > 0 && exp.Sub(iat) > lifespan {
-		return Principal{}, fmt.Errorf("claims duration is different from auth lifespan")
-	}
-
-	return Principal{
-		Subject:      claims.Subject,
-		Issuer:       claims.Issuer,
-		Organization: claims.Organization,
-		Group:        claims.Group,
-		ExpiresAt:    exp,
-		IssuedAt:     iat,
-	}, nil
-}
-
 // GetClaims extracts claims from id_token
-func (j *JWT) GetClaims(tokenString string) (gojwt.MapClaims, error) {
-	var claims gojwt.MapClaims
-
-	gojwt.TimeFunc = j.Now
-	token, err := gojwt.Parse(tokenString, j.KeyFunc)
+func (j *JWT) GetClaims(tokenString string) (jwt.Token, error) {
+	token, err := parseToken(
+		tokenString,
+		jwt.WithKeyProvider(j),
+		jwt.WithRequiredClaim(jwt.SubjectKey),
+		jwt.WithClock(jwt.ClockFunc(j.Now)),
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	if !token.Valid {
-		return nil, fmt.Errorf("token is not valid")
-	}
-
-	claims, ok := token.Claims.(gojwt.MapClaims)
-	if !ok {
-		return nil, fmt.Errorf("token has no claims")
-	}
-
-	return claims, nil
+	return token, nil
 }
 
 // Create creates a signed JWT token from user that expires at Principal's ExpireAt time.
 func (j *JWT) Create(ctx context.Context, user Principal) (Token, error) {
 	// Create a new token object, specifying signing method and the claims
 	// you would like it to contain.
-	claims := &Claims{
-		StandardClaims: gojwt.StandardClaims{
-			Subject:   user.Subject,
-			Issuer:    user.Issuer,
-			ExpiresAt: user.ExpiresAt.Unix(),
-			IssuedAt:  user.IssuedAt.Unix(),
-			NotBefore: user.IssuedAt.Unix(),
-		},
-		Organization: user.Organization,
-		Group:        user.Group,
+	b := jwt.NewBuilder().
+		Subject(user.Subject).
+		Expiration(user.ExpiresAt).
+		IssuedAt(user.IssuedAt).
+		NotBefore(user.IssuedAt)
+
+	if iss := user.Issuer; iss != "" {
+		b.Issuer(user.Issuer)
 	}
-	token := gojwt.NewWithClaims(gojwt.SigningMethodHS256, claims)
-	// Sign and get the complete encoded token as a string using the secret
-	t, err := token.SignedString([]byte(j.Secret))
-	// this will only fail if the JSON can't be encoded correctly
+	if org := user.Organization; org != "" {
+		b.Claim(`org`, org)
+	}
+	if grp := user.Group; grp != "" {
+		b.Claim(`grp`, grp)
+	}
+	tok, err := b.Build()
 	if err != nil {
 		return "", err
 	}
-	return Token(t), nil
+
+	signed, err := jwt.Sign(tok, jwt.WithKey(jwa.HS256, []byte(j.Secret)))
+	if err != nil {
+		return "", err
+	}
+	return Token(string(signed)), nil
 }
 
 // ExtendedPrincipal sets the expires at to be the current time plus the extention into the future

--- a/oauth2/jwt.go
+++ b/oauth2/jwt.go
@@ -115,8 +115,16 @@ func (j *JWT) ValidPrincipal(ctx context.Context, jwtToken Token, lifespan time.
 	}, nil
 }
 
-func (j *JWT) initCache(ctx context.Context) {
-	cache := jwk.NewCache(ctx)
+func (j *JWT) initCache() {
+	// ideally this should be controlled from whatever "main"
+	// module using this component, but we are punting it by
+	// using context.TODO() here.
+	//
+	// Also, we could be using jwk.CachedSet here, but since
+	// one of the tests explicitly asked to check for invalid
+	// JWKS urls during verification time, we are simply using
+	// jwk.Cache instead
+	cache := jwk.NewCache(context.TODO())
 	// Note: by default updates are checked every 15 minutes
 	cache.Register(j.Jwksurl)
 	j.Cache = cache
@@ -134,7 +142,7 @@ func (j *JWT) FetchKeys(ctx context.Context, sink jws.KeySink, sig *jws.Signatur
 		}
 
 		j.initCacheOnce.Do(func() {
-			j.initCache(ctx)
+			j.initCache()
 		})
 
 		set, err := j.Cache.Get(ctx, j.Jwksurl)

--- a/oauth2/jwt_test.go
+++ b/oauth2/jwt_test.go
@@ -70,10 +70,8 @@ func TestAuthenticate(t *testing.T) {
 			Err: errors.New("Token is expired"),
 		},
 		{
-			Desc:   "Test jwt token not before time",
-			Secret: "secret",
-			// Note: because expiration is checked before nbf,
-			// his token must have a valid expiration time
+			Desc:     "Test jwt token not before time",
+			Secret:   "secret",
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi00NDY3NzE4MDAsImlhdCI6LTQ0Njc3NDQwMCwibmFtZSI6IkRvYyBCcm93biIsIm5iZiI6LTQ0Njc3NDM5OSwic3ViIjoiL2Nocm9ub2dyYWYvdjEvdXNlcnMvMSJ9.Vtr_7E46II0sqvk4MDfFUqDjMlcvtKPZC44CXhUBEGw",
 			Duration: time.Second,
 			Principal: oauth2.Principal{
@@ -84,10 +82,8 @@ func TestAuthenticate(t *testing.T) {
 			Err: errors.New("\"nbf\" not satisfied"),
 		},
 		{
-			Desc:   "Test jwt with empty subject is invalid",
-			Secret: "secret",
-			// Note: because expiration is checked before required
-			// claims, this token must have a valid expiration time
+			Desc:     "Test jwt with empty subject is invalid",
+			Secret:   "secret",
 			Token:    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOi00NDY3NzE4MDAsImlhdCI6LTQ0Njc3NDQwMCwibmJmIjotNDQ2Nzc0NDAwfQ.W2KIE7OW0nWsn8_NG-URUEiP88ELfEW54lIJInG8bBs",
 			Duration: time.Second,
 			Principal: oauth2.Principal{

--- a/oauth2/jwt_test.go
+++ b/oauth2/jwt_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestAuthenticate(t *testing.T) {
-	history := time.Unix(-446774400, 0)
+	history := time.Unix(-446774400, 0).UTC()
 	var tests = []struct {
 		Desc   string
 		Secret string

--- a/oauth2/oauth2.go
+++ b/oauth2/oauth2.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"time"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/oauth2"
 )
 
@@ -97,5 +97,5 @@ type Tokenizer interface {
 	// ExtendedPrincipal adds the extention to the principal's lifespan.
 	ExtendedPrincipal(ctx context.Context, principal Principal, extension time.Duration) (Principal, error)
 	// GetClaims returns a map with verified claims
-	GetClaims(tokenString string) (gojwt.MapClaims, error)
+	GetClaims(tokenString string) (jwt.Token, error)
 }

--- a/oauth2/oauth2_test.go
+++ b/oauth2/oauth2_test.go
@@ -10,8 +10,8 @@ import (
 
 	goauth "golang.org/x/oauth2"
 
-	gojwt "github.com/golang-jwt/jwt/v4"
 	"github.com/influxdata/chronograf"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 )
 
 var _ Provider = &MockProvider{}
@@ -47,11 +47,11 @@ func (mp *MockProvider) PrincipalID(provider *http.Client) (string, error) {
 	return mp.Email, nil
 }
 
-func (mp *MockProvider) PrincipalIDFromClaims(claims gojwt.MapClaims) (string, error) {
+func (mp *MockProvider) PrincipalIDFromClaims(_ jwt.Token) (string, error) {
 	return mp.Email, nil
 }
 
-func (mp *MockProvider) GroupFromClaims(claims gojwt.MapClaims) (string, error) {
+func (mp *MockProvider) GroupFromClaims(_ jwt.Token) (string, error) {
 	email := strings.Split(mp.Email, "@")
 	if len(email) != 2 {
 		//g.Logger.Error("malformed email address, expected %q to contain @ symbol", id)
@@ -92,8 +92,8 @@ func (y *YesManTokenizer) ExtendedPrincipal(ctx context.Context, p Principal, ex
 	return p, nil
 }
 
-func (y *YesManTokenizer) GetClaims(tokenString string) (gojwt.MapClaims, error) {
-	return gojwt.MapClaims{}, nil
+func (y *YesManTokenizer) GetClaims(tokenString string) (jwt.Token, error) {
+	return jwt.New(), nil
 }
 
 func NewTestTripper(log chronograf.Logger, ts *httptest.Server, rt http.RoundTripper) (*TestTripper, error) {


### PR DESCRIPTION
This PR removes the `github.com/golang-jwt/jwt` library and uses only the existing `github.com/lestrrat-go/jwx`.

It is built on top of #5918. As noted in #5915, github.com/lestrrat-go/jwx was initially used only for verification of RSA signed JWTs, this PR changes the code so that only github.com/lestrrat-go/jwx is used.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
