### PR TITLE
fix: repair UI served under BASEPATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes
 
+1. [#6001](https://github.com/influxdata/chronograf/pull/6001): Repair UI served under BASEPATH.
+
 ### Other
 
 ## v1.10.0 [2022-08-23]

--- a/server/url_prefixer.go
+++ b/server/url_prefixer.go
@@ -84,8 +84,8 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	isSVG, _ := regexp.Match(".svg$", []byte(r.URL.String()))
-	if isSVG {
+	// do not process JS or SVG files, it only harms them
+	if isIgnored, _ := regexp.Match("\\.(svg|js)$", []byte(r.URL.String())); isIgnored {
 		up.Next.ServeHTTP(rw, r)
 		return
 	}
@@ -186,8 +186,6 @@ func NewDefaultURLPrefixer(prefix string, next http.Handler, lg chronograf.Logge
 			[]byte(`src="`),
 			[]byte(`href="`),
 			[]byte(`url(`),
-			[]byte(`new Worker("`),
-			[]byte(`new Worker('`),
 			[]byte(`data-basepath="`), // for forwarding basepath to frontend
 		},
 	}


### PR DESCRIPTION
Fixes #6000

_Briefly describe your proposed changes:_
This PR excludes JS files from preprocessing that is applied when chronograf UI is served under a specific subpath.

_What was the problem?_
Chronograf 1.10 comes with a new build system that produces different JS files comparing to chronograf 1.9 . These JS files do not need any further changes even if chronograf is served under specific  BASEPATH.

_What was the solution?_
Exclude js files from BASEPATH handling.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
