### PR TITLE
fix: set active database from query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 
-1. [#6103](https://github.com/influxdata/chronograf/pull/6103): Set active database for InfluxQL meta queries with Cloud Serverless.
+1. [#6103](https://github.com/influxdata/chronograf/pull/6103): Set active database for InfluxQL meta queries.
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+### Bug Fixes
+
+1. [#6103](https://github.com/influxdata/chronograf/pull/6103): Set active database for InfluxQL meta queries with Cloud Serverless.
+
 ### Other
 
 1. [#6102](https://github.com/influxdata/chronograf/pull/6102): Upgrade golang to 1.21.12.

--- a/server/influx.go
+++ b/server/influx.go
@@ -187,10 +187,10 @@ func setupQueryFromCommand(req *chronograf.Query) {
 			if len(dbrp) > 1 {
 				req.RP = dbrp[1]
 			}
+			return nil
 		} else {
 			return err
 		}
-		return nil
 	}
 
 	// allow to set active database with USE command or via ON clause, examples:

--- a/server/influx.go
+++ b/server/influx.go
@@ -173,25 +173,49 @@ func (s *Service) Write(w http.ResponseWriter, r *http.Request) {
 
 // setupQueryFromCommand set query parameters from its command
 func setupQueryFromCommand(req *chronograf.Query) {
-	// allow to set active database with USE command, examples:
+	// normalize whitespaces
+	req.Command = strings.Join(strings.Fields(req.Command), " ")
+
+	// set active database (and retention policy) from the query
+	useDb := func(dbSpec string) error {
+		dbSpecReader := csv.NewReader(bytes.NewReader(([]byte)(dbSpec)))
+		dbSpecReader.Comma = '.'
+		if dbrp, err := dbSpecReader.Read(); err == nil {
+			fmt.Println(dbrp)
+			if len(dbrp) > 0 {
+				req.DB = dbrp[0]
+			}
+			if len(dbrp) > 1 {
+				req.RP = dbrp[1]
+			}
+		} else {
+			return err
+		}
+		return nil
+	}
+
+	// allow to set active database with USE command or via ON clause, examples:
 	//  use mydb
 	//  use "mydb"
 	//  USE "mydb"."myrp"
 	//  use "mydb.myrp"
 	//  use mydb.myrp
+	//  show tag keys on "mydb"
+	//  SHOW TAG KEYS ON "mydb"
 	if strings.HasPrefix(req.Command, "use ") || strings.HasPrefix(req.Command, "USE ") {
 		if nextCommand := strings.IndexRune(req.Command, ';'); nextCommand > 4 {
 			dbSpec := strings.TrimSpace(req.Command[4:nextCommand])
-			dbSpecReader := csv.NewReader(bytes.NewReader(([]byte)(dbSpec)))
-			dbSpecReader.Comma = '.'
-			if dbrp, err := dbSpecReader.Read(); err == nil {
-				if len(dbrp) > 0 {
-					req.DB = dbrp[0]
-				}
-				if len(dbrp) > 1 {
-					req.RP = dbrp[1]
-				}
+			if useDb(dbSpec) == nil {
 				req.Command = strings.TrimSpace(req.Command[nextCommand+1:])
+			}
+		}
+	} else if strings.Contains(req.Command, " on ") || strings.Contains(req.Command, " ON ") {
+		fields := strings.Fields(req.Command)
+		for i, field := range fields {
+			if field == "on" || field == "ON" {
+				if i < len(fields)-1 {
+					_ = useDb(fields[i+1])
+				}
 			}
 		}
 	}

--- a/server/influx.go
+++ b/server/influx.go
@@ -216,6 +216,7 @@ func setupQueryFromCommand(req *chronograf.Query) {
 				if i < len(fields)-1 {
 					_ = useDb(fields[i+1])
 				}
+				break
 			}
 		}
 	}

--- a/server/influx.go
+++ b/server/influx.go
@@ -201,17 +201,18 @@ func setupQueryFromCommand(req *chronograf.Query) {
 	//  use mydb.myrp
 	//  show tag keys on "mydb"
 	//  SHOW TAG KEYS ON "mydb"
-	if strings.HasPrefix(req.Command, "use ") || strings.HasPrefix(req.Command, "USE ") {
+	command := strings.ToLower(req.Command)
+	if strings.HasPrefix(command, "use ") {
 		if nextCommand := strings.IndexRune(req.Command, ';'); nextCommand > 4 {
 			dbSpec := strings.TrimSpace(req.Command[4:nextCommand])
 			if useDb(dbSpec) == nil {
 				req.Command = strings.TrimSpace(req.Command[nextCommand+1:])
 			}
 		}
-	} else if strings.Contains(req.Command, " on ") || strings.Contains(req.Command, " ON ") {
+	} else if strings.Contains(command, " on ") {
 		fields := strings.Fields(req.Command)
 		for i, field := range fields {
-			if field == "on" || field == "ON" {
+			if strings.ToLower(field) == "on" {
 				if i < len(fields)-1 {
 					_ = useDb(fields[i+1])
 				}

--- a/server/influx.go
+++ b/server/influx.go
@@ -181,7 +181,6 @@ func setupQueryFromCommand(req *chronograf.Query) {
 		dbSpecReader := csv.NewReader(bytes.NewReader(([]byte)(dbSpec)))
 		dbSpecReader.Comma = '.'
 		if dbrp, err := dbSpecReader.Read(); err == nil {
-			fmt.Println(dbrp)
 			if len(dbrp) > 0 {
 				req.DB = dbrp[0]
 			}

--- a/server/influx.go
+++ b/server/influx.go
@@ -178,7 +178,6 @@ func setupQueryFromCommand(req *chronograf.Query) {
 		dbSpecReader := csv.NewReader(bytes.NewReader(([]byte)(dbSpec)))
 		dbSpecReader.Comma = '.'
 		if dbrp, err := dbSpecReader.Read(); err == nil {
-			fmt.Println(dbrp)
 			if len(dbrp) > 0 {
 				req.DB = dbrp[0]
 			}

--- a/server/influx_test.go
+++ b/server/influx_test.go
@@ -270,6 +270,10 @@ func TestService_Influx_CommandWithOnClause(t *testing.T) {
 			name: `show tag keys on "my db" from "table"`,
 			db:   "my db",
 		},
+		{
+			name: `show tag values    on   "my   db" from "table" with key = "my key"`,
+			db:   "my   db",
+		},
 	}
 
 	h := &Service{

--- a/server/influx_test.go
+++ b/server/influx_test.go
@@ -250,6 +250,22 @@ func TestService_Influx_CommandWithOnClause(t *testing.T) {
 			name: `show tag keys on "mydb" from "table"`,
 			db:   "mydb",
 		},
+		{
+			name: `show tag keys on "my_db" from "table"`,
+			db:   "my_db",
+		},
+		{
+			name: `show tag keys on "my-db" from "table"`,
+			db:   "my-db",
+		},
+		{
+			name: `show tag keys on "my/db" from "table"`,
+			db:   "my/db",
+		},
+		{
+			name: `show tag keys on "my db" from "table"`,
+			db:   "my db",
+		},
 	}
 
 	h := &Service{

--- a/server/influx_test.go
+++ b/server/influx_test.go
@@ -239,6 +239,10 @@ func TestService_Influx_CommandWithOnClause(t *testing.T) {
 			db:   "mydb",
 		},
 		{
+			name: "USE anotherdb; SHOW TAG KEYS ON mydb",
+			db:   "anotherdb",
+		},
+		{
 			name: `show tag keys on "mydb"`,
 			db:   "mydb",
 		},

--- a/server/influx_test.go
+++ b/server/influx_test.go
@@ -247,6 +247,10 @@ func TestService_Influx_CommandWithOnClause(t *testing.T) {
 			db:   "mydb",
 		},
 		{
+			name: `show tag keys oN "mydb"`,
+			db:   "mydb",
+		},
+		{
 			name: `show tag keys on "mydb" from "table"`,
 			db:   "mydb",
 		},


### PR DESCRIPTION
Fixes https://github.com/influxdata/EAR/issues/5278

For InfluxQL metaqueries to work with Cloud Serverless, active database needs to be set (via `db` HTTP query parameter). Current version only supports settings active via `USE` clause.

This PR adds sets active database using value of  `ON` clause if present in the query and no db was set with `USE`.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass