### PR TITLE
docs: remove older unreleased upgrade notice for go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 ### Other
 
-1. [#6123](https://github.com/influxdata/chronograf/pull/6123): Upgrade golang to 1.22.11.
-2. [#6129](https://github.com/influxdata/chronograf/pull/6129): Upgrade golang to 1.23.8
+1. [#6129](https://github.com/influxdata/chronograf/pull/6129): Upgrade golang to 1.23.8
 
 ## v1.10.6 [2024-12-16]
 


### PR DESCRIPTION
Delete point about upgrade to GO 1.22.11.

_What was the problem?_

No need to report unreleased support for upgrades to older releases of GO

_What was the solution?_

Remove the point about support for GO 1.22.11

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [na] Any changes to `etc/Dockerfile_build` have been pushed to DockerHub, and the changes have been added to `.circleci/config.yml`
  - [na ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
