### PR TITLE
feat(ui): select current value in dropdown search input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 1. [#5956](https://github.com/influxdata/chronograf/pull/5956): Add InfluxDB admin tabs to user/role detail page.
 1. [#5959](https://github.com/influxdata/chronograf/pull/5959): Allow to customize annotation color.
 1. [#5967](https://github.com/influxdata/chronograf/pull/5967): Remember whether to start with shown annotations on Dashboard page.
+1. [#5977](https://github.com/influxdata/chronograf/pull/5977): Select current value in dropdown search input.
 
 ### Bug Fixes
 

--- a/ui/src/shared/components/Dropdown.tsx
+++ b/ui/src/shared/components/Dropdown.tsx
@@ -204,6 +204,7 @@ export class Dropdown extends Component<Props, State> {
             searchTerm={searchTerm}
             buttonSize={buttonSize}
             buttonColor={buttonColor}
+            selectedValue={selected}
             toggleStyle={toggleStyle}
             disabled={disabled}
             onFilterChange={this.handleFilterChange}

--- a/ui/src/shared/components/DropdownInput.tsx
+++ b/ui/src/shared/components/DropdownInput.tsx
@@ -1,4 +1,10 @@
-import React, {FunctionComponent, ChangeEvent, KeyboardEvent} from 'react'
+import React, {
+  ChangeEvent,
+  KeyboardEvent,
+  useCallback,
+  useMemo,
+  useRef,
+} from 'react'
 import {CSSProperties} from 'react'
 
 const disabledClass = (disabled: boolean) => (disabled ? ' disabled' : '')
@@ -6,10 +12,14 @@ const disabledClass = (disabled: boolean) => (disabled ? ' disabled' : '')
 type OnFilterChangeHandler = (e: ChangeEvent<HTMLInputElement>) => void
 type OnFilterKeyPress = (e: KeyboardEvent<HTMLInputElement>) => void
 
+const selectAllTextInInput = (event: ChangeEvent<HTMLInputElement>) => {
+  event.target.select()
+}
 interface Props {
   searchTerm: string
   buttonSize: string
   buttonColor: string
+  selectedValue?: string
   toggleStyle?: CSSProperties
   disabled?: boolean
   placeholder?: string
@@ -17,34 +27,60 @@ interface Props {
   onFilterKeyPress: OnFilterKeyPress
 }
 
-const DropdownInput: FunctionComponent<Props> = ({
+const DropdownInput = ({
   searchTerm,
   buttonSize,
   buttonColor,
+  selectedValue = '',
   toggleStyle,
   disabled,
   onFilterChange,
   onFilterKeyPress,
   placeholder = 'Filter items...',
-}) => (
-  <div
-    className={`dropdown-autocomplete dropdown-toggle ${buttonSize} ${buttonColor}${disabledClass(
-      disabled
-    )}`}
-    style={toggleStyle}
-  >
-    <input
-      className="dropdown-autocomplete--input"
-      type="text"
-      autoFocus={true}
-      placeholder={placeholder}
-      spellCheck={false}
-      onChange={onFilterChange}
-      onKeyDown={onFilterKeyPress}
-      value={searchTerm}
-    />
-    <span className="caret" />
-  </div>
-)
+}: Props) => {
+  const renderSelected = useRef(true)
+  const value = useMemo(() => {
+    if (searchTerm) {
+      return searchTerm
+    }
+    return renderSelected.current ? selectedValue : ''
+  }, [searchTerm, renderSelected.current])
+  const onChange: OnFilterChangeHandler = useCallback(
+    e => {
+      renderSelected.current = false
+      onFilterChange(e)
+    },
+    [onFilterChange]
+  )
+  const onKeyPress: OnFilterKeyPress = useCallback(
+    e => {
+      renderSelected.current = false
+      onFilterKeyPress(e)
+    },
+    [onFilterKeyPress]
+  )
+
+  return (
+    <div
+      className={`dropdown-autocomplete dropdown-toggle ${buttonSize} ${buttonColor}${disabledClass(
+        disabled
+      )}`}
+      style={toggleStyle}
+    >
+      <input
+        className="dropdown-autocomplete--input"
+        type="text"
+        autoFocus={true}
+        placeholder={placeholder}
+        spellCheck={false}
+        onChange={onChange}
+        onKeyDown={onKeyPress}
+        onFocus={selectAllTextInInput}
+        value={value}
+      />
+      <span className="caret" />
+    </div>
+  )
+}
 
 export default DropdownInput

--- a/ui/src/shared/components/DropdownInput.tsx
+++ b/ui/src/shared/components/DropdownInput.tsx
@@ -38,7 +38,8 @@ const DropdownInput = ({
   onFilterKeyPress,
   placeholder = 'Filter items...',
 }: Props) => {
-  const renderSelected = useRef(true)
+  // show actually selected value only if search term is empty
+  const renderSelected = useRef(!searchTerm)
   const value = useMemo(() => {
     if (searchTerm) {
       return searchTerm


### PR DESCRIPTION
Closes #5971
The current dropdown value is shown when the dropdown is opened (with empty search term) in the search input. The input value is selected so that 
 - it can be quickly copied to clipboard
 - any keystroke in the input will delete the selected value (and possibly starts with typing an actual search term)

![dropdownInputWithCurrentValue](https://user-images.githubusercontent.com/16321466/177713833-7269702b-45df-4644-80af-3c8808824ff2.gif)


  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
