### PR TITLE
chore(build): upgrade Go to 1.20.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20230503
+      DOCKER_TAG: chronograf-20231013
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -96,7 +96,7 @@ jobs:
 
   deploy-nightly:
     environment:
-      DOCKER_TAG: chronograf-20230503
+      DOCKER_TAG: chronograf-20231013
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -125,7 +125,7 @@ jobs:
 
   deploy-pre-release:
     environment:
-      DOCKER_TAG: chronograf-20230503
+      DOCKER_TAG: chronograf-20231013
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -160,7 +160,7 @@ jobs:
 
   deploy-release:
     environment:
-      DOCKER_TAG: chronograf-20230503
+      DOCKER_TAG: chronograf-20231013
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.20.4'
+          go-version: '1.20.10'
 
       - uses: actions/setup-node@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 1. [#6056](https://github.com/influxdata/chronograf/pull/6056): Fix error on typing colon
 2. [#6060](https://github.com/influxdata/chronograf/pull/6060): Fix time interval in `Processor_Queue_Length` query
 
+### Other
+
+1. [#6063](https://github.com/influxdata/chronograf/pull/6063): Upgrade golang to 1.20.10
+
 ## v1.10.1
 
 ### Features

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -33,7 +33,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.20.4
+ENV GO_VERSION 1.20.10
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/scripts/docker/run.sh
+++ b/etc/scripts/docker/run.sh
@@ -14,7 +14,7 @@ test -z $SSH_KEY_PATH && SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 echo "Using SSH key located at: $SSH_KEY_PATH"
 
 # Default docker tag if not specified
-test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20230503"
+test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20231013"
 
 docker run \
        -e AWS_ACCESS_KEY_ID \


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/509

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`