### PR TITLE
fix: respect base path in minified UI HTML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.4 [unreleased]
+
+### Bug Fixes
+
+1. [#6227](https://github.com/influxdata/chronograf/pull/6227): Respect base path in minified UI HTML.
+
 ## v1.11.3 [2026-05-27]
 
 ### Other

--- a/server/url_prefixer.go
+++ b/server/url_prefixer.go
@@ -104,8 +104,8 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	// setup a buffer which is the max length of our target attrs
 	b := make([]byte, up.maxlen(up.Attrs...))
-	io.ReadFull(nextRead, b) // prime the buffer with the start of the input
-	buf := bytes.NewBuffer(b)
+	n, _ := io.ReadFull(nextRead, b) // prime the buffer with the start of the input
+	buf := bytes.NewBuffer(b[:n])
 
 	// Read next handler's response byte by byte
 	src := bufio.NewScanner(nextRead)
@@ -113,38 +113,68 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	for {
 		window := buf.Bytes()
 
-		// advance a byte if window is not a src attr
-		if matchlen, match := up.match(window, up.Attrs...); matchlen == 0 {
-			if src.Scan() {
-				// shift the next byte into buf
-				rw.Write(buf.Next(1))
-				writtenCount++
-				buf.Write(src.Bytes())
-
-				if writtenCount >= ChunkSize {
-					flusher.Flush()
-					writtenCount = 0
-				}
-			} else {
-				if err := src.Err(); err != nil {
-					up.Logger.
-						WithField("component", "prefixer").
-						Error("Error encountered while scanning: err:", err)
-				}
-				rw.Write(window)
-				flusher.Flush()
-				break
-			}
-			continue
-		} else {
-			buf.Next(matchlen) // advance to the relative URL
-			for i := 0; i < matchlen; i++ {
-				src.Scan()
-				buf.Write(src.Bytes())
-			}
-			rw.Write(match)               // add the src attr to the output
-			io.WriteString(rw, up.Prefix) // write the prefix
+		if len(window) == 0 {
+			flusher.Flush()
+			break
 		}
+
+		// advance a byte if window is not a src attr
+		matchlen, match := up.match(window, up.Attrs...)
+		if matchlen == 0 {
+			rw.Write(buf.Next(1))
+			writtenCount++
+
+			if src.Scan() {
+				buf.Write(src.Bytes())
+			} else if err := src.Err(); err != nil {
+				up.Logger.
+					WithField("component", "prefixer").
+					Error("Error encountered while scanning: err:", err)
+			}
+
+			if writtenCount >= ChunkSize {
+				flusher.Flush()
+				writtenCount = 0
+			}
+
+			continue
+		}
+
+		buf.Next(matchlen) // advance to the relative URL
+		for i := 0; i < matchlen; i++ {
+			src.Scan()
+			buf.Write(src.Bytes())
+		}
+		if bytes.Equal(match, []byte(`src=/`)) {
+			if bytes.HasPrefix(buf.Bytes(), []byte(`/`)) {
+				rw.Write(match)
+				continue
+			}
+			rw.Write([]byte(`src=`))
+			io.WriteString(rw, up.Prefix)
+			continue
+		}
+		if bytes.Equal(match, []byte(`href=/`)) {
+			if bytes.HasPrefix(buf.Bytes(), []byte(`/`)) {
+				rw.Write(match)
+				continue
+			}
+			rw.Write([]byte(`href=`))
+			io.WriteString(rw, up.Prefix)
+			continue
+		}
+		if bytes.Equal(match, []byte(`data-basepath`)) {
+			if len(buf.Bytes()) > 0 && bytes.ContainsAny(buf.Bytes()[:1], "> \t\r\n") {
+				rw.Write([]byte(`data-basepath="`))
+				io.WriteString(rw, up.Prefix)
+				rw.Write([]byte(`"`))
+				continue
+			}
+			rw.Write(match)
+			continue
+		}
+		rw.Write(match)               // add the src attr to the output
+		io.WriteString(rw, up.Prefix) // write the prefix
 	}
 }
 
@@ -154,7 +184,7 @@ func (up *URLPrefixer) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 // targets. The matching []byte is also returned as the second return parameter
 func (up *URLPrefixer) match(subject []byte, targets ...[]byte) (int, []byte) {
 	for _, target := range targets {
-		if bytes.Equal(subject[:len(target)], target) {
+		if len(subject) >= len(target) && bytes.Equal(subject[:len(target)], target) {
 			return len(target), target
 		}
 	}
@@ -186,7 +216,10 @@ func NewDefaultURLPrefixer(prefix string, next http.Handler, lg chronograf.Logge
 			[]byte(`src="`),
 			[]byte(`href="`),
 			[]byte(`url(`),
+			[]byte(`src=/`),
+			[]byte(`href=/`),
 			[]byte(`data-basepath="`), // for forwarding basepath to frontend
+			[]byte(`data-basepath`),
 		},
 	}
 }

--- a/server/url_prefixer_test.go
+++ b/server/url_prefixer_test.go
@@ -210,3 +210,53 @@ func Test_Server_Prefixer_IgnoreJsAndSvg(t *testing.T) {
 		}
 	}
 }
