### PR TITLE
chore(build): upgrade Go to 1.22.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - checkout
       - run: |
@@ -99,7 +99,7 @@ jobs:
       DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -128,7 +128,7 @@ jobs:
       DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - attach_workspace:
           at: /home/circleci
@@ -163,7 +163,7 @@ jobs:
       DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2204:current
     steps:
       - attach_workspace:
           at: /home/circleci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,7 @@ workflows:
 jobs:
   build:
     environment:
-      DOCKER_TAG: chronograf-20240710
+      DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -96,7 +96,7 @@ jobs:
 
   deploy-nightly:
     environment:
-      DOCKER_TAG: chronograf-20240710
+      DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -125,7 +125,7 @@ jobs:
 
   deploy-pre-release:
     environment:
-      DOCKER_TAG: chronograf-20240710
+      DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02
@@ -160,7 +160,7 @@ jobs:
 
   deploy-release:
     environment:
-      DOCKER_TAG: chronograf-20240710
+      DOCKER_TAG: chronograf-20240919
       GO111MODULE: "ON"
     machine:
       image: ubuntu-2004:202201-02

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.21.12'
+          go-version: '1.22.7'
 
       - uses: actions/setup-node@v2
         with:

--- a/etc/Dockerfile_build
+++ b/etc/Dockerfile_build
@@ -34,7 +34,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && \
 
 # Install go
 ENV GOPATH /root/go
-ENV GO_VERSION 1.21.12
+ENV GO_VERSION 1.22.7
 ENV GO_ARCH amd64
 ENV GO111MODULES ON
 RUN wget https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz; \

--- a/etc/scripts/docker/run.sh
+++ b/etc/scripts/docker/run.sh
@@ -14,7 +14,7 @@ test -z $SSH_KEY_PATH && SSH_KEY_PATH="$HOME/.ssh/id_rsa"
 echo "Using SSH key located at: $SSH_KEY_PATH"
 
 # Default docker tag if not specified
-test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20240710"
+test -z "$DOCKER_TAG" && DOCKER_TAG="chronograf-20240919"
 
 docker run \
        -e AWS_ACCESS_KEY_ID \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/chronograf
 
-go 1.21
+go 1.22
 
 require (
 	cloud.google.com/go/bigtable v1.10.0 // indirect

--- a/server/protoboards_test.go
+++ b/server/protoboards_test.go
@@ -239,7 +239,7 @@ func Test_ProtoboardsID(t *testing.T) {
 			wants: wants{
 				statusCode:  http.StatusOK,
 				contentType: "application/json",
-				body:        `{"id":"1","meta":{"name":"","version":"","dashboardVersion":""},"data":{"cells":null},"links":{"self":"/chronograf/v1/protoboards/1"}}`,
+				body:        `{"id":"1","meta":{"name":"","version":"","measurements":null,"dashboardVersion":""},"data":{"cells":null,"templates":null},"links":{"self":"/chronograf/v1/protoboards/1"}}`,
 			},
 			args: args{
 				id: "1",


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/739

This PR also updates our Ubuntu image to the same versions used in InfluxDB ([reference](https://github.com/influxdata/influxdb/blob/54d209d0bff44f3ebdc8f3f5bfdd9873268cbb93/.circleci/config.yml#L311)) due to the end of life (EOL) of the current version. For more information, see:

![image](https://github.com/user-attachments/assets/ba66ec45-2894-4b14-a3d6-7e7a46220098)
https://app.circleci.com/pipelines/github/influxdata/chronograf/1685/workflows/f67ccad1-abbe-4a3f-8691-a7ea37e2a1df/jobs/20114
https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177