### PR TITLE
fix(ui): repair rendering of AllUsersTableRow

### DIFF
--- a/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
+++ b/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
@@ -49,16 +49,7 @@ interface Props {
 @ErrorHandling
 export default class AllUsersTableRow extends Component<Props> {
   public shouldComponentUpdate(nextProps) {
-    if (
-      _.isEqual(
-        _.omit(nextProps.user, 'superAdmin'),
-        _.omit(this.props.user, 'superAdmin')
-      )
-    ) {
-      return false
-    }
-
-    return true
+    return !_.isEqual(nextProps.user, this.props.user)
   }
 
   public render() {


### PR DESCRIPTION
Closes #5978

_Briefly describe your proposed changes:_
The table row re-renders upon any change of the user structure.

_What was the problem?_
The row did not re-render when user's superAdmin status changed. It was caused by some relict from the past, which excluded superAdmin status from re-rendering. The rows were however completely replaced upon any change in 1.9.4, the buggy code was thus never effective. Cypress tests were hard to do with frequent useless replacements of rows in DOM. #5947 fixed it and ensured that row DOM elements are updated upon changes. As a side-effect, the forgotten wrong behavior of optimized row rendering becomes effective.

_What was the solution?_
Re-rerender row on change of the user, including superAdmin status.

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
