### PR TITLE
fix: avoid error on typing colon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Bug Fixes
+
+1. [#6056](https://github.com/influxdata/chronograf/pull/6056): Fix error on typing colon
+
 ## v1.10.1
 
 ### Features

--- a/ui/package.json
+++ b/ui/package.json
@@ -71,6 +71,7 @@
     "@types/react-dnd": "^2.0.36",
     "@types/react-dnd-html5-backend": "^2.1.9",
     "@types/react-dom": "^16.8.4",
+    "@types/react-onclickoutside": "^6.7.4",
     "@types/react-router": "^3.0.15",
     "@types/react-router-redux": "4",
     "@types/react-virtualized": "^9.18.3",

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -4,9 +4,13 @@ import classnames from 'classnames'
 
 import {Template} from 'src/types'
 
+interface TempVar {
+  tempVar: string
+}
+
 interface Props {
   templates: Template[]
-  selected: Template
+  selected: TempVar
   onMouseOverTempVar: (
     template: Template
   ) => (e: MouseEvent<HTMLDivElement>) => void

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -15,16 +15,14 @@ interface Props {
   ) => (e: MouseEvent<HTMLDivElement>) => void
 }
 
-class TemplateDrawer extends Component<Props>{
-
-  constructor(props: Props | Readonly<Props>){  
-    super(props);
+class TemplateDrawer extends Component<Props> {
+  constructor(props: Props | Readonly<Props>) {
+    super(props)
   }
 
-  public render(): React.ReactNode { 
-    
+  public render(): React.ReactNode {
     const {templates, selected, onMouseOverTempVar, onClickTempVar} = this.props
-    
+
     return (
       <div className="template-drawer">
         {templates.map(t => (

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -19,6 +19,8 @@ interface Props {
   ) => (e: MouseEvent<HTMLDivElement>) => void
 }
 
+// TemplateDrawer must be a class component,
+// functional components are not supported by react-onclickoutside
 class TemplateDrawer extends Component<Props> {
   constructor(props: Props | Readonly<Props>) {
     super(props)

--- a/ui/src/shared/components/TemplateDrawer.tsx
+++ b/ui/src/shared/components/TemplateDrawer.tsx
@@ -1,4 +1,4 @@
-import React, {FunctionComponent, MouseEvent} from 'react'
+import React, {Component, MouseEvent} from 'react'
 import OnClickOutside from 'react-onclickoutside'
 import classnames from 'classnames'
 
@@ -14,27 +14,35 @@ interface Props {
     template: Template
   ) => (e: MouseEvent<HTMLDivElement>) => void
 }
-const TemplateDrawer: FunctionComponent<Props> = ({
-  templates,
-  selected,
-  onMouseOverTempVar,
-  onClickTempVar,
-}) => (
-  <div className="template-drawer">
-    {templates.map(t => (
-      <div
-        className={classnames('template-drawer--item', {
-          'template-drawer--selected': t.tempVar === selected.tempVar,
-        })}
-        onMouseOver={onMouseOverTempVar(t)}
-        onMouseDown={onClickTempVar(t)}
-        key={t.tempVar}
-      >
-        {' '}
-        {t.tempVar}{' '}
+
+class TemplateDrawer extends Component<Props>{
+
+  constructor(props: Props | Readonly<Props>){  
+    super(props);
+  }
+
+  public render(): React.ReactNode { 
+    
+    const {templates, selected, onMouseOverTempVar, onClickTempVar} = this.props
+    
+    return (
+      <div className="template-drawer">
+        {templates.map(t => (
+          <div
+            className={classnames('template-drawer--item', {
+              'template-drawer--selected': t.tempVar === selected.tempVar,
+            })}
+            onMouseOver={onMouseOverTempVar(t)}
+            onMouseDown={onClickTempVar(t)}
+            key={t.tempVar}
+          >
+            {' '}
+            {t.tempVar}{' '}
+          </div>
+        ))}
       </div>
-    ))}
-  </div>
-)
+    )
+  }
+}
 
 export default OnClickOutside(TemplateDrawer)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2663,6 +2663,13 @@
   dependencies:
     "@types/react" "^16"
 
+"@types/react-onclickoutside@^6.7.4":
+  version "6.7.4"
+  resolved "https://registry.yarnpkg.com/@types/react-onclickoutside/-/react-onclickoutside-6.7.4.tgz#05b1ec0d31a85999873c51e166f57aefa3f037a4"
+  integrity sha512-N7EnMhxqb+TaUOGJQUV8YJeL3n5qP5+cXwtWRS/FYW+DSEAb8T3xwNsgZ6wEJMHP4/QpfVHcBaFopFjJ9XBuOg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-redux@^7.1.20":
   version "7.1.23"
   resolved "https://registry.yarnpkg.com/@types/react-redux/-/react-redux-7.1.23.tgz#3c2bb1bcc698ae69d70735f33c5a8e95f41ac528"


### PR DESCRIPTION
Closes #6007
Closes #6009
Closes #6011
Closes #6013
Closes #6017
Closes #6031
Closes #6034
Closes #6037
Closes #6038
Closes #6039
Closes #6044
Closes #6048
Closes #6051
Closes #6052
Closes #6053
Closes #6055
I might have missed a few issues describing the same error.

_Briefly describe your proposed changes:_

Replace FunctionComponent by Component in the `TemplateDrawer` to restore compatibility with `react-onclickoutside`

_What was the problem?_

Error when typing a colon: `Cannot read properties of undefined (reading 'getInstance')`

_What was the solution?_

Replacing FunctionComponent by Component, setting properties and adding a render function.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [x] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
