### PR TITLE
chore: add "influxdata-archive-keyring" package

### DIFF
--- a/etc/build.py
+++ b/etc/build.py
@@ -701,7 +701,9 @@ def package(build_output, pkg_name, version, nightly=False, iteration=1, static=
                             package_build_root,
                             current_location)
                         if package_type == "rpm":
-                            fpm_command += "--depends coreutils --depends shadow-utils"
+                            fpm_command += "--depends coreutils --depends shadow-utils --rpm-tag 'Recommends: influxdata-archive-keyring'"
+                        if package_type == "deb":
+                            fpm_command += "--deb-recommends influxdata-archive-keyring"
                         # TODO: Check for changelog
                         # elif package_type == "deb":
                         #     fpm_command += "--deb-changelog {} ".format(os.path.join(os.getcwd(), "CHANGELOG.md"))


### PR DESCRIPTION
This adds the "influxdata-archive-keyring" package as a recommended package. 

```sh
$ dpkg -I build/chronograf_1.10.8~221494588_amd64.deb
 new Debian package, version 2.0.
 size 46011656 bytes: control archive=4036 bytes.
      28 bytes,     1 lines      conffiles
     369 bytes,    12 lines      control
    6683 bytes,    85 lines      md5sums
    2158 bytes,    82 lines   *  postinst             #!/bin/bash
    1216 bytes,    56 lines   *  postrm               #!/bin/bash
     166 bytes,     8 lines   *  preinst              #!/bin/bash
 Package: chronograf
 Version: 1.10.8~221494588-0
 License: AGPLv3
 Vendor: InfluxData
 Architecture: amd64
 Maintainer: contact@influxdb.com
 Installed-Size: 138226
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: https://github.com/influxdata/chronograf
 Description: Open source monitoring and visualization UI for the entire TICK stack.
```
```sh
$ rpm -q --recommends build/chronograf-1.10.8~221494588.x86_64.rpm
influxdata-archive-keyring
```