### PR TITLE
fix: replace unmaintained docker-run action (#6140)

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -98,17 +98,13 @@ jobs:
           cat out.log || true
 
       - name: Cypress
-        uses: addnab/docker-run-action@v3
-        with:
-          image: cypress/browsers:node16.14.0-slim-chrome99-ff97
-          options: -i -v ${{ github.workspace }}:/chronograf -w /chronograf/ui --network=host
-          shell: sh
-          run: |
-            apt update
-            apt install -y build-essential
-            yarn install --frozen-lockfile
-            yarn run cypress install
-            yarn run cypress run --env oauth2ServerURL=http://${{ env.OAUTH2_HOSTNAME }}:${{ env.OAUTH2_PORT }} --browser chrome --config-file githubActions-config.json --reporter junit --reporter-options 'mochaFile=cypress/results/results-[hash].xml'
+        run: |
+          docker run --rm \
+            -v ${{ github.workspace }}:/chronograf \
+            -w /chronograf/ui \
+            --network=host \
+            cypress/browsers:node16.14.0-slim-chrome99-ff97 \
+            sh -c "apt update && apt install -y build-essential && yarn install --frozen-lockfile && yarn run cypress install && yarn run cypress run --env oauth2ServerURL=http://${{ env.OAUTH2_HOSTNAME }}:${{ env.OAUTH2_PORT }} --browser chrome --config-file githubActions-config.json --reporter junit --reporter-options 'mochaFile=cypress/results/results-[hash].xml'"
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Closes #6140

Replace unmaintained `addnab/docker-run-action` with pure `docker run`
