### PR TITLE
chore(build): upgrade golang to 1.18.6

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.4'
+          go-version: '1.18.5'
 
       - uses: actions/setup-node@v2
         with:

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.18.5'
+          go-version: '1.18.6'
 
       - uses: actions/setup-node@v2
         with:

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -33,7 +33,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.18.4
+ENV GO_VERSION 1.18.5
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -33,7 +33,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.18.5
+ENV GO_VERSION 1.18.6
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \


### PR DESCRIPTION
Closes #5995 

This PR upgrades golang to 1.18.5

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [ ] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [ ] Rebased/mergeable
  - [ ] Tests pass
  - [ ] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
