### PR TITLE
fix(security): stop forwarding auth headers in upstream proxy requests

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -72,8 +72,6 @@ jobs:
           helm upgrade --install influxdb influxdata/influxdb-enterprise --namespace default \
               --wait \
               --timeout 5m \
-              --set-string image.tag=1.11 \
-              --set image.addsuffix=true \
               --set-string envFromSecret=influxdb-license \
               --set-string data.service.type=NodePort \
               --set-string meta.service.type=NodePort \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#6186](https://github.com/influxdata/chronograf/pull/6186): Hardened CSRF protections on Data Explorer and unsafe query endpoints.
 1. [#6191](https://github.com/influxdata/chronograf/pull/6191): Hardened Reader-only access and read-only query enforcement.
+2. [#6198](https://github.com/influxdata/chronograf/pull/6198): Prevent proxy credential leakage by default.
 
 ## v1.11.0 [2026-02-19]
 

--- a/server/proxy.go
+++ b/server/proxy.go
@@ -49,6 +49,12 @@ func (s *Service) Proxy(w http.ResponseWriter, r *http.Request) {
 	}
 
 	director := func(req *http.Request) {
+		// Do not forward Chronograf user credentials to external upstreams.
+		// This prevents session token disclosure via configured proxy targets.
+		req.Header.Del("Cookie")
+		req.Header.Del("Authorization")
+		req.Header.Del("Proxy-Authorization")
+
 		// Set the Host header of the original Kapacitor URL
 		req.Host = u.Host
 		req.URL = u

--- a/server/proxy_test.go
+++ b/server/proxy_test.go
@@ -28,7 +28,7 @@ func TestService_Proxy_AuthHeaderForwarding(t *testing.T) {
 			name:                       "strips incoming cookie and auth headers",
 			incomingCookie:             "session=victim-session",
 			incomingAuthorization:      "Bearer victim-token",
-			incomingProxyAuthorization: "Basic dmljdGltOnRva2Vu",
+			incomingProxyAuthorization: "Basic test_only_not_real_credentials",
 		},
 		{
 			name:           "does not set authorization when upstream credentials are empty",

--- a/server/proxy_test.go
+++ b/server/proxy_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bouk/httprouter"
+	"github.com/influxdata/chronograf"
+	"github.com/influxdata/chronograf/mocks"
+)
+
+func TestService_Proxy_AuthHeaderForwarding(t *testing.T) {
+	tests := []struct {
+		name                       string
+		incomingCookie             string
+		incomingAuthorization      string
+		incomingProxyAuthorization string
+		storedUsername             string
+		storedPassword             string
+		wantCookie                 string
+		wantAuthorization          string
+		wantProxyAuthorization     string
+	}{
+		{
+			name:                       "strips incoming cookie and auth headers",
+			incomingCookie:             "session=victim-session",
+			incomingAuthorization:      "Bearer victim-token",
+			incomingProxyAuthorization: "Basic dmljdGltOnRva2Vu",
+		},
+		{
+			name:           "does not set authorization when upstream credentials are empty",
+			incomingCookie: "session=victim-session",
+		},
+		{
+			name:              "uses stored basic auth when configured",
+			incomingCookie:    "session=victim-session",
+			storedUsername:    "kap-user",
+			storedPassword:    "kap-pass",
+			wantAuthorization: "Basic " + base64.StdEncoding.EncodeToString([]byte("kap-user:kap-pass")),
+		},
+		{
+			name:                  "stored basic auth overrides incoming bearer auth",
+			incomingAuthorization: "Bearer victim-token",
+			storedUsername:        "kap-user",
+			storedPassword:        "kap-pass",
+			wantAuthorization:     "Basic " + base64.StdEncoding.EncodeToString([]byte("kap-user:kap-pass")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var gotCookie string
+			var gotAuthorization string
+			var gotProxyAuthorization string
+
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotCookie = r.Header.Get("Cookie")
+				gotAuthorization = r.Header.Get("Authorization")
+				gotProxyAuthorization = r.Header.Get("Proxy-Authorization")
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer upstream.Close()
+
+			svc := &Service{
+				Store: &mocks.Store{
+					ServersStore: &mocks.ServersStore{
+						GetF: func(ctx context.Context, id int) (chronograf.Server, error) {
+							return chronograf.Server{
+								ID:       id,
+								SrcID:    1,
+								URL:      upstream.URL,
+								Username: tt.storedUsername,
+								Password: tt.storedPassword,
+							}, nil
+						},
+					},
+				},
+			}
+
+			req := httptest.NewRequest(
+				http.MethodGet,
+				"/chronograf/v1/sources/1/services/2/proxy?path=/kapacitor/v1/ping",
+				nil,
+			)
+			if tt.incomingCookie != "" {
+				req.Header.Set("Cookie", tt.incomingCookie)
+			}
+			if tt.incomingAuthorization != "" {
+				req.Header.Set("Authorization", tt.incomingAuthorization)
+			}
+			if tt.incomingProxyAuthorization != "" {
+				req.Header.Set("Proxy-Authorization", tt.incomingProxyAuthorization)
+			}
+
+			req = req.WithContext(httprouter.WithParams(
+				context.Background(),
+				httprouter.Params{
+					{Key: "id", Value: "1"},
+					{Key: "kid", Value: "2"},
+				},
+			))
+
+			rr := httptest.NewRecorder()
+			svc.ProxyGet(rr, req)
+
+			if rr.Code != http.StatusNoContent {
+				t.Fatalf("expected status %d, got %d", http.StatusNoContent, rr.Code)
+			}
+			if gotCookie != tt.wantCookie {
+				t.Fatalf("expected forwarded Cookie %q, got %q", tt.wantCookie, gotCookie)
+			}
+			if gotAuthorization != tt.wantAuthorization {
+				t.Fatalf(
+					"expected forwarded Authorization %q, got %q",
+					tt.wantAuthorization,
+					gotAuthorization,
+				)
+			}
+			if gotProxyAuthorization != tt.wantProxyAuthorization {
+				t.Fatalf(
+					"expected forwarded Proxy-Authorization %q, got %q",
+					tt.wantProxyAuthorization,
+					gotProxyAuthorization,
+				)
+			}
+		})
+	}
+}

--- a/ui/cypress/integration/explore_influxql.test.ts
+++ b/ui/cypress/integration/explore_influxql.test.ts
@@ -138,7 +138,7 @@ describe('InfluxQL', () => {
       })
     cy.get('.query-editor--status-actions').within(() => {
       cy.get('button').contains('Submit Query').click()
-      cy.wait('@postQuery')
+      cy.wait('@postQuery').its('response.statusCode').should('eq', 200)
       cy.reload()
     })
 
@@ -151,7 +151,8 @@ describe('InfluxQL', () => {
       cy.get('.dropdown').contains('Metaquery Templates').click()
       cy.getByTestID('dropdown--item').contains('Drop Database').click()
       cy.get('button').contains('Submit Query').click()
-      cy.wait('@postQuery')
+      cy.wait('@postQuery').its('response.statusCode').should('eq', 200)
+      cy.reload()
     })
     cy.contains('.query-builder--column', 'DB.RetentionPolicy').within(() => {
       cy.contains('.query-builder--list-item', `${targetDatabase}.autogen`, {


### PR DESCRIPTION
Prevents credential leakage in Kapacitor/service proxy requests by stripping user-provided Cookie, Authorization, and Proxy-Authorization headers before forwarding. The proxy now only sends explicitly configured upstream credentials (basic auth) when present.

Kapacitor authentication continues to use explicitly configured upstream credentials (for example configured   username/password), which is expected and separate from session forwarding. The suggested “token exchange” model is a conditional follow-up for delegated per-user upstream auth, **and because it is unclear if needed and also requires cross-product solution**, is out of scope for this fix.

Unit test added. Manual test described bellow. [1]

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass

---

[1]:  **Manual verification**

  1. Setup listener
      - Run a local listener to capture proxied requests:  `nc -lnvp 8765`
  2. Configure target in Chronograf
      - Create or update a Kapacitor/service entry with URL `http://localhost:8765`
  3. Trigger proxy request while authenticated (_when you add kapacitor connection, it attempts to connect, you may be able to already see the request with headers in the listener_)
      - Call (or open) a proxy endpoint, for example:
      - `/chronograf/v1/sources/<sourceID>/kapacitors/<kapacitorID>/proxy?path=/kapacitor/v1/ping`
      - or
      - `/chronograf/v1/sources/<sourceID>/services/<serviceID>/proxy?path=/kapacitor/v1/ping`
  4. Verify credential headers are not forwarded
      - In listener output, confirm request does not include:
      - `Cookie: session=...`
      - user `Authorization: Bearer ...`
      - `Proxy-Authorization: ...`
  5. Verify configured upstream auth still works
      - Set username/password on the Kapacitor/service config.
      - Trigger proxy request again.
      - Confirm upstream request includes Authorization: Basic ... and request succeeds.