### PR TITLE
chore(ci): do not run e2e tests for Dependabot

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   e2e:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:


### PR DESCRIPTION
This PR fix Dependabot updates which will pass due the skip the e2e tests (we don't want to publicly share InfluxDB Enterprise license key).

  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
