### PR TITLE
feat(ui): simplify flux labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#5959](https://github.com/influxdata/chronograf/pull/5959): Allow to customize annotation color.
 1. [#5967](https://github.com/influxdata/chronograf/pull/5967): Remember whether to start with shown annotations on Dashboard page.
 1. [#5977](https://github.com/influxdata/chronograf/pull/5977): Select current value in dropdown search input.
+1. [#5997](https://github.com/influxdata/chronograf/pull/5997): Simplify flux labels.
 1. [#5998](https://github.com/influxdata/chronograf/pull/5998): Setup DBRP mapping automatically for a v2 connection.
 
 ### Bug Fixes

--- a/ui/src/shared/parsing/flux/parseTablesByTime.ts
+++ b/ui/src/shared/parsing/flux/parseTablesByTime.ts
@@ -33,7 +33,7 @@ function fluxTableKey(table: FluxTable, columnName: string): string {
     }
     return acc
   }, [])
-  return groupKeys.length ? `${name} (${groupKeys.join(' ')})` : name
+  return groupKeys.length ? `${name} ${groupKeys.join(' ')}` : name
 }
 
 export const parseTablesByTime = (

--- a/ui/src/shared/parsing/flux/parseTablesByTime.ts
+++ b/ui/src/shared/parsing/flux/parseTablesByTime.ts
@@ -42,64 +42,68 @@ export const parseTablesByTime = (
   const allColumnNames = []
   const nonNumericColumns = []
 
-  const tablesByTime = tables.map(table => {
-    const header = table.data[0] as string[]
-    const columnNames: {[k: number]: string} = {}
+  const tablesByTime = tables
+    .map(table => {
+      const header = table.data[0] as string[]
+      const columnNames: {[k: number]: string} = {}
 
-    for (let i = 0; i < header.length; i++) {
-      const columnName = header[i]
-      const dataType = table.dataTypes[columnName]
+      for (let i = 0; i < header.length; i++) {
+        const columnName = header[i]
+        const dataType = table.dataTypes[columnName]
 
-      if (COLUMN_BLACKLIST.has(columnName)) {
-        continue
+        if (COLUMN_BLACKLIST.has(columnName)) {
+          continue
+        }
+
+        if (table.groupKey[columnName]) {
+          continue
+        }
+
+        if (!NUMERIC_DATATYPES.includes(dataType)) {
+          nonNumericColumns.push(columnName)
+          continue
+        }
+
+        const uniqueColumnName = fluxTableKey(table, columnName)
+
+        columnNames[i] = uniqueColumnName
+        allColumnNames.push(uniqueColumnName)
       }
 
-      if (table.groupKey[columnName]) {
-        continue
+      let timeIndex = header.indexOf('_time')
+
+      let isTimeFound = true
+      if (timeIndex < 0) {
+        timeIndex = header.indexOf('_stop')
+        if (timeIndex < 0) {
+          return undefined
+        }
+        isTimeFound = false
       }
 
-      if (!NUMERIC_DATATYPES.includes(dataType)) {
-        nonNumericColumns.push(columnName)
-        continue
+      const result = {}
+      for (let i = 1; i < table.data.length; i++) {
+        const row = table.data[i]
+        const timeValue = row[timeIndex]
+        let time: string
+        if (isTimeFound) {
+          time = timeValue.toString()
+        } else {
+          // _stop and _start have values in date string format instead of number
+          time = Date.parse(timeValue as string).toString()
+        }
+        result[time] = Object.entries(columnNames).reduce(
+          (acc, [valueIndex, columnName]) => ({
+            ...acc,
+            [columnName]: row[valueIndex],
+          }),
+          {}
+        )
       }
 
-      const uniqueColumnName = fluxTableKey(table, columnName)
-
-      columnNames[i] = uniqueColumnName
-      allColumnNames.push(uniqueColumnName)
-    }
-
-    let timeIndex = header.indexOf('_time')
-
-    let isTimeFound = true
-    if (timeIndex < 0) {
-      timeIndex = header.indexOf('_stop')
-      isTimeFound = false
-    }
-
-    const result = {}
-    for (let i = 1; i < table.data.length; i++) {
-      const row = table.data[i]
-      const timeValue = row[timeIndex]
-      let time = ''
-
-      if (isTimeFound) {
-        time = timeValue.toString()
-      } else {
-        // _stop and _start have values in date string format instead of number
-        time = Date.parse(timeValue as string).toString()
-      }
-      result[time] = Object.entries(columnNames).reduce(
-        (acc, [valueIndex, columnName]) => ({
-          ...acc,
-          [columnName]: row[valueIndex],
-        }),
-        {}
-      )
-    }
-
-    return result
-  })
+      return result
+    })
+    .filter(x => x !== undefined)
 
   return {nonNumericColumns, tablesByTime, allColumnNames}
 }

--- a/ui/test/shared/parsing/flux/dygraph.test.ts
+++ b/ui/test/shared/parsing/flux/dygraph.test.ts
@@ -39,10 +39,10 @@ describe('fluxTablesToDygraph', () => {
     const expected = {
       labels: [
         'time',
-        'mean_usage_idle[_measurement=cpu]',
-        'mean_usage_user[_measurement=cpu]',
-        'mean_usage_idle[_measurement=mem]',
-        'mean_usage_user[_measurement=mem]',
+        'mean_usage_idle measurement=cpu',
+        'mean_usage_user measurement=cpu',
+        'mean_usage_idle measurement=mem',
+        'mean_usage_user measurement=mem',
       ],
       dygraphsData: [
         [new Date('2018-09-10T16:54:37Z'), 85, 10, 8, 1],
@@ -60,8 +60,8 @@ describe('fluxTablesToDygraph', () => {
     const expected = {
       labels: [
         'time',
-        'mean_usage_idle[_measurement=cpu]',
-        'mean_usage_idle[_measurement=mem]',
+        'mean_usage_idle measurement=cpu',
+        'mean_usage_idle measurement=mem',
       ],
       dygraphsData: [
         [new Date('2018-09-10T16:54:37Z'), 85, 8],

--- a/ui/test/shared/parsing/flux/parseTablesByTime.test.ts
+++ b/ui/test/shared/parsing/flux/parseTablesByTime.test.ts
@@ -1,0 +1,39 @@
+import {parseResponse} from 'src/shared/parsing/flux/response'
+import {SIMPLE, TAGS_RESPONSE} from 'test/shared/parsing/flux/constants'
+import {parseTablesByTime} from 'src/shared/parsing/flux/parseTablesByTime'
+
+describe('parseTablesByTime', () => {
+  it('can parse common flux table with simplified column names', () => {
+    const fluxTables = parseResponse(SIMPLE)
+    const actual = parseTablesByTime(fluxTables)
+    const expected = {
+      allColumnNames: [
+        'usage_guest measurement=cpu cpu=cpu1 host=bertrand.local',
+      ],
+      nonNumericColumns: [],
+      tablesByTime: [
+        {
+          '1536618869000': {
+            'usage_guest measurement=cpu cpu=cpu1 host=bertrand.local': 0,
+          },
+          '1536618879000': {
+            'usage_guest measurement=cpu cpu=cpu1 host=bertrand.local': 10,
+          },
+        },
+      ],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+  it('can parse metadata flux response', () => {
+    const fluxTables = parseResponse(TAGS_RESPONSE)
+    const actual = parseTablesByTime(fluxTables)
+    const expected = {
+      allColumnNames: [],
+      nonNumericColumns: ['_value'],
+      tablesByTime: [],
+    }
+
+    expect(actual).toEqual(expected)
+  })
+})


### PR DESCRIPTION
This PR simplifies labels of flux-based line charts.

_Briefly describe your proposed changes:_
A label value before this PR
```
_value[_start=2022-08-17T06:54:02.67759815Z][_stop=2022-08-17T07:54:02.657Z][_field=numSeries][_measurement=database][database=_internal][hostname=66fec3b3194f]
```
is herein simplified to
```
numSeries measurement=database database=_internal hostname=66fec3b3194f
```

with a help of the following rules
- `_field` value is used in place of `_value` string, it just shows the field that was measured
- `_start`, `_stop` and `_field` groups keys are removed from the label
- `measurement` is used in place of `_measurement`
- + queries that do have no `_value` and `_field` columns are also handled properly

_What was the problem?_
![image](https://user-images.githubusercontent.com/16321466/185066326-06a2ed4f-06fa-4fc2-a363-e6010abb7894.png)

_What was the solution?_
![image](https://user-images.githubusercontent.com/16321466/185066371-8bc27c55-affb-4660-968a-d1e17195beb0.png)

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
