### PR TITLE
chore(ui): rename dataTest attribute

### DIFF
--- a/ui/src/admin/components/chronograf/AllUsersTableHeader.tsx
+++ b/ui/src/admin/components/chronograf/AllUsersTableHeader.tsx
@@ -49,7 +49,7 @@ class AllUsersTableHeader extends Component<Props> {
               size={ComponentSize.Small}
               active={superAdminNewUsers}
               onChange={this.handleToggleClick}
-              dataTest="new-user-admins--toggle"
+              testId="new-user-admins--toggle"
             />
             <span>All new users are SuperAdmins</span>
           </div>

--- a/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
+++ b/ui/src/admin/components/chronograf/AllUsersTableRow.tsx
@@ -80,7 +80,7 @@ export default class AllUsersTableRow extends Component<Props> {
             color={ComponentColor.Success}
             disabled={this.userIsMe}
             tooltipText={this.toggleTooltipText}
-            dataTest="superAdmin--toggle"
+            testId="superAdmin--toggle"
           />
         </td>
         <td style={{textAlign: 'right', width: colActions}}>

--- a/ui/src/admin/containers/influxdb/RolesPage.tsx
+++ b/ui/src/admin/containers/influxdb/RolesPage.tsx
@@ -162,7 +162,7 @@ const RolesPage = ({
               active={showUsers}
               onChange={toggleShowUsers}
               size={ComponentSize.ExtraSmall}
-              dataTest="show-users--toggle"
+              testId="show-users--toggle"
             />
             Show Users
           </div>

--- a/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
+++ b/ui/src/reusable_ui/components/slide_toggle/SlideToggle.tsx
@@ -14,7 +14,7 @@ interface Props {
   color?: ComponentColor
   disabled?: boolean
   tooltipText?: string
-  dataTest?: string
+  testId?: string
 }
 
 @ErrorHandling
@@ -27,14 +27,14 @@ class SlideToggle extends Component<Props> {
   }
 
   public render() {
-    const {tooltipText, dataTest} = this.props
+    const {tooltipText, testId} = this.props
 
     return (
       <div
         className={this.className}
         onClick={this.handleClick}
         title={tooltipText}
-        data-test={dataTest}
+        data-test={testId}
       >
         <div className="slide-toggle--knob" />
       </div>

--- a/ui/src/reusable_ui/components/wizard/WizardCheckbox.tsx
+++ b/ui/src/reusable_ui/components/wizard/WizardCheckbox.tsx
@@ -26,7 +26,7 @@ class WizardCheckbox extends PureComponent<Props> {
             active={isChecked}
             onChange={this.onChangeSlideToggle}
             tooltipText={text}
-            dataTest={testId}
+            testId={testId}
           />
           <span
             className="wizard-checkbox--label"


### PR DESCRIPTION
This PR:
- changes an attribute's name from dataTest to testId to preserve naming consistency