### PR TITLE
chore: upgrade go to 1.26.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 executors:
   cross-builder:
     docker:
-      - image: quay.io/influxdb/cross-builder:go1.25.10-latest
+      - image: quay.io/influxdb/cross-builder:go1.26.5-latest
     resource_class: large
     environment:
       GOPATH: /root/go

--- a/.github/workflows/chronograf-cypress-tests.yaml
+++ b/.github/workflows/chronograf-cypress-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.10'
+          go-version: '1.26.5'
 
       - name: Install pkg-config
         run: go install github.com/influxdata/pkg-config@v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v1.11.5 [unreleased]
+
+### Other
+
+1. [#6248](https://github.com/influxdata/chronograf/pull/6248): Upgrade golang to 1.26.5.
+
 ## v1.11.4 [2026-06-16]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Other
 
-1. [#6248](https://github.com/influxdata/chronograf/pull/6248): Upgrade golang to 1.26.5.
+1. [#6249](https://github.com/influxdata/chronograf/pull/6249): Upgrade golang to 1.26.5.
 
 ## v1.11.4 [2026-06-16]
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/influxdata/chronograf
 
-go 1.25.10
+go 1.26.5
 
 require (
 	github.com/NYTimes/gziphandler v1.1.1


### PR DESCRIPTION
upgrades reference go to the v1.26.5 release

  - [x] CHANGELOG.md updated with a link to the PR (not the Issue)
  - [x] [Well-formatted commit messages](https://www.conventionalcommits.org/en/v1.0.0-beta.3/)
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [ ] swagger.json updated (if modified Go structs or API) N.A.
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
