### PR TITLE
fix: Handle missing queryConfig in Host page queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [unreleased]
 
+### Bug Fixes
+
+1. [#6131](https://github.com/influxdata/chronograf/pull/6131): Handle missing queryConfig in Host page queries
+
 ### Other
 
 1. [#6123](https://github.com/influxdata/chronograf/pull/6123): Upgrade golang to 1.22.11.

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -61,11 +61,11 @@ export const executeQuery = async (
   const text = await replace(query.text, source, templates)
 
   const {data} = await proxy({
-     source: source.links.proxy,
-     rp: query.queryConfig?.retentionPolicy,
-     query: text,
-     db: query.queryConfig?.database,
-     uuid,
+    source: source.links.proxy,
+    rp: query.queryConfig?.retentionPolicy,
+    query: text,
+    db: query.queryConfig?.database,
+    uuid,
   })
 
   return data

--- a/ui/src/shared/apis/query.ts
+++ b/ui/src/shared/apis/query.ts
@@ -27,8 +27,8 @@ export function executeQueries(
     for (let i = 0; i < queries.length; i++) {
       const q = queries[i]
       if (
-        q.queryConfig.isExcluded &&
-        !q.queryConfig.status.isManuallySubmitted
+        q.queryConfig?.isExcluded &&
+        !q.queryConfig.status?.isManuallySubmitted
       ) {
         results[i] = {value: null, error: ErrorSkipped}
         counter -= 1
@@ -61,11 +61,11 @@ export const executeQuery = async (
   const text = await replace(query.text, source, templates)
 
   const {data} = await proxy({
-    source: source.links.proxy,
-    rp: query.queryConfig.retentionPolicy,
-    query: text,
-    db: query.queryConfig.database,
-    uuid,
+     source: source.links.proxy,
+     rp: query.queryConfig?.retentionPolicy,
+     query: text,
+     db: query.queryConfig?.database,
+     uuid,
   })
 
   return data

--- a/ui/src/shared/components/time_series/TimeSeries.tsx
+++ b/ui/src/shared/components/time_series/TimeSeries.tsx
@@ -323,7 +323,7 @@ class TimeSeries extends PureComponent<Props, State> {
     const {source, templates, editQueryStatus, queries} = this.props
 
     for (const query of queries) {
-      const prevStatus = query.queryConfig.status
+      const prevStatus = query.queryConfig?.status
       editQueryStatus(query.id, {
         loading: true,
         isManuallySubmitted: prevStatus?.isManuallySubmitted,
@@ -357,7 +357,7 @@ class TimeSeries extends PureComponent<Props, State> {
         }
       }
       const shouldPreserve =
-        query.queryConfig.isExcluded &&
+        query.queryConfig?.isExcluded &&
         !query.queryConfig.status?.isManuallySubmitted
       editQueryStatus(query.id, {
         ...queryStatus,


### PR DESCRIPTION
Closes #6128

Added a check for missing `queryConfig` in queries originating from the Host page.

  - [X] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [X] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [X] Rebased/mergeable
  - [x] Tests pass

