### PR TITLE
chore(ci): push release artifacts to Cloudflare R2 instead of AWS S3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ commands:
 
 orbs:
   browser-tools: circleci/browser-tools@1.1.3
-  aws-s3: circleci/aws-s3@2.0.0
 
 
 parameters:
@@ -161,7 +160,7 @@ jobs:
               --upload \
               --nightly \
               --version=nightly \
-              --bucket=dl.influxdata.com/chronograf/releases
+              --bucket=dl-influxdata-com/chronograf/releases
       - store_artifacts:
           path: ./build/
 
@@ -211,7 +210,7 @@ jobs:
               --arch all \
               --upload-overwrite \
               --upload \
-              --bucket dl.influxdata.com/chronograf/releases
+              --bucket dl-influxdata-com/chronograf/releases
       - store_artifacts:
           path: ./build/
       - persist_to_workspace:
@@ -241,7 +240,7 @@ jobs:
               --arch all \
               --upload-overwrite \
               --upload \
-              --bucket dl.influxdata.com/chronograf/releases
+              --bucket dl-influxdata-com/chronograf/releases
       - store_artifacts:
           path: ./build/
       - persist_to_workspace:
@@ -284,14 +283,13 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - aws-s3/sync:
-          arguments: >
-            --exclude '*'
-            --include 'chronograf-*.asc'
-            --include 'chronograf_*.asc'
-            --acl public-read
-          aws-region:            AWS_REGION
-          aws-access-key-id:     AWS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_SECRET_ACCESS_KEY
-          from: /tmp/workspace/signatures/
-          to:   s3://dl.influxdata.com/chronograf/releases/
+      - run:
+          name: "Upload signatures to R2"
+          command: |
+            pip install --quiet awscli
+            aws s3 sync /tmp/workspace/signatures/ "s3://dl-influxdata-com/chronograf/releases/" \
+              --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+              --region auto \
+              --exclude '*' \
+              --include 'chronograf-*.asc' \
+              --include 'chronograf_*.asc'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -280,6 +280,8 @@ jobs:
   packages-upload-signatures:
     docker:
       - image: cimg/python:3.12.3
+    environment:
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace

--- a/etc/build.py
+++ b/etc/build.py
@@ -38,8 +38,8 @@ LOGROTATE_SCRIPT = "etc/scripts/logrotate"
 CANNED_SCRIPTS = "canned/*json"
 PROTOBOARDS_SCRIPTS = "protoboards/*json"
 
