### PR TITLE
fix(ui): make markdown cell content selectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 1. [#5917](https://github.com/influxdata/chronograf/pull/5917): Avoid stale reads in communication with InfluxDB Enterprise meta nodes. 
 1. [#5938](https://github.com/influxdata/chronograf/pull/5938): Properly detect unsupported values in Alert Rule builder.
 1. [#5965](https://github.com/influxdata/chronograf/pull/5965): Inform the user to use v2 administration.
+1. [#5976](https://github.com/influxdata/chronograf/pull/5976): Make markdown cell content selectable.
 
 ### Other
 

--- a/ui/src/shared/components/MarkdownCell.scss
+++ b/ui/src/shared/components/MarkdownCell.scss
@@ -9,6 +9,7 @@
 }
 
 .markdown-cell--contents {
+  user-select: text;
   padding: 8px 16px;
   font-size: 13px;
 }


### PR DESCRIPTION
Closes #5973

Markdown cell content can be selected and copied in this PR.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
