### PR TITLE
fix: use new version of actions/upload-artifact

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -111,7 +111,7 @@ jobs:
             yarn run cypress run --env oauth2ServerURL=http://${{ env.OAUTH2_HOSTNAME }}:${{ env.OAUTH2_PORT }} --browser chrome --config-file githubActions-config.json --reporter junit --reporter-options 'mochaFile=cypress/results/results-[hash].xml'
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: success() || failure()
         with:
             name: results


### PR DESCRIPTION
This PR updates the `actions/upload-artifact` to version 4. Version 2 is deprecated and has been causing failures in our pipeline, as illustrated below:

![image](https://github.com/user-attachments/assets/6005141f-51b4-4807-bee7-3f29db99066e)

[View the failing job](https://github.com/influxdata/chronograf/actions/runs/10838113150/job/30075606637)

For more information, please refer to the [GitHub Changelog](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/).