### PR TITLE
feat: setup DBRP mapping automatically for a v2 connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 1. [#5959](https://github.com/influxdata/chronograf/pull/5959): Allow to customize annotation color.
 1. [#5967](https://github.com/influxdata/chronograf/pull/5967): Remember whether to start with shown annotations on Dashboard page.
 1. [#5977](https://github.com/influxdata/chronograf/pull/5977): Select current value in dropdown search input.
+1. [#5998](https://github.com/influxdata/chronograf/pull/5998): Setup DBRP mapping automatically for a v2 connection.
 
 ### Bug Fixes
 

--- a/server/mux.go
+++ b/server/mux.go
@@ -204,6 +204,7 @@ func NewMux(opts MuxOpts, service Service) http.Handler {
 	// Source Proxy to Influx's flux endpoint; compression because the responses from
 	// flux could be large.
 	router.Handler("POST", "/chronograf/v1/sources/:id/proxy/flux", EnsureReader(service.ProxyFlux))
+	router.Handler("GET", "/chronograf/v1/sources/:id/proxy/flux", EnsureReader(service.ProxyFlux))
 
 	// Write proxies line protocol write requests to InfluxDB
 	router.POST("/chronograf/v1/sources/:id/write", EnsureViewer(service.Write))

--- a/ui/src/dashboards/utils/createDBRP.ts
+++ b/ui/src/dashboards/utils/createDBRP.ts
@@ -1,0 +1,75 @@
+import {SOURCE_TYPE_INFLUX_V2} from 'src/shared/constants'
+import {Source} from 'src/types'
+import AJAX from 'src/utils/ajax'
+
+export interface DBRP {
+  id: string
+  bucketID: string
+  database: string
+  retention_policy: string
+  default: boolean
+}
+
+async function getTelegrafBucketID(
+  source: Source
+): Promise<string | undefined> {
+  // try to get bucket of the same name
+  const v2BucketsPath = `/api/v2/buckets?org=${encodeURIComponent(
+    source.username
+  )}&name=${encodeURIComponent(source.telegraf)}`
+  const response = await AJAX({
+    method: 'GET',
+    url: `${source.links.flux}?version=${encodeURIComponent(
+      source.version
+    )}&path=${encodeURIComponent(v2BucketsPath)}`,
+    data: '',
+  })
+  if (response.status !== 200) {
+    return undefined
+  }
+  return response.data?.buckets?.[0]?.id
+}
+
+async function createDBRPMapping(
+  source: Source,
+  bucketID: string
+): Promise<DBRP | undefined> {
+  // try to get bucket of the same name
+  const body = {
+    bucketID,
+    database: source.telegraf,
+    retention_policy: source.defaultRP || 'autogen',
+    default: true,
+    org: source.username,
+  }
+  const response = await AJAX({
+    method: 'POST',
+    url: `${source.links.flux}?version=${encodeURIComponent(
+      source.version
+    )}&path=/api/v2/dbrps`,
+    data: body,
+    headers: {'Content-Type': 'application/json'},
+  })
+  if (response.status === 201 && response.data.id) {
+    return response.data as DBRP
+  }
+  return
+}
+
+export async function createDBRP(source: Source): Promise<DBRP | undefined> {
+  if (
+    !source.links?.flux ||
+    source.type !== SOURCE_TYPE_INFLUX_V2 ||
+    !source.telegraf
+  ) {
+    return
+  }
+
+  const bucketID = await getTelegrafBucketID(source)
+  if (!bucketID) {
+    return
+  }
+
+  // create DBRP mappings for bucket id
+  return await createDBRPMapping(source, bucketID)
+}

--- a/ui/src/shared/copy/notifications.ts
+++ b/ui/src/shared/copy/notifications.ts
@@ -928,3 +928,13 @@ export const fluxWizardError = (message: string): Notification => ({
   duration: FIVE_SECONDS,
   message,
 })
+
+export const notifyDBRPCreated = (
+  bucket: string,
+  db: string,
+  rp: string
+): Notification => ({
+  ...defaultSuccessNotification,
+  duration: TEN_SECONDS,
+  message: `Default V1 DBRP mapping created. V2 bucket '${bucket}' is mapped to v1 database '${db}' with retention policy '${rp}'.`,
+})

--- a/ui/src/sources/components/DashboardStep.tsx
+++ b/ui/src/sources/components/DashboardStep.tsx
@@ -27,11 +27,13 @@ import {notify as notifyAction} from 'src/shared/actions/notifications'
 import {
   notifyDashboardCreated,
   notifyDashboardCreationFailed,
+  notifyDBRPCreated,
 } from 'src/shared/copy/notifications'
 
 // Types
 import {Protoboard, Source, RemoteDataState} from 'src/types'
 import {NextReturn} from 'src/types/wizard'
+import {DBRP} from 'src/dashboards/utils/createDBRP'
 
 interface SelectedDashboard {
   [x: string]: boolean
@@ -237,7 +239,7 @@ class DashboardStep extends Component<Props, State> {
 
   private handleSuggest = async () => {
     const {protoboards} = this.state
-    const {source} = this.props
+    const {source, notify} = this.props
 
     if (source) {
       if (this.isComponentMounted) {
@@ -247,7 +249,16 @@ class DashboardStep extends Component<Props, State> {
       try {
         const suggestedProtoboardsList = await getSuggestedProtoboards(
           source,
-          protoboards
+          protoboards,
+          (dbrp: DBRP) => {
+            notify(
+              notifyDBRPCreated(
+                source.telegraf,
+                dbrp.database,
+                dbrp.retention_policy
+              )
+            )
+          }
         )
 
         if (suggestedProtoboardsList.length === 0) {


### PR DESCRIPTION
This PR makes it possible to use pre-defined dashboards when setting up a new InfluxDB v2 connection. When a database is not available in a v2 connection (missing V1 DBRP mapping), the implementation tries to create a v1 DBRP mapping so that the existing InfluxQL dashboards (and dashboard suggestions) work properly. 

When a V2 connection is specified (InfluxDB v2 Auth is selected)
![image](https://user-images.githubusercontent.com/16321466/185606176-c9813e67-188d-4277-b179-70cfea3ced5d.png)

and the user presses `Next`, the implementation then tries to suggest dashboards. Newly in this PR, if it detects that there is no `telegraf` database, it attempts to create a v1 DBRP mapping for a v2 bucket of the same name as the database. If such a bucket exists and the DBRP mapping can be created, it creates a database and notifies a user with a message:

![image](https://user-images.githubusercontent.com/16321466/185606543-747ea875-0664-42f2-87f6-1d35366c1c7f.png)

The `suggested dashboards` functionality immediately works OOTB.
![image](https://user-images.githubusercontent.com/16321466/185606576-8dbd52e6-8863-436e-994b-0e7e2d044957.png)


The new functionality requires privileges that allow getting v2 buckets and creating v1 DBRP mapping, an admin (all-access) token for a v2 InfluxDB OSS is required.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
