### PR TITLE
chore: upgrade reference go to v1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   cross-builder:
     docker:
-      - image: quay.io/influxdb/cross-builder:go1.25.9-latest
+      - image: quay.io/influxdb/cross-builder:go1.26.3-latest
     resource_class: large
     environment:
       GOPATH: /root/go

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.25.9'
+          go-version: '1.26.3'
 
       - name: Install pkg-config
         run: go install github.com/influxdata/pkg-config@v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.3 [unreleased]
+
+### Other
+
+1. [#6219](https://github.com/influxdata/chronograf/pull/6219): Upgrade golang to 1.26.3
+
 ## v1.11.2 [2026-05-06]
 
 ### Other

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/chronograf
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
Updates reference go to v1.26.3

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API)
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
