### PR TITLE
chore: ensure builds use latest go

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   cross-builder:
     docker:
-      - image: quay.io/influxdb/cross-builder:go1.25.7-latest
+      - image: quay.io/influxdb/cross-builder:go1.25.8-latest
     resource_class: large
     environment:
       GOPATH: /root/go

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.25.7'
+          go-version: '1.25.8'
 
       - name: Install pkg-config
         run: go install github.com/influxdata/pkg-config@v0.3.0


### PR DESCRIPTION
Sets crossbuilder and go target to 1.25.8 in all CI configs.

  - [ ] CHANGELOG.md updated with a link to the PR (not the Issue) N.A.
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API) N.A.
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
