### PR TITLE
chore: upgrade go 1.25.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   cross-builder:
     docker:
-      - image: quay.io/influxdb/cross-builder:go1.25.9-latest
+      - image: quay.io/influxdb/cross-builder:go1.25.10-latest
     resource_class: large
     environment:
       GOPATH: /root/go

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.9'
+          go-version: '1.25.10'
 
       - name: Install pkg-config
         run: go install github.com/influxdata/pkg-config@v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
    caused by lack of write permissions.
    * Add write permission to the `chronograf-cypress-tests-report.yaml` workflow.
    * Upgrade `dorny/test-reporter` action to v3
+   1. [#6220](https://github.com/influxdata/chronograf/pull/6220): Upgrade golang to 1.25.10.
 
 ## v1.11.2 [2026-05-06]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/chronograf
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
upgrades reference go to the v1.25.10 release

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API) N.A.
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
