### PR TITLE
chore(ci): upgrade Cypress tests workflow items

### DIFF
--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
           go-version: '1.25.9'
 
@@ -39,7 +39,7 @@ jobs:
         uses: dtolnay/rust-toolchain@1.72
 
       - name: Setup Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '24'
       - run: if [ ! -x "$(command -v yarn)" ]; then npm install -g yarn; fi
@@ -48,10 +48,10 @@ jobs:
       - name: Setup Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.6.3
+          version: v3.21.0
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.13.0
         with:
           cluster_name: "chronograf-testing"
           config: .github/workflows/resources/kind-config.yaml
@@ -66,7 +66,7 @@ jobs:
               cert-manager jetstack/cert-manager \
               --namespace cert-manager \
               --create-namespace \
-              --version v1.5.4 \
+              --version v1.19.5 \
               --set prometheus.enabled=false \
               --set webhook.timeoutSeconds=30 \
               --set installCRDs=true

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       - run: yarn node --version
 
       - name: Setup Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
           version: v3.21.0
 


### PR DESCRIPTION
Upgrades most outdated items in CI workflows, all are Cypress E2E tests related.

  - [ ] ~~CHANGELOG.md updated with a link to the PR (not the Issue)~~
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
