### PR TITLE
chore(build): upgrade golang to 1.18.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ workflows:
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20220609
+      DOCKER_TAG: chronograf-20220721
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -61,7 +61,7 @@ jobs:
 
   deploy-nightly:
     environment:
-      DOCKER_TAG: chronograf-20220609
+      DOCKER_TAG: chronograf-20220721
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -90,7 +90,7 @@ jobs:
 
   deploy-pre-release:
     environment:
-      DOCKER_TAG: chronograf-20220609
+      DOCKER_TAG: chronograf-20220721
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -121,7 +121,7 @@ jobs:
 
   deploy-release:
     environment:
-      DOCKER_TAG: chronograf-20220609
+      DOCKER_TAG: chronograf-20220721
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.3'
+          go-version: '1.18.4'
 
       - uses: actions/setup-node@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 1. [#5915](https://github.com/influxdata/chronograf/pull/5915): Upgrade github.com/lestrrat-go/jwx to v2.
 1. [#5933](https://github.com/influxdata/chronograf/pull/5933): Upgrade golang to 1.18.3 .
 1. [#5947](https://github.com/influxdata/chronograf/pull/5947): Use stable component keys.
+1. [#5990](https://github.com/influxdata/chronograf/pull/5990): Upgrade golang to 1.18.4 .
 
 ## v1.9.4 [2022-03-22]
 

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -33,7 +33,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.18.3
+ENV GO_VERSION 1.18.4
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/scripts/docker/run.sh
+++ b/etc/scripts/docker/run.sh
@@ -14,7 +14,7 @@ test -z $SSH_KEY_PATH && SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 echo "Using SSH key located at: $SSH_KEY_PATH"
 
 # Default docker tag if not specified
-test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20220609"
+test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20220721"
 
 docker run \
        -e AWS_ACCESS_KEY_ID \


### PR DESCRIPTION
Closes #5989 

This PR upgrades golang to 1.18.4

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
