### PR TITLE
chore: sign packages/binaries on release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ jobs:
       - attach_workspace:
           at: /home/circleci
       - run: |
+          ./etc/import-signing-key
           ./etc/scripts/docker/run.sh \
             --clean \
             --debug \
@@ -136,6 +137,7 @@ jobs:
             --package \
             --platform all \
             --arch all \
+            --sign \
             --upload-overwrite \
             --upload \
             --bucket dl.influxdata.com/chronograf/releases

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -6,6 +6,7 @@ RUN apt update && DEBIAN_FRONTEND=noninteractive apt install -y \
     wget \
     curl \
     git \
+    gnupg \
     mercurial \
     make \
     ruby \

--- a/etc/import-signing-key
+++ b/etc/import-signing-key
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+sudo -s <<EOF
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install --yes --no-install-recommends gnupg
+EOF
+
+# CircleCI automatically removes newlines from environment
+# variables. gpg cannot process keys (even if armored) without
+# the newlines present. To preserve special characters, the
+# gpg key has been base64 encoded.
+gpg --batch --yes --import <(base64 -d <<<"${GPG_1X_SIGNING_KEY}")
+

--- a/etc/scripts/docker/run.sh
+++ b/etc/scripts/docker/run.sh
@@ -9,6 +9,9 @@
 
 set -e
 
+# Default ${GNUPGHOME} to ${HOME}/.gnupg if not set
+GNUPGHOME="${GNUPGHOME:-${HOME}/.gnupg}"
+
 # Default SSH key to $HOME/.ssh/id_rsa if not set
 test -z $SSH_KEY_PATH && SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 echo "Using SSH key located at: $SSH_KEY_PATH"
@@ -19,6 +22,7 @@ test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20220721"
 docker run \
        -e AWS_ACCESS_KEY_ID \
        -e AWS_SECRET_ACCESS_KEY \
+       -v "${GNUPGHOME}:/root/.gnupg" \
        -v $SSH_KEY_PATH:/root/.ssh/id_rsa \
        -v ~/.ssh/known_hosts:/root/.ssh/known_hosts \
        -v $(pwd):/root/go/src/github.com/influxdata/chronograf \


### PR DESCRIPTION
This updates the release automation so that Chronograf releases are signed.

  - [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [X] Rebased/mergeable
  - [X] Tests pass
  - [ ] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`