### PR TITLE
ci: fix `chronograf-cypress-tests-report.yaml` workflow

### DIFF
--- a/.github/workflows/chronograf-cypress-tests-report.yaml
+++ b/.github/workflows/chronograf-cypress-tests-report.yaml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  checks: write
 
 jobs:
   report:

--- a/.github/workflows/chronograf-cypress-tests-report.yaml
+++ b/.github/workflows/chronograf-cypress-tests-report.yaml
@@ -14,7 +14,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@v1
+      - uses: dorny/test-reporter@v3
         if: success() || failure()
         with:
           artifact: results

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## v1.11.3 [unreleased]
+
+### Other
+
+1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow
+   caused by lack of write permissions.
+   * Add write permission to the `chronograf-cypress-tests-report.yaml` workflow.
+   * Upgrade `dorny/test-reporter` action to v3
+
 ## v1.11.2 [2026-05-06]
 
 ### Other
@@ -7,10 +16,6 @@
    * Upgrade "uuid" package version to "^14.0.0".
    * Upgrade "@parcel/core" version to "^2.16.4".
    * Remove "@types/uuid" because newer "uuid" versions are included types in the package.
-1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow
-caused by lack of write permissions.
-   * Add write permission to the `chronograf-cypress-tests-report.yaml` workflow.
-   * Upgrade `dorny/test-reporter` action to v3
 
 ## v1.11.1 [2026-04-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
    * Remove "@types/uuid" because newer "uuid" versions are included types in the package.
 1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow
 caused by lack of write permissions.
+   * Add write permission to the `chronograf-cypress-tests-report.yaml` workflow.
+   * Upgrade `dorny/test-reporter` action to v3
 
 ## v1.11.1 [2026-04-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
    * Upgrade "uuid" package version to "^14.0.0".
    * Upgrade "@parcel/core" version to "^2.16.4".
    * Remove "@types/uuid" because newer "uuid" versions are included types in the package.
+1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow.
 
 ## v1.11.1 [2026-04-15]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
    * Upgrade "uuid" package version to "^14.0.0".
    * Upgrade "@parcel/core" version to "^2.16.4".
    * Remove "@types/uuid" because newer "uuid" versions are included types in the package.
-1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow.
+1. [#6214](https://github.com/influxdata/chronograf/pull/6214): Fix `chronograf-cypress-tests-report.yaml` workflow
+caused by lack of write permissions.
 
 ## v1.11.1 [2026-04-15]
 


### PR DESCRIPTION
Closes #

### Changes

1. Add more permission for `GITHUB_TOKEN` in `chronograf-cypress-tests-report.yaml` so forking PRs will work.
2. Upgrade `dorny/test-reporter` to v3.

 - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
 - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
 - [x] Rebased/mergeable
 - [x] Tests pass
 - [x] swagger.json updated (if modified Go structs or API)
 - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