-# Default AWS S3 bucket for uploads
-DEFAULT_BUCKET = "dl.influxdata.com/chronograf/artifacts"
+# Default S3-compatible bucket for uploads (Cloudflare R2)
+DEFAULT_BUCKET = "dl-influxdata-com/chronograf/artifacts"
 
 CONFIGURATION_FILES = [
     LOGROTATE_DIR + '/chronograf',
@@ -381,7 +381,7 @@ def check_prereqs():
     return True
 
 def upload_packages(packages, bucket_name=None, overwrite=False):
-    """Upload provided package output to AWS S3.
+    """Upload provided package output to S3-compatible storage.
     """
     logging.debug("Uploading files to bucket '{}': {}".format(bucket_name, packages))
     try:
@@ -392,7 +392,7 @@ def upload_packages(packages, bucket_name=None, overwrite=False):
     except ImportError:
         logging.warning("Cannot upload packages without 'boto3' Python library!")
         return False
-    logging.info("Connecting to AWS S3...")
+    logging.info("Connecting to S3-compatible storage...")
 
     if bucket_name is None:
         bucket_name = DEFAULT_BUCKET
@@ -405,13 +405,15 @@ def upload_packages(packages, bucket_name=None, overwrite=False):
         # delimiter.
         prefix = '/'.join(bucket_name.split('/')[1:])
 
-    # Keep retries at 10 attempts and use path-style addressing for dotted bucket names.
-    # Also ensure robust EC2 instance metadata (IMDS) credential retrieval by setting
-    # botocore's IMDS retry/timeout defaults if they are not already configured.
-    os.environ.setdefault("AWS_EC2_METADATA_SERVICE_NUM_ATTEMPTS", "10")
-    os.environ.setdefault("AWS_EC2_METADATA_SERVICE_TIMEOUT", "1")
+    # Cloudflare R2 (or another S3-compatible endpoint) is selected via the
+    # standard AWS_ENDPOINT_URL_S3 environment variable; without it boto3
+    # falls back to plain AWS S3. R2 requires the region to be "auto".
+    endpoint_url = os.environ.get("AWS_ENDPOINT_URL_S3")
     config = Config(retries={'max_attempts': 10}, s3={'addressing_style': 'path'})
-    s3 = boto3.client('s3', config=config)
+    s3 = boto3.client('s3',
+                      endpoint_url=endpoint_url,
+                      region_name="auto" if endpoint_url else None,
+                      config=config)
 
     for p in packages:
         if prefix:
@@ -433,7 +435,7 @@ def upload_packages(packages, bucket_name=None, overwrite=False):
 
         logging.info("Uploading file {}".format(name))
         try:
-            s3.upload_file(p, bucket, name, ExtraArgs={'ACL': 'public-read'})
+            s3.upload_file(p, bucket, name)
         except ClientError as exc:
             logging.error("Uploading file '{}' failed: {}".format(name, exc))
             return False
@@ -1093,10 +1095,10 @@ if __name__ == '__main__':
                         help='Fail if uncommitted changes exist in the working directory')
     parser.add_argument('--upload',
                         action='store_true',
-                        help='Upload output packages to AWS S3')
+                        help='Upload output packages to S3-compatible storage')
     parser.add_argument('--upload-overwrite','-w',
                         action='store_true',
-                        help='Upload output packages to AWS S3')
+                        help='Overwrite existing packages in S3-compatible storage')
     parser.add_argument('--bucket',
                         metavar='<S3 bucket name>',
                         type=str,


### PR DESCRIPTION
_Briefly describe your proposed changes:_

Retargets CI artifact uploads from the AWS S3 bucket `dl.influxdata.com` to the
Cloudflare R2 bucket `dl-influxdata-com`. Artifact key paths are unchanged
(`chronograf/releases/...`, `chronograf/artifacts/...`).

**What was the problem?**
Build artifacts and package signatures were pushed to AWS S3; distribution has
moved to Cloudflare R2. Finishing this will allow us to stop our Sippy replication
job.

**What was the solution?**

`etc/build.py`:
- `upload_packages()` now reads the standard `AWS_ENDPOINT_URL_S3` environment
  variable and passes it to the boto3 client with `region_name="auto"` (required
  by R2). If the variable is unset, behavior falls back to plain AWS S3.
- `DEFAULT_BUCKET` changed to `dl-influxdata-com/chronograf/artifacts`.
- Removed the per-object `public-read` ACL — R2 rejects canned ACLs; public
  access is served via the bucket's custom domain (dl.influxdata.com).
- Removed EC2 IMDS credential tuning (credentials now always come from env vars).

`.circleci/config.yml`:
- `--bucket` now `dl-influxdata-com/chronograf/releases` in deploy-nightly,
  deploy-pre-release, and deploy-release.
- `packages-upload-signatures` replaces the `aws-s3` orb with a plain
  `aws s3 sync --endpoint-url "${AWS_ENDPOINT_URL_S3}" --region auto`; the
  unused orb was removed.

**Rollout (before merge):**
- [x] `AWS_ENDPOINT_URL_S3` variable created in CircleCI project settings
- [ ] Approver: review and approve
- [ ] Contact @tkyocum to swap `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`
      values to the R2 token pair in CircleCI
- [ ] Merge

---
- [ ] CHANGELOG.md updated with a link to the PR (not the Issue) — N/A, CI-only change
- [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
- [x] Rebased/mergeable
- [x] Tests pass — no code paths exercised by tests changed; `py_compile` clean
- [ ] swagger.json updated (if modified Go structs or API) — N/A
- [x] Sign [CLA](https://influxdata.com/community/cla/)