+
+func Test_Server_Prefixer_RewritesMinifiedHTML(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		subject  string
+		expected string
+	}{
+		{"Unquoted href", `<link rel=stylesheet href=/ui.css>`, `<link rel=stylesheet href=/chronograf/ui.css>`},
+		{"Unquoted src", `<script src=/ui.js></script>`, `<script src=/chronograf/ui.js></script>`},
+		{"Empty data-basepath", `<div id=react-root data-basepath></div>`, `<div id=react-root data-basepath="/chronograf/"></div>`},
+		{
+			"Minified index HTML",
+			`<link rel=stylesheet href=/ui.f8bbc9c4.css><link rel="icon shortcut" href=/favicon.70d63073.ico><div id=react-root data-basepath></div><script type=module src=/ui.eb3e79e6.js></script>`,
+			`<link rel=stylesheet href=/chronograf/ui.f8bbc9c4.css><link rel="icon shortcut" href=/chronograf/favicon.70d63073.ico><div id=react-root data-basepath="/chronograf/"></div><script type=module src=/chronograf/ui.eb3e79e6.js></script>`,
+		},
+	}
+
+	for _, test := range tests {
+		backend := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprint(w, test.subject)
+		})
+
+		pfx := server.NewDefaultURLPrefixer("/chronograf/", backend, nil)
+
+		ts := httptest.NewServer(pfx)
+		defer ts.Close()
+
+		res, err := http.Get(ts.URL)
+		if err != nil {
+			t.Fatal("Unexpected error fetching from prefixer: err:", err)
+		}
+
+		actual, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal("Unable to read prefixed body: err:", err)
+		}
+
+		if string(actual) != test.expected {
+			t.Error(
+				test.name,
+				":\n Unsuccessful prefixing.\n\tWant:",
+				fmt.Sprintf("%+q", test.expected),
+				"\n\tGot: ",
+				fmt.Sprintf("%+q", string(actual)),
+			)
+		}
+	}
+}

--- a/server/url_prefixer_test.go
+++ b/server/url_prefixer_test.go
@@ -222,6 +222,7 @@ func Test_Server_Prefixer_RewritesMinifiedHTML(t *testing.T) {
 		{"Unquoted href", `<link rel=stylesheet href=/ui.css>`, `<link rel=stylesheet href=/chronograf/ui.css>`},
 		{"Unquoted src", `<script src=/ui.js></script>`, `<script src=/chronograf/ui.js></script>`},
 		{"Empty data-basepath", `<div id=react-root data-basepath></div>`, `<div id=react-root data-basepath="/chronograf/"></div>`},
+		{"Quoted data-basepath", `<div id=react-root data-basepath=""></div>`, `<div id=react-root data-basepath="/chronograf/"></div>`},
 		{
 			"Minified index HTML",
 			`<link rel=stylesheet href=/ui.f8bbc9c4.css><link rel="icon shortcut" href=/favicon.70d63073.ico><div id=react-root data-basepath></div><script type=module src=/ui.eb3e79e6.js></script>`,


### PR DESCRIPTION
Closes #6226

`parcel` newer HTML minifier (since v2.15) ) can emit unquoted asset attributes and a boolean data-basepath. The existing prefixer only handled quoted attributes, so UI assets were not rewritten when Chronograf was served under a non-root base path.

This PR updates the prefixer to handle minified `src=/...`, `href=/...`, and boolean `data-basepath` forms while preserving existing quoted behavior.

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
