### PR TITLE
doc: forgot to update CHANGELOG.md in PR6181 with latest changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 1. [#6170](https://github.com/influxdata/chronograf/pull/6170): Update Flux help in the UI to align with stdlib `0.199`.
 1. [#6171](https://github.com/influxdata/chronograf/pull/6171): Upgrade dependencies. Upgrade typescript to 4.9.5. Upgrade jest to 30.2.0. Upgrade eslint to 9.34.0.  Reconfigure eslint.
 1. [#6174](https://github.com/influxdata/chronograf/pull/6174): Upgrade dependencies. Upgrade nodejs to v24.13.0. Upgrade sass to 1.97.3. Remove dependency on node-sass.
-1. [#6181](https://github.com/influxdata/chronograf/pull/6181): Upgrade dependencies. Upgrade golang to 1.25.7
+1. [#6181](https://github.com/influxdata/chronograf/pull/6181): Upgrade dependencies. Upgrade golang to 1.25.8. Upgrade flux to `0.200`.
     * All darwin builds will now be dynamic only.
     * All windows builds will now be dynamic only.
     * All linux builds will now be static only.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@
 1. [#6186](https://github.com/influxdata/chronograf/pull/6186): Hardened CSRF protections on Data Explorer and unsafe query endpoints.
 1. [#6191](https://github.com/influxdata/chronograf/pull/6191): Hardened Reader-only access and read-only query enforcement.
 
+### Other
+
+1. [#6181](https://github.com/influxdata/chronograf/pull/6181): Upgrade dependencies. Upgrade golang to 1.25.8. Upgrade flux to `0.200`.
+   * All darwin builds will now be dynamic only.
+   * All windows builds will now be dynamic only.
+   * All linux builds will now be static only.
+
 ## v1.11.0 [2026-02-19]
 
 ⚠️ Removed support for Linux i386, armhf, armel and static build. Removed support for Darwin arm64.
@@ -15,10 +22,6 @@
 1. [#6170](https://github.com/influxdata/chronograf/pull/6170): Update Flux help in the UI to align with stdlib `0.199`.
 1. [#6171](https://github.com/influxdata/chronograf/pull/6171): Upgrade dependencies. Upgrade typescript to 4.9.5. Upgrade jest to 30.2.0. Upgrade eslint to 9.34.0.  Reconfigure eslint.
 1. [#6174](https://github.com/influxdata/chronograf/pull/6174): Upgrade dependencies. Upgrade nodejs to v24.13.0. Upgrade sass to 1.97.3. Remove dependency on node-sass.
-1. [#6181](https://github.com/influxdata/chronograf/pull/6181): Upgrade dependencies. Upgrade golang to 1.25.8. Upgrade flux to `0.200`.
-    * All darwin builds will now be dynamic only.
-    * All windows builds will now be dynamic only.
-    * All linux builds will now be static only.
 
 ## v1.10.9 [2026-01-07]
 


### PR DESCRIPTION
In PR6181 merged moments ago, the CHANGELOG.md was last updated a month ago.  PR6181 updates to newer versions of Go and Flux. 

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API) N.A.
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
